### PR TITLE
feat(ios): Settings Tree Navigation

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -21,6 +21,15 @@
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
 		49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */; };
+		49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */; };
+		49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */; };
+		49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */; };
+		49F0B0E12FC0EF3A003A3B89 /* NotificationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */; };
+		49F0B0E22FC0EF3A003A3B89 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D92FC0EF3A003A3B89 /* Colors.swift */; };
+		49F0B0E32FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DC2FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift */; };
+		49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */; };
+		49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */; };
+		49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */; };
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
 		62340228B969D280C66FD733 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC40949E35E9317ACA30E35 /* AppState.swift */; };
@@ -94,6 +103,15 @@
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccessSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0D92FC0EF3A003A3B89 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsView.swift; sourceTree = "<group>"; };
+		49F0B0DC2FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushConnectivitySettingsView.swift; sourceTree = "<group>"; };
+		49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StablePositionView.swift; sourceTree = "<group>"; };
 		4F10632049E3C904E518EDD2 /* TradeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeDetailView.swift; sourceTree = "<group>"; };
 		4F22F6639A59D4B86A959586 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		61BB0D1D623E0794FC1ED6ED /* NodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeService.swift; sourceTree = "<group>"; };
@@ -221,6 +239,15 @@
 		9EB6CDA4F614F973AF602691 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */,
+				49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */,
+				49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */,
+				49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */,
+				49F0B0D92FC0EF3A003A3B89 /* Colors.swift */,
+				49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */,
+				49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */,
+				49F0B0DC2FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift */,
+				49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */,
 				49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */,
 				7DB261201C1C656BAAED5283 /* SettingsView.swift */,
 			);
@@ -454,6 +481,15 @@
 				B58FDE639A431D2000E0F86D /* StableChannel.swift in Sources */,
 				49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */,
 				06C3B1697681F176DD44C146 /* StableChannelsApp.swift in Sources */,
+				49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */,
+				49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */,
+				49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */,
+				49F0B0E12FC0EF3A003A3B89 /* NotificationsSettingsView.swift in Sources */,
+				49F0B0E22FC0EF3A003A3B89 /* Colors.swift in Sources */,
+				49F0B0E32FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift in Sources */,
+				49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */,
+				49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */,
+				49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */,
 				CF42CAD5BA55B3F759B62E22 /* Trade.swift in Sources */,
 				55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */,
 				6929CC2C37EEDC6219317621 /* TradeService.swift in Sources */,

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -20,6 +20,9 @@
         }
       }
     },
+    "Active" : {
+
+    },
     "alert_close_channel_cancel" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -96,9 +99,6 @@
           }
         }
       }
-    },
-    "App Access" : {
-
     },
     "app_name" : {
       "extractionState" : "manual",
@@ -309,6 +309,17 @@
         }
       }
     },
+    "button_copy_anyway" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy Anyway"
+          }
+        }
+      }
+    },
     "button_copy_invoice" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -338,6 +349,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Done"
+          }
+        }
+      }
+    },
+    "button_enable_in_settings" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable in Settings"
           }
         }
       }
@@ -481,6 +503,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Swap"
+          }
+        }
+      }
+    },
+    "button_view_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Seed Words"
           }
         }
       }
@@ -738,6 +771,17 @@
         }
       }
     },
+    "error_restore_failed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore failed: "
+          }
+        }
+      }
+    },
     "error_seed_word_count" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -936,6 +980,31 @@
         }
       }
     },
+    "Inactive" : {
+
+    },
+    "info_backup_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Write these words down and store them safely. Anyone with these words can access your funds."
+          }
+        }
+      }
+    },
+    "info_device_token" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Used to deliver push notifications to this device."
+          }
+        }
+      }
+    },
     "info_fee_approx" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -969,6 +1038,28 @@
         }
       }
     },
+    "info_no_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No channel open yet."
+          }
+        }
+      }
+    },
+    "info_node_id" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your node's public key. Share this to receive Lightning payments."
+          }
+        }
+      }
+    },
     "info_notifications_needed" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -987,6 +1078,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trade pending — check back soon"
+          }
+        }
+      }
+    },
+    "info_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your device maintains a persistent connection to receive incoming payments and stability updates."
+          }
+        }
+      }
+    },
+    "info_push_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Background payments and stability updates"
+          }
+        }
+      }
+    },
+    "info_restore" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore will stop your current node and start fresh."
           }
         }
       }
@@ -1053,6 +1177,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Note: Funds require on-chain confirmation after splice completes."
+          }
+        }
+      }
+    },
+    "info_theme_setting" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System uses your device's appearance setting."
           }
         }
       }
@@ -1200,6 +1335,17 @@
         }
       }
     },
+    "label_background_service" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Background Service"
+          }
+        }
+      }
+    },
     "label_backing_sats" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1288,6 +1434,17 @@
         }
       }
     },
+    "label_build" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Build"
+          }
+        }
+      }
+    },
     "label_camera_denied" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1310,6 +1467,17 @@
         }
       }
     },
+    "label_channel_info" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel Info"
+          }
+        }
+      }
+    },
     "label_confirmations" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1317,6 +1485,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Confirmations"
+          }
+        }
+      }
+    },
+    "label_connection" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection"
           }
         }
       }
@@ -1416,6 +1595,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Expected USD"
+          }
+        }
+      }
+    },
+    "label_explorer" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Explorer"
           }
         }
       }
@@ -1541,6 +1731,39 @@
         }
       }
     },
+    "label_node_identity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node Identity"
+          }
+        }
+      }
+    },
+    "label_node_status" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node Status"
+          }
+        }
+      }
+    },
+    "label_none" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "None"
+          }
+        }
+      }
+    },
     "label_notifications" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1607,6 +1830,17 @@
         }
       }
     },
+    "label_push_token" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Push Token"
+          }
+        }
+      }
+    },
     "label_sats_btc" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1625,6 +1859,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Status"
+          }
+        }
+      }
+    },
+    "label_theme" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Theme"
           }
         }
       }
@@ -1717,6 +1962,94 @@
         }
       }
     },
+    "link_about" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "About"
+          }
+        }
+      }
+    },
+    "link_app_access" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Access"
+          }
+        }
+      }
+    },
+    "link_appearance" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
+    "link_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
+          }
+        }
+      }
+    },
+    "link_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel"
+          }
+        }
+      }
+    },
+    "link_node" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node"
+          }
+        }
+      }
+    },
+    "link_notifications" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
+    "link_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Push Connectivity"
+          }
+        }
+      }
+    },
     "link_send_on_chain" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1724,6 +2057,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Send On-Chain"
+          }
+        }
+      }
+    },
+    "link_stable_position" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Position"
           }
         }
       }
