### PR TITLE
cln-plugin: make it more universally useable + tests + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+name: CI
+
+# Cancel duplicate jobs
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+on:
+    workflow_call:
+        inputs:
+          cln-version:
+            required: true
+            type: string
+          pyln-version:
+            required: true
+            type: string
+          tagged-release:
+            required: true
+            type: boolean
+
+jobs:
+  build:
+    name: Test CLN=${{ inputs.cln-version }}, OS=${{ matrix.os }}, PY=${{ matrix.python-version }}, BCD=${{ matrix.bitcoind-version }}, EXP=${{ matrix.experimental }}, DEP=${{ matrix.deprecated }}
+    strategy:
+        fail-fast: false
+        matrix:
+            bitcoind-version: ["26.1"]
+            experimental: [1]
+            deprecated: [0]
+            python-version: ["3.8", "3.12"]
+            os: ["ubuntu-latest"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Create cache paths
+      run: |
+        sudo mkdir /usr/local/libexec
+        sudo mkdir /usr/local/libexec/c-lightning
+        sudo mkdir /usr/local/libexec/c-lightning/plugins
+        sudo chown -R $USER /usr/local/libexec
+
+    - name: Cache CLN
+      id: cache-cln
+      uses: actions/cache@v4
+      with:
+        path: |
+          /usr/local/bin/lightning*
+          /usr/local/libexec/c-lightning
+        key: cache-cln-${{ inputs.cln-version }}-${{ runner.os }}
+
+    - name: Cache bitcoind
+      id: cache-bitcoind
+      uses: actions/cache@v4
+      with:
+        path: /usr/local/bin/bitcoin*
+        key: cache-bitcoind-${{ matrix.bitcoind-version }}-${{ runner.os }}
+
+    - name: Download Bitcoin ${{ matrix.bitcoind-version }} & install binaries
+      if: ${{ steps.cache-bitcoind.outputs.cache-hit != 'true' }}
+      run: |
+        export BITCOIND_VERSION=${{ matrix.bitcoind-version }}
+        if [[ "${{ matrix.os }}" =~ "ubuntu" ]]; then
+          export TARGET_ARCH="x86_64-linux-gnu"
+        fi
+        if [[ "${{ matrix.os }}" =~ "macos" ]]; then
+          export TARGET_ARCH="x86_64-apple-darwin"
+        fi
+        wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIND_VERSION}/bitcoin-${BITCOIND_VERSION}-${TARGET_ARCH}.tar.gz
+        tar -xzf bitcoin-${BITCOIND_VERSION}-${TARGET_ARCH}.tar.gz
+        sudo mv bitcoin-${BITCOIND_VERSION}/bin/* /usr/local/bin
+        rm -rf bitcoin-${BITCOIND_VERSION}-${TARGET_ARCH}.tar.gz bitcoin-${BITCOIND_VERSION}
+
+    - name: Download Core Lightning ${{ inputs.cln-version }} & install binaries
+      if: ${{ contains(matrix.os, 'ubuntu') &&  steps.cache-cln.outputs.cache-hit != 'true' }}
+      run: |
+          url=$(curl -s https://api.github.com/repos/ElementsProject/lightning/releases/tags/${{ inputs.cln-version }} \
+            | jq '.assets[] | select(.name | contains("22.04")) | .browser_download_url' \
+            | tr -d '\"')
+          wget $url
+          sudo tar -xvf ${url##*/} -C /usr/local --strip-components=2
+          echo "CLN_VERSION=$(lightningd --version)" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Checkout Core Lightning ${{ inputs.cln-version }}
+      if: ${{ contains(matrix.os, 'macos') && steps.cache-cln.outputs.cache-hit != 'true' }}
+      uses: actions/checkout@v4
+      with:
+        repository: 'ElementsProject/lightning'
+        path: 'lightning'
+        ref: ${{ inputs.cln-version }}
+        submodules: 'recursive'
+
+    - name: Install Python and System dependencies
+      run: |
+        if [[ "${{ matrix.os }}" =~ "macos" ]]; then
+          brew install autoconf automake libtool gnu-sed gettext libsodium sqlite
+        fi
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install -U pip poetry wheel
+        pip3 install "pyln-proto<=${{ inputs.pyln-version }}" "pyln-client<=${{ inputs.pyln-version }}" "pyln-testing<=${{ inputs.pyln-version }}"
+        pip3 install pytest-xdist pytest-test-groups pytest-timeout
+        pip3 install -r requirements.txt
+
+    - name: Compile Core Lightning ${{ inputs.cln-version }} & install binaries
+      if: ${{ contains(matrix.os, 'macos') && steps.cache-cln.outputs.cache-hit != 'true' }}
+      run: |
+        export EXPERIMENTAL_FEATURES=${{ matrix.experimental }}
+        export COMPAT=${{ matrix.deprecated }}
+        export VALGRIND=0
+        source venv/bin/activate
+
+        cd lightning
+
+        poetry lock
+        poetry install
+        ./configure --disable-valgrind
+        poetry run make
+        sudo make install
+
+    - name: Run tests
+      run: |
+        export CLN_PATH=${{ github.workspace }}/lightning
+        export COMPAT=${{ matrix.deprecated }}
+        export EXPERIMENTAL_FEATURES=${{ matrix.experimental }}
+        export SLOW_MACHINE=1
+        export TEST_DEBUG=1
+        export TRAVIS=1
+        export VALGRIND=0
+        export PYTEST_TIMEOUT=600
+        source venv/bin/activate
+        pytest -n=5 test_stablechannels.py

