### PR TITLE
feat(android): add syncing indicator on home screen, enable text selection

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -37,6 +37,9 @@ class AppState(private val context: Context) : ViewModel() {
     private val _phase = MutableStateFlow(Phase.LOADING)
     val phase: StateFlow<Phase> = _phase
 
+    private val _isSyncing = MutableStateFlow(false)
+    val isSyncing: StateFlow<Boolean> = _isSyncing
+
     private val _errorMessage = MutableStateFlow("")
     val errorMessage: StateFlow<String> = _errorMessage
 
@@ -154,10 +157,16 @@ class AppState(private val context: Context) : ViewModel() {
                 val seedFile = File(Constants.userDataDir(context), "keys_seed")
                 val seedPhraseFile = File(Constants.userDataDir(context), "seed_phrase")
                 if (seedFile.exists() || seedPhraseFile.exists()) {
-                    _phase.value = Phase.SYNCING
+                    val hasCachedChannel = _stableChannel.value.userChannelId.isNotEmpty()
+                    if (hasCachedChannel) {
+                        _phase.value = Phase.WALLET
+                        _isSyncing.value = true
+                    } else {
+                        _phase.value = Phase.SYNCING
+                    }
                     waitForBackgroundService()
                     nodeService.start(Network.BITCOIN, chainUrl, null)
-                    _phase.value = Phase.WALLET
+                    _isSyncing.value = false
                     refreshBalances()
                     detectOnchainDeposit()
                     // Restore fundingTxid

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -1,6 +1,7 @@
 package com.stablechannels.app.ui.history
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,6 +16,7 @@ fun PaymentDetailDialog(payment: PaymentRecord, onDismiss: () -> Unit) {
         onDismissRequest = onDismiss,
         title = { Text("Payment Details") },
         text = {
+            SelectionContainer {
             Column {
                 DetailRow("Direction", if (payment.isIncoming) "Received" else "Sent")
                 val typeLabel = when (payment.paymentType) {
@@ -35,6 +37,7 @@ fun PaymentDetailDialog(payment: PaymentRecord, onDismiss: () -> Unit) {
                 payment.txid?.let { DetailRow("TXID", it) }
                 payment.address?.let { DetailRow("Address", it) }
                 if (payment.confirmations > 0) DetailRow("Confirmations", payment.confirmations.toString())
+            }
             }
         },
         confirmButton = {

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -1,6 +1,7 @@
 package com.stablechannels.app.ui.history
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,6 +16,7 @@ fun TradeDetailDialog(trade: TradeRecord, onDismiss: () -> Unit) {
         onDismissRequest = onDismiss,
         title = { Text("Trade Details") },
         text = {
+            SelectionContainer {
             Column {
                 DetailRow("Action", if (trade.action == "buy") "Buy BTC" else "Sell BTC")
                 DetailRow("Amount", trade.amountUSD.usdFormatted())
@@ -24,6 +26,7 @@ fun TradeDetailDialog(trade: TradeRecord, onDismiss: () -> Unit) {
                 DetailRow("Status", trade.status)
                 DetailRow("Date", trade.date.toString())
                 trade.paymentId?.let { DetailRow("Payment ID", it) }
+            }
             }
         },
         confirmButton = {

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
@@ -3,6 +3,7 @@ package com.stablechannels.app.ui.home
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -49,12 +50,14 @@ fun FundWalletScreen(appState: AppState) {
                 )
             }
             Spacer(Modifier.height(16.dp))
-            Text(
-                text = addr,
-                fontFamily = FontFamily.Monospace,
-                style = MaterialTheme.typography.bodySmall,
-                textAlign = TextAlign.Center
-            )
+            SelectionContainer {
+                Text(
+                    text = addr,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Center
+                )
+            }
             Spacer(Modifier.height(12.dp))
             Button(onClick = {
                 clipboardManager.setText(AnnotatedString(addr))

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -60,6 +60,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val onchainSats by appState.onchainBalanceSats.collectAsState()
     val hasReadyChannel by appState.hasReadyChannel.collectAsState()
     val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
+    val isSyncing by appState.isSyncing.collectAsState()
 
     var showSend by remember { mutableStateOf(false) }
     var showReceive by remember { mutableStateOf(false) }
@@ -225,6 +226,28 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     }
                 )
                 Spacer(Modifier.height(16.dp))
+            }
+
+            // Syncing indicator
+            if (isSyncing) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        "Syncing...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
             }
 
             // On-chain section


### PR DESCRIPTION
## Summary

  Two UX improvements matching iOS behavior:

1.  **Syncing indicator** — Returning users now see the wallet immediately with cached data instead of a full-screen blocking "Syncing wallet..." view. A small "Syncing..." spinner with caption text
  appears below the balance bar until the node finishes syncing. New users without cached data still see the full-screen SyncingView.

2. **Text selection** — Invoice addresses, payment IDs, TXIDs, and addresses are now selectable via long-press. Wrapped detail dialogs and the fund wallet screen in `SelectionContainer`.

  ## Changes

  - `AppState.kt`: Added `isSyncing` StateFlow. When cached channel data exists, skips `Phase.SYNCING` and shows wallet immediately with `isSyncing = true`
  - `HomeScreen.kt`: Added syncing indicator row (small spinner + "Syncing..." caption) below balance bar
  - `FundWalletScreen.kt`: Wrapped address text in `SelectionContainer`
  - `PaymentDetailDialog.kt`: Wrapped dialog content in `SelectionContainer`
  - `TradeDetailDialog.kt`: Wrapped dialog content in `SelectionContainer`

  ## Test plan

  - [x] Returning user: wallet shows immediately + syncing indicator appears then disappears
  - [x] Long-press on address/invoice text: selection handles appear
  - [x] Long-press on payment/trade detail values: text becomes selectable