### PR TITLE
feat(ios): add theme selection feature in settings and update appearance options

### DIFF
--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -1288,7 +1288,7 @@ class AppState {
         }
 
         let feeRateSatVb = fetchFeeRate() ?? 2
-        let feeReserve = feeRateSatVb * 250  // ~250 vbytes for splice tx (170 was too tight at low fees)
+        let feeReserve = feeRateSatVb * 250 // ~250 vbytes for splice tx (170 was too tight at low fees)
         let spendable = balances.spendableOnchainBalanceSats
         guard spendable > feeReserve else {
             statusMessage = "Insufficient on-chain balance"

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1998,6 +1998,17 @@
         }
       }
     },
+    "section_appearance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
     "section_backup" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2594,6 +2605,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Send On-Chain"
+          }
+        }
+      }
+    },
+    "label_theme" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Theme"
+          }
+        }
+      }
+    },
+    "theme_system" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System"
+          }
+        }
+      }
+    },
+    "theme_light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Light"
+          }
+        }
+      }
+    },
+    "theme_dark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dark"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Views/ContentView.swift
+++ b/ios/StableChannels/StableChannels/Views/ContentView.swift
@@ -8,6 +8,16 @@ struct ContentView: View {
     @State private var authInProgress = false
     @State private var hasTriggeredAuth = false
 
+    @AppStorage("user_theme") private var themeSelection: String = "system"
+
+    private var colorScheme: ColorScheme? {
+        switch themeSelection {
+        case "light": return .light
+        case "dark": return .dark
+        default: return nil
+        }
+    }
+
     private var biometricEnabled: Bool {
         UserDefaults.standard.bool(forKey: "biometricAuthEnabled")
     }
@@ -49,6 +59,7 @@ struct ContentView: View {
                     }
             }
         }
+        .preferredColorScheme(colorScheme)
         .onChange(of: scenePhase) { _, newPhase in
             // Lock only on .background. .inactive fires during app switcher and Face ID prompts.
             if newPhase == .background {

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -26,16 +26,6 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             List {
-                // Appearance
-                Section(String(localized: "section_appearance", defaultValue: "Appearance")) {
-                    Picker(String(localized: "label_theme", defaultValue: "Theme"), selection: $themeSelection) {
-                        Text(String(localized: "theme_system", defaultValue: "System")).tag("system")
-                        Text(String(localized: "theme_light", defaultValue: "Light")).tag("light")
-                        Text(String(localized: "theme_dark", defaultValue: "Dark")).tag("dark")
-                    }
-                    .pickerStyle(.segmented)
-                }
-
                 // Node Info
                 Section(String(localized: "section_node", defaultValue: "Node")) {
                     HStack {
@@ -62,6 +52,16 @@ struct SettingsView: View {
                             showNodeId = true
                         }
                     }
+                }
+
+                // Appearance
+                Section(String(localized: "section_appearance", defaultValue: "Appearance")) {
+                    Picker(String(localized: "label_theme", defaultValue: "Theme"), selection: $themeSelection) {
+                        Text(String(localized: "theme_system", defaultValue: "System")).tag("system")
+                        Text(String(localized: "theme_light", defaultValue: "Light")).tag("light")
+                        Text(String(localized: "theme_dark", defaultValue: "Dark")).tag("dark")
+                    }
+                    .pickerStyle(.segmented)
                 }
 
                 // Privacy & Security

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import UserNotifications
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
+    @AppStorage("user_theme") private var themeSelection: String = "system"
     @State private var showCloseChannelAlert = false
     @State private var showNodeId = false
     @State private var copiedField: String?
@@ -13,9 +14,28 @@ struct SettingsView: View {
     @State private var isRestoring = false
     @State private var restoreError: String?
 
+    private func themeButton(_ tag: String, _ label: String) -> some View {
+        Button {
+            themeSelection = tag
+        } label: {
+            Text(label)
+                .font(.caption.bold())
+        }
+    }
+
     var body: some View {
         NavigationStack {
             List {
+                // Appearance
+                Section(String(localized: "section_appearance", defaultValue: "Appearance")) {
+                    Picker(String(localized: "label_theme", defaultValue: "Theme"), selection: $themeSelection) {
+                        Text(String(localized: "theme_system", defaultValue: "System")).tag("system")
+                        Text(String(localized: "theme_light", defaultValue: "Light")).tag("light")
+                        Text(String(localized: "theme_dark", defaultValue: "Dark")).tag("dark")
+                    }
+                    .pickerStyle(.segmented)
+                }
+
                 // Node Info
                 Section(String(localized: "section_node", defaultValue: "Node")) {
                     HStack {


### PR DESCRIPTION
## Summary

Add System/Light/Dark theme toggle in Settings. Users can switch appearance without changing OS-wide setting. Instant reactivity via `@AppStorage` binding.

## Changes

### Files Modified/Added
- `Views/ContentView.swift` -- added `@AppStorage` binding + .preferredColorScheme()
- `Views/Settings/SettingsView.swift` -- added Appearance section with segmented picker
- `Localizable.xcstrings` -- added theme keys

## Screenshots

<img width="200" alt="Auth failed retry" src="https://github.com/user-attachments/assets/1c699dbb-b67f-4158-bc6f-f59256ddb9d6" />

## How It Works

1. `SettingsView` has `@AppStorage("user_theme")` bound to segmented picker
2. User selects → UserDefaults updated instantly
3. `ContentView` reads same `@AppStorage` → `.preferredColorScheme()` updates
4. SwiftUI diffs and re-renders with new color scheme

## Testing Checklist

- [x] Theme persists after kill + relaunch
- [x] All 3 options work (system/light/dark)
- [x] No UI flicker on switch

## Related

Closes #68 