--- a/.github/workflows/main_v24.02.yml
+++ b/.github/workflows/main_v24.02.yml
@@ -1,0 +1,24 @@
+name: main on CLN v24.02.2
+
+on:
+    push:
+        branches:
+            - main
+        paths-ignore:
+            - 'Dockerfile'
+            - '*.md'
+            - 'LICENSE'
+            - '.gitignore'
+            - 'coffee.yml'
+            - '*.sh'
+            - 'lnd.py'
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+    call-ci:
+        uses: ./.github/workflows/ci.yml
+        with:
+            cln-version: "v24.02.2"
+            pyln-version: "24.02"
+            tagged-release: false

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Now, we need to start the Stable Channels plugin and with the relevant details o
 The plugin startup command will look something like this:
 
 ```bash
-lightning-cli plugin subcommand=start plugin=/home/clightning/stablechannels.py channel-id=b37a51423e67a1f6733a78bb654535b2b81c427435600b0756bb65e21bdd411a stable-dollar-amount=95 is-stable-receiver=True counterparty=026b9c2a005b182ff5b2a7002a03d6ea9d005d18ed2eb3113852d679b3ec3832c2 lightning-rpc-path=/home/clightning/.lightning/regtest/lightning-rpc native-btc-amount=0
+lightning-cli plugin subcommand=start plugin=/home/clightning/stablechannels.py channel-id=b37a51423e67a1f6733a78bb654535b2b81c427435600b0756bb65e21bdd411a stable-dollar-amount=95 is-stable-receiver=True counterparty=026b9c2a005b182ff5b2a7002a03d6ea9d005d18ed2eb3113852d679b3ec3832c2 native-btc-amount=0
 ```
-Modify the directory for your plugin and your lighning-rpc.
+Modify the directory for your plugin.
 
