### PR TITLE
feat(ios): adopt String(localized:) across all Swift views

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
+		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
 		49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */; };
@@ -89,6 +90,7 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
+		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccessSettingsView.swift; sourceTree = "<group>"; };
@@ -114,7 +116,7 @@
 		B785A33E02FD999CB62019AD /* StableChannelsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableChannelsApp.swift; sourceTree = "<group>"; };
 		BE6DE49D25B7A85291504E77 /* PaymentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailView.swift; sourceTree = "<group>"; };
 		CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditService.swift; sourceTree = "<group>"; };
-		D34C08DCF6ACD28A3898859D /* StableChannelsTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StableChannelsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D34C08DCF6ACD28A3898859D /* StableChannelsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StableChannelsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D62A82EA774DC10F10A6574A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D9FF3A7A30FD6A84388868F3 /* OnChainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainView.swift; sourceTree = "<group>"; };
 		DF383D962C3260EA8D14692A /* StabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StabilityService.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				7EE46C95963B6C9F86006346 /* Services */,
 				AD3E779FC98D09AA36FFCAE9 /* Utilities */,
 				B94101FB9F6D7A28B1CA6C2C /* Views */,
+				49948C302FBB9DF900327290 /* Localizable.xcstrings */,
 			);
 			path = StableChannels;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */,
 				76D934F4495402F7B4944BE3 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -531,6 +535,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 			};
@@ -610,6 +615,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -10,6 +10,16 @@
     "%lld." : {
 
     },
+    "%lld%% USD  %lld%% BTC" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld%% USD  %2$lld%% BTC"
+          }
+        }
+      }
+    },
     "alert_close_channel_cancel" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -185,17 +195,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Authentication Failed"
-          }
-        }
-      }
-    },
-    "auth_try_again" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try Again"
           }
         }
       }
@@ -482,17 +481,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Swap"
-          }
-        }
-      }
-    },
-    "button_try_again" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try Again"
           }
         }
       }
@@ -2726,7 +2714,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Try again"
+            "value" : "Try Again"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1,0 +1,2758 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%@" : {
+
+    },
+    "%@ BTC" : {
+
+    },
+    "%lld." : {
+
+    },
+    "alert_close_channel_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "alert_close_channel_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel"
+          }
+        }
+      }
+    },
+    "alert_close_channel_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to close this channel?"
+          }
+        }
+      }
+    },
+    "alert_close_channel_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel?"
+          }
+        }
+      }
+    },
+    "alert_no_qr" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No QR code found"
+          }
+        }
+      }
+    },
+    "alert_qr_error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error reading QR code"
+          }
+        }
+      }
+    },
+    "and_spending_account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "and spending account"
+          }
+        }
+      }
+    },
+    "App Access" : {
+
+    },
+    "app_name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Channels"
+          }
+        }
+      }
+    },
+    "app_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-custodial bitcoin trading"
+          }
+        }
+      }
+    },
+    "auth_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "auth_confirm_on_chain_send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to send on-chain"
+          }
+        }
+      }
+    },
+    "auth_confirm_on_chain_withdrawal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to confirm on-chain withdrawal"
+          }
+        }
+      }
+    },
+    "auth_disable_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to disable App Unlock"
+          }
+        }
+      }
+    },
+    "auth_disable_payment_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to disable Payment Confirmation"
+          }
+        }
+      }
+    },
+    "auth_required" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication required"
+          }
+        }
+      }
+    },
+    "auth_title_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Failed"
+          }
+        }
+      }
+    },
+    "auth_try_again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        }
+      }
+    },
+    "available_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available: "
+          }
+        }
+      }
+    },
+    "available_native_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available: "
+          }
+        }
+      }
+    },
+    "button_any_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any Amount"
+          }
+        }
+      }
+    },
+    "button_backup_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup Seed"
+          }
+        }
+      }
+    },
+    "button_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy BTC"
+          }
+        }
+      }
+    },
+    "button_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "button_close_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel"
+          }
+        }
+      }
+    },
+    "button_continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        }
+      }
+    },
+    "button_copied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied"
+          }
+        }
+      }
+    },
+    "button_copy_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Address"
+          }
+        }
+      }
+    },
+    "button_copy_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Invoice"
+          }
+        }
+      }
+    },
+    "button_copy_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Seed"
+          }
+        }
+      }
+    },
+    "button_done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "button_enable_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Settings"
+          }
+        }
+      }
+    },
+    "button_generate_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate Invoice"
+          }
+        }
+      }
+    },
+    "button_hide_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide Seed"
+          }
+        }
+      }
+    },
+    "button_ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "button_open_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
+          }
+        }
+      }
+    },
+    "button_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive"
+          }
+        }
+      }
+    },
+    "button_restore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
+          }
+        }
+      }
+    },
+    "button_restore_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Seed"
+          }
+        }
+      }
+    },
+    "button_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sell BTC"
+          }
+        }
+      }
+    },
+    "button_send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
+          }
+        }
+      }
+    },
+    "button_send_payment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
+          }
+        }
+      }
+    },
+    "button_show_node_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Node ID"
+          }
+        }
+      }
+    },
+    "button_swap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swap"
+          }
+        }
+      }
+    },
+    "button_try_again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        }
+      }
+    },
+    "channel_status_pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opening"
+          }
+        }
+      }
+    },
+    "channel_status_ready" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready"
+          }
+        }
+      }
+    },
+    "custody_self" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-custodial"
+          }
+        }
+      }
+    },
+    "empty_payments_desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No payments yet"
+          }
+        }
+      }
+    },
+    "empty_payments_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Payments"
+          }
+        }
+      }
+    },
+    "empty_trades_desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No trades yet"
+          }
+        }
+      }
+    },
+    "empty_trades_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Trades"
+          }
+        }
+      }
+    },
+    "error_biometric_cancelled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication cancelled"
+          }
+        }
+      }
+    },
+    "error_biometric_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication failed"
+          }
+        }
+      }
+    },
+    "error_biometric_lockout" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics locked. Use passcode."
+          }
+        }
+      }
+    },
+    "error_biometric_not_available" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics not available"
+          }
+        }
+      }
+    },
+    "error_biometric_not_enrolled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics not enrolled"
+          }
+        }
+      }
+    },
+    "error_db_init" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to initialize database"
+          }
+        }
+      }
+    },
+    "error_exceeds_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exceeds available balance"
+          }
+        }
+      }
+    },
+    "error_exceeds_limit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount exceeds $"
+          }
+        }
+      }
+    },
+    "error_exceeds_native" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exceeds native BTC balance"
+          }
+        }
+      }
+    },
+    "error_insufficient_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient balance"
+          }
+        }
+      }
+    },
+    "error_no_ready_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No ready channel"
+          }
+        }
+      }
+    },
+    "error_node_start" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to start node"
+          }
+        }
+      }
+    },
+    "error_not_enough_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not enough funds"
+          }
+        }
+      }
+    },
+    "error_open_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to open channel"
+          }
+        }
+      }
+    },
+    "error_passcode_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passcode failed"
+          }
+        }
+      }
+    },
+    "error_read_balances" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to read balances"
+          }
+        }
+      }
+    },
+    "error_seed_word_count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed phrase must be 12 or 24 words"
+          }
+        }
+      }
+    },
+    "error_seed_words" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid seed words"
+          }
+        }
+      }
+    },
+    "error_splice_in_progress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A splice is already in progress — try again shortly"
+          }
+        }
+      }
+    },
+    "error_sweep_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sweep failed"
+          }
+        }
+      }
+    },
+    "error_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        }
+      }
+    },
+    "error_trade_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade failed — check amount and try again"
+          }
+        }
+      }
+    },
+    "error_unrecognized_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unrecognized invoice format"
+          }
+        }
+      }
+    },
+    "error_wallet_creation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to create wallet"
+          }
+        }
+      }
+    },
+    "header_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
+          }
+        }
+      }
+    },
+    "header_destination_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Address"
+          }
+        }
+      }
+    },
+    "header_invoice_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invoice Address"
+          }
+        }
+      }
+    },
+    "headline_how_much_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How much BTC?"
+          }
+        }
+      }
+    },
+    "headline_how_much_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How much USD?"
+          }
+        }
+      }
+    },
+    "hint_create_account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create your account to get started"
+          }
+        }
+      }
+    },
+    "hint_scan_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
+          }
+        }
+      }
+    },
+    "home_header" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Channels"
+          }
+        }
+      }
+    },
+    "home_hint_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive sats via Lightning or on-chain"
+          }
+        }
+      }
+    },
+    "home_syncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing..."
+          }
+        }
+      }
+    },
+    "info_fee_approx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee: ~"
+          }
+        }
+      }
+    },
+    "info_first_payment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make your first payment to activate the channel"
+          }
+        }
+      }
+    },
+    "info_funds_arrive_onchain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds arrive after 1 on-chain confirmation"
+          }
+        }
+      }
+    },
+    "info_notifications_needed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable notifications to receive payment alerts"
+          }
+        }
+      }
+    },
+    "info_pending_trade" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade pending — check back soon"
+          }
+        }
+      }
+    },
+    "info_seed_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed unavailable"
+          }
+        }
+      }
+    },
+    "info_self_custody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-custodial — you control your funds"
+          }
+        }
+      }
+    },
+    "info_splice_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm splice-out of "
+          }
+        }
+      }
+    },
+    "info_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice-out initiated"
+          }
+        }
+      }
+    },
+    "info_splice_out_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds will be sent via splice-out from your Lightning channel."
+          }
+        }
+      }
+    },
+    "info_splice_out_note" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: Funds require on-chain confirmation after splice completes."
+          }
+        }
+      }
+    },
+    "instruction_restore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your 12 or 24 word seed phrase"
+          }
+        }
+      }
+    },
+    "invoice_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invoice"
+          }
+        }
+      }
+    },
+    "label_action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action"
+          }
+        }
+      }
+    },
+    "label_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
+          }
+        }
+      }
+    },
+    "label_all_available_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All available funds"
+          }
+        }
+      }
+    },
+    "label_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
+          }
+        }
+      }
+    },
+    "label_amount_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Amount"
+          }
+        }
+      }
+    },
+    "label_amount_row" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
+          }
+        }
+      }
+    },
+    "label_amount_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD Amount"
+          }
+        }
+      }
+    },
+    "label_any_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any Amount"
+          }
+        }
+      }
+    },
+    "label_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Unlock"
+          }
+        }
+      }
+    },
+    "label_auth_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Failed"
+          }
+        }
+      }
+    },
+    "label_authenticate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate"
+          }
+        }
+      }
+    },
+    "label_backing_sats" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backing Sats"
+          }
+        }
+      }
+    },
+    "label_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balance"
+          }
+        }
+      }
+    },
+    "label_balance_pct" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "% USD % BTC"
+          }
+        }
+      }
+    },
+    "label_bolt11" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolt 11"
+          }
+        }
+      }
+    },
+    "label_bolt12_offer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offer"
+          }
+        }
+      }
+    },
+    "label_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC"
+          }
+        }
+      }
+    },
+    "label_btc_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Balance"
+          }
+        }
+      }
+    },
+    "label_btc_price" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Price"
+          }
+        }
+      }
+    },
+    "label_camera_denied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera access required. Enable in Settings."
+          }
+        }
+      }
+    },
+    "label_capacity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capacity"
+          }
+        }
+      }
+    },
+    "label_confirmations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmations"
+          }
+        }
+      }
+    },
+    "label_counterparty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Counterparty"
+          }
+        }
+      }
+    },
+    "label_custody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custody"
+          }
+        }
+      }
+    },
+    "label_dash" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
+          }
+        }
+      }
+    },
+    "label_date" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
+          }
+        }
+      }
+    },
+    "label_device_token" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device Token"
+          }
+        }
+      }
+    },
+    "label_direction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direction"
+          }
+        }
+      }
+    },
+    "label_distance_from_par" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distance from PAR"
+          }
+        }
+      }
+    },
+    "label_dollar_sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$"
+          }
+        }
+      }
+    },
+    "label_expected_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected USD"
+          }
+        }
+      }
+    },
+    "label_fee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
+          }
+        }
+      }
+    },
+    "label_fee_percent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee %"
+          }
+        }
+      }
+    },
+    "label_fee_row" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
+          }
+        }
+      }
+    },
+    "label_fee_sats" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee (sats)"
+          }
+        }
+      }
+    },
+    "label_funding_tx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funding TX"
+          }
+        }
+      }
+    },
+    "label_inbound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inbound"
+          }
+        }
+      }
+    },
+    "label_native_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Native BTC"
+          }
+        }
+      }
+    },
+    "label_network" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network"
+          }
+        }
+      }
+    },
+    "label_network_fee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Fee"
+          }
+        }
+      }
+    },
+    "label_no_camera" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No camera available. Paste invoice manually."
+          }
+        }
+      }
+    },
+    "label_node_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Node ID"
+          }
+        }
+      }
+    },
+    "label_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
+    "label_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain"
+          }
+        }
+      }
+    },
+    "label_on_chain_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain Address"
+          }
+        }
+      }
+    },
+    "label_outbound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outbound"
+          }
+        }
+      }
+    },
+    "label_payment_confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Confirmation"
+          }
+        }
+      }
+    },
+    "label_payment_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment ID"
+          }
+        }
+      }
+    },
+    "label_sats_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sats / BTC"
+          }
+        }
+      }
+    },
+    "label_status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        }
+      }
+    },
+    "label_total_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Balance"
+          }
+        }
+      }
+    },
+    "label_txid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TXID"
+          }
+        }
+      }
+    },
+    "label_type" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
+          }
+        }
+      }
+    },
+    "label_unrecognized_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unrecognized format"
+          }
+        }
+      }
+    },
+    "label_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD"
+          }
+        }
+      }
+    },
+    "label_usd_value" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD Value"
+          }
+        }
+      }
+    },
+    "label_version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        }
+      }
+    },
+    "label_you_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You Receive"
+          }
+        }
+      }
+    },
+    "link_send_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send On-Chain"
+          }
+        }
+      }
+    },
+    "loading_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading balance..."
+          }
+        }
+      }
+    },
+    "max_channel_limit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum: $"
+          }
+        }
+      }
+    },
+    "Min" : {
+
+    },
+    "move_to_trading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move to Trading"
+          }
+        }
+      }
+    },
+    "notifications_disabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications Disabled"
+          }
+        }
+      }
+    },
+    "notifications_disabled_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable notifications to receive payment alerts"
+          }
+        }
+      }
+    },
+    "notifications_enabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications Enabled"
+          }
+        }
+      }
+    },
+    "payment_received" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received"
+          }
+        }
+      }
+    },
+    "payment_sent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent"
+          }
+        }
+      }
+    },
+    "payment_type_bolt12" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolt 12"
+          }
+        }
+      }
+    },
+    "payment_type_channel_close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Close"
+          }
+        }
+      }
+    },
+    "payment_type_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain"
+          }
+        }
+      }
+    },
+    "payment_type_settlement" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settlement"
+          }
+        }
+      }
+    },
+    "payment_type_splice_in" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice In"
+          }
+        }
+      }
+    },
+    "payment_type_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Out"
+          }
+        }
+      }
+    },
+    "payment_type_stability" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stability"
+          }
+        }
+      }
+    },
+    "picker_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
+          }
+        }
+      }
+    },
+    "placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00"
+          }
+        }
+      }
+    },
+    "placeholder_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bc1..."
+          }
+        }
+      }
+    },
+    "placeholder_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00"
+          }
+        }
+      }
+    },
+    "placeholder_amount_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00"
+          }
+        }
+      }
+    },
+    "placeholder_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lnbc1..."
+          }
+        }
+      }
+    },
+    "placeholder_loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading..."
+          }
+        }
+      }
+    },
+    "placeholder_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "word1 word2 word3..."
+          }
+        }
+      }
+    },
+    "Price" : {
+
+    },
+    "section_about" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        }
+      }
+    },
+    "section_backup" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup"
+          }
+        }
+      }
+    },
+    "section_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel"
+          }
+        }
+      }
+    },
+    "section_metadata" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadata"
+          }
+        }
+      }
+    },
+    "section_node" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Node"
+          }
+        }
+      }
+    },
+    "section_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
+    "section_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain"
+          }
+        }
+      }
+    },
+    "section_payment_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Details"
+          }
+        }
+      }
+    },
+    "section_privacy_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy & Security"
+          }
+        }
+      }
+    },
+    "section_stable_position" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Position"
+          }
+        }
+      }
+    },
+    "section_trade_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade Details"
+          }
+        }
+      }
+    },
+    "section_wallet_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Security"
+          }
+        }
+      }
+    },
+    "segment_payments" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payments"
+          }
+        }
+      }
+    },
+    "segment_trades" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trades"
+          }
+        }
+      }
+    },
+    "Selected" : {
+
+    },
+    "status_channel_closed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Closed"
+          }
+        }
+      }
+    },
+    "status_channel_opening" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Opening"
+          }
+        }
+      }
+    },
+    "status_channel_ready" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Ready"
+          }
+        }
+      }
+    },
+    "status_collecting_data" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collecting price data..."
+          }
+        }
+      }
+    },
+    "status_opening_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opening Channel"
+          }
+        }
+      }
+    },
+    "status_payment_confirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Confirmed"
+          }
+        }
+      }
+    },
+    "status_payment_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Failed"
+          }
+        }
+      }
+    },
+    "status_received_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received BTC"
+          }
+        }
+      }
+    },
+    "status_received_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received USD"
+          }
+        }
+      }
+    },
+    "status_running" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running"
+          }
+        }
+      }
+    },
+    "status_splice_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Failed"
+          }
+        }
+      }
+    },
+    "status_splice_pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Pending"
+          }
+        }
+      }
+    },
+    "status_stopped" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopped"
+          }
+        }
+      }
+    },
+    "status_sweeping" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sweeping"
+          }
+        }
+      }
+    },
+    "status_syncing_moment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing Moment"
+          }
+        }
+      }
+    },
+    "status_syncing_wallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing Wallet"
+          }
+        }
+      }
+    },
+    "status_trade_confirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade Confirmed"
+          }
+        }
+      }
+    },
+    "status_trade_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade Failed"
+          }
+        }
+      }
+    },
+    "status_waiting_lsp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for LSP"
+          }
+        }
+      }
+    },
+    "subtitle_disable_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable app lock requirement on launch and resume"
+          }
+        }
+      }
+    },
+    "subtitle_disable_payment_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require auth before sending Lightning payments"
+          }
+        }
+      }
+    },
+    "success_sent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent!"
+          }
+        }
+      }
+    },
+    "success_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice-out initiated!"
+          }
+        }
+      }
+    },
+    "tab_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
+          }
+        }
+      }
+    },
+    "tab_home" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
+    },
+    "tab_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "Time" : {
+
+    },
+    "title_app_access" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Access"
+          }
+        }
+      }
+    },
+    "title_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy BTC"
+          }
+        }
+      }
+    },
+    "title_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "title_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
+          }
+        }
+      }
+    },
+    "title_confirm_buy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Buy"
+          }
+        }
+      }
+    },
+    "title_confirm_sell" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Sell"
+          }
+        }
+      }
+    },
+    "title_fund_wallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fund Wallet"
+          }
+        }
+      }
+    },
+    "title_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
+          }
+        }
+      }
+    },
+    "title_on_chain_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain Receive"
+          }
+        }
+      }
+    },
+    "title_payment_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Detail"
+          }
+        }
+      }
+    },
+    "title_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive"
+          }
+        }
+      }
+    },
+    "title_restore_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Seed"
+          }
+        }
+      }
+    },
+    "title_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security"
+          }
+        }
+      }
+    },
+    "title_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sell BTC"
+          }
+        }
+      }
+    },
+    "title_send_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send On-Chain"
+          }
+        }
+      }
+    },
+    "title_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "title_trade_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade Detail"
+          }
+        }
+      }
+    },
+    "toggle_send_all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send All"
+          }
+        }
+      }
+    },
+    "toolbar_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-Chain"
+          }
+        }
+      }
+    },
+    "trade_bought_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bought "
+          }
+        }
+      }
+    },
+    "trade_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy BTC"
+          }
+        }
+      }
+    },
+    "trade_buying_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buying "
+          }
+        }
+      }
+    },
+    "trade_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sell BTC"
+          }
+        }
+      }
+    },
+    "trade_selling_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selling "
+          }
+        }
+      }
+    },
+    "trade_sold_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sold "
+          }
+        }
+      }
+    },
+    "try_again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        }
+      }
+    },
+    "view_on_explorer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View on Explorer"
+          }
+        }
+      }
+    },
+    "warning_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Never share your seed phrase with anyone."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.2"
+}