@@ -1935,7 +2279,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "0.00"
+            "value" : "Amount (USD)"
           }
         }
       }
@@ -1998,6 +2342,17 @@
         }
       }
     },
+    "section_app_info" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Info"
+          }
+        }
+      }
+    },
     "section_appearance" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2020,6 +2375,17 @@
         }
       }
     },
+    "section_backup_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
+          }
+        }
+      }
+    },
     "section_channel" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2027,6 +2393,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Channel"
+          }
+        }
+      }
+    },
+    "section_custody" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custody Model"
           }
         }
       }
@@ -2042,6 +2419,17 @@
         }
       }
     },
+    "section_network" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Network"
+          }
+        }
+      }
+    },
     "section_node" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2049,6 +2437,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Node"
+          }
+        }
+      }
+    },
+    "section_node_network" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node & Network"
           }
         }
       }
@@ -2086,6 +2485,17 @@
         }
       }
     },
+    "section_preferences" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferences"
+          }
+        }
+      }
+    },
     "section_privacy_security" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2093,6 +2503,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Privacy & Security"
+          }
+        }
+      }
+    },
+    "section_restore" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore"
+          }
+        }
+      }
+    },
+    "section_seed_phrase" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Seed Phrase"
           }
         }
       }
@@ -2115,6 +2547,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trade Details"
+          }
+        }
+      }
+    },
+    "section_wallet" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Wallet"
           }
         }
       }
@@ -2441,8 +2884,52 @@
         }
       }
     },
+    "theme_dark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dark"
+          }
+        }
+      }
+    },
+    "theme_light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Light"
+          }
+        }
+      }
+    },
+    "theme_system" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System"
+          }
+        }
+      }
+    },
     "Time" : {
 
+    },
+    "title_about" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "About"
+          }
+        }
+      }
     },
     "title_app_access" : {
       "extractionState" : "manual",
@@ -2451,6 +2938,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "App Access"
+          }
+        }
+      }
+    },
+    "title_appearance" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
+    "title_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
           }
         }
       }
@@ -2473,6 +2982,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "title_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel"
           }
         }
       }
@@ -2532,6 +3052,28 @@
         }
       }
     },
+    "title_node" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node"
+          }
+        }
+      }
+    },
+    "title_notifications" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
     "title_on_chain_receive" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2550,6 +3092,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Payment Detail"
+          }
+        }
+      }
+    },
+    "title_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Push Connectivity"
           }
         }
       }
@@ -2609,50 +3162,6 @@
         }
       }
     },
-    "label_theme" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Theme"
-          }
-        }
-      }
-    },
-    "theme_system" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "System"
-          }
-        }
-      }
-    },
-    "theme_light" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Light"
-          }
-        }
-      }
-    },
-    "theme_dark" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dark"
-          }
-        }
-      }
-    },
     "title_settings" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2660,6 +3169,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Settings"
+          }
+        }
+      }
+    },
+    "title_stable_position" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Position"
           }
         }
       }
@@ -2781,6 +3301,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "View on Explorer"
+          }
+        }
+      }
+    },
+    "warning_copy_seed_message" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clipboard is shared with other apps. Consider writing down your seed instead."
+          }
+        }
+      }
+    },
+    "warning_copy_seed_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy Seed Words?"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -994,17 +994,6 @@
         }
       }
     },
-    "info_device_token" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Used to deliver push notifications to this device."
-          }
-        }
-      }
-    },
     "info_fee_approx" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1132,7 +1121,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Self-custodial — you control your funds"
+            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
           }
         }
       }
