### PR TITLE
ldk node bump: 16eaa6f4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ regtest = []
 
 [dependencies]
 chrono = "0.4"
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "9e0a8124cbe2c00a06fc5c880113213d4b36d8aa" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
 lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "98393b3de3d8aec897e9ab783cb2418da504e204", features = ["std"] }
 bitcoin = "0.32"
 ureq = { version = "2.10.1", features = ["json"] }

--- a/src/bin/lsp_backend.rs
+++ b/src/bin/lsp_backend.rs
@@ -1219,6 +1219,7 @@ impl ServerApp {
                 min_payment_size_msat: MIN_PAYMENT_SIZE_MSAT,
                 max_payment_size_msat: MAX_PAYMENT_SIZE_MSAT,
                 client_trusts_lsp: true,
+                disable_client_reserve: false,
             };
             builder.set_liquidity_provider_lsps2(service_config);
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -253,6 +253,7 @@ pub fn setup_lsp_node(electrsd: &ElectrsD) -> Node {
         min_payment_size_msat: 0,
         max_payment_size_msat: 100_000_000_000,
         client_trusts_lsp: true,
+        disable_client_reserve: false,
     };
     builder.set_liquidity_provider_lsps2(service_config);
 


### PR DESCRIPTION
## Summary

Bumps `ldk-node` from `9e0a8124` to `16eaa6f4`, matching the rev that upstream `lightningdevkit/ldk-server` is on. Unblocks `toneloc/ldk-server` from rebasing onto upstream's gRPC architecture (currently blocked by this crate pinning an older `ldk-node`).

## Change scope

- `Cargo.toml`: the actual rev bump
- `src/bin/lsp_backend.rs` and `tests/common/mod.rs`: both add `disable_client_reserve: false` to a `LSPS2ServiceConfig` literal (new field in the new rev)

The library itself needed no changes. `cargo build --lib` and `cargo test --lib` pass with just the `Cargo.toml` bump alone. The two struct-literal fixes are only needed to keep the rest of the crate (legacy binaries + integration-test harness) buildable.

## Verification

```bash
cargo build                                  # lib + all bins
cargo test --lib                             # 70/70 pass
cargo test --test regtest -- --ignored --test-threads=1   # 11/11 pass
```

## Follow-up

The `src/bin/lsp_backend.rs` fix exists only because the legacy `lsp_backend` and `lsp_frontend` binaries are still in this crate. Both lsp_backend and lsp_frontend could be removed in a separate PR, which would shrink future ldk-node bumps further. Happy to follow up with that.