### PR TITLE
fix: reconcile_incoming does not reset backing_sats after payment received

### DIFF
--- a/ios/StableChannels/StableChannels/Services/StabilityService.swift
+++ b/ios/StableChannels/StableChannels/Services/StabilityService.swift
@@ -88,8 +88,12 @@ enum StabilityService {
         sc.nativeChannelBTC = Bitcoin(sats: nativeSats)
     }
 
-    /// Reconcile an incoming payment — backingSats stays the same, native absorbs the increase.
+    /// Reconcile an incoming payment — derive backingSats from channel balance.
     static func reconcileIncoming(_ sc: inout StableChannel) {
+        if sc.expectedUSD.amount > 0.0 && sc.latestPrice > 0.0 {
+            let btcAmount = sc.expectedUSD.amount / sc.latestPrice
+            sc.backingSats = UInt64(btcAmount * 100_000_000.0)
+        }
         recomputeNative(&sc)
     }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -150,10 +150,13 @@ pub fn recompute_native(sc: &mut StableChannel) {
 /// Reconcile an incoming payment — derive backing_sats from channel balance.
 ///
 /// After receiving a payment, the user's balance increased but
-/// `native_sats` hasn't changed. Derive `backing_sats` from the
-/// actual balance so the extra sats are attributed correctly.
+/// `native_sats` hasn't changed. Reset `backing_sats` to equilibrium
+/// so the extra sats are attributed correctly.
 pub fn reconcile_incoming(sc: &mut StableChannel) {
-    // backingSats stays the same on incoming — native absorbs the increase.
+    if sc.expected_usd.0 > 0.0 && sc.latest_price > 0.0 {
+        let btc_amount = sc.expected_usd.0 / sc.latest_price;
+        sc.backing_sats = (btc_amount * 100_000_000.0) as u64;
+    }
     recompute_native(sc);
 }
 
@@ -753,14 +756,12 @@ mod tests {
     }
 
     #[test]
-    fn incoming_derives_from_balance_not_price() {
-        // With native_sats model, reconcile_incoming derives backing from balance,
-        // not from price. Even with zero price, it should work correctly.
+    fn incoming_skips_backing_reset_when_price_zero() {
+        // When price is unavailable, backing_sats is left unchanged.
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
         sc.latest_price = 0.0; // price unavailable
         let backing_before = sc.backing_sats;
         reconcile_incoming(&mut sc);
-        // backing_sats = receiver_sats - native_sats = 1M - 500k = 500k
         assert_eq!(sc.backing_sats, backing_before);
     }
 


### PR DESCRIPTION
### Description

`reconcile_incoming` was not resetting `backing_sats` after a stability payment is received.

When a stability payment occurs (i.e., price drops and the LSP compensates the user), the `backing_sats` must be updated to reflect the new equilibrium:

```
backing_sats = expected_usd / price * 1e8
```

Without this reset, subsequent stability checks compute drift against an outdated baseline, leading to compounding errors across multiple payment cycles.

Two existing tests in the repository were intended to catch this issue but were failing silently. This change corrects the behavior and ensures both tests pass.


### Changes

* `src/stable.rs`

  * Reset `backing_sats` before calling `recompute_native`
  * Add guard to skip update when price is zero

* `ios/StableChannels/StableChannels/Services/StabilityService.swift`

  * Apply equivalent fix to reset `backing_sats` in Swift implementation