### PR TITLE
fix(android): wire pull-to-refresh to fetch live price, style spinner

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -92,14 +92,22 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val totalUSD = (totalSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
     val scope = rememberCoroutineScope()
 
+    var isRefreshing by remember { mutableStateOf(false) }
     val pullRefreshState = rememberPullToRefreshState()
 
     PullToRefreshBox(
-        isRefreshing = false,
+        isRefreshing = isRefreshing,
         onRefresh = {
             scope.launch {
+                isRefreshing = true
+                val startTime = System.currentTimeMillis()
                 appState.refreshBalances()
+                appState.priceService.fetchPrice()
                 appState.recordCurrentPrice()
+                // Prevent spinner from flashing on instant fetches
+                val elapsed = System.currentTimeMillis() - startTime
+                if (elapsed < 500) kotlinx.coroutines.delay(500 - elapsed)
+                isRefreshing = false
             }
         },
         state = pullRefreshState,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Sell
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -111,6 +112,15 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
             }
         },
         state = pullRefreshState,
+        indicator = {
+            PullToRefreshDefaults.Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                state = pullRefreshState,
+                color = MaterialTheme.colorScheme.primary,
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        },
         modifier = modifier.fillMaxSize()
     ) {
         Column(


### PR DESCRIPTION
## Summary

 Pull-to-refresh on the home screen was broken — it called `refreshBalances()` but never fetched a live price, and the spinner was hardcoded to `isRefreshing = false` so it never showed.

  ## Changes

  - `HomeScreen.kt`: Added `isRefreshing` state that tracks the refresh lifecycle
  - `HomeScreen.kt`: Added `priceService.fetchPrice()` to pull-to-refresh so the price actually updates
  - `HomeScreen.kt`: Added 500ms minimum spinner duration to prevent flash on instant fetches
  - `HomeScreen.kt`: Styled spinner with `PullToRefreshDefaults.Indicator` using primary color

  ## Test plan

  - [x] Pull down on home screen — spinner appears, price updates
  - [x] Spinner uses app theme colors