### PR TITLE
fix(user): create user data dir before writing seed phrase

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -276,6 +276,13 @@ impl UserApp {
         println!("Initializing user node...");
 
         let data_dir = get_user_data_dir();
+        std::fs::create_dir_all(&data_dir).map_err(|e| {
+            format!(
+                "Failed to create user data directory {}: {}",
+                data_dir.display(),
+                e
+            )
+        })?;
 
         let lsp_pubkey = DEFAULT_LSP_PUBKEY
             .parse::<PublicKey>()


### PR DESCRIPTION
This Pull Request fixes/closes #28 

It changes the following:

- Create the desktop user data directory with `std::fs::create_dir_all` immediately after resolving `get_user_data_dir()`, before writing `seed_phrase` or starting LDK storage, so a fresh install no longer panics with `ENOENT` on first run.

## Testing

- `cargo check --bin stable-channels`
- `cargo run --bin stable-channels user` on a clean data dir (or after removing `~/Library/Application Support/StableChannels/` on macOS) — app should start without the previous panic when generating a new wallet.
