### PR TITLE
fix(iOS): make explorer links network aware

### DIFF
--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -1,6 +1,25 @@
 import Foundation
 
 enum Constants {
+    enum BitcoinNetwork: String {
+        case mainnet = "bitcoin"
+        case testnet
+        case signet
+
+        init?(networkString: String) {
+            let normalized = networkString.lowercased()
+            switch normalized {
+            case "mainnet", "bitcoin":
+                self = .mainnet
+            case "testnet":
+                self = .testnet
+            case "signet":
+                self = .signet
+            default:
+                return nil
+            }
+        }
+    }
 
     // MARK: - Network
 
@@ -23,6 +42,46 @@ enum Constants {
     static let defaultLSPAddress = "34.198.44.89:9735"
     static let defaultGatewayPubkey = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"
     static let defaultGatewayAddress = "213.174.156.80:9735"
+
+    private static var currentBitcoinNetwork: BitcoinNetwork {
+        if let network = BitcoinNetwork(networkString: defaultNetwork) {
+            return network
+        }
+        assertionFailure("Unsupported Bitcoin network '\(defaultNetwork)' fallback to mainnet explorer URLs")
+        return .mainnet
+    }
+
+    // mempool.space explorer base URL for a Bitcoin network
+    static func explorerBaseURL(network: BitcoinNetwork = .mainnet) -> String {
+        switch network {
+        case .signet:
+            return "https://mempool.space/signet"
+        case .testnet:
+            return "https://mempool.space/testnet"
+        case .mainnet:
+            return "https://mempool.space"
+        }
+    }
+
+    // Transaction explorer URL for txid and network
+    static func explorerTxURL(txid: String, network: BitcoinNetwork = .mainnet) -> URL? {
+        URL(string: "\(explorerBaseURL(network: network))/tx/\(txid)")
+    }
+
+    // Transaction explorer URL using configured default network
+    static func explorerTxURL(txid: String) -> URL? {
+        explorerTxURL(txid: txid, network: currentBitcoinNetwork)
+    }
+
+    // Address explorer URL for address and network
+    static func explorerAddressURL(address: String, network: BitcoinNetwork = .mainnet) -> URL? {
+        URL(string: "\(explorerBaseURL(network: network))/address/\(address)")
+    }
+
+    // Address explorer URL using configured default network
+    static func explorerAddressURL(address: String) -> URL? {
+        explorerAddressURL(address: address, network: currentBitcoinNetwork)
+    }
 
     // MARK: - Timing
 

--- a/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
@@ -30,7 +30,7 @@ struct PaymentDetailView: View {
                     }
                     if let txid = payment.txid {
                         row("TXID", txid)
-                        if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                        if let url = Constants.explorerTxURL(txid: txid) {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
                                     Text("View on explorer")

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -382,8 +382,8 @@ struct HomeView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
             Spacer()
-            if let txid, !txid.isEmpty {
-                Link(destination: URL(string: "https://mempool.space/tx/\(txid)")!) {
+            if let txid, !txid.isEmpty, let txURL = Constants.explorerTxURL(txid: txid) {
+                Link(destination: txURL) {
                     HStack(spacing: 2) {
                         Text("View on explorer")
                             .font(.caption2)

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -75,7 +75,7 @@ struct SettingsView: View {
                                     .font(.system(.caption, design: .monospaced))
                                     .foregroundStyle(.secondary)
                             }
-                            if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                            if let url = Constants.explorerTxURL(txid: txid) {
                                 Link(destination: url) {
                                     HStack(spacing: 4) {
                                         Text("View on explorer")


### PR DESCRIPTION
### Summary
Fix explorer links always pointing to mainnet regardless of configured network.

### Changes
- Added `BitcoinNetwork` enum for safe network handling
- Centralized explorer URL generation in `Constants`
- Replaced hardcoded `mempool.space` URLs in:
  - `HomeView`
  - `SettingsView`
  - `PaymentDetailView`
- Removed force unwrap and used safe optional URL handling

### Implementation
Explorer URLs are now derived from `Constants.defaultNetwork`:

```swift
static func explorerTxURL(txid: String) -> URL? {
    explorerTxURL(txid: txid, network: currentBitcoinNetwork)
}

static func explorerBaseURL(network: BitcoinNetwork) -> String {
    switch network {
    case .mainnet: return "https://mempool.space"
    case .testnet: return "https://mempool.space/testnet"
    case .signet:  return "https://mempool.space/signet"
    }
}
```

### Result
Correct explorer links for mainnet, testnet, and signet.