-What this command says is: "Start the plugin at this directory. Make the Lightning channel with channel ID b37a51423e67a1f6733a78bb654535b2b81c427435600b0756bb65e21bdd411a a stable channel at $95.00. and 0 sats of BTC. Is is `True` that the node running this command is the Stable Receiver. Here's the ID of the counterparty `026b9c..` and here's the RPC path."
+What this command says is: "Start the plugin at this directory. Make the Lightning channel with channel ID b37a51423e67a1f6733a78bb654535b2b81c427435600b0756bb65e21bdd411a a stable channel at $95.00. and 0 sats of BTC. Is is `True` that the node running this command is the Stable Receiver. Here's the ID of the counterparty `026b9c..`."
 
 Your counterparty will need to run a similar command, and the Stable Channels software should do the rest. 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![main on CLN v24.02.2](https://github.com/toneloc/stable-channels/actions/workflows/main_v24.02.yml/badge.svg?branch=main)](https://github.com/toneloc/stable-channels/actions/workflows/main_v24.02.yml)
+
 #### Note: Skip to [Getting Started](#getting-started) for technical startup instructions.
 
 ## Stable Channels - Version 02MAY2024

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Stable Channels has a few dependencies.
 - Either copy the `requirements.txt` file and run `pip3 install -r requirements.txt`.
 - Or: `python3 install` each of the five dependencies listed in `requirements.txt`.
 
-Logs are written to either `stablelog1.json` if you are the Stable Receiver or `stablelog2.json` if you are the Stable Provider. You should create the log file and change the code to write to it. 
+Stablechannel balance results are written to either `stablelog1.json` if you are the Stable Receiver or `stablelog2.json` if you are the Stable Provider. These are in the `stablechannels` directory inside your network directory, e.g. `~/.lightning/bitcoin/stablechannels/stablelog1.json`.
 
 ### Connecting and creating a dual-funded channel (for CLN)
 
@@ -117,11 +117,7 @@ Now this needs to be confirmed on the blockchain.
 
 ### Starting Stable Channels
 
-First let's create the log file. If you are the stable receiver, your logs get written to `stablelog1.json`. Create that file.
-
-Note: this log file path is hardcoded in the code. Change this path to your location. 
-
-Now, we need to start the Stable Channels plugin and with the relevant details of the Stable Channel.
+We need to start the Stable Channels plugin with the relevant details of the Stable Channel.
 
 The plugin startup command will look something like this:
 
@@ -134,7 +130,7 @@ What this command says is: "Start the plugin at this directory. Make the Lightni
 
 Your counterparty will need to run a similar command, and the Stable Channels software should do the rest. 
 
-Logs for the Stable Receiver a are written to `stablelog1.json` file  and logs for the Stable Provider are written to the `stablelog2.json` file. 
+Stablechannel balance results for the Stable Receiver are written to the `stablelog1.json` file  and logs for the Stable Provider are written to the `stablelog2.json` file. 
 
 ##  Payout matrix
 

--- a/stablechannels.py
+++ b/stablechannels.py
@@ -24,6 +24,7 @@ from apscheduler.schedulers.blocking import BlockingScheduler # Used to check ba
 import threading # Standard on Python 3
 
 plugin = Plugin()
+sc = None
 
 class StableChannel:
     def __init__(
@@ -436,6 +437,17 @@ def parse_boolean(value):
         elif value_lower in {'false', 'no', '0'}:
             return False
     raise ValueError(f"Invalid boolean value: {value}")
+
+@plugin.method("dev-check-stable")
+def dev_check_stable(plugin):
+    # immediately run check_stable, but only if we are a dev
+    # this can be used in tests and maybe to pass artificial currency rate changes
+    dev = plugin.rpc.listconfigs("developer")["configs"]["developer"]["set"]
+    if dev:
+        check_stables(plugin, sc)
+        return {"result": "OK"}
+    else:
+        raise Exception("ERROR: not a --developer")
 
 # Section 4 - Plug-in initialization
 @plugin.init()

--- a/stablechannels.py
+++ b/stablechannels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Stable Channels: p2p BTCUSD trading on Lightning
 # Contents

--- a/stablechannels.py
+++ b/stablechannels.py
@@ -425,6 +425,17 @@ def handle_coin_movement(sc, *args, **kwargs):
                         print("post stable_dollar_amount", sc.expected_dollar_amount)
                         # sc.our_balance = sc.our_balance + credit_msat
 
+def parse_boolean(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        value_lower = value.strip().lower()
+        if value_lower in {'true', 'yes', '1'}:
+            return True
+        elif value_lower in {'false', 'no', '0'}:
+            return False
+    raise ValueError(f"Invalid boolean value: {value}")
+
 # Section 4 - Plug-in initialization
 @plugin.init()
 def init(options, configuration, plugin):
@@ -433,10 +444,7 @@ def init(options, configuration, plugin):
     print(options['is-stable-receiver'])
     
     # Need to handle boolean input this way
-    if options['is-stable-receiver'] == "False":
-        is_stable_receiver = False
-    elif options['is-stable-receiver'] == "True":
-        is_stable_receiver = True
+    is_stable_receiver = parse_boolean(options['is-stable-receiver'])
 
     # convert to millsatoshis ...
     if int(options['native-btc-amount']) > 0:

--- a/test_stablechannels.py
+++ b/test_stablechannels.py
@@ -1,0 +1,52 @@
+import logging
+import os
+
+from pyln.testing.fixtures import *  # noqa: F403
+from pyln.testing.utils import sync_blockheight
+
+LOGGER = logging.getLogger(__name__)
+
+PLUGIN_PATH = os.path.join(os.path.dirname(__file__), "./stablechannels.py")
+
+
+def test_start(node_factory, bitcoind):
+    l1, l2 = node_factory.get_nodes(
+        2,
+        opts={"experimental-dual-fund": None},
+    )
+    funder = l2.rpc.funderupdate(
+        policy="match",
+        policy_mod=100,
+        leases_only=True,
+        lease_fee_base_msat=2_000,
+        lease_fee_basis=10,
+        channel_fee_max_base_msat=1000,
+        channel_fee_max_proportional_thousandths=2,
+    )
+    l1.fundwallet(10_000_000)
+    l2.fundwallet(10_000_000)
+
+    cl1 = l1.rpc.fundchannel(
+        l2.info["id"] + "@localhost:" + str(l2.port),
+        1_000_000,
+        request_amt=1_000_000,
+        compact_lease=funder["compact_lease"],
+    )
+    bitcoind.generate_block(6)
+    sync_blockheight(bitcoind, [l1, l2])
+
+    # configs = l1.rpc.listconfigs()["configs"]
+    l1.rpc.plugin_start(
+        PLUGIN_PATH,
+        **{
+            "channel-id": cl1["channel_id"],
+            "is-stable-receiver": False,
+            "stable-dollar-amount": 400,
+            "native-btc-amount": 500_000,
+            "counterparty": l2.info["id"],
+        },
+    )
+    l1.daemon.wait_for_log("Starting Stable Channel with these details")
+    invoice = l2.rpc.invoice(5_000_000, "label1", "desc")
+    l1.rpc.pay(invoice["bolt11"])
+    l1.rpc.call("dev-check-stable")


### PR DESCRIPTION
Hi,
interesting project you have here. I saw that you had no tests for you cln-plugin and since i'm a cln plugin dev myself i thought i'd help you get started on that. This PR contains:

- Some fixes to make the plugin less dependable on hard coded stuff like the log file paths, the python env path
- Removed the need to pass in the rpc path, we can get it from the plugin
- I added the execution bit to the plugin file so not everyone has to do it again
- Also replaced all `print`'s with `plugin.log` since `print` should not be used in cln plugins (or atleast you should not write non json-rpc line to stdout)
- Boolean options can be passed in as `str` or `bool` so i handled both cases
- Added a basic startup test that runs the `check_stables` function once (i've added a `dev_check_stables` rpc method to the plugin for this) and triggers the `handle_coin_movement` event
- Added CI that will run the tests for the cln plugin on every PR and on commits to main (you can test more cln versions by copying `main_v24.02.yml` and editing the versions)