### PR TITLE
Fix(iOS): align node runtime network

### DIFF
--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -65,6 +65,21 @@ class AppState {
     private var stabilityTimer: Task<Void, Never>?
     private(set) var chainURL: String = Constants.primaryChainURL
 
+    var runtimeNetwork: Network {
+        guard let btcNetwork = Constants.BitcoinNetwork(networkString: Constants.defaultNetwork) else {
+            assertionFailure("Unsupported defaultNetwork '\(Constants.defaultNetwork)'")
+            return .bitcoin
+        }
+        switch btcNetwork {
+        case .mainnet:
+            return .bitcoin
+        case .testnet:
+            return .testnet
+        case .signet:
+            return .signet
+        }
+    }
+
     // Auto-sweep state
     private(set) var isSweeping = false
     var spliceTxid: String? = nil
@@ -152,7 +167,7 @@ class AppState {
 
             do {
                 try await nodeService.start(
-                    network: .bitcoin,
+                    network: runtimeNetwork,
                     esploraURL: chainURL,
                     mnemonic: ""  // Uses existing seed from data dir
                 )
@@ -195,7 +210,7 @@ class AppState {
             await MainActor.run { phase = .syncing }
             do {
                 try await nodeService.start(
-                    network: .bitcoin,
+                    network: runtimeNetwork,
                     esploraURL: chainURL,
                     mnemonic: ""
                 )
@@ -349,7 +364,7 @@ class AppState {
         restoreGossipToDB()
         do {
             try await nodeService.start(
-                network: .bitcoin,
+                network: runtimeNetwork,
                 esploraURL: chainURL,
                 mnemonic: ""
             )

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -1,6 +1,25 @@
 import Foundation
 
 enum Constants {
+    enum BitcoinNetwork: String {
+        case mainnet = "bitcoin"
+        case testnet
+        case signet
+
+        init?(networkString: String) {
+            let normalized = networkString.lowercased()
+            switch normalized {
+            case "mainnet", "bitcoin":
+                self = .mainnet
+            case "testnet":
+                self = .testnet
+            case "signet":
+                self = .signet
+            default:
+                return nil
+            }
+        }
+    }
 
     // MARK: - Network
 
@@ -23,6 +42,46 @@ enum Constants {
     static let defaultLSPAddress = "34.198.44.89:9735"
     static let defaultGatewayPubkey = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"
     static let defaultGatewayAddress = "213.174.156.80:9735"
+
+    private static var currentBitcoinNetwork: BitcoinNetwork {
+        if let network = BitcoinNetwork(networkString: defaultNetwork) {
+            return network
+        }
+        assertionFailure("Unsupported Bitcoin network '\(defaultNetwork)' fallback to mainnet explorer URLs")
+        return .mainnet
+    }
+
+    // mempool.space explorer base URL for a Bitcoin network
+    static func explorerBaseURL(network: BitcoinNetwork = .mainnet) -> String {
+        switch network {
+        case .signet:
+            return "https://mempool.space/signet"
+        case .testnet:
+            return "https://mempool.space/testnet"
+        case .mainnet:
+            return "https://mempool.space"
+        }
+    }
+
+    // Transaction explorer URL for txid and network
+    static func explorerTxURL(txid: String, network: BitcoinNetwork = .mainnet) -> URL? {
+        URL(string: "\(explorerBaseURL(network: network))/tx/\(txid)")
+    }
+
+    // Transaction explorer URL using configured default network
+    static func explorerTxURL(txid: String) -> URL? {
+        explorerTxURL(txid: txid, network: currentBitcoinNetwork)
+    }
+
+    // Address explorer URL for address and network
+    static func explorerAddressURL(address: String, network: BitcoinNetwork = .mainnet) -> URL? {
+        URL(string: "\(explorerBaseURL(network: network))/address/\(address)")
+    }
+
+    // Address explorer URL using configured default network
+    static func explorerAddressURL(address: String) -> URL? {
+        explorerAddressURL(address: address, network: currentBitcoinNetwork)
+    }
 
     // MARK: - Timing
 

--- a/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
@@ -30,7 +30,7 @@ struct PaymentDetailView: View {
                     }
                     if let txid = payment.txid {
                         row("TXID", txid)
-                        if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                        if let url = Constants.explorerTxURL(txid: txid) {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
                                     Text("View on explorer")

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -382,8 +382,8 @@ struct HomeView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
             Spacer()
-            if let txid, !txid.isEmpty {
-                Link(destination: URL(string: "https://mempool.space/tx/\(txid)")!) {
+            if let txid, !txid.isEmpty, let txURL = Constants.explorerTxURL(txid: txid) {
+                Link(destination: txURL) {
                     HStack(spacing: 2) {
                         Text("View on explorer")
                             .font(.caption2)

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -75,7 +75,7 @@ struct SettingsView: View {
                                     .font(.system(.caption, design: .monospaced))
                                     .foregroundStyle(.secondary)
                             }
-                            if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                            if let url = Constants.explorerTxURL(txid: txid) {
                                 Link(destination: url) {
                                     HStack(spacing: 4) {
                                         Text("View on explorer")

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -380,7 +380,7 @@ struct SettingsView: View {
 
         do {
             try await appState.nodeService.start(
-                network: .bitcoin,
+                network: appState.runtimeNetwork,
                 esploraURL: appState.chainURL,
                 mnemonic: input
             )


### PR DESCRIPTION
### Depends on
#32

### Summary
Start the LDK node using the configured Bitcoin network (`Constants.defaultNetwork`), instead of hardcoding mainnet.

### Changes
- Add `runtimeNetwork` on `AppState` (maps `Constants.BitcoinNetwork` to LDK `Network`)
- Use `runtimeNetwork` for all `nodeService.start` calls:
  - existing wallet startup
  - new wallet creation
  - foreground restart
- Update `SettingsView` to use `appState.runtimeNetwork` instead of `.bitcoin`

### Notes
Includes changes from #32 for stacking. Will rebase after #32 merges.

### Implementation
`AppState`:

```swift
var runtimeNetwork: Network {
    guard let btcNetwork = Constants.BitcoinNetwork(networkString: Constants.defaultNetwork) else {
        assertionFailure("Unsupported defaultNetwork '\(Constants.defaultNetwork)'")
        return .bitcoin
    }
    switch btcNetwork {
    case .mainnet: return .bitcoin
    case .testnet: return .testnet
    case .signet: return .signet
    }
}
```

All `nodeService.start(..., network: ...)` use `runtimeNetwork` or `appState.runtimeNetwork`.

### Result
Node startup uses the configured Bitcoin network (mainnet / testnet / signet).