--- a/ios/StableChannels/StableChannels/Views/ContentView.swift
+++ b/ios/StableChannels/StableChannels/Views/ContentView.swift
@@ -89,7 +89,7 @@ struct ContentView: View {
                 .font(.system(size: 60))
                 .foregroundStyle(.green.opacity(0.5))
 
-            Text("Authenticate")
+            Text(String(localized: "label_authenticate", defaultValue: "Authenticate"))
                 .font(.headline)
                 .foregroundStyle(.white)
         }
@@ -101,7 +101,7 @@ struct ContentView: View {
                 .font(.system(size: 60))
                 .foregroundStyle(.green)
 
-            Text("Authentication Failed")
+            Text(String(localized: "label_auth_failed", defaultValue: "Authentication Failed"))
                 .font(.headline)
                 .foregroundStyle(.white)
 
@@ -113,13 +113,13 @@ struct ContentView: View {
                     .padding(.horizontal)
             }
 
-            Button("Try Again") {
+            Button(String(localized: "button_try_again", defaultValue: "Try Again")) {
                 Task { await runAuth() }
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
 
-            Button("Cancel") { }
+            Button(String(localized: "button_cancel", defaultValue: "Cancel")) { }
                 .foregroundStyle(.white.opacity(0.6))
         }
     }
@@ -171,10 +171,10 @@ struct LoadingView: View {
                 .onAppear { pulse = true }
 
             VStack(spacing: 4) {
-                Text("Stable Channels")
+                Text(String(localized: "app_name", defaultValue: "Stable Channels"))
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(.primary)
-                Text("Self-custodial bitcoin trading")
+                Text(String(localized: "app_subtitle", defaultValue: "Self-custodial bitcoin trading"))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -198,9 +198,9 @@ struct SyncingView: View {
 
             VStack(spacing: 12) {
                 ProgressView()
-                Text("Syncing wallet...")
+                Text(String(localized: "status_syncing_wallet", defaultValue: "Syncing wallet..."))
                     .foregroundStyle(.secondary)
-                Text("This may take a moment")
+                Text(String(localized: "status_syncing_moment", defaultValue: "This may take a moment"))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -217,14 +217,14 @@ struct ErrorDisplayView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.largeTitle)
                 .foregroundStyle(.red)
-            Text("Error")
+            Text(String(localized: "error_title", defaultValue: "Error"))
                 .font(.title2.bold())
             Text(message)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
-            Button("Try Again") {
+            Button(String(localized: "try_again", defaultValue: "Try Again")) {
                 appState.phase = .loading
                 Task { await appState.start() }
             }

--- a/ios/StableChannels/StableChannels/Views/ContentView.swift
+++ b/ios/StableChannels/StableChannels/Views/ContentView.swift
@@ -113,7 +113,7 @@ struct ContentView: View {
                     .padding(.horizontal)
             }
 
-            Button(String(localized: "button_try_again", defaultValue: "Try Again")) {
+            Button(String(localized: "try_again", defaultValue: "Try Again")) {
                 Task { await runAuth() }
             }
             .buttonStyle(.borderedProminent)

--- a/ios/StableChannels/StableChannels/Views/History/HistoryView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/HistoryView.swift
@@ -12,9 +12,9 @@ struct HistoryView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 // Segment picker
-                Picker("History", selection: $selectedSegment) {
-                    Text("Trades").tag(0)
-                    Text("Payments").tag(1)
+                Picker(String(localized: "picker_history", defaultValue: "History"), selection: $selectedSegment) {
+                    Text(String(localized: "segment_trades", defaultValue: "Trades")).tag(0)
+                    Text(String(localized: "segment_payments", defaultValue: "Payments")).tag(1)
                 }
                 .pickerStyle(.segmented)
                 .padding()
@@ -30,15 +30,27 @@ struct HistoryView: View {
                 .listStyle(.plain)
                 .overlay {
                     if selectedSegment == 0 && trades.isEmpty {
-                        ContentUnavailableView("No Trades", systemImage: "arrow.left.arrow.right",
-                                               description: Text("Buy or sell BTC to see trades here."))
+                        ContentUnavailableView(
+                            String(localized: "empty_trades_title", defaultValue: "No Trades"),
+                            systemImage: "arrow.left.arrow.right",
+                            description: Text(String(
+                                localized: "empty_trades_desc",
+                                defaultValue: "Buy or sell BTC to see trades here."
+                            ))
+                        )
                     } else if selectedSegment == 1 && payments.isEmpty {
-                        ContentUnavailableView("No Payments", systemImage: "bolt.fill",
-                                               description: Text("Send or receive payments to see history here."))
+                        ContentUnavailableView(
+                            String(localized: "empty_payments_title", defaultValue: "No Payments"),
+                            systemImage: "bolt.fill",
+                            description: Text(String(
+                                localized: "empty_payments_desc",
+                                defaultValue: "Send or receive payments to see history here."
+                            ))
+                        )
                     }
                 }
             }
-            .navigationTitle("History")
+            .navigationTitle(String(localized: "title_history", defaultValue: "History"))
             .navigationBarTitleDisplayMode(.inline)
             .task {
                 loadHistory()
@@ -98,7 +110,9 @@ struct TradeRowView: View {
                 .font(.title3)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(isBuy ? "Buy BTC" : "Sell BTC")
+                Text(isBuy
+                    ? String(localized: "trade_buy_btc", defaultValue: "Buy BTC")
+                    : String(localized: "trade_sell_btc", defaultValue: "Sell BTC"))
                     .fontWeight(.medium)
                 Text(trade.date, style: .relative)
                     .font(.caption)
@@ -139,7 +153,9 @@ struct PaymentRowView: View {
                 .font(.title3)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(payment.isIncoming ? "Received" : "Sent")
+                Text(payment.isIncoming
+                    ? String(localized: "payment_received", defaultValue: "Received")
+                    : String(localized: "payment_sent", defaultValue: "Sent"))
                     .fontWeight(.medium)
                 Text(paymentTypeLabel)
                     .font(.caption)

--- a/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
@@ -7,33 +7,36 @@ struct PaymentDetailView: View {
     var body: some View {
         NavigationStack {
             List {
-                Section("Payment Details") {
-                    row("Direction", payment.isIncoming ? "Received" : "Sent")
-                    row("Type", paymentTypeLabel)
-                    row("Amount", "\(payment.amountSats) sats")
+                Section(String(localized: "section_payment_details", defaultValue: "Payment Details")) {
+                    row(String(localized: "label_direction", defaultValue: "Direction"),
+                        payment.isIncoming
+                            ? String(localized: "payment_received", defaultValue: "Received")
+                            : String(localized: "payment_sent", defaultValue: "Sent"))
+                    row(String(localized: "label_type", defaultValue: "Type"), paymentTypeLabel)
+                    row(String(localized: "label_amount", defaultValue: "Amount"), "\(payment.amountSats) sats")
                     if let usd = payment.amountUSD {
-                        row("USD Value", usd.usdFormatted)
+                        row(String(localized: "label_usd_value", defaultValue: "USD Value"), usd.usdFormatted)
                     }
                     if let price = payment.btcPrice {
-                        row("BTC Price", price.usdFormatted)
+                        row(String(localized: "label_btc_price", defaultValue: "BTC Price"), price.usdFormatted)
                     }
                     if payment.feeMsat > 0 {
-                        row("Fee", "\(payment.feeMsat) msat")
+                        row(String(localized: "label_fee", defaultValue: "Fee"), "\(payment.feeMsat) msat")
                     }
-                    row("Status", payment.status.capitalized)
+                    row(String(localized: "label_status", defaultValue: "Status"), payment.status.capitalized)
                 }
 
-                Section("Metadata") {
-                    row("Date", payment.date.formatted())
+                Section(String(localized: "section_metadata", defaultValue: "Metadata")) {
+                    row(String(localized: "label_date", defaultValue: "Date"), payment.date.formatted())
                     if let paymentId = payment.paymentId {
-                        row("Payment ID", paymentId)
+                        row(String(localized: "label_payment_id", defaultValue: "Payment ID"), paymentId)
                     }
                     if let txid = payment.txid {
-                        row("TXID", txid)
+                        row(String(localized: "label_txid", defaultValue: "TXID"), txid)
                         if let url = URL(string: "https://mempool.space/tx/\(txid)") {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
-                                    Text("View on explorer")
+                                    Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
                                     Image(systemName: "arrow.up.right.square")
                                 }
                                 .font(.caption)
@@ -41,18 +44,21 @@ struct PaymentDetailView: View {
                         }
                     }
                     if let address = payment.address {
-                        row("Address", address)
+                        row(String(localized: "label_address", defaultValue: "Address"), address)
                     }
                     if payment.confirmations > 0 {
-                        row("Confirmations", "\(payment.confirmations)")
+                        row(
+                            String(localized: "label_confirmations", defaultValue: "Confirmations"),
+                            "\(payment.confirmations)"
+                        )
                     }
                 }
             }
-            .navigationTitle("Payment Detail")
+            .navigationTitle(String(localized: "title_payment_detail", defaultValue: "Payment Detail"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
+                    Button(String(localized: "button_done", defaultValue: "Done")) { dismiss() }
                 }
             }
         }
@@ -70,13 +76,13 @@ struct PaymentDetailView: View {
 
     private var paymentTypeLabel: String {
         switch payment.paymentType {
-        case "stability": return "Stability Payment"
-        case "lightning": return "Settlement"
-        case "splice_in": return "Splice In"
-        case "splice_out": return "Splice Out"
-        case "onchain": return "On-chain"
-        case "channel_close": return "Channel Close"
-        case "bolt12": return "Bolt12"
+        case "stability": return String(localized: "payment_type_stability", defaultValue: "Stability Payment")
+        case "lightning": return String(localized: "payment_type_settlement", defaultValue: "Settlement")
+        case "splice_in": return String(localized: "payment_type_splice_in", defaultValue: "Splice In")
+        case "splice_out": return String(localized: "payment_type_splice_out", defaultValue: "Splice Out")
+        case "onchain": return String(localized: "payment_type_on_chain", defaultValue: "On-chain")
+        case "channel_close": return String(localized: "payment_type_channel_close", defaultValue: "Channel Close")
+        case "bolt12": return String(localized: "payment_type_bolt12", defaultValue: "Bolt12")
         default: return payment.paymentType
         }
     }

--- a/ios/StableChannels/StableChannels/Views/History/TradeDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/TradeDetailView.swift
@@ -7,27 +7,36 @@ struct TradeDetailView: View {
     var body: some View {
         NavigationStack {
             List {
-                Section("Trade Details") {
-                    row("Action", trade.action == "buy" ? "Buy BTC" : "Sell BTC")
-                    row("Amount (USD)", trade.amountUSD.usdFormatted)
-                    row("Amount (BTC)", String(format: "%.8f", trade.amountBTC))
-                    row("BTC Price", trade.btcPrice.usdFormatted)
-                    row("Fee", trade.feeUSD.usdFormatted)
-                    row("Status", trade.status.capitalized)
+                Section(String(localized: "section_trade_details", defaultValue: "Trade Details")) {
+                    row(String(localized: "label_action", defaultValue: "Action"),
+                        trade.action == "buy"
+                            ? String(localized: "trade_buy_btc", defaultValue: "Buy BTC")
+                            : String(localized: "trade_sell_btc", defaultValue: "Sell BTC"))
+                    row(
+                        String(localized: "label_amount_usd", defaultValue: "Amount (USD)"),
+                        trade.amountUSD.usdFormatted
+                    )
+                    row(
+                        String(localized: "label_amount_btc", defaultValue: "Amount (BTC)"),
+                        String(format: "%.8f", trade.amountBTC)
+                    )
+                    row(String(localized: "label_btc_price", defaultValue: "BTC Price"), trade.btcPrice.usdFormatted)
+                    row(String(localized: "label_fee", defaultValue: "Fee"), trade.feeUSD.usdFormatted)
+                    row(String(localized: "label_status", defaultValue: "Status"), trade.status.capitalized)
                 }
 
-                Section("Metadata") {
-                    row("Date", trade.date.formatted())
+                Section(String(localized: "section_metadata", defaultValue: "Metadata")) {
+                    row(String(localized: "label_date", defaultValue: "Date"), trade.date.formatted())
                     if let paymentId = trade.paymentId {
-                        row("Trade ID", paymentId)
+                        row(String(localized: "label_payment_id", defaultValue: "Trade ID"), paymentId)
                     }
                 }
             }
-            .navigationTitle("Trade Detail")
+            .navigationTitle(String(localized: "title_trade_detail", defaultValue: "Trade Detail"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
+                    Button(String(localized: "button_done", defaultValue: "Done")) { dismiss() }
                 }
             }
         }

--- a/ios/StableChannels/StableChannels/Views/Home/BalanceBarView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/BalanceBarView.swift
@@ -84,7 +84,7 @@ struct BalanceBarView: View {
                         .scaleEffect(isPressing ? 1.15 : pulseScale)
                         .overlay(alignment: .top) {
                             if isPressing {
-                                Text("\(usdPct)% USD  \(btcPct)% BTC")
+                                Text(String(localized: "label_balance_pct", defaultValue: "% USD % BTC"))
                                     .font(.caption2.bold())
                                     .fixedSize()
                                     .foregroundStyle(.primary)

--- a/ios/StableChannels/StableChannels/Views/Home/BalanceBarView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/BalanceBarView.swift
@@ -84,7 +84,7 @@ struct BalanceBarView: View {
                         .scaleEffect(isPressing ? 1.15 : pulseScale)
                         .overlay(alignment: .top) {
                             if isPressing {
-                                Text(String(localized: "label_balance_pct", defaultValue: "% USD % BTC"))
+                                Text("\(usdPct)% USD  \(btcPct)% BTC")
                                     .font(.caption2.bold())
                                     .fixedSize()
                                     .foregroundStyle(.primary)

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -51,7 +51,7 @@ struct FundWalletView: View {
             }
             .padding(32)
         }
-        .navigationTitle(String(localized: "title_fund_wallet", defaultValue: "Fund Wallet"))
+        .navigationTitle(String(localized: "title_on_chain_receive", defaultValue: "On-chain Receive"))
         .navigationBarTitleDisplayMode(.inline)
     }
 

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -32,7 +32,9 @@ struct FundWalletView: View {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCopied = false }
                         } label: {
                             Label(
-                                isCopied ? "Copied" : "Copy Address",
+                                isCopied
+                                    ? String(localized: "button_copied", defaultValue: "Copied")
+                                    : String(localized: "button_copy_address", defaultValue: "Copy Address"),
                                 systemImage: isCopied ? "checkmark" : "doc.on.doc"
                             )
                         }
@@ -49,7 +51,7 @@ struct FundWalletView: View {
             }
             .padding(32)
         }
-        .navigationTitle("On-chain Receive")
+        .navigationTitle(String(localized: "title_fund_wallet", defaultValue: "Fund Wallet"))
         .navigationBarTitleDisplayMode(.inline)
     }
 

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -21,7 +21,7 @@ struct HomeView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     HStack {
-                        Text("Stable Channels")
+                        Text(String(localized: "app_name", defaultValue: "Stable Channels"))
                             .font(.headline)
                         Spacer()
                     }
@@ -39,7 +39,7 @@ struct HomeView: View {
                         HStack(spacing: 6) {
                             ProgressView()
                                 .controlSize(.small)
-                            Text("Syncing...")
+                            Text(String(localized: "home_syncing", defaultValue: "Syncing..."))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -64,10 +64,13 @@ struct HomeView: View {
 
                     // Hint text when no channel
                     if !hasReadyChannel {
-                        Text("Receive bitcoin over Lightning to get started")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(.bottom, 4)
+                        Text(String(
+                            localized: "home_hint_receive",
+                            defaultValue: "Receive bitcoin over Lightning to get started"
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.bottom, 4)
                     }
 
                     // Action Buttons
@@ -147,13 +150,16 @@ struct HomeView: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.white)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Notifications Disabled")
+                    Text(String(localized: "notifications_disabled", defaultValue: "Notifications Disabled"))
                         .font(.subheadline)
                         .fontWeight(.semibold)
                         .foregroundStyle(.white)
-                    Text("Enable notifications for stability payments")
-                        .font(.caption)
-                        .foregroundStyle(.white.opacity(0.9))
+                    Text(String(
+                        localized: "notifications_disabled_subtitle",
+                        defaultValue: "Enable notifications for stability payments"
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.9))
                 }
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -177,16 +183,16 @@ struct HomeView: View {
         let hasBalance = appState.totalBalanceUSD > 0 || displaySats > 0
 
         return VStack(spacing: 4) {
-            Text("Total Balance")
+            Text(String(localized: "label_total_balance", defaultValue: "Total Balance"))
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
             if !hasBalance && appState.isSyncing {
-                Text("—")
+                Text(String(localized: "label_dash", defaultValue: "—"))
                     .font(.system(size: 42, weight: .bold, design: .rounded))
                     .foregroundStyle(.secondary)
 
-                Text("Loading balance...")
+                Text(String(localized: "loading_balance", defaultValue: "Loading balance..."))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             } else if showBTC {
@@ -196,7 +202,7 @@ struct HomeView: View {
                         .foregroundStyle(appState.paymentFlash ? .green : .primary)
                         .contentTransition(.numericText())
                         .animation(.default, value: displaySats)
-                    Text("BTC")
+                    Text(String(localized: "label_btc", defaultValue: "BTC"))
                         .font(.system(size: 18, weight: .semibold, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
@@ -212,7 +218,7 @@ struct HomeView: View {
                         .contentTransition(.numericText())
                         .animation(.default, value: appState.totalBalanceUSD)
                         .animation(.easeInOut(duration: 0.3), value: appState.paymentFlash)
-                    Text("USD")
+                    Text(String(localized: "label_usd", defaultValue: "USD"))
                         .font(.system(size: 18, weight: .semibold, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
@@ -270,7 +276,7 @@ struct HomeView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "shield.fill")
                             .font(.caption2)
-                        Text("USD")
+                        Text(String(localized: "label_usd", defaultValue: "USD"))
                             .font(.caption.bold())
                     }
                     .foregroundStyle(.green)
@@ -284,7 +290,7 @@ struct HomeView: View {
 
                 VStack(alignment: .trailing, spacing: 1) {
                     HStack(spacing: 4) {
-                        Text("BTC")
+                        Text(String(localized: "label_btc", defaultValue: "BTC"))
                             .font(.caption.bold())
                         Image(systemName: "bitcoinsign.circle.fill")
                             .font(.caption2)
@@ -319,7 +325,7 @@ struct HomeView: View {
     private var savingsSection: some View {
         VStack(spacing: 6) {
             HStack {
-                Text("On-chain")
+                Text(String(localized: "label_on_chain", defaultValue: "On-chain"))
                     .font(.caption.bold())
                 Spacer()
                 Text(showBTC
@@ -331,14 +337,17 @@ struct HomeView: View {
 
             if appState.isSweeping {
                 // 1. Splice-in in progress
-                pendingRow(text: "Swap pending...", txid: appState.spliceTxid)
+                pendingRow(
+                    text: String(localized: "status_sweeping", defaultValue: "Swap pending..."),
+                    txid: appState.spliceTxid
+                )
             } else if hasReadyChannel && appState.spendableOnchainSats > 0 {
                 // 2. Channel + confirmed funds — offer to sweep
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Move to Trading")
+                        Text(String(localized: "move_to_trading", defaultValue: "Move to Trading"))
                             .font(.caption2)
-                        Text("and Spending Account")
+                        Text(String(localized: "and_spending_account", defaultValue: "and Spending Account"))
                             .font(.caption2)
                     }
                     .foregroundStyle(.secondary)
@@ -346,7 +355,7 @@ struct HomeView: View {
                     Button {
                         appState.sweepToChannel()
                     } label: {
-                        Text("Swap")
+                        Text(String(localized: "button_swap", defaultValue: "Swap"))
                             .font(.caption.bold())
                             .padding(.horizontal, 16)
                             .padding(.vertical, 6)
@@ -357,17 +366,26 @@ struct HomeView: View {
                 }
             } else if appState.spendableOnchainSats == 0 {
                 // 3. Unconfirmed deposit (with or without channel)
-                pendingRow(text: "Deposit confirming...", txid: appState.fundingTxid)
+                pendingRow(
+                    text: String(localized: "status_channel_opening", defaultValue: "Deposit confirming..."),
+                    txid: appState.fundingTxid
+                )
                 if !hasReadyChannel {
-                    Text("Receive over Lightning to create your Trading and Spending Account")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                    Text(String(
+                        localized: "hint_create_account",
+                        defaultValue: "Receive over Lightning to create your Trading and Spending Account"
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
                 }
             } else {
                 // 4. No channel, confirmed deposit — just needs a Lightning receive
-                Text("Receive over Lightning to create your Trading and Spending Account")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                Text(String(
+                    localized: "hint_create_account",
+                    defaultValue: "Receive over Lightning to create your Trading and Spending Account"
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
             }
         }
         .padding(10)
@@ -386,7 +404,7 @@ struct HomeView: View {
             if let txid, !txid.isEmpty {
                 Link(destination: URL(string: "https://mempool.space/tx/\(txid)")!) {
                     HStack(spacing: 2) {
-                        Text("View on explorer")
+                        Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
                             .font(.caption2)
                         Image(systemName: "arrow.up.right.square")
                             .font(.caption2)
@@ -402,19 +420,36 @@ struct HomeView: View {
     private var actionButtons: some View {
         return VStack(spacing: 8) {
             HStack(spacing: 8) {
-                ActionButton(title: "Send", icon: "arrow.up.circle.fill", color: .blue) {
+                ActionButton(
+                    title: String(localized: "button_send", defaultValue: "Send"),
+                    icon: "arrow.up.circle.fill",
+                    color: .blue
+                ) {
                     showSendSheet = true
                 }
-                ActionButton(title: "Receive", icon: "arrow.down.circle.fill", color: .green, pulse: !hasReadyChannel) {
+                ActionButton(
+                    title: String(localized: "button_receive", defaultValue: "Receive"),
+                    icon: "arrow.down.circle.fill",
+                    color: .green,
+                    pulse: !hasReadyChannel
+                ) {
                     showReceiveSheet = true
                 }
             }
 
             HStack(spacing: 8) {
-                ActionButton(title: "Buy BTC", icon: "arrow.up.right.circle.fill", color: .orange) {
+                ActionButton(
+                    title: String(localized: "button_buy_btc", defaultValue: "Buy BTC"),
+                    icon: "arrow.up.right.circle.fill",
+                    color: .orange
+                ) {
                     showBuySheet = true
                 }
-                ActionButton(title: "Sell BTC", icon: "arrow.down.right.circle.fill", color: .purple) {
+                ActionButton(
+                    title: String(localized: "button_sell_btc", defaultValue: "Sell BTC"),
+                    icon: "arrow.down.right.circle.fill",
+                    color: .purple
+                ) {
                     showSellSheet = true
                 }
             }

--- a/ios/StableChannels/StableChannels/Views/Home/PriceChartView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/PriceChartView.swift
@@ -88,7 +88,7 @@ struct PriceChartView: View {
                             .font(.title3.bold())
                     } else {
                         if !compact {
-                            Text("BTC Price")
+                            Text(String(localized: "label_btc_price", defaultValue: "BTC Price"))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -209,7 +209,7 @@ struct PriceChartView: View {
                     .fill(.quaternary)
                     .frame(height: compact ? 220 : 150)
                     .overlay {
-                        Text("Collecting price data...")
+                        Text(String(localized: "status_collecting_data", defaultValue: "Collecting price data..."))
                             .font(.caption)
                             .foregroundStyle(.tertiary)
                     }

--- a/ios/StableChannels/StableChannels/Views/MainTabView.swift
+++ b/ios/StableChannels/StableChannels/Views/MainTabView.swift
@@ -13,19 +13,19 @@ struct MainTabView: View {
         TabView(selection: $selectedTab) {
             HomeView()
                 .tabItem {
-                    Label("Home", systemImage: "house.fill")
+                    Label(String(localized: "tab_home", defaultValue: "Home"), systemImage: "house.fill")
                 }
                 .tag(Tab.home)
 
             HistoryView()
                 .tabItem {
-                    Label("History", systemImage: "clock.fill")
+                    Label(String(localized: "tab_history", defaultValue: "History"), systemImage: "clock.fill")
                 }
                 .tag(Tab.history)
 
             SettingsView()
                 .tabItem {
-                    Label("Settings", systemImage: "gearshape.fill")
+                    Label(String(localized: "tab_settings", defaultValue: "Settings"), systemImage: "gearshape.fill")
                 }
                 .tag(Tab.settings)
         }

--- a/ios/StableChannels/StableChannels/Views/Settings/AppAccessSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/AppAccessSettingsView.swift
@@ -31,12 +31,12 @@ struct AppAccessSettingsView: View {
 
     var body: some View {
         List {
-            Section("Wallet Security") {
+            Section(String(localized: "section_wallet_security", defaultValue: "Wallet Security")) {
                 Toggle(isOn: Binding(
                     get: { isEnabled(.appUnlock) },
                     set: { if $0 { enable(.appUnlock) } else { requestAuth(for: .appUnlock) } }
                 )) {
-                    Label { Text("App Unlock") }
+                    Label { Text(String(localized: "label_app_unlock", defaultValue: "App Unlock")) }
                         icon: { Image(systemName: "faceid").foregroundStyle(.green) }
                 }
                 .disabled(!BiometricService.canUseBiometrics)
@@ -45,13 +45,15 @@ struct AppAccessSettingsView: View {
                     get: { isEnabled(.transaction) },
                     set: { if $0 { enable(.transaction) } else { requestAuth(for: .transaction) } }
                 )) {
-                    Label { Text("Payment Confirmation") }
-                        icon: { Image(systemName: "faceid").foregroundStyle(.green) }
+                    Label {
+                        Text(String(localized: "label_payment_confirmation", defaultValue: "Payment Confirmation"))
+                    }
+                    icon: { Image(systemName: "faceid").foregroundStyle(.green) }
                 }
                 .disabled(!BiometricService.canUseBiometrics)
             }
         }
-        .navigationTitle("App Access")
+        .navigationTitle(String(localized: "title_app_access", defaultValue: "App Access"))
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $authTarget) { target in
             ToggleAuthSheet(target: target)
@@ -86,23 +88,23 @@ struct ToggleAuthSheet: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
-                Button("Continue") {
+                Button(String(localized: "button_continue", defaultValue: "Continue")) {
                     Task { await performAuth() }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
 
-                Button("Cancel") {
+                Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
                     dismiss()
                 }
                 .foregroundStyle(.secondary)
             }
             .padding()
-            .navigationTitle("Security")
+            .navigationTitle(String(localized: "title_security", defaultValue: "Security"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
                 }
             }
         }

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -17,28 +17,35 @@ struct SettingsView: View {
         NavigationStack {
             List {
                 // Node Info
-                Section("Node") {
+                Section(String(localized: "section_node", defaultValue: "Node")) {
                     HStack {
-                        Text("Status")
+                        Text(String(localized: "label_status", defaultValue: "Status"))
                         Spacer()
                         HStack(spacing: 4) {
                             Circle()
                                 .fill(appState.nodeService.isRunning ? .green : .red)
                                 .frame(width: 8, height: 8)
-                            Text(appState.nodeService.isRunning ? "Running" : "Stopped")
+                            Text(appState.nodeService.isRunning
+                                ? String(localized: "status_running", defaultValue: "Running")
+                                : String(localized: "status_stopped", defaultValue: "Stopped"))
                                 .foregroundStyle(appState.nodeService.isRunning ? .green : .red)
                         }
                     }
 
                     if showNodeId {
-                        copyableRow("Node ID", appState.nodeService.nodeId)
+                        copyableRow(
+                            String(localized: "label_node_id", defaultValue: "Node ID"),
+                            appState.nodeService.nodeId
+                        )
                     } else {
-                        Button("Show Node ID") { showNodeId = true }
+                        Button(String(localized: "button_show_node_id", defaultValue: "Show Node ID")) {
+                            showNodeId = true
+                        }
                     }
                 }
 
                 // Privacy & Security
-                Section("Privacy & Security") {
+                Section(String(localized: "section_privacy_security", defaultValue: "Privacy & Security")) {
                     NavigationLink("App Access") {
                         AppAccessSettingsView()
                     }
@@ -46,36 +53,38 @@ struct SettingsView: View {
 
                 // Channel Info
                 if let channel = appState.nodeService.channels.first {
-                    Section("Channel") {
+                    Section(String(localized: "section_channel", defaultValue: "Channel")) {
                         HStack {
-                            Text("Capacity")
+                            Text(String(localized: "label_capacity", defaultValue: "Capacity"))
                             Spacer()
                             Text(channel.channelValueSats.satsFormatted)
                         }
                         HStack {
-                            Text("Status")
+                            Text(String(localized: "label_status", defaultValue: "Status"))
                             Spacer()
                             HStack(spacing: 4) {
                                 Circle()
                                     .fill(channel.isChannelReady ? .green : .orange)
                                     .frame(width: 8, height: 8)
-                                Text(channel.isChannelReady ? "Ready" : "Pending")
+                                Text(channel.isChannelReady
+                                    ? String(localized: "channel_status_ready", defaultValue: "Ready")
+                                    : String(localized: "channel_status_pending", defaultValue: "Pending"))
                             }
                         }
                         HStack {
-                            Text("Outbound")
+                            Text(String(localized: "label_outbound", defaultValue: "Outbound"))
                             Spacer()
                             Text((channel.outboundCapacityMsat / 1000).satsFormatted)
                         }
                         HStack {
-                            Text("Inbound")
+                            Text(String(localized: "label_inbound", defaultValue: "Inbound"))
                             Spacer()
                             Text(((channel.inboundCapacityMsat) / 1000).satsFormatted)
                         }
 
                         if let txid = appState.fundingTxid, !txid.isEmpty {
                             HStack {
-                                Text("Funding Tx")
+                                Text(String(localized: "label_funding_tx", defaultValue: "Funding Tx"))
                                     .foregroundStyle(.secondary)
                                 Spacer()
                                 Text(String(txid.prefix(8)) + "..." + String(txid.suffix(8)))
@@ -85,7 +94,7 @@ struct SettingsView: View {
                             if let url = URL(string: "https://mempool.space/tx/\(txid)") {
                                 Link(destination: url) {
                                     HStack(spacing: 4) {
-                                        Text("View on explorer")
+                                        Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
                                         Image(systemName: "arrow.up.right.square")
                                     }
                                     .font(.caption)
@@ -95,20 +104,20 @@ struct SettingsView: View {
                         }
                     }
 
-                    Section("Stable Position") {
+                    Section(String(localized: "section_stable_position", defaultValue: "Stable Position")) {
                         HStack {
-                            Text("Expected USD")
+                            Text(String(localized: "label_expected_usd", defaultValue: "Expected USD"))
                             Spacer()
                             Text(appState.stableChannel.expectedUSD.formatted)
                                 .fontWeight(.medium)
                         }
                         HStack {
-                            Text("Backing Sats")
+                            Text(String(localized: "label_backing_sats", defaultValue: "Backing Sats"))
                             Spacer()
                             Text(appState.stableChannel.backingSats.satsFormatted)
                         }
                         HStack {
-                            Text("Native BTC")
+                            Text(String(localized: "label_native_btc", defaultValue: "Native BTC"))
                             Spacer()
                             Text(appState.stableChannel.nativeChannelBTC.sats.satsFormatted)
                         }
@@ -119,14 +128,14 @@ struct SettingsView: View {
                                 appState.stableChannel, price: appState.btcPrice
                             )
                             HStack {
-                                Text("Status")
+                                Text(String(localized: "label_status", defaultValue: "Status"))
                                 Spacer()
                                 Text(result.action.rawValue)
                                     .foregroundStyle(stabilityColor(result.action))
                                     .fontWeight(.medium)
                             }
                             HStack {
-                                Text("Distance from Par")
+                                Text(String(localized: "label_distance_from_par", defaultValue: "Distance from Par"))
                                 Spacer()
                                 Text(String(format: "%.2f%%", result.percentFromPar))
                                     .foregroundStyle(result.percentFromPar < 0.1 ? .green : .orange)
@@ -134,72 +143,84 @@ struct SettingsView: View {
                         }
 
                         if !appState.stableChannel.counterparty.isEmpty {
-                            copyableRow("Counterparty", appState.stableChannel.counterparty)
+                            copyableRow(
+                                String(localized: "label_counterparty", defaultValue: "Counterparty"),
+                                appState.stableChannel.counterparty
+                            )
                         }
                     }
 
                     Section {
-                        Button("Close Channel", role: .destructive) {
+                        Button(
+                            String(localized: "button_close_channel", defaultValue: "Close Channel"),
+                            role: .destructive
+                        ) {
                             showCloseChannelAlert = true
                         }
                     }
                 }
 
                 // On-Chain
-                Section("On-Chain") {
+                Section(String(localized: "section_on_chain", defaultValue: "On-Chain")) {
                     HStack {
-                        Text("Balance")
+                        Text(String(localized: "label_balance", defaultValue: "Balance"))
                         Spacer()
                         Text(appState.onchainBalanceSats.satsFormatted)
                     }
 
                     if appState.onchainBalanceSats > 0 {
-                        NavigationLink("Send On-Chain") {
+                        NavigationLink(String(localized: "link_send_on_chain", defaultValue: "Send On-Chain")) {
                             OnChainSendView()
                         }
                     }
                 }
 
                 // Push Notifications
-                Section("Push Notifications") {
+                Section(String(localized: "section_notifications", defaultValue: "Push Notifications")) {
                     HStack {
-                        Text("Notifications")
+                        Text(String(localized: "label_notifications", defaultValue: "Notifications"))
                         Spacer()
                         if notificationsEnabled {
-                            Text("Enabled")
+                            Text(String(localized: "notifications_enabled", defaultValue: "Enabled"))
                                 .foregroundStyle(.green)
                         } else {
-                            Text("Disabled")
+                            Text(String(localized: "notifications_disabled", defaultValue: "Disabled"))
                                 .foregroundStyle(.red)
                         }
                     }
 
                     if !notificationsEnabled {
-                        Button("Enable in Settings") {
+                        Button(String(localized: "button_enable_settings", defaultValue: "Enable in Settings")) {
                             if let url = URL(string: UIApplication.openSettingsURLString) {
                                 UIApplication.shared.open(url)
                             }
                         }
-                        Text("Notifications are required to receive stability payments while the app is closed.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Text(String(
+                            localized: "info_notifications_needed",
+                            defaultValue: "Notifications are required to receive stability payments while the app is closed."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
 
                     if let token = UserDefaults.standard.string(forKey: "apns_device_token") {
-                        copyableRow("Device Token", token)
+                        copyableRow(String(localized: "label_device_token", defaultValue: "Device Token"), token)
                     }
                 }
 
                 // Backup
-                Section("Backup") {
-                    Button(showSeedWords ? "Hide Seed Words" : "Backup Seed Words") {
-                        showSeedWords.toggle()
-                    }
+                Section(String(localized: "section_backup", defaultValue: "Backup")) {
+                    Button(showSeedWords
+                        ? String(localized: "button_hide_seed", defaultValue: "Hide Seed Words")
+                        : String(localized: "button_backup_seed", defaultValue: "Backup Seed Words")) {
+                            showSeedWords.toggle()
+                        }
                     if showSeedWords {
                         if let words = appState.nodeService.savedMnemonic, !words.isEmpty {
-                            Text(
-                                "Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds."
-                            )
+                            Text(String(
+                                localized: "warning_seed",
+                                defaultValue: "Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds."
+                            ))
                             .font(.caption)
                             .foregroundStyle(.orange)
                             ForEach(Array(words.split(separator: " ").enumerated()), id: \.offset) { index, word in
@@ -217,47 +238,53 @@ struct SettingsView: View {
                             } label: {
                                 HStack {
                                     Image(systemName: copiedField == "Seed Words" ? "checkmark" : "doc.on.doc")
-                                    Text(copiedField == "Seed Words" ? "Copied" : "Copy Seed Words")
+                                    Text(copiedField == "Seed Words"
+                                        ? String(localized: "button_copied", defaultValue: "Copied")
+                                        : String(localized: "button_copy_seed", defaultValue: "Copy Seed Words"))
                                 }
                             }
                         } else {
-                            Text("Seed phrase not available for this wallet.")
-                                .foregroundStyle(.secondary)
+                            Text(String(
+                                localized: "info_seed_unavailable",
+                                defaultValue: "Seed phrase not available for this wallet."
+                            ))
+                            .foregroundStyle(.secondary)
                         }
                     }
-                    Button("Restore from Seed") {
+                    Button(String(localized: "button_restore_seed", defaultValue: "Restore from Seed")) {
                         showRestore = true
                     }
                 }
 
                 // About
-                Section("About") {
+                Section(String(localized: "section_about", defaultValue: "About")) {
                     HStack {
-                        Text("Version")
+                        Text(String(localized: "label_version", defaultValue: "Version"))
                         Spacer()
                         Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")
                             .foregroundStyle(.secondary)
                     }
                     HStack {
-                        Text("Network")
+                        Text(String(localized: "label_network", defaultValue: "Network"))
                         Spacer()
                         Text(Constants.defaultNetwork)
                             .foregroundStyle(.secondary)
                     }
                     HStack {
-                        Text("Custody")
+                        Text(String(localized: "label_custody", defaultValue: "Custody"))
                         Spacer()
-                        Text("Self-custodial")
+                        Text(String(localized: "custody_self", defaultValue: "Self-custodial"))
                             .foregroundStyle(.secondary)
                     }
-                    Text(
-                        "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
-                    )
+                    Text(String(
+                        localized: "info_self_custody",
+                        defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
+                    ))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 }
             }
-            .navigationTitle("Settings")
+            .navigationTitle(String(localized: "title_settings", defaultValue: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
             .refreshable {
                 appState.refreshBalances()
@@ -272,19 +299,26 @@ struct SettingsView: View {
             .sheet(isPresented: $showRestore) {
                 NavigationStack {
                     VStack(spacing: 20) {
-                        Text("Enter your 12 or 24-word seed phrase to restore a wallet.")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal)
+                        Text(String(
+                            localized: "instruction_restore",
+                            defaultValue: "Enter your 12 or 24-word seed phrase to restore a wallet."
+                        ))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal)
 
-                        TextField("word1 word2 word3 ...", text: $restoreMnemonic, axis: .vertical)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .lineLimit(3...5)
-                            .font(.system(.body, design: .monospaced))
-                            .padding()
-                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-                            .padding(.horizontal)
+                        TextField(
+                            String(localized: "placeholder_seed", defaultValue: "word1 word2 word3 ..."),
+                            text: $restoreMnemonic,
+                            axis: .vertical
+                        )
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .lineLimit(3...5)
+                        .font(.system(.body, design: .monospaced))
+                        .padding()
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                        .padding(.horizontal)
 
                         if let error = restoreError {
                             Text(error)
@@ -299,7 +333,8 @@ struct SettingsView: View {
                             if isRestoring {
                                 ProgressView().frame(maxWidth: .infinity)
                             } else {
-                                Text("Restore").frame(maxWidth: .infinity)
+                                Text(String(localized: "button_restore", defaultValue: "Restore"))
+                                    .frame(maxWidth: .infinity)
                             }
                         }
                         .buttonStyle(.borderedProminent)
@@ -310,10 +345,10 @@ struct SettingsView: View {
                         Spacer()
                     }
                     .padding(.top)
-                    .navigationTitle("Restore from Seed")
+                    .navigationTitle(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") {
+                            Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
                                 showRestore = false
                                 restoreMnemonic = ""
                                 restoreError = nil
@@ -322,13 +357,19 @@ struct SettingsView: View {
                     }
                 }
             }
-            .alert("Close Channel?", isPresented: $showCloseChannelAlert) {
-                Button("Cancel", role: .cancel) { }
-                Button("Close", role: .destructive) {
+            .alert(
+                String(localized: "alert_close_channel_title", defaultValue: "Close Channel?"),
+                isPresented: $showCloseChannelAlert
+            ) {
+                Button(String(localized: "alert_close_channel_cancel", defaultValue: "Cancel"), role: .cancel) { }
+                Button(String(localized: "alert_close_channel_confirm", defaultValue: "Close"), role: .destructive) {
                     closeChannel()
                 }
             } message: {
-                Text("This will cooperatively close the channel and sweep funds on-chain.")
+                Text(String(
+                    localized: "alert_close_channel_message",
+                    defaultValue: "This will cooperatively close the channel and sweep funds on-chain."
+                ))
             }
         }
     }
@@ -344,7 +385,7 @@ struct SettingsView: View {
                     .foregroundStyle(.primary)
                 Spacer()
                 if copiedField == label {
-                    Label("Copied", systemImage: "checkmark")
+                    Label(String(localized: "button_copied", defaultValue: "Copied"), systemImage: "checkmark")
                         .font(.caption)
                         .foregroundStyle(.green)
                 } else {
@@ -382,7 +423,10 @@ struct SettingsView: View {
         let input = restoreMnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
         let wordCount = input.split(separator: " ").count
         guard wordCount == 12 || wordCount == 24 else {
-            restoreError = "Seed phrase must be 12 or 24 words"
+            restoreError = String(
+                localized: "error_seed_word_count",
+                defaultValue: "Seed phrase must be 12 or 24 words"
+            )
             return
         }
 

--- a/ios/StableChannels/StableChannels/Views/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Views/Trade/BuyView.swift
@@ -36,6 +36,10 @@ struct BuyView: View {
         return amountUSD / appState.btcPrice
     }
 
+    private var btcAmountFinal: Double {
+        btcAmount * 0.99
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
@@ -49,11 +53,11 @@ struct BuyView: View {
                 }
             }
             .padding()
-            .navigationTitle("Buy BTC")
+            .navigationTitle(String(localized: "title_buy_btc", defaultValue: "Buy BTC"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
                 }
             }
         }
@@ -61,10 +65,10 @@ struct BuyView: View {
 
     private var amountScreen: some View {
         VStack(spacing: 20) {
-            Text("How much USD to convert to BTC?")
+            Text(String(localized: "headline_how_much_usd", defaultValue: "How much USD to convert to BTC?"))
                 .font(.headline)
 
-            TextField("0.00", text: $amountStr)
+            TextField(String(localized: "placeholder_amount_usd", defaultValue: "0.00"), text: $amountStr)
                 .keyboardType(.decimalPad)
                 .font(.system(size: 36, weight: .bold, design: .rounded))
                 .multilineTextAlignment(.center)
@@ -75,7 +79,7 @@ struct BuyView: View {
                             let textWidth = amountStr.size(withAttributes: [
                                 .font: UIFont.rounded(ofSize: 36, weight: .bold)
                             ]).width
-                            Text("$")
+                            Text(String(localized: "label_dollar_sign", defaultValue: "$"))
                                 .font(.system(size: 36, weight: .bold, design: .rounded))
                                 .position(x: geo.size.width / 2 - textWidth / 2 - 10,
                                           y: geo.size.height / 2)
@@ -88,18 +92,20 @@ struct BuyView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Text("Available: \(maxBuyUSD.usdFormatted)")
+            let availableStr = String(localized: "available_balance", defaultValue: "Available: ") + maxBuyUSD
+                .usdFormatted
+            Text(availableStr)
                 .foregroundStyle(.secondary)
 
             if amountUSD > maxBuyUSD && amountUSD > 0 {
-                Text("Exceeds available stable balance")
+                Text(String(localized: "error_exceeds_balance", defaultValue: "Exceeds available stable balance"))
                     .font(.caption)
                     .foregroundStyle(.red)
             }
 
             Spacer()
 
-            Button("Continue") { step = .confirm }
+            Button(String(localized: "button_continue", defaultValue: "Continue")) { step = .confirm }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .disabled(amountUSD <= 0 || amountUSD > maxBuyUSD)
@@ -108,15 +114,28 @@ struct BuyView: View {
 
     private var confirmScreen: some View {
         VStack(spacing: 20) {
-            Text("Confirm Buy")
+            Text(String(localized: "title_confirm_buy", defaultValue: "Confirm Buy"))
                 .font(.title2.bold())
 
             VStack(spacing: 12) {
-                confirmRow("Amount", String(format: "$%.2f", amountUSD))
-                confirmRow("Fee (1%)", String(format: "$%.2f", amountUSD * 0.01))
-                confirmRow("BTC Price", appState.btcPrice.usdFormatted)
+                confirmRow(
+                    String(localized: "label_amount", defaultValue: "Amount"),
+                    String(format: "$%.2f", amountUSD)
+                )
+                confirmRow(
+                    String(localized: "label_fee_percent", defaultValue: "Fee (1%)"),
+                    String(format: "$%.2f", amountUSD * 0.01)
+                )
+                confirmRow(
+                    String(localized: "label_btc_price", defaultValue: "BTC Price"),
+                    appState.btcPrice.usdFormatted
+                )
                 Divider()
-                confirmRow("You receive", String(format: "%.8f BTC", btcAmount * 0.99), bold: true)
+                confirmRow(
+                    String(localized: "label_you_receive", defaultValue: "You receive"),
+                    String(format: "%.8f BTC", btcAmount * 0.99),
+                    bold: true
+                )
             }
             .padding()
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
@@ -137,7 +156,7 @@ struct BuyView: View {
                     ProgressView()
                         .frame(maxWidth: .infinity)
                 } else {
-                    Text("Buy BTC")
+                    Text(String(localized: "title_buy_btc", defaultValue: "Buy BTC"))
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -159,10 +178,13 @@ struct BuyView: View {
                     .font(.system(size: 64))
                     .foregroundStyle(.green)
 
-                Text("Trade Confirmed")
+                Text(String(localized: "status_trade_confirmed", defaultValue: "Trade Confirmed"))
                     .font(.title2.bold())
 
-                Text(String(format: "Bought %.8f BTC for %@", btcAmount * 0.99, amountUSD.usdFormatted))
+                Text(String(localized: "trade_bought_btc_for", defaultValue: "Bought ") + String(
+                    format: "%.8f",
+                    btcAmountFinal
+                ) + " BTC for " + amountUSD.usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             } else {
@@ -170,22 +192,25 @@ struct BuyView: View {
                     .font(.system(size: 64))
                     .foregroundStyle(.orange)
 
-                Text("Trade Pending")
+                Text(String(localized: "status_waiting_lsp", defaultValue: "Trade Pending"))
                     .font(.title2.bold())
 
-                Text(String(format: "Buying %.8f BTC for %@", btcAmount * 0.99, amountUSD.usdFormatted))
+                Text(String(localized: "trade_buying_btc_for", defaultValue: "Buying ") + String(
+                    format: "%.8f",
+                    btcAmountFinal
+                ) + " BTC for " + amountUSD.usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
                 ProgressView()
                     .padding(.top, 4)
 
-                Text("Waiting for LSP confirmation...")
+                Text(String(localized: "status_waiting_lsp", defaultValue: "Waiting for LSP confirmation..."))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
 
-            Button("Done") { dismiss() }
+            Button(String(localized: "button_done", defaultValue: "Done")) { dismiss() }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
@@ -214,7 +239,10 @@ struct BuyView: View {
                 feeUSD: feeUSD,
                 price: price
             ) else {
-                errorMessage = "Trade failed — check amount and try again"
+                errorMessage = String(
+                    localized: "error_trade_failed",
+                    defaultValue: "Trade failed — check amount and try again"
+                )
                 isExecuting = false
                 return
             }

--- a/ios/StableChannels/StableChannels/Views/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Views/Trade/SellView.swift
@@ -40,6 +40,10 @@ struct SellView: View {
         return amountUSD / appState.btcPrice
     }
 
+    private var btcAmountFinal: Double {
+        btcAmount * 0.99
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
@@ -53,11 +57,11 @@ struct SellView: View {
                 }
             }
             .padding()
-            .navigationTitle("Sell BTC")
+            .navigationTitle(String(localized: "title_sell_btc", defaultValue: "Sell BTC"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
                 }
             }
         }
@@ -65,10 +69,10 @@ struct SellView: View {
 
     private var amountScreen: some View {
         VStack(spacing: 20) {
-            Text("How much BTC to convert to USD?")
+            Text(String(localized: "headline_how_much_btc", defaultValue: "How much BTC to convert to USD?"))
                 .font(.headline)
 
-            TextField("0.00", text: $amountStr)
+            TextField(String(localized: "placeholder_amount_usd", defaultValue: "0.00"), text: $amountStr)
                 .keyboardType(.decimalPad)
                 .font(.system(size: 36, weight: .bold, design: .rounded))
                 .multilineTextAlignment(.center)
@@ -78,7 +82,7 @@ struct SellView: View {
                             let textWidth = amountStr.size(withAttributes: [
                                 .font: UIFont.rounded(ofSize: 36, weight: .bold)
                             ]).width
-                            Text("$")
+                            Text(String(localized: "label_dollar_sign", defaultValue: "$"))
                                 .font(.system(size: 36, weight: .bold, design: .rounded))
                                 .position(x: geo.size.width / 2 - textWidth / 2 - 10,
                                           y: geo.size.height / 2)
@@ -91,18 +95,20 @@ struct SellView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Text("Available: \(maxSellUSD.usdFormatted) in native BTC")
+            let availableStr = String(localized: "available_native_btc", defaultValue: "Available: ") + maxSellUSD
+                .usdFormatted + " in native BTC"
+            Text(availableStr)
                 .foregroundStyle(.secondary)
 
             if amountUSD > maxSellUSD && amountUSD > 0 {
-                Text("Exceeds available native BTC")
+                Text(String(localized: "error_exceeds_native", defaultValue: "Exceeds available native BTC"))
                     .font(.caption)
                     .foregroundStyle(.red)
             }
 
             Spacer()
 
-            Button("Continue") { step = .confirm }
+            Button(String(localized: "button_continue", defaultValue: "Continue")) { step = .confirm }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .disabled(amountUSD <= 0 || amountUSD > maxSellUSD)
@@ -111,15 +117,28 @@ struct SellView: View {
 
     private var confirmScreen: some View {
         VStack(spacing: 20) {
-            Text("Confirm Sell")
+            Text(String(localized: "title_confirm_sell", defaultValue: "Confirm Sell"))
                 .font(.title2.bold())
 
             VStack(spacing: 12) {
-                confirmRow("Amount", String(format: "$%.2f", amountUSD))
-                confirmRow("Fee (1%)", String(format: "$%.2f", amountUSD * 0.01))
-                confirmRow("BTC Price", appState.btcPrice.usdFormatted)
+                confirmRow(
+                    String(localized: "label_amount", defaultValue: "Amount"),
+                    String(format: "$%.2f", amountUSD)
+                )
+                confirmRow(
+                    String(localized: "label_fee_percent", defaultValue: "Fee (1%)"),
+                    String(format: "$%.2f", amountUSD * 0.01)
+                )
+                confirmRow(
+                    String(localized: "label_btc_price", defaultValue: "BTC Price"),
+                    appState.btcPrice.usdFormatted
+                )
                 Divider()
-                confirmRow("You receive", String(format: "$%.2f USD", amountUSD * 0.99), bold: true)
+                confirmRow(
+                    String(localized: "label_you_receive", defaultValue: "You receive"),
+                    String(format: "$%.2f USD", amountUSD * 0.99),
+                    bold: true
+                )
             }
             .padding()
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
@@ -140,7 +159,7 @@ struct SellView: View {
                     ProgressView()
                         .frame(maxWidth: .infinity)
                 } else {
-                    Text("Sell BTC")
+                    Text(String(localized: "title_sell_btc", defaultValue: "Sell BTC"))
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -162,10 +181,13 @@ struct SellView: View {
                     .font(.system(size: 64))
                     .foregroundStyle(.green)
 
-                Text("Trade Confirmed")
+                Text(String(localized: "status_trade_confirmed", defaultValue: "Trade Confirmed"))
                     .font(.title2.bold())
 
-                Text(String(format: "Sold %.8f BTC for %@", btcAmount, (amountUSD * 0.99).usdFormatted))
+                Text(String(localized: "trade_sold_btc_for", defaultValue: "Sold ") + String(
+                    format: "%.8f",
+                    btcAmountFinal
+                ) + " BTC for " + (amountUSD * 0.99).usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             } else {
@@ -173,22 +195,25 @@ struct SellView: View {
                     .font(.system(size: 64))
                     .foregroundStyle(.orange)
 
-                Text("Trade Pending")
+                Text(String(localized: "status_waiting_lsp", defaultValue: "Trade Pending"))
                     .font(.title2.bold())
 
-                Text(String(format: "Selling %.8f BTC for %@", btcAmount, (amountUSD * 0.99).usdFormatted))
+                Text(String(localized: "trade_selling_btc_for", defaultValue: "Selling ") + String(
+                    format: "%.8f",
+                    btcAmountFinal
+                ) + " BTC for " + (amountUSD * 0.99).usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
                 ProgressView()
                     .padding(.top, 4)
 
-                Text("Waiting for LSP confirmation...")
+                Text(String(localized: "status_waiting_lsp", defaultValue: "Waiting for LSP confirmation..."))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
 
-            Button("Done") { dismiss() }
+            Button(String(localized: "button_done", defaultValue: "Done")) { dismiss() }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
@@ -219,7 +244,10 @@ struct SellView: View {
                 price: price,
                 maxUSD: totalUSD
             ) else {
-                errorMessage = "Trade failed — check amount and try again"
+                errorMessage = String(
+                    localized: "error_trade_failed",
+                    defaultValue: "Trade failed — check amount and try again"
+                )
                 isExecuting = false
                 return
             }

--- a/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/InvoiceScanView.swift
@@ -54,7 +54,7 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
         }
 
         let close = UIButton(type: .system)
-        close.setTitle(String(localized: "Cancel"), for: .normal)
+        close.setTitle(String(localized: "button_cancel", defaultValue: "Cancel"), for: .normal)
         close.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
         close.translatesAutoresizingMaskIntoConstraints = false
         close.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
@@ -87,7 +87,7 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
 
     private func showNoCamera() {
         let label = UILabel()
-        label.text = String(localized: "No camera available. Paste invoice manually.")
+        label.text = String(localized: "label_no_camera", defaultValue: "No camera available. Paste invoice manually.")
         label.textColor = .white
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -113,7 +113,10 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
         ])
 
         let label = UILabel()
-        label.text = String(localized: "Camera access required. Enable in Settings.")
+        label.text = String(
+            localized: "label_camera_denied",
+            defaultValue: "Camera access required. Enable in Settings."
+        )
         label.textColor = .white
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -122,7 +125,7 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
         container.addSubview(label)
 
         let settingsButton = UIButton(type: .system)
-        settingsButton.setTitle(String(localized: "Open Settings"), for: .normal)
+        settingsButton.setTitle(String(localized: "button_open_settings", defaultValue: "Open Settings"), for: .normal)
         settingsButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
         settingsButton.setTitleColor(.systemBlue, for: .normal)
         settingsButton.translatesAutoresizingMaskIntoConstraints = false
@@ -182,7 +185,8 @@ final class InvoiceScannerViewController: UIViewController, AVCaptureMetadataOut
 
         let hint = UILabel()
         hint.text = String(
-            localized: "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
+            localized: "hint_scan_invoice",
+            defaultValue: "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
         )
         hint.textColor = UIColor.white.withAlphaComponent(0.85)
         hint.font = .systemFont(ofSize: 14)

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -86,7 +86,7 @@ struct OnChainSendView: View {
                             systemImage: "checkmark.circle.fill"
                         )
                         .foregroundStyle(.green)
-                        Text(String(localized: "label_txid", defaultValue: "TXID: \(txid)"))
+                        Text(String(localized: "label_txid", defaultValue: "TXID") + ": \(txid)")
                             .font(.caption)
                             .textSelection(.enabled)
                     }

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -24,23 +24,26 @@ struct OnChainSendView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Destination Address") {
-                    TextField("bc1...", text: $address)
+                Section(String(localized: "header_destination_address", defaultValue: "Destination Address")) {
+                    TextField(String(localized: "placeholder_address", defaultValue: "bc1..."), text: $address)
                         .font(.system(.body, design: .monospaced))
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                 }
 
-                Section("Amount") {
+                Section(String(localized: "header_amount", defaultValue: "Amount")) {
                     if sendAll {
-                        Text("All available funds")
+                        Text(String(localized: "label_all_available_funds", defaultValue: "All available funds"))
                             .foregroundStyle(.secondary)
                     } else {
                         HStack {
-                            Text("$")
+                            Text(String(localized: "label_dollar_sign", defaultValue: "$"))
                                 .foregroundStyle(.secondary)
-                            TextField("0.00", text: $amountUSDStr)
-                                .keyboardType(.decimalPad)
+                            TextField(
+                                String(localized: "placeholder_amount_usd", defaultValue: "0.00"),
+                                text: $amountUSDStr
+                            )
+                            .keyboardType(.decimalPad)
                         }
                         if let sats = amountSats, sats > 0 {
                             Text("\(sats.btcSpacedFormatted) BTC")
@@ -48,14 +51,17 @@ struct OnChainSendView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    Toggle("Send All", isOn: $sendAll)
+                    Toggle(String(localized: "toggle_send_all", defaultValue: "Send All"), isOn: $sendAll)
                 }
 
                 if hasReadyChannel {
                     Section {
-                        Text("Funds will be sent via splice-out from your Lightning channel.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Text(String(
+                            localized: "info_splice_out_funds",
+                            defaultValue: "Funds will be sent via splice-out from your Lightning channel."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                 }
 
@@ -66,7 +72,8 @@ struct OnChainSendView: View {
                         if isSending {
                             ProgressView().frame(maxWidth: .infinity)
                         } else {
-                            Text("Send").frame(maxWidth: .infinity)
+                            Text(String(localized: "button_send_payment", defaultValue: "Send"))
+                                .frame(maxWidth: .infinity)
                         }
                     }
                     .disabled(address.isEmpty || (!sendAll && (amountSats ?? 0) == 0) || isSending)
@@ -74,9 +81,12 @@ struct OnChainSendView: View {
 
                 if let txid {
                     Section {
-                        Label("Sent!", systemImage: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("TXID: \(txid)")
+                        Label(
+                            String(localized: "success_sent", defaultValue: "Sent!"),
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .foregroundStyle(.green)
+                        Text(String(localized: "label_txid", defaultValue: "TXID: \(txid)"))
                             .font(.caption)
                             .textSelection(.enabled)
                     }
@@ -84,11 +94,17 @@ struct OnChainSendView: View {
 
                 if spliceSuccess {
                     Section {
-                        Label("Splice-out initiated!", systemImage: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text("Funds will arrive on-chain after confirmation.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Label(
+                            String(localized: "success_splice_out", defaultValue: "Splice-out initiated!"),
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .foregroundStyle(.green)
+                        Text(String(
+                            localized: "info_funds_arrive_onchain",
+                            defaultValue: "Funds will arrive on-chain after confirmation."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                 }
 
@@ -98,11 +114,11 @@ struct OnChainSendView: View {
                     }
                 }
             }
-            .navigationTitle("Send On-Chain")
+            .navigationTitle(String(localized: "title_send_on_chain", defaultValue: "Send On-Chain"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
                 }
             }
         }
@@ -138,7 +154,10 @@ struct OnChainSendView: View {
                     throw NSError(
                         domain: "",
                         code: 0,
-                        userInfo: [NSLocalizedDescriptionKey: "A splice is already in progress — try again shortly"]
+                        userInfo: [NSLocalizedDescriptionKey: String(
+                            localized: "error_splice_in_progress",
+                            defaultValue: "A splice is already in progress — try again shortly"
+                        )]
                     )
                 }
                 try appState.nodeService.spliceOut(

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -43,17 +43,17 @@ struct ReceiveView: View {
 
                 Spacer()
             }
-            .navigationTitle("Receive")
+            .navigationTitle(String(localized: "title_receive", defaultValue: "Receive"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
+                    Button(String(localized: "button_done", defaultValue: "Done")) { dismiss() }
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Button {
                         showOnChain = true
                     } label: {
-                        Label("On-Chain", systemImage: "link")
+                        Label(String(localized: "toolbar_on_chain", defaultValue: "On-Chain"), systemImage: "link")
                     }
                 }
             }
@@ -67,10 +67,10 @@ struct ReceiveView: View {
 
     private var amountInput: some View {
         VStack(spacing: 16) {
-            Text("Amount (USD)")
+            Text(String(localized: "placeholder_amount", defaultValue: "Amount (USD)"))
                 .font(.headline)
 
-            TextField("0.00", text: $amountUSD)
+            TextField(String(localized: "placeholder_amount_usd", defaultValue: "0.00"), text: $amountUSD)
                 .keyboardType(.decimalPad)
                 .font(.system(size: 32, weight: .bold, design: .rounded))
                 .multilineTextAlignment(.center)
@@ -80,7 +80,7 @@ struct ReceiveView: View {
                             let textWidth = amountUSD.size(withAttributes: [
                                 .font: UIFont.rounded(ofSize: 32, weight: .bold)
                             ]).width
-                            Text("$")
+                            Text(String(localized: "label_dollar_sign", defaultValue: "$"))
                                 .font(.system(size: 32, weight: .bold, design: .rounded))
                                 .position(x: geo.size.width / 2 - textWidth / 2 - 10,
                                           y: geo.size.height / 2)
@@ -95,24 +95,29 @@ struct ReceiveView: View {
             }
 
             if !hasChannel {
-                Text("First payment — a channel will be opened automatically via LSP")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
+                Text(String(
+                    localized: "info_first_payment",
+                    defaultValue: "First payment — a channel will be opened automatically via LSP"
+                ))
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
 
-                Text("$\(Int(Constants.maxChannelUSD)) Maximum")
+                Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $") +
+                    "\(Int(Constants.maxChannelUSD))")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
             if !hasChannel && enteredUSDValue > Constants.maxChannelUSD {
-                Text("Amount exceeds $\(Int(Constants.maxChannelUSD)) channel limit")
+                let limitStr = String(localized: "error_exceeds_limit", defaultValue: "Amount exceeds $") + "\(Int(Constants.maxChannelUSD)) channel limit"
+                Text(limitStr)
                     .font(.caption)
                     .foregroundStyle(.red)
             }
 
-            Button("Generate Invoice") {
+            Button(String(localized: "button_generate_invoice", defaultValue: "Generate Invoice")) {
                 createInvoice()
             }
             .buttonStyle(.borderedProminent)
@@ -120,7 +125,7 @@ struct ReceiveView: View {
             .disabled(enteredSats == 0 || (!hasChannel && enteredUSDValue > Constants.maxChannelUSD))
 
             if hasChannel {
-                Button("Any Amount") {
+                Button(String(localized: "button_any_amount", defaultValue: "Any Amount")) {
                     createVariableInvoice()
                 }
                 .buttonStyle(.bordered)
@@ -147,7 +152,7 @@ struct ReceiveView: View {
                         .foregroundStyle(.secondary)
                 }
             } else {
-                Text("Any amount")
+                Text(String(localized: "label_any_amount", defaultValue: "Any amount"))
                     .font(.title3)
                     .foregroundStyle(.secondary)
             }
@@ -175,7 +180,10 @@ struct ReceiveView: View {
                 isCopied = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCopied = false }
             } label: {
-                Label(isCopied ? "Copied" : "Copy Invoice", systemImage: isCopied ? "checkmark" : "doc.on.doc")
+                Label(isCopied
+                    ? String(localized: "button_copied", defaultValue: "Copied")
+                    : String(localized: "button_copy_invoice", defaultValue: "Copy Invoice"),
+                    systemImage: isCopied ? "checkmark" : "doc.on.doc")
             }
             .buttonStyle(.borderedProminent)
         }

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -86,24 +86,32 @@ struct SendView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Invoice, Offer, or Address") {
-                    TextField("Paste invoice, bolt12 offer, or address...", text: $input, axis: .vertical)
-                        .font(.system(.body, design: .monospaced))
-                        .lineLimit(3...6)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
+                Section(String(localized: "header_invoice_address", defaultValue: "Invoice, Offer, or Address")) {
+                    TextField(
+                        String(localized: "placeholder_invoice",
+                               defaultValue: "Paste invoice, bolt12 offer, or address..."),
+                        text: $input,
+                        axis: .vertical
+                    )
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(3...6)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
                 }
 
                 if !input.trimmingCharacters(in: .whitespaces).isEmpty {
                     Section {
                         switch detectedType {
                         case .bolt11:
-                            Label("Bolt11 Invoice", systemImage: "bolt.fill")
-                                .foregroundStyle(.blue)
+                            Label(
+                                String(localized: "label_bolt11", defaultValue: "Bolt11 Invoice"),
+                                systemImage: "bolt.fill"
+                            )
+                            .foregroundStyle(.blue)
                             if let msat = parsedBolt11Msat, msat > 0 {
                                 let sats = msat / 1000
                                 HStack {
-                                    Text("Amount")
+                                    Text(String(localized: "label_amount_row", defaultValue: "Amount"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
                                     VStack(alignment: .trailing, spacing: 2) {
@@ -117,19 +125,22 @@ struct SendView: View {
                                     }
                                 }
                                 HStack {
-                                    Text("Fee")
+                                    Text(String(localized: "label_fee_row", defaultValue: "Fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text("< 1%")
+                                    Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
                             } else if isAmountlessBolt11 {
-                                TextField("Amount (USD)", text: $amountUSDStr)
-                                    .keyboardType(.decimalPad)
+                                TextField(
+                                    String(localized: "placeholder_amount_usd", defaultValue: "Amount (USD)"),
+                                    text: $amountUSDStr
+                                )
+                                .keyboardType(.decimalPad)
                                 if manualAmountMsat > 0 {
                                     HStack {
-                                        Text("Amount")
+                                        Text(String(localized: "label_amount_row", defaultValue: "Amount"))
                                             .foregroundStyle(.secondary)
                                         Spacer()
                                         VStack(alignment: .trailing, spacing: 2) {
@@ -143,24 +154,30 @@ struct SendView: View {
                                         }
                                     }
                                     HStack {
-                                        Text("Fee")
+                                        Text(String(localized: "label_fee_row", defaultValue: "Fee"))
                                             .foregroundStyle(.secondary)
                                         Spacer()
-                                        Text("< 1%")
+                                        Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
                                     }
                                 }
                             }
                         case .bolt12:
-                            Label("Bolt12 Offer", systemImage: "bolt.fill")
-                                .foregroundStyle(.purple)
-                            TextField("Amount (USD)", text: $amountSats)
-                                .keyboardType(.decimalPad)
-                                .autocorrectionDisabled()
+                            Label(
+                                String(localized: "label_bolt12_offer", defaultValue: "Bolt12 Offer"),
+                                systemImage: "bolt.fill"
+                            )
+                            .foregroundStyle(.purple)
+                            TextField(
+                                String(localized: "placeholder_amount_usd", defaultValue: "Amount (USD)"),
+                                text: $amountSats
+                            )
+                            .keyboardType(.decimalPad)
+                            .autocorrectionDisabled()
                             if let usd = displayUSD {
                                 HStack {
-                                    Text("Amount")
+                                    Text(String(localized: "label_amount", defaultValue: "Amount"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
                                     VStack(alignment: .trailing, spacing: 2) {
@@ -172,23 +189,29 @@ struct SendView: View {
                                     }
                                 }
                                 HStack {
-                                    Text("Fee")
+                                    Text(String(localized: "label_fee", defaultValue: "Fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text("< 1%")
+                                    Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
                             }
                         case .onchain:
-                            Label("On-chain Address", systemImage: "link")
-                                .foregroundStyle(.orange)
-                            TextField("Amount (USD)", text: $amountSats)
-                                .keyboardType(.decimalPad)
-                                .autocorrectionDisabled()
+                            Label(
+                                String(localized: "label_on_chain_address", defaultValue: "On-chain Address"),
+                                systemImage: "link"
+                            )
+                            .foregroundStyle(.orange)
+                            TextField(
+                                String(localized: "placeholder_amount_usd", defaultValue: "Amount (USD)"),
+                                text: $amountSats
+                            )
+                            .keyboardType(.decimalPad)
+                            .autocorrectionDisabled()
                             if let usd = displayUSD {
                                 HStack {
-                                    Text("Amount")
+                                    Text(String(localized: "label_amount", defaultValue: "Amount"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
                                     VStack(alignment: .trailing, spacing: 2) {
@@ -200,22 +223,25 @@ struct SendView: View {
                                     }
                                 }
                                 HStack {
-                                    Text("Fee")
+                                    Text(String(localized: "label_network_fee", defaultValue: "Network fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text("Network fee")
+                                    Text(String(localized: "label_network_fee", defaultValue: "Network fee"))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
                             }
                             if appState.nodeService.channels.contains(where: \.isChannelReady) {
-                                Text("Will route via splice-out")
+                                Text(String(localized: "info_splice_out", defaultValue: "Will route via splice-out"))
                                     .font(.caption)
                                     .foregroundStyle(.orange)
                             }
                         case .unknown:
-                            Label("Unrecognized format", systemImage: "questionmark.circle")
-                                .foregroundStyle(.secondary)
+                            Label(
+                                String(localized: "label_unrecognized_format", defaultValue: "Unrecognized format"),
+                                systemImage: "questionmark.circle"
+                            )
+                            .foregroundStyle(.secondary)
                         }
                     }
 
@@ -232,8 +258,11 @@ struct SendView: View {
                 if success {
                     Section {
                         VStack(spacing: 4) {
-                            Label("Payment sent!", systemImage: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
+                            Label(
+                                String(localized: "success_sent", defaultValue: "Payment sent!"),
+                                systemImage: "checkmark.circle.fill"
+                            )
+                            .foregroundStyle(.green)
                             if sentAmountSats > 0 {
                                 let price = appState.btcPrice
                                 if price > 0 {
@@ -259,7 +288,7 @@ struct SendView: View {
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
                         } else {
-                            Text("Send Payment")
+                            Text(String(localized: "button_send_payment", defaultValue: "Send Payment"))
                                 .fontWeight(.semibold)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
@@ -272,11 +301,14 @@ struct SendView: View {
                     .padding(.bottom, 8)
                 }
             }
-            .navigationTitle("Send")
+            .navigationTitle(String(localized: "button_send", defaultValue: "Send"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(success ? "Done" : "Cancel") { dismiss() }
+                    Button(success ? String(localized: "button_done", defaultValue: "Done") : String(
+                        localized: "button_cancel",
+                        defaultValue: "Cancel"
+                    )) { dismiss() }
                 }
                 ToolbarItem(placement: .primaryAction) {
                     HStack(spacing: 16) {
@@ -302,7 +334,10 @@ struct SendView: View {
                        let code = extractQRCode(from: image) {
                         input = code
                     } else {
-                        qrAlertMessage = "Selected image doesn't contain a Lightning invoice or Bitcoin address QR code."
+                        qrAlertMessage = String(
+                            localized: "alert_qr_error",
+                            defaultValue: "Selected image doesn't contain a Lightning invoice or Bitcoin address QR code."
+                        )
                         showQRAlert = true
                     }
                     selectedPhotoItem = nil
@@ -317,8 +352,8 @@ struct SendView: View {
                     onCancel: { showScanner = false }
                 )
             }
-            .alert("No QR Code Found", isPresented: $showQRAlert) {
-                Button("OK", role: .cancel) {}
+            .alert(String(localized: "alert_no_qr", defaultValue: "No QR Code Found"), isPresented: $showQRAlert) {
+                Button(String(localized: "button_ok", defaultValue: "OK"), role: .cancel) {}
             } message: {
                 Text(qrAlertMessage)
             }
@@ -469,7 +504,10 @@ struct SendView: View {
                 sentAmountSats = sats
 
             case .unknown:
-                errorMessage = "Unrecognized payment format"
+                errorMessage = String(
+                    localized: "error_unrecognized_format",
+                    defaultValue: "Unrecognized payment format"
+                )
                 return
             }
 


### PR DESCRIPTION
## Summary

Complete i18n foundation for Stable Channels iOS wallet. All 17 Swift view files now use `String(localized: "key", defaultValue: "...")` for every user-facing string. Added 248 keys to `Localizable.xcstrings` with English translations. Sets the stage for multi-language support across 9 target locales.

## Key Patterns

**String(localized:) pattern:**
```swift
// Before
Text("Send")

// After
Text(String(localized: "button_send_payment", defaultValue: "Send"))
```

**Dynamic values via concatenation:**
```swift
// Before (interpolation inside defaultValue breaks catalog)
Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $\(limit)"))

// After
Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $") + "\(Int(Constants.maxChannelUSD))")
```

**Not localized (dynamic values):**
- `btcSpacedFormatted` — computed property, changes per state
- BTC/USD amounts — computed from wallet state
- Node IDs, TXIDs, pubkeys — technical identifiers
- Numeric interpolation like `"\(index + 1)."`

## Catalog Structure

- `sourceLanguage: "en"` — English is source
- All keys have `"extractionState": "manual"` — Xcode won't auto-extract and create orphan keys
- Each key has English `"localizations": { "en": { "stringUnit": { "state": "translated", "value": "..." } } }`
- No `%` interpolation in `defaultValue:` — use let binding + concatenation instead

## Related

Closes #64