### PR TITLE
Remove stale recover/sweep bin targets from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,6 @@ path = "src/bin/lsp_backend.rs"
 name = "lsp_frontend"
 path = "src/bin/lsp_frontend.rs"
 
-[[bin]]
-name = "recover"
-path = "src/bin/recover.rs"
-
-[[bin]]
-name = "sweep"
-path = "src/bin/sweep.rs"
-
 [dev-dependencies]
 tempfile = "3"
 electrsd = { version = "0.36.1", features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }


### PR DESCRIPTION
This PR removes stale binary target declarations from `Cargo.toml` that pointed to missing source files and caused Cargo to fail while enumerating bin targets.

The manifest declared two bin targets that no longer exist in the repository. As a result, build commands could fail with missing file errors before completing normal compilation.

