### PR TITLE
Refactor settings into navigation hub with 10 dedicated sub-views

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -92,6 +92,10 @@ dependencies {
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
     implementation("com.google.firebase:firebase-messaging-ktx")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0")
+
+    // Biometric authentication
+    implementation("androidx.biometric:biometric:1.2.0-alpha05")
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.stablechannels.app.AppState
 import com.stablechannels.app.ui.history.HistoryScreen
 import com.stablechannels.app.ui.home.HomeScreen
-import com.stablechannels.app.ui.settings.SettingsScreen
+import com.stablechannels.app.ui.settings.SettingsNavHost
 
 enum class Tab(val label: String, val icon: ImageVector) {
     HOME("Home", Icons.Default.Home),
@@ -41,7 +41,7 @@ fun MainTabView(appState: AppState) {
         when (selectedTab) {
             Tab.HOME -> HomeScreen(appState, Modifier.padding(padding))
             Tab.HISTORY -> HistoryScreen(appState, Modifier.padding(padding))
-            Tab.SETTINGS -> SettingsScreen(appState, Modifier.padding(padding))
+            Tab.SETTINGS -> SettingsNavHost(appState, Modifier.padding(padding))
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/AboutView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/AboutView.kt
@@ -1,0 +1,58 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stablechannels.app.BuildConfig
+
+@Composable
+fun AboutView() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // App info card
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                AboutRow("Version", BuildConfig.VERSION_NAME)
+                Spacer(Modifier.height(14.dp))
+                AboutRow("Network", "Bitcoin", valueColor = Color(0xFFF59E0B))
+                Spacer(Modifier.height(14.dp))
+                AboutRow("Custody", "Self-custodial", valueColor = Color(0xFF10B981))
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        Text(
+            text = "Stable Channels is a self-custodial Bitcoin wallet that maintains a stable USD value using Lightning Network channels. You control your private keys. No third party can access or freeze your funds.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun AboutRow(label: String, value: String, valueColor: Color = Color.Unspecified) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = if (valueColor != Color.Unspecified) valueColor else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
@@ -1,0 +1,142 @@
+package com.stablechannels.app.ui.settings
+
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.biometric.BiometricManager
+
+@Composable
+fun AppAccessView() {
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("app_access_prefs", Context.MODE_PRIVATE)
+
+    var appUnlockEnabled by remember {
+        mutableStateOf(prefs.getBoolean("app_unlock_enabled", false))
+    }
+    var paymentConfirmEnabled by remember {
+        mutableStateOf(prefs.getBoolean("payment_confirm_enabled", false))
+    }
+
+    val biometricManager = BiometricManager.from(context)
+    val biometricsAvailable = biometricManager.canAuthenticate(
+        BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                BiometricManager.Authenticators.DEVICE_CREDENTIAL
+    ) == BiometricManager.BIOMETRIC_SUCCESS
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        if (!biometricsAvailable) {
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                tonalElevation = 1.dp,
+                color = MaterialTheme.colorScheme.errorContainer,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "Biometric enrollment is required to use these features. Please set up fingerprint, face, or device credentials in your device settings.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+            Spacer(Modifier.height(20.dp))
+        }
+
+        // App Unlock
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "App Unlock",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "Require authentication on app launch and resume",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = appUnlockEnabled,
+                    onCheckedChange = { newValue ->
+                        if (biometricsAvailable) {
+                            appUnlockEnabled = newValue
+                            prefs.edit().putBoolean("app_unlock_enabled", newValue).apply()
+                        }
+                    },
+                    enabled = biometricsAvailable,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Color.White,
+                        checkedTrackColor = Color(0xFF10B981),
+                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    modifier = Modifier.height(24.dp)
+                )
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // Payment Confirmation
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Payment Confirmation",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "Require authentication before Lightning sends",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = paymentConfirmEnabled,
+                    onCheckedChange = { newValue ->
+                        if (biometricsAvailable) {
+                            paymentConfirmEnabled = newValue
+                            prefs.edit().putBoolean("payment_confirm_enabled", newValue).apply()
+                        }
+                    },
+                    enabled = biometricsAvailable,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Color.White,
+                        checkedTrackColor = Color(0xFF10B981),
+                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    modifier = Modifier.height(24.dp)
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/AppearanceView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/AppearanceView.kt
@@ -1,0 +1,104 @@
+package com.stablechannels.app.ui.settings
+
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+enum class ThemePreference(val label: String) {
+    LIGHT("Light"),
+    DARK("Dark"),
+    SYSTEM("System");
+
+    companion object {
+        private const val PREFS_NAME = "theme_prefs"
+        private const val KEY_THEME = "theme_preference"
+
+        fun load(context: Context): ThemePreference {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val stored = prefs.getString(KEY_THEME, null)
+            return entries.find { it.name == stored } ?: SYSTEM
+        }
+
+        fun save(context: Context, preference: ThemePreference) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_THEME, preference.name)
+                .apply()
+        }
+    }
+}
+
+@Composable
+fun AppearanceView() {
+    val context = LocalContext.current
+    var selectedTheme by remember { mutableStateOf(ThemePreference.load(context)) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Theme",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Choose how the app looks. Changes apply immediately.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(20.dp))
+
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(Modifier.selectableGroup().padding(vertical = 4.dp)) {
+                ThemePreference.entries.forEach { preference ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .selectable(
+                                selected = (selectedTheme == preference),
+                                onClick = {
+                                    selectedTheme = preference
+                                    ThemePreference.save(context, preference)
+                                },
+                                role = Role.RadioButton
+                            )
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = (selectedTheme == preference),
+                            onClick = null,
+                            colors = RadioButtonDefaults.colors(
+                                selectedColor = Color(0xFF10B981),
+                                unselectedColor = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        )
+                        Spacer(Modifier.width(16.dp))
+                        Text(
+                            text = preference.label,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/BackupView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/BackupView.kt
@@ -1,0 +1,173 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.stablechannels.app.AppState
+import com.stablechannels.app.util.Constants
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.lightningdevkit.ldknode.Network
+
+@Composable
+fun BackupView(appState: AppState) {
+    val clipboardManager = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
+
+    var showSeedWords by remember { mutableStateOf(false) }
+    var showRestore by remember { mutableStateOf(false) }
+    var restoreMnemonic by remember { mutableStateOf("") }
+    var restoreError by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Show/hide seed words
+        Button(
+            onClick = { showSeedWords = !showSeedWords },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFF10B981),
+                contentColor = Color.White
+            )
+        ) {
+            Text(if (showSeedWords) "Hide Seed Words" else "Backup Seed Words")
+        }
+
+        if (showSeedWords) {
+            val words = appState.nodeService.savedMnemonic
+            if (!words.isNullOrEmpty()) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    "Write these words down on paper and store them in a safe place. Never share them. Anyone with these words can access your funds.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFFD97706)
+                )
+                Spacer(Modifier.height(12.dp))
+                words.split(" ").forEachIndexed { index, word ->
+                    Text(
+                        "${index + 1}. $word",
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+                var copied by remember { mutableStateOf(false) }
+                OutlinedButton(
+                    onClick = {
+                        clipboardManager.setText(AnnotatedString(words))
+                        copied = true
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(if (copied) "Copied" else "Copy Seed Words")
+                }
+            } else {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Seed phrase not available for this wallet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Restore from seed
+        OutlinedButton(
+            onClick = { showRestore = true },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = Color(0xFF3B82F6)
+            ),
+            border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF3B82F6))
+        ) {
+            Text("Restore from Seed")
+        }
+    }
+
+    // Restore dialog
+    if (showRestore) {
+        AlertDialog(
+            onDismissRequest = {
+                showRestore = false
+                restoreMnemonic = ""
+                restoreError = null
+            },
+            title = { Text("Restore from Seed") },
+            text = {
+                Column {
+                    Text(
+                        "Enter your 12 or 24-word seed phrase to restore a wallet.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = restoreMnemonic,
+                        onValueChange = { restoreMnemonic = it },
+                        label = { Text("word1 word2 word3 ...") },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 3
+                    )
+                    if (restoreError != null) {
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            restoreError!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val input = restoreMnemonic.trim()
+                        val wordCount = input.split("\\s+".toRegex()).size
+                        if (wordCount != 12 && wordCount != 24) {
+                            restoreError = "Seed phrase must be 12 or 24 words"
+                            return@TextButton
+                        }
+                        scope.launch(Dispatchers.IO) {
+                            try {
+                                appState.nodeService.stop()
+                                appState.nodeService.start(Network.BITCOIN, Constants.PRIMARY_CHAIN_URL, input)
+                                withContext(Dispatchers.Main) {
+                                    showRestore = false
+                                    restoreMnemonic = ""
+                                    restoreError = null
+                                    appState.refreshBalances()
+                                }
+                            } catch (e: Exception) {
+                                withContext(Dispatchers.Main) {
+                                    restoreError = e.message ?: "Restore failed"
+                                }
+                            }
+                        }
+                    },
+                    enabled = restoreMnemonic.trim().isNotEmpty()
+                ) { Text("Restore") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showRestore = false
+                    restoreMnemonic = ""
+                    restoreError = null
+                }) { Text("Cancel") }
+            }
+        )
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -1,0 +1,171 @@
+package com.stablechannels.app.ui.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stablechannels.app.AppState
+import com.stablechannels.app.util.satsFormatted
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun ChannelView(appState: AppState) {
+    val sc by appState.stableChannel.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var showCloseConfirm by remember { mutableStateOf(false) }
+
+    val channels = appState.nodeService.channels
+    val hasReadyChannel = channels.any { it.isChannelReady }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        if (channels.isNotEmpty()) {
+            val ch = channels.first()
+
+            // Status with colored dot
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Status", style = MaterialTheme.typography.bodyLarge)
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Surface(
+                        shape = MaterialTheme.shapes.small,
+                        color = if (ch.isChannelReady) Color(0xFF10B981) else Color(0xFFF59E0B),
+                        modifier = Modifier.size(8.dp)
+                    ) {}
+                    Text(
+                        text = if (ch.isChannelReady) "Ready" else "Pending",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = if (ch.isChannelReady) Color(0xFF10B981) else Color(0xFFF59E0B)
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Capacity
+            ChannelDetailRow("Capacity", ch.channelValueSats.toLong().satsFormatted())
+            Spacer(Modifier.height(16.dp))
+
+            // Outbound
+            ChannelDetailRow("Outbound", (ch.outboundCapacityMsat.toLong() / 1000).satsFormatted())
+            Spacer(Modifier.height(16.dp))
+
+            // Inbound
+            ChannelDetailRow("Inbound", (ch.inboundCapacityMsat.toLong() / 1000).satsFormatted())
+
+            // Funding Tx
+            appState.fundingTxid?.let { txid ->
+                if (txid.isNotEmpty()) {
+                    Spacer(Modifier.height(20.dp))
+                    Surface(
+                        shape = MaterialTheme.shapes.medium,
+                        tonalElevation = 1.dp,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Funding Transaction",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = "${txid.take(8)}...${txid.takeLast(8)}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = FontFamily.Monospace
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            TextButton(
+                                onClick = {
+                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://mempool.space/tx/$txid"))
+                                    context.startActivity(intent)
+                                },
+                                contentPadding = PaddingValues(0.dp)
+                            ) {
+                                Text("View on explorer ↗", color = Color(0xFF3B82F6))
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (hasReadyChannel) {
+                Spacer(Modifier.height(32.dp))
+                OutlinedButton(
+                    onClick = { showCloseConfirm = true },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = Color(0xFFEF4444)
+                    ),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFEF4444))
+                ) {
+                    Text("Close Channel")
+                }
+            }
+        } else {
+            Text(
+                text = "No channel open yet",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Receive bitcoin over Lightning to open your first channel.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+
+    if (showCloseConfirm) {
+        AlertDialog(
+            onDismissRequest = { showCloseConfirm = false },
+            title = { Text("Close Channel?") },
+            text = { Text("This will cooperatively close the channel and sweep funds on-chain.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showCloseConfirm = false
+                    appState.isChannelClosing = true
+                    scope.launch(Dispatchers.IO) {
+                        try {
+                            appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)
+                        } catch (_: Exception) {}
+                    }
+                }) { Text("Close", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCloseConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun ChannelDetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        Text(text = value, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/NodeView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/NodeView.kt
@@ -1,0 +1,130 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stablechannels.app.AppState
+import com.stablechannels.app.util.Constants
+
+@Composable
+fun NodeView(appState: AppState) {
+    val clipboardManager = LocalClipboardManager.current
+    var showNodeId by remember { mutableStateOf(false) }
+    var copiedNodeId by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Status section
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Status", style = MaterialTheme.typography.bodyLarge)
+                Spacer(Modifier.weight(1f))
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Surface(
+                        shape = MaterialTheme.shapes.small,
+                        color = if (appState.nodeService.isRunning) Color(0xFF10B981) else Color(0xFFEF4444),
+                        modifier = Modifier.size(8.dp)
+                    ) {}
+                    Text(
+                        text = if (appState.nodeService.isRunning) "Running" else "Stopped",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = if (appState.nodeService.isRunning) Color(0xFF10B981) else Color(0xFFEF4444)
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Node ID section
+        Surface(
+            onClick = {
+                if (!showNodeId) {
+                    showNodeId = true
+                } else if (appState.nodeService.nodeId.isNotEmpty()) {
+                    clipboardManager.setText(AnnotatedString(appState.nodeService.nodeId))
+                    copiedNodeId = true
+                }
+            },
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Node ID", style = MaterialTheme.typography.bodyLarge)
+                    if (showNodeId) {
+                        Text(
+                            text = if (copiedNodeId) "Copied ✓" else "Tap to copy",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (copiedNodeId) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        Text(
+                            text = "Tap to reveal",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFF3B82F6)
+                        )
+                    }
+                }
+                if (showNodeId && appState.nodeService.nodeId.isNotEmpty()) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = appState.nodeService.nodeId,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // Connection info
+        Text(
+            text = "Connection",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text("Network", style = MaterialTheme.typography.bodyLarge)
+            Text(Constants.DEFAULT_NETWORK, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+        }
+        Spacer(Modifier.height(12.dp))
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text("Explorer", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                Constants.PRIMARY_CHAIN_URL.removePrefix("https://").take(20),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/NotificationsView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/NotificationsView.kt
@@ -1,0 +1,90 @@
+package com.stablechannels.app.ui.settings
+
+import android.Manifest
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.core.content.PermissionChecker
+
+@Composable
+fun NotificationsView() {
+    val context = LocalContext.current
+
+    val notifEnabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.POST_NOTIFICATIONS
+        ) == PermissionChecker.PERMISSION_GRANTED
+    } else true
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Status card
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Push Notifications", style = MaterialTheme.typography.bodyLarge)
+                Spacer(Modifier.weight(1f))
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Surface(
+                        shape = MaterialTheme.shapes.small,
+                        color = if (notifEnabled) Color(0xFF10B981) else Color(0xFFEF4444),
+                        modifier = Modifier.size(8.dp)
+                    ) {}
+                    Text(
+                        text = if (notifEnabled) "Enabled" else "Disabled",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = if (notifEnabled) Color(0xFF10B981) else Color(0xFFEF4444)
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = "Notifications are required to receive stability payments while the app is closed. Without them, your USD position may drift when BTC price moves.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        if (!notifEnabled) {
+            Spacer(Modifier.height(20.dp))
+            Button(
+                onClick = {
+                    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                    }
+                    context.startActivity(intent)
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF10B981),
+                    contentColor = Color.White
+                )
+            ) {
+                Text("Enable in Settings")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/OnChainSendSettingsView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/OnChainSendSettingsView.kt
@@ -1,0 +1,14 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.runtime.Composable
+import com.stablechannels.app.AppState
+import com.stablechannels.app.ui.transfer.OnChainSendScreen
+
+/**
+ * Wrapper that embeds the existing OnChainSendScreen within the settings navigation.
+ * The dismiss callback is a no-op since back navigation is handled by the scaffold.
+ */
+@Composable
+fun OnChainSendSettingsView(appState: AppState) {
+    OnChainSendScreen(appState = appState, onDismiss = {})
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/PushConnectivityView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/PushConnectivityView.kt
@@ -1,0 +1,194 @@
+package com.stablechannels.app.ui.settings
+
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.google.firebase.messaging.FirebaseMessaging
+import com.stablechannels.app.push.FCMService
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.Date
+import com.stablechannels.app.util.relativeString
+
+@Composable
+fun PushConnectivityView() {
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
+
+    val prefs = FCMService.getPrefs(context)
+    var fcmToken by remember { mutableStateOf(prefs.getString("fcm_token", null)) }
+    var isRetrying by remember { mutableStateOf(false) }
+    var retryError by remember { mutableStateOf<String?>(null) }
+    var copiedToken by remember { mutableStateOf(false) }
+
+    val nodeId = FCMService.getNodeId(context)
+    val isRegistered = fcmToken != null && nodeId != null
+
+    val lastHeartbeat = prefs.getLong("main_app_last_active", 0L)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // FCM Token card
+        Surface(
+            onClick = {
+                if (fcmToken != null) {
+                    clipboardManager.setText(AnnotatedString(fcmToken!!))
+                    copiedToken = true
+                }
+            },
+            shape = MaterialTheme.shapes.medium,
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("FCM Token", style = MaterialTheme.typography.bodyLarge)
+                    if (fcmToken != null) {
+                        Text(
+                            text = if (copiedToken) "Copied ✓" else "Tap to copy",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (copiedToken) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                if (fcmToken != null) {
+                    val truncated = if (fcmToken!!.length > 24) {
+                        "${fcmToken!!.take(16)}...${fcmToken!!.takeLast(8)}"
+                    } else {
+                        fcmToken!!
+                    }
+                    Text(
+                        text = truncated,
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = "No token available",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Registration status
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Registration", style = MaterialTheme.typography.bodyLarge)
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = if (isRegistered) Color(0xFF10B981) else Color(0xFFEF4444),
+                    modifier = Modifier.size(8.dp)
+                ) {}
+                Text(
+                    text = if (isRegistered) "Registered" else "Unregistered",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = if (isRegistered) Color(0xFF10B981) else Color(0xFFEF4444)
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Last heartbeat
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Last Heartbeat", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = if (lastHeartbeat > 0) {
+                    Date(lastHeartbeat * 1000).relativeString()
+                } else {
+                    "No heartbeat recorded"
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        // Retry button — green to match app branding
+        Button(
+            onClick = {
+                isRetrying = true
+                retryError = null
+                scope.launch {
+                    try {
+                        val token = withTimeoutOrNull(10_000L) {
+                            FirebaseMessaging.getInstance().token.await()
+                        }
+                        if (token != null) {
+                            FCMService.saveToken(context, token)
+                            fcmToken = token
+                            copiedToken = false
+                            retryError = null
+                        } else {
+                            retryError = "Token could not be retrieved (timeout)"
+                        }
+                    } catch (e: Exception) {
+                        retryError = e.message ?: "Token retrieval failed"
+                    } finally {
+                        isRetrying = false
+                    }
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !isRetrying,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFF10B981),
+                contentColor = Color.White
+            )
+        ) {
+            if (isRetrying) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = Color.White
+                )
+                Spacer(Modifier.width(8.dp))
+            }
+            Text("Retry Token Retrieval")
+        }
+
+        if (retryError != null) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = retryError!!,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
@@ -1,0 +1,176 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.stablechannels.app.AppState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsHub(appState: AppState, navController: NavController) {
+    val onchainSats by appState.onchainBalanceSats.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Settings") })
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Wallet section
+            SettingsSectionHeader(title = "Wallet", color = Color(0xFF10B981))
+            SettingsNavLink(
+                icon = Icons.Default.AccountBalance,
+                iconBackground = Color(0xFF10B981),
+                label = "Stable Position",
+                onClick = { navController.navigate(SettingsRoute.StablePosition.route) }
+            )
+            SettingsNavLink(
+                icon = Icons.Default.Hub,
+                iconBackground = Color(0xFF10B981),
+                label = "Channel",
+                onClick = { navController.navigate(SettingsRoute.Channel.route) }
+            )
+            SettingsNavLink(
+                icon = Icons.Default.Key,
+                iconBackground = Color(0xFF10B981),
+                label = "Backup",
+                onClick = { navController.navigate(SettingsRoute.Backup.route) }
+            )
+            if (onchainSats > 0) {
+                SettingsNavLink(
+                    icon = Icons.Default.Send,
+                    iconBackground = Color(0xFF10B981),
+                    label = "Send On-Chain",
+                    onClick = { navController.navigate(SettingsRoute.OnChainSend.route) }
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Preferences section
+            SettingsSectionHeader(title = "Preferences", color = Color(0xFF8B5CF6))
+            SettingsNavLink(
+                icon = Icons.Default.Palette,
+                iconBackground = Color(0xFF8B5CF6),
+                label = "Appearance",
+                onClick = { navController.navigate(SettingsRoute.Appearance.route) }
+            )
+            SettingsNavLink(
+                icon = Icons.Default.Notifications,
+                iconBackground = Color(0xFF8B5CF6),
+                label = "Notifications",
+                onClick = { navController.navigate(SettingsRoute.Notifications.route) }
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // Node & Network section
+            SettingsSectionHeader(title = "Node & Network", color = Color(0xFF3B82F6))
+            SettingsNavLink(
+                icon = Icons.Default.Memory,
+                iconBackground = Color(0xFF3B82F6),
+                label = "Node",
+                onClick = { navController.navigate(SettingsRoute.Node.route) }
+            )
+            SettingsNavLink(
+                icon = Icons.Default.Cloud,
+                iconBackground = Color(0xFF3B82F6),
+                label = "Push Connectivity",
+                onClick = { navController.navigate(SettingsRoute.PushConnectivity.route) }
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // Privacy & Security section
+            SettingsSectionHeader(title = "Privacy & Security", color = Color(0xFF6366F1))
+            SettingsNavLink(
+                icon = Icons.Default.Lock,
+                iconBackground = Color(0xFF6366F1),
+                label = "App Access",
+                onClick = { navController.navigate(SettingsRoute.AppAccess.route) }
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // About section
+            SettingsSectionHeader(title = "About", color = Color(0xFF6B7280))
+            SettingsNavLink(
+                icon = Icons.Default.Info,
+                iconBackground = Color(0xFF6B7280),
+                label = "About",
+                onClick = { navController.navigate(SettingsRoute.About.route) }
+            )
+
+            Spacer(Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingsSectionHeader(title: String, color: Color) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+        color = color,
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp)
+    )
+}
+
+@Composable
+private fun SettingsNavLink(
+    icon: ImageVector,
+    iconBackground: Color,
+    label: String,
+    onClick: () -> Unit
+) {
+    ListItem(
+        headlineContent = { Text(label) },
+        leadingContent = {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .background(
+                        color = iconBackground.copy(alpha = 0.15f),
+                        shape = RoundedCornerShape(8.dp)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = label,
+                    tint = iconBackground,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        },
+        trailingContent = {
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick)
+    )
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
@@ -1,0 +1,121 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.stablechannels.app.AppState
+
+sealed class SettingsRoute(val route: String) {
+    object Hub : SettingsRoute("settings_hub")
+    object StablePosition : SettingsRoute("settings_stable_position")
+    object Channel : SettingsRoute("settings_channel")
+    object Backup : SettingsRoute("settings_backup")
+    object OnChainSend : SettingsRoute("settings_onchain_send")
+    object Appearance : SettingsRoute("settings_appearance")
+    object Notifications : SettingsRoute("settings_notifications")
+    object Node : SettingsRoute("settings_node")
+    object PushConnectivity : SettingsRoute("settings_push_connectivity")
+    object AppAccess : SettingsRoute("settings_app_access")
+    object About : SettingsRoute("settings_about")
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsNavHost(appState: AppState, modifier: Modifier = Modifier) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = SettingsRoute.Hub.route,
+        modifier = modifier
+    ) {
+        composable(SettingsRoute.Hub.route) {
+            SettingsHub(appState = appState, navController = navController)
+        }
+        composable(SettingsRoute.StablePosition.route) {
+            SettingsSubViewScaffold(title = "Stable Position", navController = navController) {
+                StablePositionView(appState = appState)
+            }
+        }
+        composable(SettingsRoute.Channel.route) {
+            SettingsSubViewScaffold(title = "Channel", navController = navController) {
+                ChannelView(appState = appState)
+            }
+        }
+        composable(SettingsRoute.Backup.route) {
+            SettingsSubViewScaffold(title = "Backup", navController = navController) {
+                BackupView(appState = appState)
+            }
+        }
+        composable(SettingsRoute.OnChainSend.route) {
+            SettingsSubViewScaffold(title = "Send On-Chain", navController = navController) {
+                OnChainSendSettingsView(appState = appState)
+            }
+        }
+        composable(SettingsRoute.Appearance.route) {
+            SettingsSubViewScaffold(title = "Appearance", navController = navController) {
+                AppearanceView()
+            }
+        }
+        composable(SettingsRoute.Notifications.route) {
+            SettingsSubViewScaffold(title = "Notifications", navController = navController) {
+                NotificationsView()
+            }
+        }
+        composable(SettingsRoute.Node.route) {
+            SettingsSubViewScaffold(title = "Node", navController = navController) {
+                NodeView(appState = appState)
+            }
+        }
+        composable(SettingsRoute.PushConnectivity.route) {
+            SettingsSubViewScaffold(title = "Push Connectivity", navController = navController) {
+                PushConnectivityView()
+            }
+        }
+        composable(SettingsRoute.AppAccess.route) {
+            SettingsSubViewScaffold(title = "App Access", navController = navController) {
+                AppAccessView()
+            }
+        }
+        composable(SettingsRoute.About.route) {
+            SettingsSubViewScaffold(title = "About", navController = navController) {
+                AboutView()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsSubViewScaffold(
+    title: String,
+    navController: NavHostController,
+    content: @Composable () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Surface(modifier = Modifier.padding(padding)) {
+            content()
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/StablePositionView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/StablePositionView.kt
@@ -1,0 +1,163 @@
+package com.stablechannels.app.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stablechannels.app.AppState
+import com.stablechannels.app.services.StabilityService
+import com.stablechannels.app.util.satsFormatted
+
+@Composable
+fun StablePositionView(appState: AppState) {
+    val sc by appState.stableChannel.collectAsState()
+    val btcPrice by appState.priceService.currentPrice.collectAsState()
+    val clipboardManager = LocalClipboardManager.current
+    var copiedCounterparty by remember { mutableStateOf(false) }
+
+    val stabilityResult = remember(sc, btcPrice) {
+        StabilityService.checkStabilityAction(sc, btcPrice)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        if (sc.expectedUSD.amount > 0) {
+            // Expected USD — prominent
+            SettingsDetailRow(
+                label = "Expected USD",
+                value = sc.expectedUSD.formatted,
+                valueColor = Color(0xFF10B981),
+                valueBold = true
+            )
+            Spacer(Modifier.height(16.dp))
+
+            // Backing Sats
+            SettingsDetailRow(
+                label = "Backing Sats",
+                value = sc.backingSats.satsFormatted()
+            )
+            Spacer(Modifier.height(16.dp))
+
+            // Native BTC
+            SettingsDetailRow(
+                label = "Native BTC",
+                value = sc.nativeChannelBTC.formatted,
+                valueColor = Color(0xFFF59E0B)
+            )
+            Spacer(Modifier.height(16.dp))
+
+            // Stability Status — colored
+            val statusColor = when (stabilityResult.action.value) {
+                "STABLE" -> Color(0xFF10B981)
+                "PAY" -> Color(0xFFF59E0B)
+                "CHECK_ONLY" -> Color(0xFF3B82F6)
+                "HIGH_RISK_NO_ACTION" -> Color(0xFFEF4444)
+                else -> MaterialTheme.colorScheme.onSurface
+            }
+            SettingsDetailRow(
+                label = "Status",
+                value = stabilityResult.action.value,
+                valueColor = statusColor,
+                valueBold = true
+            )
+            Spacer(Modifier.height(16.dp))
+
+            // Distance from Par — colored
+            if (stabilityResult.percentFromPar > 0) {
+                val parColor = if (stabilityResult.percentFromPar < 0.1) Color(0xFF10B981) else Color(0xFFF59E0B)
+                SettingsDetailRow(
+                    label = "Distance from Par",
+                    value = String.format("%.2f%%", stabilityResult.percentFromPar),
+                    valueColor = parColor
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            // Counterparty — tap to copy
+            val cpk = sc.counterparty
+            if (cpk.isNotEmpty()) {
+                Surface(
+                    onClick = {
+                        clipboardManager.setText(AnnotatedString(cpk))
+                        copiedCounterparty = true
+                    },
+                    shape = MaterialTheme.shapes.medium,
+                    tonalElevation = 1.dp,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Counterparty",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = "${cpk.take(8)}...${cpk.takeLast(8)}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = FontFamily.Monospace
+                            )
+                        }
+                        Text(
+                            text = if (copiedCounterparty) "Copied ✓" else "Tap to copy",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (copiedCounterparty) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        } else {
+            Text(
+                text = "No stable position active",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Trade BTC to USD to create a stable position.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsDetailRow(
+    label: String,
+    value: String,
+    valueColor: Color = Color.Unspecified,
+    valueBold: Boolean = false
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (valueColor != Color.Unspecified) valueColor else MaterialTheme.colorScheme.onSurface,
+            fontWeight = if (valueBold) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
@@ -1,29 +1,28 @@
 package com.stablechannels.app.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import com.stablechannels.app.ui.settings.ThemePreference
 
 private val LightColorScheme = lightColorScheme()
 private val DarkColorScheme = darkColorScheme()
 
 @Composable
 fun StableChannelsTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context)
-            else dynamicLightColorScheme(context)
-        }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
+    val context = LocalContext.current
+    val themePreference = ThemePreference.load(context)
+
+    val darkTheme = when (themePreference) {
+        ThemePreference.LIGHT -> false
+        ThemePreference.DARK -> true
+        ThemePreference.SYSTEM -> isSystemInDarkTheme()
     }
+
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
     MaterialTheme(
         colorScheme = colorScheme,


### PR DESCRIPTION
## Summary

Replaces the monolithic scrollable SettingsScreen with a proper Compose Navigation hub linking to 10 dedicated sub-views — matching the iOS `SettingsView.swift` pattern with `NavigationStack` + `List` + `Section` grouping.

The old Settings was one long page with Cards crammed together. Now it's a sectioned hub with colored icons, and each sub-view has its own screen with TopAppBar + back navigation.

## Changes

- `ui/settings/SettingsNavigation.kt`: NavHost with sealed routes, shared `SettingsSubViewScaffold` (TopAppBar + back arrow)
- `ui/settings/SettingsHub.kt`: Sectioned list — Wallet (green), Preferences (purple), Node & Network (blue), Privacy & Security (indigo), About (gray). Each link has colored icon background + chevron.
- `ui/settings/StablePositionView.kt`: Expected USD in green, colored stability status, tap-to-copy counterparty
- `ui/settings/ChannelView.kt`: Status with colored dot, tonal card for funding tx, red outlined close button
- `ui/settings/BackupView.kt`: Green "Backup Seed Words" button, blue "Restore from Seed" outline
- `ui/settings/NodeView.kt`: Tonal cards for status + node ID, tap-to-reveal + tap-to-copy
- `ui/settings/NotificationsView.kt`: Status card with colored dot, green "Enable in Settings" button
- `ui/settings/PushConnectivityView.kt`: Tonal card for FCM token with tap-to-copy, colored registration status
- `ui/settings/AppAccessView.kt`: Green switches (smaller), tonal cards for each toggle
- `ui/settings/AppearanceView.kt`: Green radio buttons, tonal card grouping
- `ui/settings/AboutView.kt`: Tonal card with colored values (orange Bitcoin, green Self-custodial)
- `ui/settings/OnChainSendSettingsView.kt`: Wrapper for existing OnChainSendScreen
- `ui/MainTabView.kt`: Replaced `SettingsScreen` with `SettingsNavHost`
- `ui/theme/Theme.kt`: Updated to read ThemePreference for dark/light selection
- `build.gradle.kts`: Added `kotlinx-coroutines-play-services` for Firebase task await

## Test plan

- Open Settings tab → sectioned list with colored icons visible
- Tap each link → navigates to sub-view with title + back arrow
- System back gesture → returns to hub
- Stable Position → colored status, tap counterparty → "Copied ✓"
- Channel → green/orange status dot, red "Close Channel" button
- Backup → green button, blue outlined restore
- Node → tap to reveal node ID, tap to copy
- Appearance → green radio buttons, theme changes immediately
- App Access → green switches (smaller), enrollment message when no biometrics
- Push Connectivity → tonal token card, colored registration status
- Notifications → green "Enable in Settings" button
- When on-chain balance is 0 → "Send On-Chain" link hidden
- Bottom nav bar remains visible on all sub-views
