### PR TITLE
feat(android): add Stable Provider role selection via SharedPreferences

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -56,12 +56,17 @@ class AppState(private val context: Context) : ViewModel() {
     val totalBalanceSats: StateFlow<Long> get() = _totalBalanceSats
 
     init {
-        val prefs = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+        val prefs = context.getSharedPreferences(Constants.PREFS_NAME_BALANCE_CACHE, Context.MODE_PRIVATE)
         val cachedLightning = prefs.getLong("cached_lightning_sats", 0L)
         val cachedOnchain = prefs.getLong("cached_onchain_sats", 0L)
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
         _totalBalanceSats = MutableStateFlow(cachedLightning + cachedOnchain)
+
+        // Restore the user's stable channel role. Defaults to true (Stable Receiver)
+        // so existing installations are completely unaffected.
+        val isStableReceiver = prefs.getBoolean(Constants.PREFS_KEY_IS_STABLE_RECEIVER, true)
+        _stableChannel.value = StableChannel.DEFAULT.copy(isStableReceiver = isStableReceiver)
     }
 
     private val _pendingTradePayments = MutableStateFlow<Map<String, PendingTradePayment>>(emptyMap())
@@ -178,6 +183,16 @@ class AppState(private val context: Context) : ViewModel() {
         stabilityJob?.cancel()
         priceService.stopAutoRefresh()
         nodeService.stop()
+    }
+
+    /** Persists and applies the user's stable channel role (Receiver vs Provider). */
+    fun setStableRole(isReceiver: Boolean) {
+        context.getSharedPreferences(Constants.PREFS_NAME_BALANCE_CACHE, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(Constants.PREFS_KEY_IS_STABLE_RECEIVER, isReceiver)
+            .apply()
+        val updated = _stableChannel.value.copy(isStableReceiver = isReceiver)
+        _stableChannel.value = updated
     }
 
     private fun handleEvent(event: Event) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -299,7 +299,7 @@ fun PriceChart(
                             val sx = (selectedIndex.toFloat() / (priceHistory.size - 1)) * w
                             val record = priceHistory[selectedIndex]
                             val sy = h - ((record.price - minPrice) / priceRange).toFloat() * h
-                            drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
+                            drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
                             drawCircle(lineColor, 5f, Offset(sx, sy))
                             drawCircle(Color.White, 3f, Offset(sx, sy))
                         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -94,6 +94,38 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                 } else {
                     TextButton(onClick = { showNodeId = true }) { Text("Show Node ID") }
                 }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                // Role selector — disabled when an active channel exists to prevent
+                // mid-channel role switching which would invert balance attribution.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Role", style = MaterialTheme.typography.labelLarge)
+                        Text(
+                            if (sc.isStableReceiver) "Stable Receiver - holds USD-pegged balance"
+                            else "Stable Provider - absorbs BTC price exposure",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (hasReadyChannel) {
+                            Text(
+                                "Close channel to change role",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+                    Switch(
+                        checked = sc.isStableReceiver,
+                        onCheckedChange = { appState.setStableRole(it) },
+                        enabled = !hasReadyChannel
+                    )
+                }
             }
         }
 

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -9,6 +9,10 @@ object Constants {
     const val TRADE_MESSAGE_TYPE = "TRADE_V1"
     const val SYNC_MESSAGE_TYPE = "SYNC_V1"
 
+    /** SharedPreferences key for persisting the user's stable channel role. */
+    const val PREFS_KEY_IS_STABLE_RECEIVER = "is_stable_receiver"
+    const val PREFS_NAME_BALANCE_CACHE = "balance_cache"
+
     const val DEFAULT_NETWORK = "bitcoin"
     const val DEFAULT_USER_ALIAS = "user"
     const val DEFAULT_USER_PORT = 9736


### PR DESCRIPTION
`isStableReceiver` was hardcoded to `true` everywhere in the app,
making the Stable Provider role completely inaccessible. A user who
wants to run as a Provider had no way to set that, even though
`StabilityService` already has correct branching logic for both roles.

**What this PR does:**

- Reads `is_stable_receiver` from SharedPreferences at app init
- Defaults to `true` so existing installations are completely unaffected
- Adds `setStableRole()` in `AppState` to persist and apply the role immediately
- Adds a Role toggle in Settings under the Node card with a description
  of what each role means
- Disables the toggle when a ready channel exists, since switching roles
  mid-channel would invert balance attribution between the two parties

**What stays the same:**

- No DB changes, no migration
- Default behavior is identical to before for all existing users
- The stability logic in `StabilityService` needed no changes since it
  already handles both roles correctly

Also includes the `PriceChart` named-parameter fix to unblock
compilation on this branch, since that fix is pending merge separately.