@@ -1826,17 +1815,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Payment ID"
-          }
-        }
-      }
-    },
-    "label_push_token" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Push Token"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Views/Settings/AboutSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/AboutSettingsView.swift
@@ -46,7 +46,7 @@ struct AboutSettingsView: View {
 
                 Text(String(
                     localized: "info_self_custody",
-                    defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
+                    defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
                 ))
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/ios/StableChannels/StableChannels/Views/Settings/AboutSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/AboutSettingsView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct AboutSettingsView: View {
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Text(String(localized: "label_version", defaultValue: "Version"))
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text(String(localized: "label_build", defaultValue: "Build"))
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—")
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text(String(localized: "section_app_info", defaultValue: "App Info"))
+            }
+
+            Section {
+                HStack {
+                    Text(String(localized: "label_network", defaultValue: "Network"))
+                    Spacer()
+                    Text(Constants.defaultNetwork)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text(String(localized: "section_network", defaultValue: "Network"))
+            }
+
+            Section {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(String(localized: "label_custody", defaultValue: "Custody"))
+                            Spacer()
+                            Text(String(localized: "custody_self", defaultValue: "Self-custodial"))
+                                .foregroundStyle(.green)
+                                .fontWeight(.medium)
+                        }
+                    }
+                }
+
+                Text(String(
+                    localized: "info_self_custody",
+                    defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } header: {
+                Text(String(localized: "section_custody", defaultValue: "Custody Model"))
+            }
+        }
+        .navigationTitle(String(localized: "title_about", defaultValue: "About"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/AppearanceSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/AppearanceSettingsView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct AppearanceSettingsView: View {
+    @Binding var themeSelection: String
+
+    private let primaryColor = Color(red: 0/255, green: 163/255, blue: 224/255)
+
+    var body: some View {
+        List {
+            Section {
+                Picker(String(localized: "label_theme", defaultValue: "Theme"), selection: $themeSelection) {
+                    HStack {
+                        Image(systemName: "circle.lefthalf.filled")
+                        Text(String(localized: "theme_system", defaultValue: "System"))
+                    }
+                    .tag("system")
+
+                    HStack {
+                        Image(systemName: "sun.max.fill")
+                        Text(String(localized: "theme_light", defaultValue: "Light"))
+                    }
+                    .tag("light")
+
+                    HStack {
+                        Image(systemName: "moon.fill")
+                        Text(String(localized: "theme_dark", defaultValue: "Dark"))
+                    }
+                    .tag("dark")
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            } header: {
+                Text(String(localized: "section_appearance", defaultValue: "Appearance"))
+            } footer: {
+                Text(String(
+                    localized: "info_theme_setting",
+                    defaultValue: "System uses your device's appearance setting."
+                ))
+            }
+        }
+        .navigationTitle(String(localized: "title_appearance", defaultValue: "Appearance"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/BackupSettingsView.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+struct BackupSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var showSeedWords = false
+    @State private var showRestore = false
+    @State private var restoreMnemonic = ""
+    @State private var isRestoring = false
+    @State private var restoreError: String?
+    @State private var copiedSeed = false
+    @State private var showCopyWarning = false
+
+    var body: some View {
+        List {
+            // View Seed
+            Section {
+                Button {
+                    showSeedWords.toggle()
+                } label: {
+                    HStack {
+                        Image(systemName: showSeedWords ? "eye.slash.fill" : "eye.fill")
+                            .foregroundStyle(Color.stablePrimary)
+                        Text(showSeedWords
+                            ? String(localized: "button_hide_seed", defaultValue: "Hide Seed Words")
+                            : String(localized: "button_view_seed", defaultValue: "View Seed Words"))
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .foregroundStyle(.primary)
+            } header: {
+                Text(String(localized: "section_backup_seed", defaultValue: "Backup"))
+            } footer: {
+                Text(String(
+                    localized: "info_backup_seed",
+                    defaultValue: "Write these words down and store them safely. Anyone with these words can access your funds."
+                ))
+            }
+
+            // Seed Words Display
+            if showSeedWords, let words = appState.nodeService.savedMnemonic, !words.isEmpty {
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text(String(localized: "warning_seed", defaultValue: "Never share your seed words"))
+                                .font(.caption.bold())
+                                .foregroundStyle(.orange)
+                        }
+
+                        let wordList = words.split(separator: " ").map(String.init)
+                        LazyVGrid(columns: [
+                            GridItem(.flexible()),
+                            GridItem(.flexible()),
+                            GridItem(.flexible())
+                        ], spacing: 6) {
+                            ForEach(Array(wordList.enumerated()), id: \.offset) { index, word in
+                                HStack(spacing: 4) {
+                                    Text("\(index + 1).")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 18, alignment: .trailing)
+                                    Text(word)
+                                        .font(.system(.caption, design: .monospaced))
+                                }
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 6)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            }
+                        }
+
+                        Button {
+                            showCopyWarning = true
+                        } label: {
+                            HStack {
+                                Image(systemName: copiedSeed ? "checkmark" : "doc.on.doc")
+                                Text(copiedSeed
+                                    ? String(localized: "button_copied", defaultValue: "Copied")
+                                    : String(localized: "button_copy_seed", defaultValue: "Copy to Clipboard"))
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Color(uiColor: .secondarySystemGroupedBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
+                        .disabled(copiedSeed)
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text(String(localized: "section_seed_phrase", defaultValue: "Seed Phrase"))
+                }
+            }
+
+            // Restore
+            Section {
+                Button {
+                    showRestore = true
+                } label: {
+                    HStack {
+                        Image(systemName: "arrow.uturn.backward.circle.fill")
+                            .foregroundStyle(.orange)
+                        Text(String(localized: "button_restore_seed", defaultValue: "Restore from Seed"))
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .foregroundStyle(.primary)
+            } header: {
+                Text(String(localized: "section_restore", defaultValue: "Restore"))
+            } footer: {
+                Text(String(
+                    localized: "info_restore",
+                    defaultValue: "Restore will stop your current node and start fresh."
+                ))
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "title_backup", defaultValue: "Backup"))
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showRestore) {
+            restoreSheet
+        }
+        .confirmationDialog(
+            String(localized: "warning_copy_seed_title", defaultValue: "Copy Seed Words?"),
+            isPresented: $showCopyWarning,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "button_copy_anyway", defaultValue: "Copy Anyway")) {
+                copySeedToClipboard()
+            }
+            Button(String(localized: "button_cancel", defaultValue: "Cancel"), role: .cancel) { }
+        } message: {
+            Text(String(
+                localized: "warning_copy_seed_message",
+                defaultValue: "Clipboard is shared with other apps. Consider writing down your seed instead."
+            ))
+        }
+    }
+
+    private func copySeedToClipboard() {
+        guard let words = appState.nodeService.savedMnemonic else { return }
+        UIPasteboard.general.string = words
+        withAnimation { copiedSeed = true }
+
+        // Clear clipboard after 60 seconds for security
+        DispatchQueue.main.asyncAfter(deadline: .now() + 60) {
+            if UIPasteboard.general.string == words {
+                UIPasteboard.general.string = ""
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { copiedSeed = false }
+        }
+    }
+
+    private var restoreSheet: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Image(systemName: "arrow.uturn.backward.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.orange)
+                Text(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
+                    .font(.title2.bold())
+                Text(String(
+                    localized: "instruction_restore",
+                    defaultValue: "Enter your 12 or 24-word seed phrase."
+                ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+                TextField(
+                    String(localized: "placeholder_seed", defaultValue: "word1 word2 word3 ..."),
+                    text: $restoreMnemonic,
+                    axis: .vertical
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .lineLimit(3...5)
+                .font(.system(.body, design: .monospaced))
+                .padding()
+                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .padding(.horizontal)
+
+                if let error = restoreError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                Button {
+                    Task { await restoreWallet() }
+                } label: {
+                    if isRestoring {
+                        ProgressView()
+                    } else {
+                        Text(String(localized: "button_restore", defaultValue: "Restore"))
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(isRestoring || restoreMnemonic.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                Spacer()
+            }
+            .padding()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
+                        showRestore = false
+                        restoreMnemonic = ""
+                        restoreError = nil
+                    }
+                }
+            }
+        }
+    }
+
+    private func restoreWallet() async {
+        isRestoring = true
+        restoreError = nil
+
+        let input = restoreMnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
+        let wordCount = input.split(separator: " ").count
+        guard wordCount == 12 || wordCount == 24 else {
+            isRestoring = false
+            restoreError = String(
+                localized: "error_seed_word_count",
+                defaultValue: "Seed phrase must be 12 or 24 words"
+            )
+            return
+        }
+
+        // Validate mnemonic format before stopping node
+        do {
+            // Attempt initialization in isolated flow - if fails, node keeps running
+            try await appState.nodeService.start(
+                network: .bitcoin,
+                esploraURL: appState.chainURL,
+                mnemonic: input
+            )
+            await MainActor.run {
+                showRestore = false
+                restoreMnemonic = ""
+                appState.refreshBalances()
+                isRestoring = false
+            }
+        } catch {
+            // Node start failed - old state preserved, user notified
+            await MainActor.run {
+                restoreError = String(
+                    localized: "error_restore_failed",
+                    defaultValue: "Restore failed: "
+                ) + error.localizedDescription
+                isRestoring = false
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import UIKit
+
+struct ChannelSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var showCloseChannelAlert = false
+
+    var body: some View {
+        List {
+            if let channel = appState.nodeService.channels.first {
+                Section {
+                    HStack {
+                        Text(String(localized: "label_capacity", defaultValue: "Capacity"))
+                        Spacer()
+                        Text(channel.channelValueSats.satsFormatted)
+                    }
+                    HStack {
+                        Text(String(localized: "label_status", defaultValue: "Status"))
+                        Spacer()
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(channel.isChannelReady ? .green : .orange)
+                                .frame(width: 8, height: 8)
+                            Text(channel.isChannelReady
+                                ? String(localized: "channel_status_ready", defaultValue: "Ready")
+                                : String(localized: "channel_status_pending", defaultValue: "Pending"))
+                        }
+                    }
+                    HStack {
+                        Text(String(localized: "label_outbound", defaultValue: "Outbound"))
+                        Spacer()
+                        Text((channel.outboundCapacityMsat / 1000).satsFormatted)
+                    }
+                    HStack {
+                        Text(String(localized: "label_inbound", defaultValue: "Inbound"))
+                        Spacer()
+                        Text(((channel.inboundCapacityMsat) / 1000).satsFormatted)
+                    }
+
+                    if let txid = appState.fundingTxid, !txid.isEmpty {
+                        HStack {
+                            Text(String(localized: "label_funding_tx", defaultValue: "Funding Tx"))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(String(txid.prefix(8)) + "..." + String(txid.suffix(8)))
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                        if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                            Link(destination: url) {
+                                HStack(spacing: 4) {
+                                    Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
+                                    Image(systemName: "arrow.up.right.square")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.blue)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    Button(
+                        String(localized: "button_close_channel", defaultValue: "Close Channel"),
+                        role: .destructive
+                    ) {
+                        showCloseChannelAlert = true
+                    }
+                }
+            } else {
+                Section {
+                    Text(String(
+                        localized: "info_no_channel",
+                        defaultValue: "No channel open yet."
+                    ))
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle(String(localized: "title_channel", defaultValue: "Channel"))
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(
+            String(localized: "alert_close_channel_title", defaultValue: "Close Channel?"),
+            isPresented: $showCloseChannelAlert
+        ) {
+            Button(String(localized: "alert_close_channel_cancel", defaultValue: "Cancel"), role: .cancel) { }
+            Button(String(localized: "alert_close_channel_confirm", defaultValue: "Close"), role: .destructive) {
+                closeChannel()
+            }
+        } message: {
+            Text(String(
+                localized: "alert_close_channel_message",
+                defaultValue: "This will cooperatively close the channel and sweep funds on-chain."
+            ))
+        }
+    }
+
+    private func closeChannel() {
+        guard let channel = appState.nodeService.channels.first else { return }
+        appState.isChannelClosing = true
+        try? appState.nodeService.closeChannel(
+            userChannelId: channel.userChannelId,
+            counterpartyNodeId: channel.counterpartyNodeId
+        )
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/Colors.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/Colors.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+extension Color {
+    static let stablePrimary = Color(red: 0/255, green: 163/255, blue: 224/255)
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/NodeSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/NodeSettingsView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct NodeSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var showNodeId = false
+    @State private var copiedNodeId = false
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "label_status", defaultValue: "Status"))
+                            .font(.subheadline)
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(appState.nodeService.isRunning ? .green : .red)
+                                .frame(width: 8, height: 8)
+                            Text(appState.nodeService.isRunning
+                                ? String(localized: "status_running", defaultValue: "Running")
+                                : String(localized: "status_stopped", defaultValue: "Stopped"))
+                                .font(.caption)
+                                .foregroundStyle(appState.nodeService.isRunning ? .green : .red)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: appState.nodeService.isRunning ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(appState.nodeService.isRunning ? .green : .red)
+                }
+            } header: {
+                Text(String(localized: "label_node_status", defaultValue: "Node Status"))
+            }
+
+            Section {
+                if showNodeId {
+                    nodeIdRow
+                } else {
+                    Button {
+                        showNodeId = true
+                    } label: {
+                        HStack {
+                            Text(String(localized: "button_show_node_id", defaultValue: "Show Node ID"))
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text(String(localized: "label_node_identity", defaultValue: "Node Identity"))
+            } footer: {
+                Text(String(
+                    localized: "info_node_id",
+                    defaultValue: "Your node's public key. Share this to receive Lightning payments."
+                ))
+            }
+
+            Section {
+                HStack {
+                    Text(String(localized: "label_network", defaultValue: "Network"))
+                    Spacer()
+                    Text(Constants.defaultNetwork)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text(String(localized: "label_explorer", defaultValue: "Explorer"))
+                    Spacer()
+                    Text(String(appState.chainURL.replacingOccurrences(of: "https://", with: "").prefix(20)))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text(String(localized: "label_connection", defaultValue: "Connection"))
+            }
+        }
+        .navigationTitle(String(localized: "title_node", defaultValue: "Node"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var nodeIdRow: some View {
+        Button {
+            UIPasteboard.general.string = appState.nodeService.nodeId
+            withAnimation { copiedNodeId = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                withAnimation { copiedNodeId = false }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(String(localized: "label_node_id", defaultValue: "Node ID"))
+                        .font(.subheadline)
+                    Spacer()
+                    if copiedNodeId {
+                        Label(String(localized: "button_copied", defaultValue: "Copied"), systemImage: "checkmark")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                            .transition(.scale.combined(with: .opacity))
+                    } else {
+                        Image(systemName: "doc.on.doc")
+                            .font(.caption)
+                            .foregroundStyle(Color.stablePrimary)
+                    }
+                }
+                Text(appState.nodeService.nodeId)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/NotificationsSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/NotificationsSettingsView.swift
@@ -45,35 +45,6 @@ struct NotificationsSettingsView: View {
                     ))
                 }
             }
-
-            if let token = UserDefaults.standard.string(forKey: "apns_device_token") {
-                Section {
-                    Button {
-                        UIPasteboard.general.string = token
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(String(localized: "label_device_token", defaultValue: "Device Token"))
-                                    .font(.subheadline)
-                                Text(String(token.prefix(16)) + "...")
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Image(systemName: "doc.on.doc")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                } header: {
-                    Text(String(localized: "label_push_token", defaultValue: "Push Token"))
-                } footer: {
-                    Text(String(
-                        localized: "info_device_token",
-                        defaultValue: "Used to deliver push notifications to this device."
-                    ))
-                }
-            }
         }
         .navigationTitle(String(localized: "title_notifications", defaultValue: "Notifications"))
         .navigationBarTitleDisplayMode(.inline)

--- a/ios/StableChannels/StableChannels/Views/Settings/NotificationsSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/NotificationsSettingsView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import UIKit
+
+struct NotificationsSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @Binding var notificationsEnabled: Bool
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Text(String(localized: "label_notifications", defaultValue: "Notifications"))
+                    Spacer()
+                    if notificationsEnabled {
+                        Text(String(localized: "notifications_enabled", defaultValue: "Enabled"))
+                            .foregroundStyle(.green)
+                    } else {
+                        Text(String(localized: "notifications_disabled", defaultValue: "Disabled"))
+                            .foregroundStyle(.red)
+                    }
+                }
+            } header: {
+                Text(String(localized: "label_status", defaultValue: "Status"))
+            }
+
+            if !notificationsEnabled {
+                Section {
+                    Button {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: "gear")
+                            Text(String(localized: "button_enable_in_settings", defaultValue: "Enable in Settings"))
+                            Spacer()
+                            Image(systemName: "arrow.up.right")
+                                .font(.caption)
+                        }
+                    }
+                } footer: {
+                    Text(String(
+                        localized: "info_notifications_needed",
+                        defaultValue: "Notifications are required to receive stability payments while the app is closed."
+                    ))
+                }
+            }
+
+            if let token = UserDefaults.standard.string(forKey: "apns_device_token") {
+                Section {
+                    Button {
+                        UIPasteboard.general.string = token
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(String(localized: "label_device_token", defaultValue: "Device Token"))
+                                    .font(.subheadline)
+                                Text(String(token.prefix(16)) + "...")
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "doc.on.doc")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } header: {
+                    Text(String(localized: "label_push_token", defaultValue: "Push Token"))
+                } footer: {
+                    Text(String(
+                        localized: "info_device_token",
+                        defaultValue: "Used to deliver push notifications to this device."
+                    ))
+                }
+            }
+        }
+        .navigationTitle(String(localized: "title_notifications", defaultValue: "Notifications"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            checkNotificationStatus()
+        }
+    }
+
+    private func checkNotificationStatus() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                notificationsEnabled = settings.authorizationStatus == .authorized
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/PushConnectivitySettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/PushConnectivitySettingsView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct PushConnectivitySettingsView: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(String(localized: "label_node_status", defaultValue: "Node Status"))
+                            .font(.subheadline)
+                        Text(String(
+                            localized: "info_push_description",
+                            defaultValue: "Background payments and stability updates"
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if appState.nodeService.isRunning {
+                        Label("Active", systemImage: "bolt.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    } else {
+                        Label("Inactive", systemImage: "bolt.slash")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text(String(localized: "label_background_service", defaultValue: "Background Service"))
+            }
+
+            Section {
+                HStack {
+                    Text(String(localized: "label_counterparty", defaultValue: "Counterparty"))
+                    Spacer()
+                    if !appState.stableChannel.counterparty.isEmpty {
+                        Text(String(appState.stableChannel.counterparty.prefix(8)) + "...")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(String(localized: "label_none", defaultValue: "None"))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text(String(localized: "label_channel_info", defaultValue: "Channel Info"))
+            } footer: {
+                Text(String(
+                    localized: "info_push_connectivity",
+                    defaultValue: "Your device maintains a persistent connection to receive incoming payments and stability updates."
+                ))
+            }
+        }
+        .navigationTitle(String(localized: "title_push_connectivity", defaultValue: "Push Connectivity"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -4,304 +4,146 @@ import UserNotifications
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
     @AppStorage("user_theme") private var themeSelection: String = "system"
-    @State private var showCloseChannelAlert = false
-    @State private var showNodeId = false
-    @State private var copiedField: String?
     @State private var notificationsEnabled = true
-    @State private var showSeedWords = false
-    @State private var showRestore = false
-    @State private var restoreMnemonic = ""
-    @State private var isRestoring = false
-    @State private var restoreError: String?
-
-    private func themeButton(_ tag: String, _ label: String) -> some View {
-        Button {
-            themeSelection = tag
-        } label: {
-            Text(label)
-                .font(.caption.bold())
-        }
-    }
 
     var body: some View {
         NavigationStack {
             List {
-                // Node Info
-                Section(String(localized: "section_node", defaultValue: "Node")) {
-                    HStack {
-                        Text(String(localized: "label_status", defaultValue: "Status"))
-                        Spacer()
-                        HStack(spacing: 4) {
-                            Circle()
-                                .fill(appState.nodeService.isRunning ? .green : .red)
-                                .frame(width: 8, height: 8)
-                            Text(appState.nodeService.isRunning
-                                ? String(localized: "status_running", defaultValue: "Running")
-                                : String(localized: "status_stopped", defaultValue: "Stopped"))
-                                .foregroundStyle(appState.nodeService.isRunning ? .green : .red)
-                        }
-                    }
+                // MARK: - Wallet
 
-                    if showNodeId {
-                        copyableRow(
-                            String(localized: "label_node_id", defaultValue: "Node ID"),
-                            appState.nodeService.nodeId
+                Section {
+                    NavigationLink {
+                        StablePositionView()
+                    } label: {
+                        rowLabel(
+                            icon: "banknote.fill",
+                            color: .green,
+                            text: String(localized: "link_stable_position", defaultValue: "Stable Position")
                         )
-                    } else {
-                        Button(String(localized: "button_show_node_id", defaultValue: "Show Node ID")) {
-                            showNodeId = true
-                        }
                     }
-                }
-
-                // Appearance
-                Section(String(localized: "section_appearance", defaultValue: "Appearance")) {
-                    Picker(String(localized: "label_theme", defaultValue: "Theme"), selection: $themeSelection) {
-                        Text(String(localized: "theme_system", defaultValue: "System")).tag("system")
-                        Text(String(localized: "theme_light", defaultValue: "Light")).tag("light")
-                        Text(String(localized: "theme_dark", defaultValue: "Dark")).tag("dark")
+                    NavigationLink {
+                        ChannelSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "arrow.left.arrow.right.circle.fill",
+                            color: Color.stablePrimary,
+                            text: String(localized: "link_channel", defaultValue: "Channel")
+                        )
                     }
-                    .pickerStyle(.segmented)
-                }
-
-                // Privacy & Security
-                Section(String(localized: "section_privacy_security", defaultValue: "Privacy & Security")) {
-                    NavigationLink("App Access") {
-                        AppAccessSettingsView()
+                    NavigationLink {
+                        BackupSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "lock.doc.fill",
+                            color: .orange,
+                            text: String(localized: "link_backup", defaultValue: "Backup")
+                        )
                     }
-                }
-
-                // Channel Info
-                if let channel = appState.nodeService.channels.first {
-                    Section(String(localized: "section_channel", defaultValue: "Channel")) {
-                        HStack {
-                            Text(String(localized: "label_capacity", defaultValue: "Capacity"))
-                            Spacer()
-                            Text(channel.channelValueSats.satsFormatted)
-                        }
-                        HStack {
-                            Text(String(localized: "label_status", defaultValue: "Status"))
-                            Spacer()
-                            HStack(spacing: 4) {
-                                Circle()
-                                    .fill(channel.isChannelReady ? .green : .orange)
-                                    .frame(width: 8, height: 8)
-                                Text(channel.isChannelReady
-                                    ? String(localized: "channel_status_ready", defaultValue: "Ready")
-                                    : String(localized: "channel_status_pending", defaultValue: "Pending"))
-                            }
-                        }
-                        HStack {
-                            Text(String(localized: "label_outbound", defaultValue: "Outbound"))
-                            Spacer()
-                            Text((channel.outboundCapacityMsat / 1000).satsFormatted)
-                        }
-                        HStack {
-                            Text(String(localized: "label_inbound", defaultValue: "Inbound"))
-                            Spacer()
-                            Text(((channel.inboundCapacityMsat) / 1000).satsFormatted)
-                        }
-
-                        if let txid = appState.fundingTxid, !txid.isEmpty {
-                            HStack {
-                                Text(String(localized: "label_funding_tx", defaultValue: "Funding Tx"))
-                                    .foregroundStyle(.secondary)
-                                Spacer()
-                                Text(String(txid.prefix(8)) + "..." + String(txid.suffix(8)))
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                            if let url = URL(string: "https://mempool.space/tx/\(txid)") {
-                                Link(destination: url) {
-                                    HStack(spacing: 4) {
-                                        Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
-                                        Image(systemName: "arrow.up.right.square")
-                                    }
-                                    .font(.caption)
-                                    .foregroundStyle(.blue)
-                                }
-                            }
-                        }
-                    }
-
-                    Section(String(localized: "section_stable_position", defaultValue: "Stable Position")) {
-                        HStack {
-                            Text(String(localized: "label_expected_usd", defaultValue: "Expected USD"))
-                            Spacer()
-                            Text(appState.stableChannel.expectedUSD.formatted)
-                                .fontWeight(.medium)
-                        }
-                        HStack {
-                            Text(String(localized: "label_backing_sats", defaultValue: "Backing Sats"))
-                            Spacer()
-                            Text(appState.stableChannel.backingSats.satsFormatted)
-                        }
-                        HStack {
-                            Text(String(localized: "label_native_btc", defaultValue: "Native BTC"))
-                            Spacer()
-                            Text(appState.stableChannel.nativeChannelBTC.sats.satsFormatted)
-                        }
-
-                        // Stability status
-                        if appState.btcPrice > 0 && appState.stableChannel.expectedUSD.amount > 0 {
-                            let result = StabilityService.checkStabilityAction(
-                                appState.stableChannel, price: appState.btcPrice
-                            )
-                            HStack {
-                                Text(String(localized: "label_status", defaultValue: "Status"))
-                                Spacer()
-                                Text(result.action.rawValue)
-                                    .foregroundStyle(stabilityColor(result.action))
-                                    .fontWeight(.medium)
-                            }
-                            HStack {
-                                Text(String(localized: "label_distance_from_par", defaultValue: "Distance from Par"))
-                                Spacer()
-                                Text(String(format: "%.2f%%", result.percentFromPar))
-                                    .foregroundStyle(result.percentFromPar < 0.1 ? .green : .orange)
-                            }
-                        }
-
-                        if !appState.stableChannel.counterparty.isEmpty {
-                            copyableRow(
-                                String(localized: "label_counterparty", defaultValue: "Counterparty"),
-                                appState.stableChannel.counterparty
-                            )
-                        }
-                    }
-
-                    Section {
-                        Button(
-                            String(localized: "button_close_channel", defaultValue: "Close Channel"),
-                            role: .destructive
-                        ) {
-                            showCloseChannelAlert = true
-                        }
-                    }
-                }
-
-                // On-Chain
-                Section(String(localized: "section_on_chain", defaultValue: "On-Chain")) {
-                    HStack {
-                        Text(String(localized: "label_balance", defaultValue: "Balance"))
-                        Spacer()
-                        Text(appState.onchainBalanceSats.satsFormatted)
-                    }
-
                     if appState.onchainBalanceSats > 0 {
-                        NavigationLink(String(localized: "link_send_on_chain", defaultValue: "Send On-Chain")) {
+                        NavigationLink {
                             OnChainSendView()
+                        } label: {
+                            rowLabel(
+                                icon: "bitcoinsign.circle.fill",
+                                color: Color.stablePrimary,
+                                text: String(localized: "link_send_on_chain", defaultValue: "Send On-Chain")
+                            )
                         }
                     }
+                } header: {
+                    Text(String(localized: "section_wallet", defaultValue: "Wallet"))
+                        .font(.headline)
+                        .foregroundStyle(.green)
                 }
 
-                // Push Notifications
-                Section(String(localized: "section_notifications", defaultValue: "Push Notifications")) {
-                    HStack {
-                        Text(String(localized: "label_notifications", defaultValue: "Notifications"))
-                        Spacer()
-                        if notificationsEnabled {
-                            Text(String(localized: "notifications_enabled", defaultValue: "Enabled"))
-                                .foregroundStyle(.green)
-                        } else {
-                            Text(String(localized: "notifications_disabled", defaultValue: "Disabled"))
-                                .foregroundStyle(.red)
-                        }
-                    }
+                // MARK: - Preferences
 
-                    if !notificationsEnabled {
-                        Button(String(localized: "button_enable_settings", defaultValue: "Enable in Settings")) {
-                            if let url = URL(string: UIApplication.openSettingsURLString) {
-                                UIApplication.shared.open(url)
-                            }
-                        }
-                        Text(String(
-                            localized: "info_notifications_needed",
-                            defaultValue: "Notifications are required to receive stability payments while the app is closed."
-                        ))
-                        .font(.caption)
+                Section {
+                    NavigationLink {
+                        AppearanceSettingsView(themeSelection: $themeSelection)
+                    } label: {
+                        rowLabel(
+                            icon: "sparkles",
+                            color: .purple,
+                            text: String(localized: "link_appearance", defaultValue: "Appearance")
+                        )
+                    }
+                    NavigationLink {
+                        NotificationsSettingsView(notificationsEnabled: $notificationsEnabled)
+                    } label: {
+                        rowLabel(
+                            icon: "bell.and.waves.left.and.right.fill",
+                            color: .red,
+                            text: String(localized: "link_notifications", defaultValue: "Notifications")
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "section_preferences", defaultValue: "Preferences"))
+                        .font(.headline)
+                        .foregroundStyle(.purple)
+                }
+
+                // MARK: - Node & Network
+
+                Section {
+                    NavigationLink {
+                        NodeSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "cube.transparent.fill",
+                            color: Color.stablePrimary,
+                            text: String(localized: "link_node", defaultValue: "Node")
+                        )
+                    }
+                    NavigationLink {
+                        PushConnectivitySettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "wifi.router.fill",
+                            color: .green,
+                            text: String(localized: "link_push_connectivity", defaultValue: "Push Connectivity")
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "section_node_network", defaultValue: "Node & Network"))
+                        .font(.headline)
+                        .foregroundStyle(Color.stablePrimary)
+                }
+
+                // MARK: - Privacy & Security
+
+                Section {
+                    NavigationLink {
+                        AppAccessSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "faceid",
+                            color: .indigo,
+                            text: String(localized: "link_app_access", defaultValue: "App Access")
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "section_privacy_security", defaultValue: "Privacy & Security"))
+                        .font(.headline)
+                        .foregroundStyle(.indigo)
+                }
+
+                // MARK: - About
+
+                Section {
+                    NavigationLink {
+                        AboutSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "questionmark.circle.fill",
+                            color: .secondary,
+                            text: String(localized: "link_about", defaultValue: "About")
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "section_about", defaultValue: "About"))
+                        .font(.headline)
                         .foregroundStyle(.secondary)
-                    }
-
-                    if let token = UserDefaults.standard.string(forKey: "apns_device_token") {
-                        copyableRow(String(localized: "label_device_token", defaultValue: "Device Token"), token)
-                    }
-                }
-
-                // Backup
-                Section(String(localized: "section_backup", defaultValue: "Backup")) {
-                    Button(showSeedWords
-                        ? String(localized: "button_hide_seed", defaultValue: "Hide Seed Words")
-                        : String(localized: "button_backup_seed", defaultValue: "Backup Seed Words")) {
-                            showSeedWords.toggle()
-                        }
-                    if showSeedWords {
-                        if let words = appState.nodeService.savedMnemonic, !words.isEmpty {
-                            Text(String(
-                                localized: "warning_seed",
-                                defaultValue: "Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds."
-                            ))
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                            ForEach(Array(words.split(separator: " ").enumerated()), id: \.offset) { index, word in
-                                HStack {
-                                    Text("\(index + 1).")
-                                        .foregroundStyle(.secondary)
-                                        .frame(width: 30, alignment: .trailing)
-                                    Text(String(word))
-                                        .font(.system(.body, design: .monospaced))
-                                }
-                            }
-                            Button {
-                                UIPasteboard.general.string = words
-                                copiedField = "Seed Words"
-                            } label: {
-                                HStack {
-                                    Image(systemName: copiedField == "Seed Words" ? "checkmark" : "doc.on.doc")
-                                    Text(copiedField == "Seed Words"
-                                        ? String(localized: "button_copied", defaultValue: "Copied")
-                                        : String(localized: "button_copy_seed", defaultValue: "Copy Seed Words"))
-                                }
-                            }
-                        } else {
-                            Text(String(
-                                localized: "info_seed_unavailable",
-                                defaultValue: "Seed phrase not available for this wallet."
-                            ))
-                            .foregroundStyle(.secondary)
-                        }
-                    }
-                    Button(String(localized: "button_restore_seed", defaultValue: "Restore from Seed")) {
-                        showRestore = true
-                    }
-                }
-
-                // About
-                Section(String(localized: "section_about", defaultValue: "About")) {
-                    HStack {
-                        Text(String(localized: "label_version", defaultValue: "Version"))
-                        Spacer()
-                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")
-                            .foregroundStyle(.secondary)
-                    }
-                    HStack {
-                        Text(String(localized: "label_network", defaultValue: "Network"))
-                        Spacer()
-                        Text(Constants.defaultNetwork)
-                            .foregroundStyle(.secondary)
-                    }
-                    HStack {
-                        Text(String(localized: "label_custody", defaultValue: "Custody"))
-                        Spacer()
-                        Text(String(localized: "custody_self", defaultValue: "Self-custodial"))
-                            .foregroundStyle(.secondary)
-                    }
-                    Text(String(
-                        localized: "info_self_custody",
-                        defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. No third party can access or freeze your funds."
-                    ))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
                 }
             }
             .navigationTitle(String(localized: "title_settings", defaultValue: "Settings"))
@@ -316,158 +158,23 @@ struct SettingsView: View {
                     }
                 }
             }
-            .sheet(isPresented: $showRestore) {
-                NavigationStack {
-                    VStack(spacing: 20) {
-                        Text(String(
-                            localized: "instruction_restore",
-                            defaultValue: "Enter your 12 or 24-word seed phrase to restore a wallet."
-                        ))
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal)
-
-                        TextField(
-                            String(localized: "placeholder_seed", defaultValue: "word1 word2 word3 ..."),
-                            text: $restoreMnemonic,
-                            axis: .vertical
-                        )
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .lineLimit(3...5)
-                        .font(.system(.body, design: .monospaced))
-                        .padding()
-                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
-                        .padding(.horizontal)
-
-                        if let error = restoreError {
-                            Text(error)
-                                .font(.caption)
-                                .foregroundStyle(.red)
-                                .padding(.horizontal)
-                        }
-
-                        Button {
-                            Task { await restoreWallet() }
-                        } label: {
-                            if isRestoring {
-                                ProgressView().frame(maxWidth: .infinity)
-                            } else {
-                                Text(String(localized: "button_restore", defaultValue: "Restore"))
-                                    .frame(maxWidth: .infinity)
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
-                        .disabled(isRestoring || restoreMnemonic.trimmingCharacters(in: .whitespaces).isEmpty)
-                        .padding(.horizontal, 32)
-
-                        Spacer()
-                    }
-                    .padding(.top)
-                    .navigationTitle(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
-                                showRestore = false
-                                restoreMnemonic = ""
-                                restoreError = nil
-                            }
-                        }
-                    }
-                }
-            }
-            .alert(
-                String(localized: "alert_close_channel_title", defaultValue: "Close Channel?"),
-                isPresented: $showCloseChannelAlert
-            ) {
-                Button(String(localized: "alert_close_channel_cancel", defaultValue: "Cancel"), role: .cancel) { }
-                Button(String(localized: "alert_close_channel_confirm", defaultValue: "Close"), role: .destructive) {
-                    closeChannel()
-                }
-            } message: {
-                Text(String(
-                    localized: "alert_close_channel_message",
-                    defaultValue: "This will cooperatively close the channel and sweep funds on-chain."
-                ))
-            }
         }
     }
 
-    private func copyableRow(_ label: String, _ value: String) -> some View {
-        Button {
-            UIPasteboard.general.string = value
-            copiedField = label
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { copiedField = nil }
-        } label: {
-            HStack {
-                Text(label)
-                    .foregroundStyle(.primary)
-                Spacer()
-                if copiedField == label {
-                    Label(String(localized: "button_copied", defaultValue: "Copied"), systemImage: "checkmark")
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                } else {
-                    Text(String(value.prefix(8)) + "..." + String(value.suffix(8)))
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
+    private func rowLabel(icon: String, color: Color, text: String) -> some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(color.opacity(0.12))
+                    .frame(width: 30, height: 30)
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(color)
             }
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.primary)
         }
-    }
-
-    private func stabilityColor(_ action: StabilityService.StabilityAction) -> Color {
-        switch action {
-        case .stable: return .green
-        case .pay: return .orange
-        case .checkOnly: return .blue
-        case .highRiskNoAction: return .red
-        }
-    }
-
-    private func closeChannel() {
-        guard let channel = appState.nodeService.channels.first else { return }
-        appState.isChannelClosing = true
-        try? appState.nodeService.closeChannel(
-            userChannelId: channel.userChannelId,
-            counterpartyNodeId: channel.counterpartyNodeId
-        )
-    }
-
-    private func restoreWallet() async {
-        isRestoring = true
-        restoreError = nil
-        defer { isRestoring = false }
-
-        let input = restoreMnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
-        let wordCount = input.split(separator: " ").count
-        guard wordCount == 12 || wordCount == 24 else {
-            restoreError = String(
-                localized: "error_seed_word_count",
-                defaultValue: "Seed phrase must be 12 or 24 words"
-            )
-            return
-        }
-
-        // Stop existing node first
-        appState.nodeService.stop()
-
-        do {
-            try await appState.nodeService.start(
-                network: .bitcoin,
-                esploraURL: appState.chainURL,
-                mnemonic: input
-            )
-            await MainActor.run {
-                showRestore = false
-                restoreMnemonic = ""
-                appState.refreshBalances()
-            }
-        } catch {
-            await MainActor.run {
-                restoreError = error.localizedDescription
-            }
-        }
+        .padding(.vertical, 2)
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Settings/StablePositionView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/StablePositionView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import UIKit
+
+struct StablePositionView: View {
+    @Environment(AppState.self) private var appState
+    @State private var copiedCounterparty = false
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Text(String(localized: "label_expected_usd", defaultValue: "Expected USD"))
+                    Spacer()
+                    Text(appState.stableChannel.expectedUSD.formatted)
+                        .fontWeight(.medium)
+                }
+                HStack {
+                    Text(String(localized: "label_backing_sats", defaultValue: "Backing Sats"))
+                    Spacer()
+                    Text(appState.stableChannel.backingSats.satsFormatted)
+                }
+                HStack {
+                    Text(String(localized: "label_native_btc", defaultValue: "Native BTC"))
+                    Spacer()
+                    Text(appState.stableChannel.nativeChannelBTC.sats.satsFormatted)
+                }
+
+                if appState.btcPrice > 0 && appState.stableChannel.expectedUSD.amount > 0 {
+                    let result = StabilityService.checkStabilityAction(
+                        appState.stableChannel, price: appState.btcPrice
+                    )
+                    HStack {
+                        Text(String(localized: "label_status", defaultValue: "Status"))
+                        Spacer()
+                        Text(result.action.rawValue)
+                            .foregroundStyle(stabilityColor(result.action))
+                            .fontWeight(.medium)
+                    }
+                    HStack {
+                        Text(String(localized: "label_distance_from_par", defaultValue: "Distance from Par"))
+                        Spacer()
+                        Text(String(format: "%.2f%%", result.percentFromPar))
+                            .foregroundStyle(result.percentFromPar < 0.1 ? .green : .orange)
+                    }
+                }
+
+                if !appState.stableChannel.counterparty.isEmpty {
+                    Button {
+                        UIPasteboard.general.string = appState.stableChannel.counterparty
+                        withAnimation { copiedCounterparty = true }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            withAnimation { copiedCounterparty = false }
+                        }
+                    } label: {
+                        HStack {
+                            Text(String(localized: "label_counterparty", defaultValue: "Counterparty"))
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            if copiedCounterparty {
+                                Label(
+                                    String(localized: "button_copied", defaultValue: "Copied"),
+                                    systemImage: "checkmark"
+                                )
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                                .transition(.scale.combined(with: .opacity))
+                            } else {
+                                Text(String(appState.stableChannel.counterparty.prefix(8)) + "..."
+                                    + String(appState.stableChannel.counterparty.suffix(8)))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(String(localized: "title_stable_position", defaultValue: "Stable Position"))
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func stabilityColor(_ action: StabilityService.StabilityAction) -> Color {
+        switch action {
+        case .stable: return .green
+        case .pay: return .orange
+        case .checkOnly: return .blue
+        case .highRiskNoAction: return .red
+        }
+    }
+}

--- a/ios/StableChannels/project.yml
+++ b/ios/StableChannels/project.yml
@@ -60,7 +60,7 @@ targets:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-UIBackgroundModes:
+        UIBackgroundModes:
           - fetch
           - processing
           - remote-notification


### PR DESCRIPTION
## Summary

Reorganized Settings from monolithic view into iOS system-style tree navigation. Each category now has a dedicated sub-view with proper navigation, premium SF icons, and colored section headers.

## Screenshots

| Settings Home | Stable Position | Channel | Backup |
|:---:|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/47f084d2-cc28-4b70-98c8-b8b1274a858c" width="150"/> | <img src="https://github.com/user-attachments/assets/4388d137-2b52-4362-8524-7024a09863d7" width="150"/> | <img src="https://github.com/user-attachments/assets/b2d700a5-f443-49ed-9cf1-5ed1f23ff5e1" width="150"/> | <img src="https://github.com/user-attachments/assets/ef06f7c9-74b2-4fe1-9afc-8eb6d5dc3573" width="150"/> |

| Node | Push Connectivity | Appearance | About |
|:---:|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/fd42a02c-bf0c-41e8-99f1-b92bf0a7ea4e" width="150"/> | <img src="https://github.com/user-attachments/assets/f8e6eda4-750c-4ac8-b42a-d208aaf5681d" width="150"/> | <img src="https://github.com/user-attachments/assets/223db7e0-6ec7-4df9-8ad1-4c525a9fec8d" width="150"/> | <img src="https://github.com/user-attachments/assets/92f0826c-5d9b-44d3-8c68-32853ce82f32" width="150"/> |

## Settings Structure

```
Settings
├── Wallet
│   ├── Stable Position
│   ├── Channel
│   ├── Backup
│   └── Send On-Chain
├── Preferences
│   ├── Appearance
│   └── Notifications
├── Node & Network
│   ├── Node
│   └── Push Connectivity
├── Privacy & Security
│   └── App Access
└── About
```

## New Views

| View | Content |
|------|---------|
| `AboutSettingsView` | Version, Build, Network, Custody Model |
| `AppearanceSettingsView` | Theme picker (System/Light/Dark) |
| `BackupSettingsView` | Seed phrase display, copy confirmation, restore flow |
| `ChannelSettingsView` | Capacity, liquidity, funding tx, close |
| `NodeSettingsView` | Status, node ID with copy animation |
| `NotificationsSettingsView` | Push notification status |
| `PushConnectivitySettingsView` | Background service, counterparty |
| `StablePositionView` | Expected USD, backing sats, native BTC, stability |
| `Colors.swift` | `Color.stablePrimary` extension |

## Related

- Closes #73