### PR TITLE
feat(android): use build variants for network/Esplora configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,6 +23,9 @@ android {
             buildConfigField("String", "NETWORK", "\"signet\"")
             buildConfigField("String", "ESPLORA_URL", "\"https://mutinynet.com/api\"")
             buildConfigField("String", "FALLBACK_ESPLORA_URL", "\"https://mutinynet.com/api\"")
+            buildConfigField("String", "LSP_PUBKEY", "\"\"") // Signet LSP placeholder
+            buildConfigField("String", "LSP_ADDRESS", "\"\"") // Signet LSP address placeholder
+            buildConfigField("String", "PUSH_REGISTER_URL", "\"https://signet.stablechannels.com/api/register-push\"") // Placeholder
         }
         release {
             isMinifyEnabled = false
@@ -30,6 +33,9 @@ android {
             buildConfigField("String", "NETWORK", "\"bitcoin\"")
             buildConfigField("String", "ESPLORA_URL", "\"https://blockstream.info/api\"")
             buildConfigField("String", "FALLBACK_ESPLORA_URL", "\"https://mempool.space/api\"")
+            buildConfigField("String", "LSP_PUBKEY", "\"0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850\"")
+            buildConfigField("String", "LSP_ADDRESS", "\"34.198.44.89:9735\"")
+            buildConfigField("String", "PUSH_REGISTER_URL", "\"https://stablechannels.com/api/register-push\"")
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,9 +19,17 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "NETWORK", "\"signet\"")
+            buildConfigField("String", "ESPLORA_URL", "\"https://mutinynet.com/api\"")
+            buildConfigField("String", "FALLBACK_ESPLORA_URL", "\"https://mutinynet.com/api\"")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            buildConfigField("String", "NETWORK", "\"bitcoin\"")
+            buildConfigField("String", "ESPLORA_URL", "\"https://blockstream.info/api\"")
+            buildConfigField("String", "FALLBACK_ESPLORA_URL", "\"https://mempool.space/api\"")
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -119,7 +119,7 @@ class AppState(private val context: Context) : ViewModel() {
                 if (seedFile.exists() || seedPhraseFile.exists()) {
                     _phase.value = Phase.SYNCING
                     waitForBackgroundService()
-                    nodeService.start(Network.BITCOIN, chainUrl, null)
+                    nodeService.start(Constants.NETWORK, chainUrl, null)
                     _phase.value = Phase.WALLET
                     refreshBalances()
                     // Restore fundingTxid
@@ -141,7 +141,7 @@ class AppState(private val context: Context) : ViewModel() {
                 } else {
                     // New wallet — auto-create
                     _phase.value = Phase.SYNCING
-                    nodeService.start(Network.BITCOIN, chainUrl, null)
+                    nodeService.start(Constants.NETWORK, chainUrl, null)
                     _phase.value = Phase.WALLET
                     refreshBalances()
                     reregisterPushTokenIfNeeded()
@@ -162,7 +162,7 @@ class AppState(private val context: Context) : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 _phase.value = Phase.SYNCING
-                nodeService.start(Network.BITCOIN, chainUrl, mnemonic)
+                nodeService.start(Constants.NETWORK, chainUrl, mnemonic)
                 _phase.value = Phase.WALLET
                 refreshBalances()
                 reregisterPushTokenIfNeeded()

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -87,7 +87,7 @@ class StabilityProcessingService : Service() {
 
         val config = Config(
             storageDirPath = dataDir.absolutePath,
-            network = Network.BITCOIN,
+            network = Constants.NETWORK,
             listeningAddresses = null,
             announcementAddresses = null,
             nodeAlias = null,

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -361,7 +361,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                         scope.launch(Dispatchers.IO) {
                             try {
                                 appState.nodeService.stop()
-                                appState.nodeService.start(Network.BITCOIN, Constants.PRIMARY_CHAIN_URL, input)
+                                appState.nodeService.start(Constants.NETWORK, Constants.PRIMARY_CHAIN_URL, input)
                                 withContext(Dispatchers.Main) {
                                     showRestore = false
                                     restoreMnemonic = ""

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -17,12 +17,12 @@ object Constants {
     const val DEFAULT_LSP_ALIAS = "lsp"
     const val DEFAULT_LSP_PORT = 9735
 
-    const val LSP_PUSH_REGISTER_URL = "https://stablechannels.com/api/register-push"
+    val LSP_PUSH_REGISTER_URL = BuildConfig.PUSH_REGISTER_URL
 
     val PRIMARY_CHAIN_URL = BuildConfig.ESPLORA_URL
     val FALLBACK_CHAIN_URL = BuildConfig.FALLBACK_ESPLORA_URL
-    const val DEFAULT_LSP_PUBKEY = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
-    const val DEFAULT_LSP_ADDRESS = "34.198.44.89:9735"
+    val DEFAULT_LSP_PUBKEY = BuildConfig.LSP_PUBKEY
+    val DEFAULT_LSP_ADDRESS = BuildConfig.LSP_ADDRESS
     const val DEFAULT_GATEWAY_PUBKEY = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"
     const val DEFAULT_GATEWAY_ADDRESS = "213.174.156.80:9735"
 

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -2,6 +2,8 @@ package com.stablechannels.app.util
 
 import android.content.Context
 import java.io.File
+import org.lightningdevkit.ldknode.Network
+import com.stablechannels.app.BuildConfig
 
 object Constants {
     const val SATS_IN_BTC: Long = 100_000_000L
@@ -9,7 +11,7 @@ object Constants {
     const val TRADE_MESSAGE_TYPE = "TRADE_V1"
     const val SYNC_MESSAGE_TYPE = "SYNC_V1"
 
-    const val DEFAULT_NETWORK = "bitcoin"
+    val NETWORK = if (BuildConfig.NETWORK == "signet") Network.SIGNET else Network.BITCOIN
     const val DEFAULT_USER_ALIAS = "user"
     const val DEFAULT_USER_PORT = 9736
     const val DEFAULT_LSP_ALIAS = "lsp"
@@ -17,8 +19,8 @@ object Constants {
 
     const val LSP_PUSH_REGISTER_URL = "https://stablechannels.com/api/register-push"
 
-    const val PRIMARY_CHAIN_URL = "https://blockstream.info/api"
-    const val FALLBACK_CHAIN_URL = "https://mempool.space/api"
+    val PRIMARY_CHAIN_URL = BuildConfig.ESPLORA_URL
+    val FALLBACK_CHAIN_URL = BuildConfig.FALLBACK_ESPLORA_URL
     const val DEFAULT_LSP_PUBKEY = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
     const val DEFAULT_LSP_ADDRESS = "34.198.44.89:9735"
     const val DEFAULT_GATEWAY_PUBKEY = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"


### PR DESCRIPTION
feat(android): add build variant-based network configuration

Replaces hardcoded Network.BITCOIN and Esplora URLs with 
BuildConfig fields driven by build type:

- debug builds → Signet (mutinynet.com)  
- release builds → Mainnet (blockstream.info)

This allows contributors to test safely without touching 
real funds. No UI changes, no user-facing impact.

Updated all hardcoded references across:
- Constants.kt
- AppState.kt (3 call sites)
- StabilityProcessingService.kt
- SettingsScreen.kt