### PR TITLE
feat(ios): add invoice QR scanner to Send view with photo picker

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		37DA6E9D4F5D4BF36DD86BC8 /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */; };
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
+		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
@@ -85,6 +86,7 @@
 		3B46630309755AE15EF291D4 /* HistoricalPrices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPrices.swift; sourceTree = "<group>"; };
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
+		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		4F10632049E3C904E518EDD2 /* TradeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeDetailView.swift; sourceTree = "<group>"; };
 		4F22F6639A59D4B86A959586 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		DD0CC2D41227228C216D4BE8 /* Transfer */ = {
 			isa = PBXGroup;
 			children = (
+				4923802C2FB51864007D9419 /* InvoiceScanView.swift */,
 				D9FF3A7A30FD6A84388868F3 /* OnChainView.swift */,
 				445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */,
 				7E0FAABBD08BCBF20220C850 /* SendView.swift */,
@@ -420,6 +423,7 @@
 				7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */,
 				DC5FA35343D89CB75FD4E402 /* ContentView.swift in Sources */,
 				3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */,
+				4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */,
 				2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */,
 				96B467E3F04FC01EB23B8413 /* FundWalletView.swift in Sources */,
 				E7E816D3AF095B47E1F58407 /* HistoricalPrices.swift in Sources */,
@@ -535,7 +539,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.stablechannels.app.tests;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StableChannels.app/StableChannels";
 			};
 			name = Release;
@@ -614,7 +618,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.stablechannels.app.tests;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StableChannels.app/StableChannels";
 			};
 			name = Debug;
@@ -638,7 +642,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -661,7 +665,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -684,7 +688,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -707,7 +711,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};

--- a/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
@@ -102,19 +102,48 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
     }
 
     private func showDenied() {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            container.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+        ])
+
         let label = UILabel()
-        label.text = String(localized: "Camera access required. Enable in Settings → Stable Channels.")
+        label.text = String(localized: "Camera access required. Enable in Settings.")
         label.textColor = .white
         label.numberOfLines = 0
         label.textAlignment = .center
+        label.font = .systemFont(ofSize: 17)
         label.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(label)
+        container.addSubview(label)
+
+        let settingsButton = UIButton(type: .system)
+        settingsButton.setTitle(String(localized: "Open Settings"), for: .normal)
+        settingsButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        settingsButton.setTitleColor(.systemBlue, for: .normal)
+        settingsButton.translatesAutoresizingMaskIntoConstraints = false
+        settingsButton.addTarget(self, action: #selector(openSettings), for: .touchUpInside)
+        container.addSubview(settingsButton)
+
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+            label.topAnchor.constraint(equalTo: container.topAnchor),
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            settingsButton.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 16),
+            settingsButton.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            settingsButton.bottomAnchor.constraint(equalTo: container.bottomAnchor)
         ])
