### PR TITLE
fix(android): mark splice payment completed when txid arrives

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -265,7 +265,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
 
     fun setPendingSpliceTxid(txid: String) {
         writableDatabase.execSQL(
-            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status = 'pending' ORDER BY created_at DESC LIMIT 1)",
+            "UPDATE payments SET txid = ?, status = 'completed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status = 'pending' ORDER BY created_at DESC LIMIT 1)",
             arrayOf(txid)
         )
     }


### PR DESCRIPTION
## Summary

Splice-in payments (sweep to channel) showed as "failed" in payment history even though the sweep completed successfully. The root cause: `setPendingSpliceTxid()` updated the txid but left the status as "pending", which auto-expired to "failed" after 1 hour.

## Changes

- `DatabaseService.kt`: `setPendingSpliceTxid()` now sets `status = 'completed'` alongside the txid update
