### PR TITLE
fix(iOS): avoid nondeterministic channel row selection

### DIFF
--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -576,7 +576,14 @@ class NotificationService: UNNotificationServiceExtension {
         defer { sqlite3_close(db) }
 
         var stmt: OpaquePointer?
-        let sql = "SELECT expected_usd, stable_sats, receiver_sats, latest_price, native_sats FROM channels LIMIT 1"
+        /// Avoid nondeterministic row selection when multiple rows exist.
+        /// Uses latest updated row as a stable fallback (not “active channel” semantics).
+        let sql = """
+            SELECT expected_usd, stable_sats, receiver_sats, latest_price, native_sats
+            FROM channels
+            ORDER BY updated_at DESC, channel_id DESC
+            LIMIT 1
+        """
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             nseLog("SQLite prepare failed")
             return nil

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -185,7 +185,14 @@ class DatabaseService {
             sql = "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, receiver_sats, latest_price, native_sats FROM channels WHERE user_channel_id = ?"
             params = [.text(id)]
         } else {
-            sql = "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, receiver_sats, latest_price, native_sats FROM channels LIMIT 1"
+            /// When multiple rows exist, pick a deterministic latest record (not “active channel” semantics).
+            sql = """
+                SELECT channel_id, expected_usd, note, stable_sats, user_channel_id,
+                       receiver_sats, latest_price, native_sats
+                FROM channels
+                ORDER BY updated_at DESC, channel_id DESC
+                LIMIT 1
+            """
             params = []
         }
         let rows = try query(sql, params: params)


### PR DESCRIPTION
This Pull Request fixes nondeterministic channel row selection in iOS/NSE state reads.

It changes the following:

- Replace `SELECT ... FROM channels LIMIT 1` with deterministic ordering in both iOS paths that read a default channel row:
  - `NotificationService.readChannelState(...)`
  - `DatabaseService.loadChannel(userChannelId: nil)`
- Use `ORDER BY updated_at DESC, channel_id DESC LIMIT 1` to avoid arbitrary row selection when multiple channel rows exist, including timestamp ties.
- Add short inline comments clarifying that this targets deterministic selection (not active-channel semantics).

## Testing
- Built the iOS project and verified no regressions in affected code paths.
- Logic change is limited to SQL ordering; behavior verified via query inspection.