### PR TITLE
fix(iOS): preserve pending push payment retry state on reconnect failure

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		37DA6E9D4F5D4BF36DD86BC8 /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */; };
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
+		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
 		62340228B969D280C66FD733 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC40949E35E9317ACA30E35 /* AppState.swift */; };
@@ -84,6 +85,7 @@
 		3B46630309755AE15EF291D4 /* HistoricalPrices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPrices.swift; sourceTree = "<group>"; };
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
+		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		4F10632049E3C904E518EDD2 /* TradeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeDetailView.swift; sourceTree = "<group>"; };
 		4F22F6639A59D4B86A959586 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		61BB0D1D623E0794FC1ED6ED /* NodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeService.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 		F11CF0F21D3319E86AF791B6 /* StableChannelsTests */ = {
 			isa = PBXGroup;
 			children = (
+				499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */,
 				8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */,
 			);
 			path = StableChannelsTests;
@@ -412,6 +415,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */,
 				1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -545,23 +545,46 @@ class AppState {
 
     // MARK: - Pending Push Payment (app was killed)
 
-    /// Check if the NSE flagged a pending payment while the app was killed.
-    /// Reconnect to LSP so the pending stability payment can land.
+    /// Check if NSE flagged a pending payment while app was killed
+    /// Reconnect to LSP so pending stability payment can land
     private func processPendingPushPayment() async {
         let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
         guard shared?.bool(forKey: "pending_push_payment") == true else { return }
 
-        shared?.set(false, forKey: "pending_push_payment")
         print("[Push] Processing pending push payment from NSE flag")
 
         // Reconnect to LSP so pending payment can be received
-        try? nodeService.node?.connect(
-            nodeId: Constants.defaultLSPPubkey,
-            address: Constants.defaultLSPAddress,
-            persist: true
-        )
-        refreshBalances()
-        updateStableBalances()
+        do {
+            try nodeService.node?.connect(
+                nodeId: Constants.defaultLSPPubkey,
+                address: Constants.defaultLSPAddress,
+                persist: true
+            )
+
+            Self.updatePendingPushPaymentFlag(shared, reconnectSucceeded: true)
+            refreshBalances()
+            updateStableBalances()
+
+            AuditService.log("PUSH_PENDING_PAYMENT_RECONNECT_OK", data: [
+                "node_running": "\(nodeService.isRunning)",
+            ])
+        } catch {
+            Self.updatePendingPushPaymentFlag(shared, reconnectSucceeded: false)
+            AuditService.log("PUSH_PENDING_PAYMENT_RECONNECT_FAILED", data: [
+                "error": error.localizedDescription,
+                "node_running": "\(nodeService.isRunning)",
+            ])
+        }
+    }
+
+    static func updatePendingPushPaymentFlag(_ shared: UserDefaults?, reconnectSucceeded: Bool) {
+        if reconnectSucceeded {
+            // Clear pending marker only after successful reconnect attempt
+            shared?.set(false, forKey: "pending_push_payment")
+        } else {
+            // Keep marker set so foreground or startup can retry
+            shared?.set(true, forKey: "pending_push_payment")
+        }
     }
 
     // MARK: - Push Notification Handling

--- a/ios/StableChannels/StableChannelsTests/PendingPushPaymentTests.swift
+++ b/ios/StableChannels/StableChannelsTests/PendingPushPaymentTests.swift
@@ -1,0 +1,51 @@
+@testable import StableChannels
+import XCTest
+
+final class PendingPushPaymentTests: XCTestCase {
+    private let key = "pending_push_payment"
+
+    private func makeDefaults(_ suffix: String) -> UserDefaults {
+        let suite = "PendingPushPaymentTests.\(suffix).\(UUID().uuidString)"
+        let ud = UserDefaults(suiteName: suite)!
+        ud.removePersistentDomain(forName: suite)
+        return ud
+    }
+
+    func testLegacyBehaviorDropsPendingFlagOnReconnectFailure() {
+        let ud = makeDefaults("legacy")
+        ud.set(true, forKey: key)
+
+        // Legacy flow in AppState before fix:
+        // shared?.set(false, forKey: "pending_push_payment") before reconnect
+        ud.set(false, forKey: key)
+
+        XCTAssertFalse(
+            ud.bool(forKey: key),
+            "Legacy behavior drops pending flag before reconnect outcome is known"
+        )
+    }
+
+    func testKeepsPendingFlagWhenReconnectFails() {
+        let ud = makeDefaults("failure")
+        ud.set(true, forKey: key)
+
+        AppState.updatePendingPushPaymentFlag(ud, reconnectSucceeded: false)
+
+        XCTAssertTrue(
+            ud.bool(forKey: key),
+            "Pending flag must remain true so foreground/startup can retry"
+        )
+    }
+
+    func testClearsPendingFlagWhenReconnectSucceeds() {
+        let ud = makeDefaults("success")
+        ud.set(true, forKey: key)
+
+        AppState.updatePendingPushPaymentFlag(ud, reconnectSucceeded: true)
+
+        XCTAssertFalse(
+            ud.bool(forKey: key),
+            "Pending flag should clear only after successful reconnect"
+        )
+    }
+}


### PR DESCRIPTION
This Pull Request fixes/closes #47

It changes the following:

- Keep `pending_push_payment` set until reconnect outcome is known in `AppState.processPendingPushPayment()`, so reconnect failures do not silently drop retry state.
- Add `AppState.updatePendingPushPaymentFlag(_:reconnectSucceeded:)` to make success/failure flag handling explicit and testable.
- Add `PendingPushPaymentTests.swift` and wire it into `StableChannelsTests` in `project.pbxproj` to cover:
  - legacy drop-before-outcome behavior
  - keep-on-failure behavior
  - clear-on-success behavior

## Testing

- Ran `PendingPushPaymentTests` from Xcode (StableChannelsTests target).
- Without `AppState` helper/change: targeted tests fail (`AppState` missing helper path).
- With `AppState` change restored: targeted tests pass (3/3).

## Scope note

- This change prevents premature retry-state loss by clearing `pending_push_payment` only after successful reconnect initiation.
- It does not guarantee full recovery/payment success; that would require clearing only after confirmed recovery state and is tracked separately.
