### PR TITLE
feat(android): add UI warning for stale price feeds and fix manual refresh

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -53,9 +53,15 @@ import kotlinx.coroutines.launch
 fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val totalSats by appState.totalBalanceSats.collectAsState()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
+    val priceLastUpdate by appState.priceService.lastUpdate.collectAsState()
     val sc by appState.stableChannel.collectAsState()
     val statusMessage by appState.statusMessage.collectAsState()
     val onchainSats by appState.onchainBalanceSats.collectAsState()
+
+    // Only check staleness if we have a valid last update time
+    val isPriceStale = btcPrice > 0 &&
+        priceLastUpdate.time > 0L &&
+        System.currentTimeMillis() - priceLastUpdate.time > 60_000L
 
     var showSend by remember { mutableStateOf(false) }
     var showReceive by remember { mutableStateOf(false) }
@@ -85,14 +91,25 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val totalUSD = (totalSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
     val scope = rememberCoroutineScope()
 
+    var isRefreshing by remember { mutableStateOf(false) }
     val pullRefreshState = rememberPullToRefreshState()
 
     PullToRefreshBox(
-        isRefreshing = false,
+        isRefreshing = isRefreshing,
         onRefresh = {
             scope.launch {
+                isRefreshing = true
+                val startTime = System.currentTimeMillis()
                 appState.refreshBalances()
+                appState.priceService.fetchPrice()
                 appState.recordCurrentPrice()
+                
+                // Prevent Compose pull-to-refresh animation glitches on fast fetches
+                val duration = System.currentTimeMillis() - startTime
+                if (duration < 500) {
+                    kotlinx.coroutines.delay(500 - duration)
+                }
+                isRefreshing = false
             }
         },
         state = pullRefreshState,
@@ -145,6 +162,28 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                 fontSize = 12.sp
                             )
                         }
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+
+            // Price staleness warning
+            if (isPriceStale) {
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFFF59E0B).copy(alpha = 0.15f)),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("⚠️", fontSize = 14.sp)
+                        Text(
+                            "Price data may be stale — check your connection",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFFB45309)
+                        )
                     }
                 }
                 Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
This PR addresses price feed staleness and improves the manual refresh UX.

**What this does:**
1. **Staleness Warning**: Adds a `isPriceStale` check. If the app has loaded a price but hasn't had a successful API fetch in >60 seconds, a red warning chip appears on the Home Screen indicating the price is stale. This protects users from making decisions on outdated data if they lose connectivity.
2. **First-launch false positives**: Ensured the warning doesn't flash immediately on app start before the first background worker finishes executing.
3. **Wired up Pull-to-Refresh**: Previously, from `HomeScreen`, the pull-to-refresh gesture only refreshed balances but did not actually fire a live network request to the `PriceService`. This now correctly triggers `fetchPrice()`.
4. **Compose UI Animation Glitch**: Added a safe `delay()` baseline to `PullToRefreshBox` to stop the 1.8-alpha spinner from abruptly freezing on the screen when a fetch event resolves instantaneously (like if the background worker happened to just finish a ping).
