### PR TITLE
fix(ios): format services + app + models

### DIFF
--- a/ios/StableChannels/Package.swift
+++ b/ios/StableChannels/Package.swift
@@ -4,12 +4,12 @@ import PackageDescription
 let package = Package(
     name: "StableChannels",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v17)
     ],
     dependencies: [
         .package(url: "https://github.com/lightningdevkit/ldk-node.git", exact: "0.7.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
-        .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.0"),
+        .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.0")
     ],
     targets: [
         .executableTarget(
@@ -17,7 +17,7 @@ let package = Package(
             dependencies: [
                 .product(name: "LDKNode", package: "ldk-node"),
                 "KeychainAccess",
-                "CodeScanner",
+                "CodeScanner"
             ],
             path: "StableChannels"
         ),
@@ -25,6 +25,6 @@ let package = Package(
             name: "StableChannelsTests",
             dependencies: ["StableChannels"],
             path: "StableChannelsTests"
-        ),
+        )
     ]
 )

--- a/ios/StableChannels/StableChannels/Models/StableChannel.swift
+++ b/ios/StableChannels/StableChannels/Models/StableChannel.swift
@@ -57,10 +57,10 @@ struct USD: Codable, Equatable {
 // MARK: - StableChannel
 
 struct StableChannel: Codable {
-    var channelId: String  // ldk-node ChannelId is a String in Swift bindings
-    var userChannelId: String  // ldk-node UserChannelId is a String in Swift bindings
+    var channelId: String // ldk-node ChannelId is a String in Swift bindings
+    var userChannelId: String // ldk-node UserChannelId is a String in Swift bindings
     var isStableReceiver: Bool
-    var counterparty: String  // hex-encoded pubkey (ldk-node PublicKey = String)
+    var counterparty: String // hex-encoded pubkey (ldk-node PublicKey = String)
     var expectedUSD: USD
     var expectedBTC: Bitcoin
     var stableReceiverBTC: Bitcoin

--- a/ios/StableChannels/StableChannels/Services/AuditService.swift
+++ b/ios/StableChannels/StableChannels/Services/AuditService.swift
@@ -22,7 +22,7 @@ enum AuditService {
         let logEntry: [String: Any] = [
             "ts": formatter.string(from: Date()),
             "event": event,
-            "data": data,
+            "data": data
         ]
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: logEntry),

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -109,7 +109,7 @@ class DatabaseService {
             "CREATE INDEX IF NOT EXISTS idx_price_history_timestamp ON price_history(timestamp DESC)",
             "CREATE INDEX IF NOT EXISTS idx_payments_created ON payments(created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_daily_prices_date ON daily_prices(date DESC)",
-            "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)"
         ]
 
         for sql in statements {
@@ -296,7 +296,7 @@ class DatabaseService {
             counterparty.map { .text($0) } ?? .null,
             .text(status),
             txid.map { .text($0) } ?? .null,
-            address.map { .text($0) } ?? .null,
+            address.map { .text($0) } ?? .null
         ])
         return Int64(sqlite3_last_insert_rowid(db))
     }

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -188,10 +188,19 @@ class NodeService {
 
     func spliceIn(userChannelId: UserChannelId, counterpartyNodeId: PublicKey, amountSats: UInt64) throws {
         guard let node else { throw NodeServiceError.notRunning }
-        try node.spliceIn(userChannelId: userChannelId, counterpartyNodeId: counterpartyNodeId, spliceAmountSats: amountSats)
+        try node.spliceIn(
+            userChannelId: userChannelId,
+            counterpartyNodeId: counterpartyNodeId,
+            spliceAmountSats: amountSats
+        )
     }
 
-    func spliceOut(userChannelId: UserChannelId, counterpartyNodeId: PublicKey, address: String, amountSats: UInt64) throws {
+    func spliceOut(
+        userChannelId: UserChannelId,
+        counterpartyNodeId: PublicKey,
+        address: String,
+        amountSats: UInt64
+    ) throws {
         guard let node else { throw NodeServiceError.notRunning }
         try node.spliceOut(
             userChannelId: userChannelId,
@@ -213,7 +222,7 @@ class NodeService {
         return try node.bolt11Payment().sendUsingAmount(invoice: invoice, amountMsat: amountMsat, routeParameters: nil)
     }
 
-    func sendBolt12(offer: Offer, amountMsat: UInt64) throws -> PaymentId {
+    func sendBolt12(offer: Offer, amountMsat _: UInt64) throws -> PaymentId {
         guard let node else { throw NodeServiceError.notRunning }
         return try node.bolt12Payment().send(
             offer: offer,
@@ -328,7 +337,7 @@ class NodeService {
             "seed_phrase",
             "ldk_node_data.sqlite",
             "ldk_node_data.sqlite-wal",
-            "ldk_node_data.sqlite-shm",
+            "ldk_node_data.sqlite-shm"
         ]
         for file in filesToDelete {
             try? FileManager.default.removeItem(at: dir.appendingPathComponent(file))

--- a/ios/StableChannels/StableChannels/Services/PriceService.swift
+++ b/ios/StableChannels/StableChannels/Services/PriceService.swift
@@ -65,7 +65,8 @@ class PriceService {
     /// Returns array of (unix_timestamp, close_price).
     func fetchKrakenOHLC(since: Int64? = nil) async -> [(timestamp: Int64, price: Double)] {
         let sinceTs = since ?? (Int64(Date().timeIntervalSince1970) - 30 * 24 * 3600)
-        guard let url = URL(string: "https://api.kraken.com/0/public/OHLC?pair=XXBTZUSD&interval=60&since=\(sinceTs)") else {
+        guard let url = URL(string: "https://api.kraken.com/0/public/OHLC?pair=XXBTZUSD&interval=60&since=\(sinceTs)")
+        else {
             return []
         }
 

--- a/ios/StableChannels/StableChannels/Services/StabilityService.swift
+++ b/ios/StableChannels/StableChannels/Services/StabilityService.swift
@@ -3,7 +3,6 @@ import LDKNode
 
 /// Pure stability logic — direct port of src/stable.rs
 enum StabilityService {
-
     // MARK: - Reconciliation
 
     /// Reconcile an outgoing payment against the stable position.
@@ -145,7 +144,7 @@ enum StabilityService {
         } else if sc.riskLevel > Constants.maxRiskLevel {
             action = .highRiskNoAction
         } else if (sc.isStableReceiver && isReceiverBelowExpected)
-                    || (!sc.isStableReceiver && !isReceiverBelowExpected) {
+            || (!sc.isStableReceiver && !isReceiverBelowExpected) {
             action = .checkOnly
         } else {
             action = .pay

--- a/ios/StableChannels/StableChannels/Services/TradeService.swift
+++ b/ios/StableChannels/StableChannels/Services/TradeService.swift
@@ -81,7 +81,7 @@ class TradeService {
             "type": Constants.tradeMessageType,
             "channel_id": channelId,
             "user_channel_id": "\(userChannelId)",
-            "expected_usd": expectedUSD,
+            "expected_usd": expectedUSD
         ]
 
         guard let payloadData = try? JSONSerialization.data(withJSONObject: payload),
@@ -93,7 +93,7 @@ class TradeService {
 
         let envelope: [String: Any] = [
             "payload": payloadStr,
-            "signature": signature,
+            "signature": signature
         ]
 
         guard let envelopeData = try? JSONSerialization.data(withJSONObject: envelope),
@@ -128,7 +128,7 @@ class TradeService {
     static func parseIncomingTLV(
         data: [UInt8],
         expectedCounterparty: String,
-        verifySignature: (([UInt8], String, String) -> Bool)
+        verifySignature: ([UInt8], String, String) -> Bool
     ) -> (type: String, expectedUSD: Double, userChannelId: String)? {
         guard let envelopeStr = String(bytes: data, encoding: .utf8),
               let envelopeData = envelopeStr.data(using: .utf8),

--- a/ios/StableChannels/StableChannels/StableChannelsApp.swift
+++ b/ios/StableChannels/StableChannels/StableChannelsApp.swift
@@ -14,11 +14,13 @@ struct StableChannelsApp: App {
                 .task {
                     await appState.start()
                 }
-                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
-                    appState.stopNodeForBackground()
+                .onReceive(NotificationCenter.default
+                    .publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
+                        appState.stopNodeForBackground()
                 }
-                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-                    Task { await appState.restartNodeFromForeground() }
+                .onReceive(NotificationCenter.default
+                    .publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+                        Task { await appState.restartNodeFromForeground() }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
                     appState.stop()
@@ -30,10 +32,9 @@ struct StableChannelsApp: App {
 // MARK: - AppDelegate for Push Notifications
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
-
     func application(
         _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
 
@@ -59,7 +60,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // MARK: - Token Registration
 
     func application(
-        _ application: UIApplication,
+        _: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
@@ -75,7 +76,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     }
 
     func application(
-        _ application: UIApplication,
+        _: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
         print("[Push] Registration failed: \(error.localizedDescription)")
@@ -84,7 +85,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // MARK: - Background Push (content-available: 1)
 
     func application(
-        _ application: UIApplication,
+        _: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
@@ -102,8 +103,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // MARK: - Foreground Notification Display
 
     func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         // Show banner + sound even when app is in foreground
@@ -113,8 +114,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     // MARK: - Notification Tap
 
     func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
+        _: UNUserNotificationCenter,
+        didReceive _: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         // App will be opened/foregrounded — normal startup handles payment processing
@@ -136,16 +137,16 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             .string(forKey: "node_id") ?? ""
 
         #if DEBUG
-        let apnsEnvironment = "sandbox"
+            let apnsEnvironment = "sandbox"
         #else
-        let apnsEnvironment = "production"
+            let apnsEnvironment = "production"
         #endif
 
         let body: [String: String] = [
             "device_token": token,
             "platform": "ios",
             "node_id": nodeId,
-            "environment": apnsEnvironment,
+            "environment": apnsEnvironment
         ]
 
         guard let httpBody = try? JSONSerialization.data(withJSONObject: body) else { return }


### PR DESCRIPTION
Apply SwiftFormat to:
- `ios/StableChannels/Package.swift`
- `ios/StableChannels/StableChannels/Models/StableChannel.swift`
- `ios/StableChannels/StableChannels/Services/AuditService.swift`
- `ios/StableChannels/StableChannels/Services/DatabaseService.swift`
- `ios/StableChannels/StableChannels/Services/NodeService.swift`
- `ios/StableChannels/StableChannels/Services/PriceService.swift`
- `ios/StableChannels/StableChannels/Services/StabilityService.swift`
- `ios/StableChannels/StableChannels/Services/TradeService.swift`
- `ios/StableChannels/StableChannels/StableChannelsApp.swift`

Closes #51