+    }
+
+    @objc private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
     }
 
     private func setupCamera() {

--- a/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
@@ -1,0 +1,197 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+
+/// Camera-based invoice/offer/address scanner for Lightning payments.
+/// Wraps `InvoiceScannerViewController` for use in SwiftUI.
+struct InvoiceScanView: UIViewControllerRepresentable {
+    var onScan: (String) -> Void
+    var onCancel: () -> Void
+
+    func makeUIViewController(context _: Context) -> InvoiceScannerViewController {
+        let vc = InvoiceScannerViewController()
+        vc.onScan = onScan
+        vc.onCancel = onCancel
+        return vc
+    }
+
+    func updateUIViewController(_: InvoiceScannerViewController, context _: Context) {}
+}
+
+/// AVFoundation QR scanner for Lightning invoices.
+///
+/// Handles:
+/// - `lnbc...` — Bolt11 invoice
+/// - `lno...`  — Bolt12 offer
+/// - `bc1.../1.../3...` — on-chain address
+final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    var onScan: ((String) -> Void)?
+    var onCancel: (() -> Void)?
+
+    private var captureSession: AVCaptureSession?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var didEmit = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            setupCamera()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    if granted {
+                        self?.setupCamera()
+                    } else {
+                        self?.showDenied()
+                    }
+                }
+            }
+        default:
+            showDenied()
+        }
+
+        let close = UIButton(type: .system)
+        close.setTitle(String(localized: "Cancel"), for: .normal)
+        close.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        close.translatesAutoresizingMaskIntoConstraints = false
+        close.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        view.addSubview(close)
+        NSLayoutConstraint.activate([
+            close.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            close.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        ])
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        didEmit = false
+        if captureSession?.isRunning == false {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.captureSession?.startRunning()
+            }
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        captureSession?.stopRunning()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.layer.bounds
+    }
+
+    private func showNoCamera() {
+        let label = UILabel()
+        label.text = String(localized: "No camera available. Paste invoice manually.")
+        label.textColor = .white
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+        ])
+    }
+
+    private func showDenied() {
+        let label = UILabel()
+        label.text = String(localized: "Camera access required. Enable in Settings → Stable Channels.")
+        label.textColor = .white
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+        ])
+    }
+
+    private func setupCamera() {
+        let session = AVCaptureSession()
+        session.sessionPreset = .high
+
+        guard let device = AVCaptureDevice.default(for: .video) else {
+            showNoCamera()
+            return
+        }
+        guard let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input)
+        else {
+            showDenied()
+            return
+        }
+
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else {
+            showDenied()
+            return
+        }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+        output.metadataObjectTypes = [.qr]
+
+        let preview = AVCaptureVideoPreviewLayer(session: session)
+        preview.videoGravity = .resizeAspectFill
+        preview.frame = view.layer.bounds
+        view.layer.insertSublayer(preview, at: 0)
+        previewLayer = preview
+
+        captureSession = session
+
+        let hint = UILabel()
+        hint.text = String(
+            localized: "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
+        )
+        hint.textColor = UIColor.white.withAlphaComponent(0.85)
+        hint.font = .systemFont(ofSize: 14)
+        hint.numberOfLines = 0
+        hint.textAlignment = .center
+        hint.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hint)
+        NSLayoutConstraint.activate([
+            hint.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            hint.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            hint.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32)
+        ])
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            session.startRunning()
+        }
+    }
+
+    func metadataOutput(
+        _: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from _: AVCaptureConnection
+    ) {
+        guard !didEmit,
+              let obj = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              obj.type == .qr,
+              let value = obj.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else { return }
+
+        didEmit = true
+        captureSession?.stopRunning()
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        onScan?(value)
+    }
+
+    @objc private func cancelTapped() {
+        captureSession?.stopRunning()
+        onCancel?()
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -293,8 +293,9 @@ struct SendView: View {
             }
             .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
             .onChange(of: selectedPhotoItem) { _, newItem in
+                guard let item = newItem else { return }
                 Task {
-                    if let data = try? await newItem?.loadTransferable(type: Data.self),
+                    if let data = try? await item.loadTransferable(type: Data.self),
                        let image = UIImage(data: data),
                        let code = extractQRCode(from: image) {
                         input = code
@@ -444,16 +445,29 @@ struct SendView: View {
     }
 
     private func extractQRCode(from image: UIImage) -> String? {
-        guard let ciImage = CIImage(image: image) else { return nil }
+        // Fix orientation before passing to CIDetector — iPhone photos have EXIF rotation
+        guard let fixedImage = fixImageOrientation(image) else { return nil }
+        guard let ciImage = CIImage(image: fixedImage) else { return nil }
+
         let detector = CIDetector(
             ofType: CIDetectorTypeQRCode,
             context: nil,
             options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]
         )
+
         guard let features = detector?.features(in: ciImage) as? [CIQRCodeFeature],
               let value = features.first?.messageString,
               !value.isEmpty
         else { return nil }
         return value
+    }
+
+    private func fixImageOrientation(_ image: UIImage) -> UIImage? {
+        guard image.imageOrientation != .up else { return image }
+        UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
+        image.draw(in: CGRect(origin: .zero, size: image.size))
+        let normalized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return normalized
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import LDKNode
 import PhotosUI
+import Vision
 import CoreImage
 
 struct SendView: View {
@@ -445,29 +446,20 @@ struct SendView: View {
     }
 
     private func extractQRCode(from image: UIImage) -> String? {
-        // Fix orientation before passing to CIDetector — iPhone photos have EXIF rotation
-        guard let fixedImage = fixImageOrientation(image) else { return nil }
-        guard let ciImage = CIImage(image: fixedImage) else { return nil }
+        guard let cgImage = image.cgImage else { return nil }
 
-        let detector = CIDetector(
-            ofType: CIDetectorTypeQRCode,
-            context: nil,
-            options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]
-        )
+        let request = VNDetectBarcodesRequest()
+        request.symbologies = [.qr]
 
-        guard let features = detector?.features(in: ciImage) as? [CIQRCodeFeature],
-              let value = features.first?.messageString,
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try? handler.perform([request])
+
+        guard let results = request.results,
+              let qrCode = results.first,
+              let value = qrCode.payloadStringValue,
               !value.isEmpty
         else { return nil }
-        return value
-    }
 
-    private func fixImageOrientation(_ image: UIImage) -> UIImage? {
-        guard image.imageOrientation != .up else { return image }
-        UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
-        image.draw(in: CGRect(origin: .zero, size: image.size))
-        let normalized = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return normalized
+        return value
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import LDKNode
+import PhotosUI
+import CoreImage
 
 struct SendView: View {
     @Environment(AppState.self) private var appState
@@ -11,6 +13,11 @@ struct SendView: View {
     @State private var errorMessage: String?
     @State private var success = false
     @State private var sentAmountSats: UInt64 = 0
+    @State private var showScanner = false
+    @State private var showPhotoPicker = false
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var showQRAlert = false
+    @State private var qrAlertMessage = ""
 
     private enum InputType {
         case bolt11
@@ -269,6 +276,48 @@ struct SendView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(success ? "Done" : "Cancel") { dismiss() }
                 }
+                ToolbarItem(placement: .primaryAction) {
+                    HStack(spacing: 16) {
+                        Button {
+                            showPhotoPicker = true
+                        } label: {
+                            Image(systemName: "photo.on.rectangle")
+                        }
+                        Button {
+                            showScanner = true
+                        } label: {
+                            Image(systemName: "qrcode.viewfinder")
+                        }
+                    }
+                }
+            }
+            .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
+            .onChange(of: selectedPhotoItem) { _, newItem in
+                Task {
+                    if let data = try? await newItem?.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data),
+                       let code = extractQRCode(from: image) {
+                        input = code
+                    } else {
+                        qrAlertMessage = "Selected image doesn't contain a Lightning invoice or Bitcoin address QR code."
+                        showQRAlert = true
+                    }
+                    selectedPhotoItem = nil
+                }
+            }
+            .sheet(isPresented: $showScanner) {
+                InvoiceScanView(
+                    onScan: { scanned in
+                        input = scanned
+                        showScanner = false
+                    },
+                    onCancel: { showScanner = false }
+                )
+            }
+            .alert("No QR Code Found", isPresented: $showQRAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(qrAlertMessage)
             }
         }
     }
@@ -392,5 +441,19 @@ struct SendView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func extractQRCode(from image: UIImage) -> String? {
+        guard let ciImage = CIImage(image: image) else { return nil }
+        let detector = CIDetector(
+            ofType: CIDetectorTypeQRCode,
+            context: nil,
+            options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]
+        )
+        guard let features = detector?.features(in: ciImage) as? [CIQRCodeFeature],
+              let value = features.first?.messageString,
+              !value.isEmpty
+        else { return nil }
+        return value
     }
 }


### PR DESCRIPTION
## Summary

Users can now scan Lightning invoices or Bitcoin addresses via camera **or** select a QR code image from Photos — no more manual copy-paste.

## Changes

### Files Modified/Added
- **`Views/Transfer/InvoiceScanView.swift`** — new, camera QR scanner (AVFoundation)
- **`Views/Transfer/SendView.swift`** — photo picker + QR extraction via CIDetector

## Screenshots

| | | |
|:---:|:---:|:---:|
| <img width="200" alt="Toolbar icons" src="https://github.com/user-attachments/assets/0163d8ba-a8f9-4dc7-9807-07fba04addb3" /> | <img width="200" alt="Camera scanner" src="https://github.com/user-attachments/assets/0495dfd0-5e0f-4acf-a327-57445dbc84d9" /> | <img width="200" alt="Photo picker" src="https://github.com/user-attachments/assets/72926236-8ec7-4f10-bff1-2e4d96e388d2" /> |
| Toolbar icons | Camera scanner | Photo picker |
| | | |
| <img width="200" alt="No QR alert" src="https://github.com/user-attachments/assets/731c0a5a-b773-4bbb-b076-9ddcc166dc05" /> | <img width="200" alt="Invoice auto-filled" src="https://github.com/user-attachments/assets/ea27fb04-935f-46c6-a452-8ff93be286b2" /> | |
| No QR alert | Invoice auto-filled | |

## Testing Checklist
- [x] Camera permission prompt
- [x] Scan Bolt11 QR → auto-fills
- [x] Scan Bolt12 QR → auto-fills
- [x] Scan on-chain address → auto-fills
- [x] Select image with QR → extracts and fills
- [x] Select image without QR → alert shown
- [x] Cancel scanner → returns to Send
- [x] Scanner reusable after re-open

## Related

Closes #59