### PR TITLE
fix(ui): correct named parameter in PriceChart drawLine call

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -299,7 +299,7 @@ fun PriceChart(
                             val sx = (selectedIndex.toFloat() / (priceHistory.size - 1)) * w
                             val record = priceHistory[selectedIndex]
                             val sy = h - ((record.price - minPrice) / priceRange).toFloat() * h
-                            drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
+                            drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
                             drawCircle(lineColor, 5f, Offset(sx, sy))
                             drawCircle(Color.White, 3f, Offset(sx, sy))
                         }


### PR DESCRIPTION
PathEffect was passed as a positional argument to drawLine() where
StrokeCap was expected. Added explicit `pathEffect =` named parameter
to fix compiler error.

Discovered while attempting a clean debug build.