### PR TITLE
fix(android): skip Kraken backfill when price history already covers 30 days

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -753,9 +753,9 @@ class AppState(private val context: Context) : ViewModel() {
     private suspend fun backfillHourlyPrices() {
         val db = databaseService ?: return
         val thirtyDaysAgo = System.currentTimeMillis() / 1000 - 30 * 24 * 3600
-        val since = db.getOldestPriceHistoryTimestamp()?.let { oldest ->
-            if (oldest < thirtyDaysAgo) null else thirtyDaysAgo
-        } ?: thirtyDaysAgo
+        val oldest = db.getOldestPriceHistoryTimestamp()
+        if (oldest != null && oldest < thirtyDaysAgo) return
+        val since = oldest ?: thirtyDaysAgo
         val candles = priceService.fetchKrakenOHLC(since)
         if (candles.isEmpty()) return
         val count = db.backfillHourlyPrices(candles)


### PR DESCRIPTION
 ## Summary

  Follow-up to merged chart PR #72  The `?.let { ... null } ?: thirtyDaysAgo` chain never short-circuited — all three code paths evaluated to `thirtyDaysAgo`, re-fetching Kraken on every app start. Added an early return
  when DB already has data covering 30+ days. Refer https://github.com/toneloc/stable-channels/pull/72#issuecomment-4529079127

  ## Changes

  - `AppState.kt`: Early return in `backfillHourlyPrices()` if oldest price timestamp is older than 30 days

  ## Test plan

  - [x] First launch: `CHART_BACKFILL` appears in logcat
  - [x] Second launch: no `CHART_BACKFILL` log (skipped)