### PR TITLE
Feat/ios settings disclaimer banner

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = VJF3VBKXV9;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -661,6 +662,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = VJF3VBKXV9;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -551,6 +551,28 @@
         }
       }
     },
+    "disclaimer_custody_body" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+          }
+        }
+      }
+    },
+    "disclaimer_custody_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your keys, your coins."
+          }
+        }
+      }
+    },
     "empty_payments_desc" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -9,6 +9,10 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             List {
+                // MARK: - Custody Disclaimer
+
+                disclaimerBanner
+
                 // MARK: - Wallet
 
                 Section {
@@ -176,5 +180,52 @@ struct SettingsView: View {
                 .foregroundStyle(.primary)
         }
         .padding(.vertical, 2)
+    }
+
+    private var disclaimerBanner: some View {
+        HStack(spacing: 14) {
+            iconBadge
+            textContent
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(.green, lineWidth: 1)
+                )
+        )
+    }
+
+    private var iconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(.green)
+                .frame(width: 44, height: 44)
+                .shadow(color: .green.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "shield.lefthalf.filled.badge.checkmark")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var textContent: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(String(localized: "disclaimer_custody_title", defaultValue: "Your keys, your coins."))
+                .font(.system(.subheadline, design: .rounded))
+                .fontWeight(.bold)
+                .foregroundStyle(.primary)
+            Text(String(
+                localized: "disclaimer_custody_body",
+                defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+            ))
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .lineSpacing(1)
+        }
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/SettingsView.swift
@@ -216,16 +216,15 @@ struct SettingsView: View {
     private var textContent: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(String(localized: "disclaimer_custody_title", defaultValue: "Your keys, your coins."))
-                .font(.system(.subheadline, design: .rounded))
+                .font(.subheadline)
                 .fontWeight(.bold)
                 .foregroundStyle(.primary)
             Text(String(
                 localized: "disclaimer_custody_body",
                 defaultValue: "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
             ))
-            .font(.system(.caption2, design: .monospaced))
-            .foregroundStyle(.secondary)
-            .lineSpacing(1)
+            .font(.caption)
+            .foregroundStyle(Color(uiColor: .label).opacity(0.7))
         }
     }
 }


### PR DESCRIPTION
## Summary

Added custody disclaimer banner at top of Settings view. Banner displays self-custody messaging using existing localization keys with premium liquid glass styling (frosted glass background, solid green icon, readable typography).

## Screenshots

<p align="center">
  <img src="https://github.com/user-attachments/assets/fa56b541-18ce-47c8-998b-1dc67e56a402" width="300"/>
</p>

## Related

- Closes #84