### PR TITLE
fix(android): backfill hourly prices from Kraken for 1M chart

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -134,6 +134,7 @@ class AppState(private val context: Context) : ViewModel() {
 
                 databaseService = DatabaseService(context)
                 launch { databaseService?.seedHistoricalPrices() }
+                launch { backfillHourlyPrices() }
                 tradeService = TradeService(nodeService)
 
                 val auditPath = File(Constants.userDataDir(context), "audit_log.txt").absolutePath
@@ -741,6 +742,20 @@ class AppState(private val context: Context) : ViewModel() {
         val price = priceService.currentPrice.value
         if (price > 0) {
             databaseService?.recordPrice(price, "median")
+        }
+    }
+
+    private suspend fun backfillHourlyPrices() {
+        val db = databaseService ?: return
+        val thirtyDaysAgo = System.currentTimeMillis() / 1000 - 30 * 24 * 3600
+        val since = db.getOldestPriceHistoryTimestamp()?.let { oldest ->
+            if (oldest < thirtyDaysAgo) null else thirtyDaysAgo
+        } ?: thirtyDaysAgo
+        val candles = priceService.fetchKrakenOHLC(since)
+        if (candles.isEmpty()) return
+        val count = db.backfillHourlyPrices(candles)
+        if (count > 0) {
+            AuditService.log("CHART_BACKFILL", mapOf("points" to count))
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -370,6 +370,35 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    fun getOldestPriceHistoryTimestamp(): Long? {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT MIN(timestamp) FROM price_history", null
+        )
+        return cursor.use { if (it.moveToFirst() && !it.isNull(0)) it.getLong(0) else null }
+    }
+
+    fun backfillHourlyPrices(candles: List<Pair<Long, Double>>): Int {
+        val db = writableDatabase
+        var count = 0
+        db.beginTransaction()
+        try {
+            val stmt = db.compileStatement(
+                "INSERT OR IGNORE INTO price_history (price, source, timestamp) VALUES (?, 'kraken_ohlc', ?)"
+            )
+            for ((ts, price) in candles) {
+                stmt.clearBindings()
+                stmt.bindDouble(1, price)
+                stmt.bindLong(2, ts)
+                stmt.executeInsert()
+                count++
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return count
+    }
+
     fun recordDailyPrice(date: String, open: Double, high: Double, low: Double, close: Double, volume: Double?, source: String?) {
         val cv = ContentValues().apply {
             put("date", date)

--- a/android/app/src/main/java/com/stablechannels/app/services/PriceService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/PriceService.kt
@@ -120,6 +120,29 @@ class PriceService {
         }
     }
 
+    suspend fun fetchKrakenOHLC(since: Long? = null): List<Pair<Long, Double>> {
+        val sinceTs = since ?: (System.currentTimeMillis() / 1000 - 30 * 24 * 3600)
+        val url = "https://api.kraken.com/0/public/OHLC?pair=XXBTZUSD&interval=60&since=$sinceTs"
+        return try {
+            val request = Request.Builder().url(url).build()
+            val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+            val body = response.body?.string() ?: return emptyList()
+            val json = JSONObject(body)
+            val result = json.optJSONObject("result") ?: return emptyList()
+            val xxbtzusd = result.optJSONArray("XXBTZUSD") ?: return emptyList()
+            val candles = mutableListOf<Pair<Long, Double>>()
+            for (i in 0 until xxbtzusd.length()) {
+                val candle = xxbtzusd.optJSONArray(i) ?: continue
+                val ts = candle.optLong(0)
+                val close = candle.optString(4).toDoubleOrNull() ?: continue
+                if (ts > 0 && close > 0) candles.add(ts to close)
+            }
+            candles.sortedBy { it.first }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
     companion object {
         fun median(values: List<Double>): Double {
             if (values.isEmpty()) return 0.0

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -108,11 +108,9 @@ fun PriceChart(
         selectedPoint = null
         val cutoffMs = System.currentTimeMillis() - chartPeriod.effectiveDays().toLong() * 86400 * 1000
         val cutoffSec = cutoffMs / 1000
-        val raw = if (chartPeriod.usesHourly) {
-            hourlyPrices.filter { it.timestamp >= cutoffSec }
-        } else {
-            allDailyPrices.filter { it.timestamp >= cutoffSec }
-        }
+        val hourly = hourlyPrices.filter { it.timestamp >= cutoffSec }
+        val daily = allDailyPrices.filter { it.timestamp >= cutoffSec }
+        val raw = if (chartPeriod.usesHourly && hourly.size >= 2) hourly else daily
         // Cap at 120 points — keeps Canvas draw O(n) work proportional
         priceHistory = downsample(raw, 120)
     }


### PR DESCRIPTION
## Summary
  - Added Kraken OHLC API backfill (matching iOS) to fetch hourly BTC price data for the last 30 days
  - 1M chart now shows actual price data instead of "Collecting price data..."
  - Falls back to daily data when hourly data is insufficient

  ## Changes
  - **PriceService.kt**: Added `fetchKrakenOHLC()` — fetches hourly BTC/USD candles from Kraken API
  - **DatabaseService.kt**: Added `getOldestPriceHistoryTimestamp()` and `backfillHourlyPrices()` — stores Kraken data in price_history table
  - **AppState.kt**: Added `backfillHourlyPrices()` called at startup after `seedHistoricalPrices()`
  - **PriceChart.kt**: Falls back to daily data when hourly data has fewer than 2 points

  ## Test 
  - [x] 1M chart shows correct data