### PR TITLE
fix(android): add price staleness check, trigger stability on push payment

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -483,6 +483,11 @@ class AppState(private val context: Context) : ViewModel() {
         val sc = _stableChannel.value
         val price = priceService.currentPrice.value
 
+        if (priceService.isPriceStale()) {
+            AuditService.log("STABILITY_SKIP", mapOf("reason" to "stale_price", "price_age_ms" to (System.currentTimeMillis() - priceService.lastUpdate.value.time)))
+            return
+        }
+
         // Do NOT recalculate backingSats here — it's set at trade time and stays fixed.
         // As price moves, the stability check detects drift and sends payments to rebalance.
 
@@ -780,8 +785,12 @@ class AppState(private val context: Context) : ViewModel() {
         FCMService.clearPendingPayment(context)
         try {
             nodeService.node?.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            Log.w("AppState", "LSP connect failed in processPendingPushPayment: ${e.message}")
+            AuditService.log("LSP_CONNECT_FAILED", mapOf("error" to (e.message ?: "")))
+        }
         refreshBalances()
         updateStableBalances()
+        runStabilityCheck()
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/services/PriceService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/PriceService.kt
@@ -25,6 +25,12 @@ class PriceService {
     private val _lastUpdate = MutableStateFlow(Date(0))
     val lastUpdate: StateFlow<Date> = _lastUpdate
 
+    /** Returns true if the price was last updated more than [maxAgeSecs] seconds ago. */
+    fun isPriceStale(maxAgeSecs: Long = 60): Boolean {
+        val ageMs = System.currentTimeMillis() - _lastUpdate.value.time
+        return ageMs > maxAgeSecs * 1000
+    }
+
     private var refreshJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO)
 


### PR DESCRIPTION
 ## Summary

  Two reliability fixes for the stability payment system:

1.   **Price staleness check** — If all price feeds fail and the cached price is older than 60 seconds, skip the stability payment instead of using a stale price. Logs `STABILITY_SKIP` with the price age to the
  audit log. Only applies to the main app timer flow — the background push service fetches fresh prices inline.

 2. **Push payment triggers stability check** — When a push payment arrives and `processPendingPushPayment()` runs, it now calls `runStabilityCheck()` immediately instead of waiting up to 60 seconds for the next
  timer tick. Also added logging to the LSP connection catch (was silent).

  ## Changes

  - `PriceService.kt`: Added `isPriceStale(maxAgeSecs: Long = 60)` method
  - `AppState.kt`: Added staleness guard in `runStabilityCheck()` with audit logging
  - `AppState.kt`: Added `runStabilityCheck()` call in `processPendingPushPayment()`
  - `AppState.kt`: Added `Log.w` + `AuditService.log()` to LSP catch in `processPendingPushPayment()`