### PR TITLE
iOS: Format More Views + Tests Files

### DIFF
--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -190,9 +190,11 @@ struct SettingsView: View {
                     }
                     if showSeedWords {
                         if let words = appState.nodeService.savedMnemonic, !words.isEmpty {
-                            Text("Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds.")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
+                            Text(
+                                "Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds."
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.orange)
                             ForEach(Array(words.split(separator: " ").enumerated()), id: \.offset) { index, word in
                                 HStack {
                                     Text("\(index + 1).")
@@ -241,9 +243,11 @@ struct SettingsView: View {
                         Text("Self-custodial")
                             .foregroundStyle(.secondary)
                     }
-                    Text("Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Text(
+                        "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
             }
             .navigationTitle("Settings")

--- a/ios/StableChannels/StableChannels/Views/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Views/Trade/BuyView.swift
@@ -205,7 +205,7 @@ struct BuyView: View {
         errorMessage = nil
         appState.ensureLSPConnected()
         let sc = appState.stableChannel
-        let feeUSD = amountUSD * 0.01  // 1% fee
+        let feeUSD = amountUSD * 0.01 // 1% fee
         let price = appState.btcPrice
         do {
             guard let result = try appState.tradeService?.executeBuy(

--- a/ios/StableChannels/StableChannels/Views/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Views/Trade/SellView.swift
@@ -209,7 +209,7 @@ struct SellView: View {
         appState.ensureLSPConnected()
         let sc = appState.stableChannel
         let totalUSD = USD.fromBitcoin(sc.stableReceiverBTC, price: appState.btcPrice).amount
-        let feeUSD = amountUSD * 0.01  // 1% fee
+        let feeUSD = amountUSD * 0.01 // 1% fee
         let price = appState.btcPrice
         do {
             guard let result = try appState.tradeService?.executeSell(

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -119,7 +119,11 @@ struct OnChainSendView: View {
             // If channel exists, route through splice-out
             if let channel = appState.nodeService.channels.first(where: { $0.isChannelReady }), !sendAll {
                 guard !appState.isSweeping else {
-                    throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "A splice is already in progress — try again shortly"])
+                    throw NSError(
+                        domain: "",
+                        code: 0,
+                        userInfo: [NSLocalizedDescriptionKey: "A splice is already in progress — try again shortly"]
+                    )
                 }
                 try appState.nodeService.spliceOut(
                     userChannelId: channel.userChannelId,

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -25,7 +25,8 @@ struct SendView: View {
             return .bolt11
         } else if trimmed.hasPrefix("lno") {
             return .bolt12
-        } else if trimmed.hasPrefix("bc1") || trimmed.hasPrefix("1") || trimmed.hasPrefix("3") || trimmed.hasPrefix("tb1") {
+        } else if trimmed.hasPrefix("bc1") || trimmed.hasPrefix("1") || trimmed.hasPrefix("3") || trimmed
+            .hasPrefix("tb1") {
             return .onchain
         }
         return .unknown
@@ -198,7 +199,7 @@ struct SendView: View {
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            if appState.nodeService.channels.contains(where: { $0.isChannelReady }) {
+                            if appState.nodeService.channels.contains(where: \.isChannelReady) {
                                 Text("Will route via splice-out")
                                     .font(.caption)
                                     .foregroundStyle(.orange)
@@ -308,7 +309,10 @@ struct SendView: View {
                     actualMsat = manualAmountMsat
                     paymentId = try appState.nodeService.sendPaymentUsingAmount(invoice: bolt11, amountMsat: actualMsat)
                 }
-                let invoiceUSD: Double? = (price > 0 && actualMsat > 0) ? (Double(actualMsat) / 1000.0 / 100_000_000.0) * price : nil
+                let invoiceUSD: Double? = (price > 0 && actualMsat > 0) ? (
+                    Double(actualMsat) / 1000.0 / 100_000_000.0
+                ) *
+                    price : nil
                 _ = try? appState.databaseService?.recordPayment(
                     paymentId: "\(paymentId)",
                     paymentType: "lightning",
@@ -347,7 +351,11 @@ struct SendView: View {
                 // Route through splice-out if channel exists
                 if let channel = appState.nodeService.channels.first(where: { $0.isChannelReady }) {
                     guard !appState.isSweeping else {
-                        throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "A splice is already in progress — try again shortly"])
+                        throw NSError(
+                            domain: "",
+                            code: 0,
+                            userInfo: [NSLocalizedDescriptionKey: "A splice is already in progress — try again shortly"]
+                        )
                     }
                     try appState.nodeService.spliceOut(
                         userChannelId: channel.userChannelId,

--- a/ios/StableChannels/StableChannelsTests/StabilityServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/StabilityServiceTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import StableChannels
 
 final class StabilityServiceTests: XCTestCase {
-
     // MARK: - Helper
 
     private func testSC(expectedUSD: Double, price: Double, receiverSats: UInt64) -> StableChannel {
@@ -31,26 +30,26 @@ final class StabilityServiceTests: XCTestCase {
         XCTAssertEqual(sc.expectedUSD.amount, 500.0)
     }
 
-    func testOutgoingEatsIntoStable() {
+    func testOutgoingEatsIntoStable() throws {
         var sc = testSC(expectedUSD: 1000.0, price: 100_000.0, receiverSats: 900_000)
         let deducted = StabilityService.reconcileOutgoing(&sc, price: 100_000.0)
         XCTAssertNotNil(deducted)
-        XCTAssertEqual(deducted!, 100.0, accuracy: 0.01)
+        XCTAssertEqual(try XCTUnwrap(deducted), 100.0, accuracy: 0.01)
         XCTAssertEqual(sc.expectedUSD.amount, 900.0, accuracy: 0.01)
         let expectedBacking = UInt64(900.0 / 100_000.0 * 100_000_000.0)
         XCTAssertEqual(sc.backingSats, expectedBacking)
     }
 
-    func testOutgoingPartialStableDeduction() {
+    func testOutgoingPartialStableDeduction() throws {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 300_000)
-        let deducted = StabilityService.reconcileOutgoing(&sc, price: 100_000.0)!
+        let deducted = try XCTUnwrap(StabilityService.reconcileOutgoing(&sc, price: 100_000.0))
         XCTAssertEqual(deducted, 200.0, accuracy: 0.01)
         XCTAssertEqual(sc.expectedUSD.amount, 300.0, accuracy: 0.01)
     }
 
-    func testOutgoingSpendsEntireStable() {
+    func testOutgoingSpendsEntireStable() throws {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 0)
-        let deducted = StabilityService.reconcileOutgoing(&sc, price: 100_000.0)!
+        let deducted = try XCTUnwrap(StabilityService.reconcileOutgoing(&sc, price: 100_000.0))
         XCTAssertEqual(deducted, 500.0, accuracy: 0.01)
         XCTAssertLessThan(sc.expectedUSD.amount, 0.01)
         XCTAssertEqual(sc.backingSats, 0)
@@ -68,12 +67,12 @@ final class StabilityServiceTests: XCTestCase {
         XCTAssertNil(StabilityService.reconcileOutgoing(&sc, price: 100_000.0))
     }
 
-    func testOutgoingAtDifferentPrices() {
+    func testOutgoingAtDifferentPrices() throws {
         var sc1 = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 400_000)
-        let d1 = StabilityService.reconcileOutgoing(&sc1, price: 100_000.0)!
+        let d1 = try XCTUnwrap(StabilityService.reconcileOutgoing(&sc1, price: 100_000.0))
 
         var sc2 = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 400_000)
-        let d2 = StabilityService.reconcileOutgoing(&sc2, price: 200_000.0)!
+        let d2 = try XCTUnwrap(StabilityService.reconcileOutgoing(&sc2, price: 200_000.0))
 
         XCTAssertEqual(d1, 100.0, accuracy: 0.01)
         XCTAssertEqual(d2, 200.0, accuracy: 0.01)
@@ -84,32 +83,57 @@ final class StabilityServiceTests: XCTestCase {
     func testForwardedCoveredByNative() {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 1_000_000)
         sc.isStableReceiver = false
-        XCTAssertNil(StabilityService.reconcileForwarded(&sc, userSats: 1_000_000, totalForwardedSats: 200_000, price: 100_000.0))
+        XCTAssertNil(StabilityService.reconcileForwarded(
+            &sc,
+            userSats: 1_000_000,
+            totalForwardedSats: 200_000,
+            price: 100_000.0
+        ))
         XCTAssertEqual(sc.expectedUSD.amount, 500.0)
     }
 
-    func testForwardedEatsIntoStable() {
+    func testForwardedEatsIntoStable() throws {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 1_000_000)
-        let deducted = StabilityService.reconcileForwarded(&sc, userSats: 1_000_000, totalForwardedSats: 700_000, price: 100_000.0)!
+        let deducted = try XCTUnwrap(StabilityService.reconcileForwarded(
+            &sc,
+            userSats: 1_000_000,
+            totalForwardedSats: 700_000,
+            price: 100_000.0
+        ))
         XCTAssertEqual(deducted, 200.0, accuracy: 0.01)
         XCTAssertEqual(sc.expectedUSD.amount, 300.0, accuracy: 0.01)
     }
 
-    func testForwardedAllStableNoNative() {
+    func testForwardedAllStableNoNative() throws {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 500_000)
-        let deducted = StabilityService.reconcileForwarded(&sc, userSats: 500_000, totalForwardedSats: 100_000, price: 100_000.0)!
+        let deducted = try XCTUnwrap(StabilityService.reconcileForwarded(
+            &sc,
+            userSats: 500_000,
+            totalForwardedSats: 100_000,
+            price: 100_000.0
+        ))
         XCTAssertEqual(deducted, 100.0, accuracy: 0.01)
         XCTAssertEqual(sc.expectedUSD.amount, 400.0, accuracy: 0.01)
     }
 
     func testForwardedZeroExpectedUSD() {
         var sc = testSC(expectedUSD: 0.0, price: 100_000.0, receiverSats: 500_000)
-        XCTAssertNil(StabilityService.reconcileForwarded(&sc, userSats: 500_000, totalForwardedSats: 100_000, price: 100_000.0))
+        XCTAssertNil(StabilityService.reconcileForwarded(
+            &sc,
+            userSats: 500_000,
+            totalForwardedSats: 100_000,
+            price: 100_000.0
+        ))
     }
 
     func testForwardedZeroPrice() {
         var sc = testSC(expectedUSD: 500.0, price: 100_000.0, receiverSats: 1_000_000)
-        XCTAssertNil(StabilityService.reconcileForwarded(&sc, userSats: 1_000_000, totalForwardedSats: 700_000, price: 0.0))
+        XCTAssertNil(StabilityService.reconcileForwarded(
+            &sc,
+            userSats: 1_000_000,
+            totalForwardedSats: 700_000,
+            price: 0.0
+        ))
     }
 
     // MARK: - reconcileIncoming


### PR DESCRIPTION
Apply SwiftFormat to:
- `ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift`
- `ios/StableChannels/StableChannels/Views/Trade/BuyView.swift`
- `ios/StableChannels/StableChannels/Views/Trade/SellView.swift`
- `ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift`
- `ios/StableChannels/StableChannels/Views/Transfer/SendView.swift`
- `ios/StableChannels/StableChannelsTests/StabilityServiceTests.swift`

Closes #55 