### PR TITLE
Polish home screen and History Screen

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/components/StatusCapsule.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/StatusCapsule.kt
@@ -1,0 +1,52 @@
+package com.stablechannels.app.ui.components
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * A pill-shaped status capsule with slide+fade enter/exit animations.
+ *
+ * - Pill shape with RoundedCornerShape(50)
+ * - tonalElevation 3dp for subtle surface tint
+ * - Slide-up + fade-in on appear (300ms)
+ * - Slide-down + fade-out on disappear (300ms)
+ */
+@Composable
+fun StatusCapsule(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = message.isNotEmpty(),
+        enter = slideInVertically(
+            initialOffsetY = { it / 2 },
+            animationSpec = tween(durationMillis = 300)
+        ) + fadeIn(animationSpec = tween(durationMillis = 300)),
+        exit = slideOutVertically(
+            targetOffsetY = { it / 2 },
+            animationSpec = tween(durationMillis = 300)
+        ) + fadeOut(animationSpec = tween(durationMillis = 300)),
+        modifier = modifier
+    ) {
+        Surface(
+            shape = RoundedCornerShape(50),
+            tonalElevation = 3.dp,
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -4,18 +4,21 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.CallMade
-import androidx.compose.material.icons.automirrored.filled.CallReceived
-import androidx.compose.material.icons.filled.CompareArrows
+import androidx.compose.material.icons.filled.ArrowCircleDown
+import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.ElectricBolt
-import androidx.compose.material.icons.filled.ShoppingCart
-import androidx.compose.material.icons.filled.Sell
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -26,6 +29,7 @@ import com.stablechannels.app.util.relativeString
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
     var selectedSegment by remember { mutableIntStateOf(0) }
@@ -41,44 +45,84 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
 
     LaunchedEffect(Unit) { loadHistory() }
 
-    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
-        Text("History", style = MaterialTheme.typography.headlineSmall)
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Title — same position as Settings and Home
+        Text(
+            text = "History",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.fillMaxWidth()
+        )
         Spacer(Modifier.height(12.dp))
 
-        // Segment tabs
-        TabRow(selectedTabIndex = selectedSegment) {
-            Tab(selected = selectedSegment == 0, onClick = { selectedSegment = 0 }) { Text("Trades", Modifier.padding(12.dp)) }
-            Tab(selected = selectedSegment == 1, onClick = { selectedSegment = 1 }) { Text("Payments", Modifier.padding(12.dp)) }
+        // Segmented control (like iOS Picker .segmented)
+        SingleChoiceSegmentedButtonRow(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            SegmentedButton(
+                selected = selectedSegment == 0,
+                onClick = { selectedSegment = 0 },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                icon = {},
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = Color(0xFF10B981).copy(alpha = 0.15f),
+                    activeContentColor = Color(0xFF10B981),
+                    inactiveContainerColor = Color.Transparent,
+                    inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text("Trades")
+            }
+            SegmentedButton(
+                selected = selectedSegment == 1,
+                onClick = { selectedSegment = 1 },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                icon = {},
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = Color(0xFF10B981).copy(alpha = 0.15f),
+                    activeContentColor = Color(0xFF10B981),
+                    inactiveContainerColor = Color.Transparent,
+                    inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text("Payments")
+            }
         }
 
-        Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(16.dp))
 
-        if (selectedSegment == 0 && trades.isEmpty()) {
-            EmptyStateView(
-                icon = Icons.Default.CompareArrows,
-                title = "No Trades",
-                description = "Buy or sell BTC to see trades here."
-            )
-        } else if (selectedSegment == 1 && payments.isEmpty()) {
-            EmptyStateView(
-                icon = Icons.Default.ElectricBolt,
-                title = "No Payments",
-                description = "Send or receive payments to see history here."
-            )
-        } else {
-            LazyColumn {
-                if (selectedSegment == 0) {
-                    items(trades) { trade ->
-                        TradeRow(trade) { selectedTrade = trade }
-                    }
-                } else {
-                    items(payments) { payment ->
-                        PaymentRow(payment) { selectedPayment = payment }
+            if (selectedSegment == 0 && trades.isEmpty()) {
+                EmptyStateView(
+                    icon = Icons.Default.SwapHoriz,
+                    title = "No Trades",
+                    description = "Buy or sell BTC to see trades here."
+                )
+            } else if (selectedSegment == 1 && payments.isEmpty()) {
+                EmptyStateView(
+                    icon = Icons.Default.ElectricBolt,
+                    title = "No Payments",
+                    description = "Send or receive payments to see history here."
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    if (selectedSegment == 0) {
+                        items(trades) { trade ->
+                            TradeRow(trade) { selectedTrade = trade }
+                        }
+                    } else {
+                        items(payments) { payment ->
+                            PaymentRow(payment) { selectedPayment = payment }
+                        }
                     }
                 }
             }
         }
-    }
 
     // Detail dialogs
     selectedTrade?.let { trade ->
@@ -90,72 +134,146 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun TradeRow(trade: TradeRecord, onClick: () -> Unit) {
+private fun TradeRow(trade: TradeRecord, onClick: () -> Unit) {
     val isBuy = trade.action == "buy"
-    val icon = if (isBuy) Icons.Default.ShoppingCart else Icons.Default.Sell
-    val color = if (isBuy) Color(0xFFF59E0B) else Color(0xFF8B5CF6)
+    val icon = if (isBuy) Icons.Default.TrendingUp else Icons.Default.TrendingDown
+    val iconColor = if (isBuy) Color(0xFFF59E0B) else Color(0xFF8B5CF6)
 
-    ListItem(
-        modifier = Modifier.clickable(onClick = onClick),
-        leadingContent = { Icon(icon, contentDescription = null, tint = color) },
-        headlineContent = { Text(if (isBuy) "Buy BTC" else "Sell BTC") },
-        supportingContent = { Text(trade.date.relativeString()) },
-        trailingContent = {
-            Column(horizontalAlignment = Alignment.End) {
-                Text(trade.amountUSD.usdFormatted())
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 1.dp,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Icon with colored background
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = iconColor.copy(alpha = 0.12f),
+                modifier = Modifier.size(40.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
+                }
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            // Title + time
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    trade.status,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = when (trade.status) {
-                        "completed" -> Color(0xFF10B981)
-                        "failed" -> MaterialTheme.colorScheme.error
-                        else -> MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                    text = if (isBuy) "Buy BTC" else "Sell BTC",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = trade.date.relativeString(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+
+            // Amount + status
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = trade.amountUSD.usdFormatted(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                StatusBadge(trade.status)
+            }
         }
-    )
+    }
 }
 
 @Composable
-fun PaymentRow(payment: PaymentRecord, onClick: () -> Unit) {
+private fun PaymentRow(payment: PaymentRecord, onClick: () -> Unit) {
     val isIncoming = payment.isIncoming
-    val icon = if (isIncoming) Icons.AutoMirrored.Filled.CallReceived else Icons.AutoMirrored.Filled.CallMade
-    val color = if (isIncoming) Color(0xFF10B981) else Color(0xFF3B82F6)
+    val icon = if (isIncoming) Icons.Default.ArrowCircleDown else Icons.Default.ArrowCircleUp
+    val iconColor = if (isIncoming) Color(0xFF10B981) else Color(0xFF3B82F6)
     val typeLabel = when (payment.paymentType) {
-        "stability" -> "Stability"
+        "stability" -> "Settlement"
+        "lightning" -> "Lightning"
         "splice_in" -> "Splice In"
         "splice_out" -> "Splice Out"
         "onchain" -> "On-chain"
         "channel_close" -> "Channel Close"
-        else -> "Lightning"
+        "bolt12" -> "Bolt12"
+        else -> payment.paymentType
     }
 
-    ListItem(
-        modifier = Modifier.clickable(onClick = onClick),
-        leadingContent = { Icon(icon, contentDescription = null, tint = color) },
-        headlineContent = { Text(if (isIncoming) "Received" else "Sent") },
-        supportingContent = { Text("$typeLabel  ${payment.date.relativeString()}") },
-        trailingContent = {
-            Column(horizontalAlignment = Alignment.End) {
-                Text(payment.amountUSD?.usdFormatted() ?: payment.amountSats.satsFormatted())
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 1.dp,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Icon with colored background
+            Surface(
+                shape = RoundedCornerShape(10.dp),
+                color = iconColor.copy(alpha = 0.12f),
+                modifier = Modifier.size(40.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
+                }
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            // Title + type + time
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    payment.status,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = when (payment.status) {
-                        "completed" -> Color(0xFF10B981)
-                        "failed" -> MaterialTheme.colorScheme.error
-                        else -> MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                    text = if (isIncoming) "Received" else "Sent",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "$typeLabel · ${payment.date.relativeString()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+
+            // Amount + status
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = payment.amountUSD?.usdFormatted() ?: payment.amountSats.satsFormatted(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                StatusBadge(payment.status)
+            }
         }
+    }
+}
+
+@Composable
+private fun StatusBadge(status: String) {
+    val color = when (status) {
+        "completed" -> Color(0xFF10B981)
+        "pending" -> Color(0xFFF59E0B)
+        "failed" -> Color(0xFFEF4444)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(
+        text = status.replaceFirstChar { it.uppercase() },
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Medium,
+        color = color
     )
 }
 
 @Composable
 private fun EmptyStateView(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     title: String,
     description: String
 ) {
@@ -166,22 +284,30 @@ private fun EmptyStateView(
         contentAlignment = Alignment.Center
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                icon,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-            )
-            Spacer(Modifier.height(12.dp))
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.size(64.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    Icon(
+                        icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
             Text(
                 title,
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
+                fontWeight = FontWeight.SemiBold
             )
             Spacer(Modifier.height(4.dp))
             Text(
                 description,
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
@@ -23,9 +23,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import android.view.HapticFeedbackConstants
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CurrencyBitcoin
 import androidx.compose.material.icons.filled.Shield
@@ -33,7 +35,6 @@ import androidx.compose.material3.Icon
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.btcSpacedFormatted
 import com.stablechannels.app.util.usdFormatted
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
@@ -63,10 +64,15 @@ fun BalanceBar(
     val minTradeUSD = 1.0
 
     var barWidthPx by remember { mutableFloatStateOf(0f) }
-    var dragOffsetPx by remember { mutableFloatStateOf(0f) }
     var isDragging by remember { mutableStateOf(false) }
+    var hasTriggeredHaptic by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val density = LocalDensity.current
+    val view = LocalView.current
+
+    // Use Animatable for smooth snap-back animation
+    val dragOffset = remember { Animatable(0f) }
+    val dragOffsetPx = dragOffset.value
 
     val thumbDiameterPx = with(density) { thumbDiameter.toPx() }
 
@@ -106,44 +112,71 @@ fun BalanceBar(
                                 onDragStart = { offset ->
                                     if (abs(offset.x - baseXPx) < thumbDiameterPx * 1.5f) {
                                         isDragging = true
-                                        dragOffsetPx = 0f
+                                        hasTriggeredHaptic = false
+                                        scope.launch { dragOffset.snapTo(0f) }
                                         onDragStarted?.invoke()
                                     }
                                 },
                                 onDrag = { change, dragAmount ->
                                     if (isDragging) {
                                         change.consume()
-                                        dragOffsetPx = (dragOffsetPx + dragAmount.x)
+                                        val newOffset = (dragOffset.value + dragAmount.x)
                                             .coerceIn(-baseXPx, barWidthPx - baseXPx)
+                                        scope.launch { dragOffset.snapTo(newOffset) }
+
+                                        // Haptic tick when drag first crosses $1.00 threshold
+                                        if (!hasTriggeredHaptic && barWidthPx > 0) {
+                                            val fraction = abs(newOffset) / barWidthPx
+                                            val tradeUSD = fraction * totalUSD
+                                            if (tradeUSD >= minTradeUSD) {
+                                                hasTriggeredHaptic = true
+                                                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                                            }
+                                        }
                                     }
                                 },
                                 onDragEnd = {
                                     if (!isDragging) {
-                                        dragOffsetPx = 0f
+                                        scope.launch { dragOffset.snapTo(0f) }
                                         return@detectDragGestures
                                     }
                                     isDragging = false
-                                    val fraction = if (barWidthPx > 0) dragOffsetPx / barWidthPx else 0f
+                                    val currentOffset = dragOffset.value
+                                    val fraction = if (barWidthPx > 0) currentOffset / barWidthPx else 0f
                                     val tradeUSD = abs(fraction) * totalUSD
                                     if (tradeUSD < minTradeUSD) {
-                                        dragOffsetPx = 0f
+                                        // Below threshold: animate snap-back (400ms ease-out)
+                                        scope.launch {
+                                            dragOffset.animateTo(
+                                                targetValue = 0f,
+                                                animationSpec = tween(400, easing = androidx.compose.animation.core.EaseOut)
+                                            )
+                                        }
                                         return@detectDragGestures
                                     }
-                                    val direction = if (dragOffsetPx > 0) TradeDirection.SELL else TradeDirection.BUY
+                                    val direction = if (currentOffset > 0) TradeDirection.SELL else TradeDirection.BUY
                                     val clamped = if (direction == TradeDirection.BUY)
                                         min(tradeUSD, stableUSD)
                                     else
                                         min(tradeUSD, nativeUSD)
                                     onTradeRequest?.invoke(direction, clamped)
-                                    // Hold position, then snap back after sheet appears
+                                    // Hold position, then animate back (400ms ease-out)
                                     scope.launch {
-                                        delay(600)
-                                        dragOffsetPx = 0f
+                                        kotlinx.coroutines.delay(600)
+                                        dragOffset.animateTo(
+                                            targetValue = 0f,
+                                            animationSpec = tween(400, easing = androidx.compose.animation.core.EaseOut)
+                                        )
                                     }
                                 },
                                 onDragCancel = {
                                     isDragging = false
-                                    dragOffsetPx = 0f
+                                    scope.launch {
+                                        dragOffset.animateTo(
+                                            targetValue = 0f,
+                                            animationSpec = tween(400, easing = androidx.compose.animation.core.EaseOut)
+                                        )
+                                    }
                                 }
                             )
                         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -14,9 +14,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallMade
 import androidx.compose.material.icons.automirrored.filled.CallReceived
-import androidx.compose.material.icons.filled.ShoppingCart
-import androidx.compose.material.icons.filled.Sell
+import androidx.compose.material.icons.filled.ArrowCircleUp
+import androidx.compose.material.icons.filled.ArrowCircleDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.TrendingDown
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
@@ -38,6 +41,7 @@ import androidx.core.content.PermissionChecker
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.stablechannels.app.AppState
+import com.stablechannels.app.ui.components.StatusCapsule
 import com.stablechannels.app.ui.trade.BuyScreen
 import com.stablechannels.app.ui.trade.SellScreen
 import com.stablechannels.app.ui.transfer.ReceiveScreen
@@ -62,6 +66,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val hasReadyChannel by appState.hasReadyChannel.collectAsState()
     val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
     val isSyncing by appState.isSyncing.collectAsState()
+    val isFlashing by appState.paymentFlash.collectAsState()
 
     var showSend by remember { mutableStateOf(false) }
     var showReceive by remember { mutableStateOf(false) }
@@ -149,7 +154,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         }
                         context.startActivity(intent)
                     },
-                    colors = CardDefaults.cardColors(containerColor = Color(0xFFDC2626)),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.error),
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Row(
@@ -157,20 +162,26 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Icon(Icons.Default.Warning, contentDescription = null, tint = Color.White)
+                        Icon(Icons.Default.Warning, contentDescription = null, tint = MaterialTheme.colorScheme.onError)
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 "Notifications Disabled",
-                                color = Color.White,
+                                color = MaterialTheme.colorScheme.onError,
                                 fontWeight = FontWeight.SemiBold,
                                 fontSize = 14.sp
                             )
                             Text(
                                 "Enable notifications for stability payments",
-                                color = Color.White.copy(alpha = 0.9f),
+                                color = MaterialTheme.colorScheme.onError.copy(alpha = 0.9f),
                                 fontSize = 12.sp
                             )
                         }
+                        Icon(
+                            imageVector = Icons.Default.ChevronRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onError.copy(alpha = 0.7f),
+                            modifier = Modifier.size(16.dp)
+                        )
                     }
                 }
                 Spacer(Modifier.height(8.dp))
@@ -181,7 +192,9 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
             // Balance (tap to toggle USD/BTC)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.clickable { showBTC = !showBTC }
+                modifier = Modifier
+                    .clickable { showBTC = !showBTC }
+                    .paymentFlash(isFlashing)
             ) {
                 Text(
                     text = "Total Balance",
@@ -275,7 +288,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
                 ) {
                     Column(Modifier.padding(12.dp)) {
                         Row(
@@ -361,8 +374,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("Send", Icons.AutoMirrored.Filled.CallMade, Color(0xFF3B82F6), Modifier.weight(1f)) { showSend = true }
-                ActionButton("Receive", Icons.AutoMirrored.Filled.CallReceived, Color(0xFF10B981), Modifier.weight(1f), pulse = !hasReadyChannel) { showReceive = true }
+                ActionButton("Send", Icons.Default.ArrowCircleUp, Color(0xFF3B82F6), Modifier.weight(1f)) { showSend = true }
+                ActionButton("Receive", Icons.Default.ArrowCircleDown, Color(0xFF10B981), Modifier.weight(1f), pulse = !hasReadyChannel) { showReceive = true }
             }
 
             Spacer(Modifier.height(8.dp))
@@ -370,17 +383,15 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("Buy BTC", Icons.Default.ShoppingCart, Color(0xFFF59E0B), Modifier.weight(1f)) { showBuy = true }
-                ActionButton("Sell BTC", Icons.Default.Sell, Color(0xFF8B5CF6), Modifier.weight(1f)) { showSell = true }
+                ActionButton("Buy BTC", Icons.Default.TrendingUp, Color(0xFFF59E0B), Modifier.weight(1f)) { showBuy = true }
+                ActionButton("Sell BTC", Icons.Default.TrendingDown, Color(0xFF8B5CF6), Modifier.weight(1f)) { showSell = true }
             }
 
-            // Status
+            // Status capsule
             if (statusMessage.isNotEmpty()) {
                 Spacer(Modifier.height(12.dp))
-                Text(
-                    text = statusMessage,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                StatusCapsule(
+                    message = statusMessage
                 )
             }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PaymentFlashModifier.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PaymentFlashModifier.kt
@@ -1,0 +1,83 @@
+package com.stablechannels.app.ui.home
+
+import androidx.compose.animation.core.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Modifier that applies a payment flash animation:
+ * - Scale 1.0 → 1.08 over 300ms (ease-out)
+ * - Scale 1.08 → 1.0 over 400ms (ease-in-out)
+ * - Green tint overlay during scale-up phase
+ *
+ * Restarts from beginning if a new flash triggers during animation.
+ */
+@Composable
+fun Modifier.paymentFlash(isFlashing: Boolean): Modifier {
+    val scale = remember { Animatable(1f) }
+    val tintAlpha = remember { Animatable(0f) }
+
+    LaunchedEffect(isFlashing) {
+        if (isFlashing) {
+            // Reset to start if re-triggered
+            scale.snapTo(1f)
+            tintAlpha.snapTo(0f)
+
+            // Phase 1: scale up + green tint (300ms ease-out)
+            coroutineScope {
+                launch {
+                    scale.animateTo(
+                        targetValue = 1.08f,
+                        animationSpec = tween(durationMillis = 300, easing = EaseOut)
+                    )
+                }
+                launch {
+                    tintAlpha.animateTo(
+                        targetValue = 0.35f,
+                        animationSpec = tween(durationMillis = 300, easing = EaseOut)
+                    )
+                }
+            }
+
+            // Phase 2: scale down + remove tint (400ms ease-in-out)
+            coroutineScope {
+                launch {
+                    scale.animateTo(
+                        targetValue = 1f,
+                        animationSpec = tween(durationMillis = 400, easing = EaseInOut)
+                    )
+                }
+                launch {
+                    tintAlpha.animateTo(
+                        targetValue = 0f,
+                        animationSpec = tween(durationMillis = 400, easing = EaseInOut)
+                    )
+                }
+            }
+        }
+    }
+
+    val currentScale by scale.asState()
+    val currentTintAlpha by tintAlpha.asState()
+
+    return this
+        .graphicsLayer {
+            scaleX = currentScale
+            scaleY = currentScale
+            alpha = 1f - (currentTintAlpha * 0.3f) // slight dim during flash
+        }
+        .drawWithContent {
+            drawContent()
+            if (currentTintAlpha > 0f) {
+                drawRect(
+                    color = Color(0xFF10B981).copy(alpha = currentTintAlpha),
+                    size = size
+                )
+            }
+        }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -37,6 +37,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.max
 
 enum class ChartPeriod(val label: String, val days: Int, val usesHourly: Boolean) {
     DAY_1("1D", 1, true),
@@ -111,8 +112,13 @@ fun PriceChart(
         val hourly = hourlyPrices.filter { it.timestamp >= cutoffSec }
         val daily = allDailyPrices.filter { it.timestamp >= cutoffSec }
         val raw = if (chartPeriod.usesHourly && hourly.size >= 2) hourly else daily
-        // Cap at 120 points — keeps Canvas draw O(n) work proportional
-        priceHistory = downsample(raw, 120)
+        // Cap at 200 points — keeps Canvas draw smooth while preserving detail
+        priceHistory = downsample(raw, 200)
+    }
+
+    // Isolate live price label via derivedStateOf so price ticks only update text, not Canvas
+    val livePriceText by remember(currentPrice) {
+        derivedStateOf { currentPrice.usdFormatted() }
     }
 
     Card(
@@ -148,7 +154,7 @@ fun PriceChart(
                     } else {
                         Text("BTC Price", style = MaterialTheme.typography.labelMedium)
                         Text(
-                            currentPrice.usdFormatted(),
+                            livePriceText,
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold
                         )
@@ -223,95 +229,122 @@ fun PriceChart(
 
                 // Chart with Y-axis labels
                 Row(Modifier.fillMaxWidth()) {
-                    // Chart canvas
-                    Canvas(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(160.dp)
-                            .pointerInput(priceHistory) {
-                                detectDragGestures(
-                                    onDragEnd = { selectedPoint = null },
-                                    onDragCancel = { selectedPoint = null },
-                                    onDrag = { change, _ ->
-                                        change.consume()
-                                        val x = change.position.x
-                                        val w = size.width.toFloat()
-                                        val index = ((x / w) * (priceHistory.size - 1))
-                                            .toInt()
-                                            .coerceIn(0, priceHistory.size - 1)
-                                        selectedPoint = priceHistory[index]
-                                    }
+                    // Chart canvas — wrapped in key(priceHistory) to skip recomposition on parent state changes
+                    key(priceHistory) {
+                        Canvas(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(160.dp)
+                                .pointerInput(priceHistory) {
+                                    detectDragGestures(
+                                        onDragEnd = { selectedPoint = null },
+                                        onDragCancel = { selectedPoint = null },
+                                        onDrag = { change, _ ->
+                                            change.consume()
+                                            val x = change.position.x
+                                            val w = size.width.toFloat()
+                                            val index = ((x / w) * (priceHistory.size - 1))
+                                                .toInt()
+                                                .coerceIn(0, priceHistory.size - 1)
+                                            selectedPoint = priceHistory[index]
+                                        }
+                                    )
+                                }
+                                .pointerInput(priceHistory) {
+                                    detectTapGestures(
+                                        onPress = {
+                                            val x = it.x
+                                            val w = size.width.toFloat()
+                                            val index = ((x / w) * (priceHistory.size - 1))
+                                                .toInt()
+                                                .coerceIn(0, priceHistory.size - 1)
+                                            selectedPoint = priceHistory[index]
+                                            tryAwaitRelease()
+                                            selectedPoint = null
+                                        }
+                                    )
+                                }
+                        ) {
+                            val w = size.width
+                            val h = size.height
+
+                            if (priceRange < 0.01) {
+                                drawLine(color = lineColor, start = Offset(0f, h / 2), end = Offset(w, h / 2), strokeWidth = 2f)
+                                return@Canvas
+                            }
+
+                            // Grid lines
+                            for (i in 1..3) {
+                                val gy = h * i / 4
+                                drawLine(
+                                    color = Color.Gray.copy(alpha = 0.15f),
+                                    start = Offset(0f, gy),
+                                    end = Offset(w, gy),
+                                    strokeWidth = 0.5f,
+                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 8f))
                                 )
                             }
-                            .pointerInput(priceHistory) {
-                                detectTapGestures(
-                                    onPress = {
-                                        val x = it.x
-                                        val w = size.width.toFloat()
-                                        val index = ((x / w) * (priceHistory.size - 1))
-                                            .toInt()
-                                            .coerceIn(0, priceHistory.size - 1)
-                                        selectedPoint = priceHistory[index]
-                                        tryAwaitRelease()
-                                        selectedPoint = null
-                                    }
-                                )
+
+                            // Build line path — Catmull-Rom spline for ≥4 points, straight lines for 2-3
+                            val linePath = Path()
+                            val points = priceHistory.mapIndexed { i, record ->
+                                val px = (i.toFloat() / (priceHistory.size - 1)) * w
+                                val py = h - ((record.price - minPrice) / priceRange).toFloat() * h
+                                Offset(px, py)
                             }
-                    ) {
-                        val w = size.width
-                        val h = size.height
 
-                        if (priceRange < 0.01) {
-                            drawLine(color = lineColor, start = Offset(0f, h / 2), end = Offset(w, h / 2), strokeWidth = 2f)
-                            return@Canvas
-                        }
+                            linePath.moveTo(points[0].x, points[0].y)
 
-                        // Grid lines
-                        for (i in 1..3) {
-                            val gy = h * i / 4
-                            drawLine(
-                                color = Color.Gray.copy(alpha = 0.15f),
-                                start = Offset(0f, gy),
-                                end = Offset(w, gy),
-                                strokeWidth = 0.5f,
-                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 8f))
+                            if (points.size >= 4) {
+                                // Catmull-Rom spline converted to cubic Bezier control points
+                                for (i in 0 until points.size - 1) {
+                                    val p0 = points[max(i - 1, 0)]
+                                    val p1 = points[i]
+                                    val p2 = points[(i + 1).coerceAtMost(points.size - 1)]
+                                    val p3 = points[(i + 2).coerceAtMost(points.size - 1)]
+
+                                    // Catmull-Rom to cubic Bezier conversion (tension = 0.3 for smoother curves)
+                                    val cp1x = p1.x + (p2.x - p0.x) / 4f
+                                    val cp1y = p1.y + (p2.y - p0.y) / 4f
+                                    val cp2x = p2.x - (p3.x - p1.x) / 4f
+                                    val cp2y = p2.y - (p3.y - p1.y) / 4f
+
+                                    linePath.cubicTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y)
+                                }
+                            } else {
+                                // 2-3 points: straight lines
+                                for (i in 1 until points.size) {
+                                    linePath.lineTo(points[i].x, points[i].y)
+                                }
+                            }
+
+                            // Area fill
+                            val areaPath = Path().apply {
+                                addPath(linePath)
+                                lineTo(w, h)
+                                lineTo(0f, h)
+                                close()
+                            }
+                            drawPath(
+                                path = areaPath,
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(lineColor.copy(alpha = 0.15f), lineColor.copy(alpha = 0.02f))
+                                ),
+                                style = Fill
                             )
-                        }
 
-                        // Line path
-                        val linePath = Path()
-                        priceHistory.forEachIndexed { i, record ->
-                            val px = (i.toFloat() / (priceHistory.size - 1)) * w
-                            val py = h - ((record.price - minPrice) / priceRange).toFloat() * h
-                            if (i == 0) linePath.moveTo(px, py) else linePath.lineTo(px, py)
-                        }
+                            // Line
+                            drawPath(path = linePath, color = lineColor, style = Stroke(width = if (selectedIndex != null) 1.5f else 2f))
 
-                        // Area fill
-                        val areaPath = Path().apply {
-                            addPath(linePath)
-                            lineTo(w, h)
-                            lineTo(0f, h)
-                            close()
-                        }
-                        drawPath(
-                            path = areaPath,
-                            brush = Brush.verticalGradient(
-                                colors = listOf(lineColor.copy(alpha = 0.15f), lineColor.copy(alpha = 0.02f))
-                            ),
-                            style = Fill
-                        )
-
-                        // Line
-                        drawPath(path = linePath, color = lineColor, style = Stroke(width = if (selectedIndex != null) 1.5f else 2f))
-
-                        // Selected indicator
-                        if (selectedIndex != null) {
-                            val sx = (selectedIndex.toFloat() / (priceHistory.size - 1)) * w
-                            val record = priceHistory[selectedIndex]
-                            val sy = h - ((record.price - minPrice) / priceRange).toFloat() * h
-                            drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
-                            drawCircle(lineColor, 5f, Offset(sx, sy))
-                            drawCircle(Color.White, 3f, Offset(sx, sy))
+                            // Selected indicator
+                            if (selectedIndex != null) {
+                                val sx = (selectedIndex.toFloat() / (priceHistory.size - 1)) * w
+                                val record = priceHistory[selectedIndex]
+                                val sy = h - ((record.price - minPrice) / priceRange).toFloat() * h
+                                drawLine(Color.Gray.copy(alpha = 0.5f), Offset(sx, 0f), Offset(sx, h), 1f, pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f)))
+                                drawCircle(lineColor, 5f, Offset(sx, sy))
+                                drawCircle(Color.White, 3f, Offset(sx, sy))
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

Visual polish for the Home and History screens — matching iOS patterns for icons, animations, chart rendering, and layout consistency. The History screen is completely redesigned from flat ListItems to card-based rows with colored icon backgrounds.

## Changes

- `ui/home/PriceChart.kt`: Catmull-Rom spline interpolation for smooth chart curves (≥4 points), increased data point cap to 200, isolated live price label via `derivedStateOf` to prevent Canvas redraws on price ticks
- `ui/home/BalanceBar.kt`: Animated snap-back using `Animatable` + `tween(400ms, EaseOut)` replacing `delay(600)`, haptic tick at $1 drag threshold
- `ui/home/PaymentFlashModifier.kt`: New — `Modifier.paymentFlash(isFlashing)` scales balance 1.0→1.08 with green tint overlay on payment events
- `ui/components/StatusCapsule.kt`: New — pill-shaped status message with slide+fade animation (300ms), tonalElevation 3dp
- `ui/home/HomeScreen.kt`: iOS-style icons (ArrowCircleUp/Down for Send/Receive, TrendingUp/Down for Buy/Sell), tonal elevation on on-chain card, notification warning with chevron, StatusCapsule replaces plain text, paymentFlash wired to balance
- `ui/history/HistoryScreen.kt`: Complete redesign — card-based rows with colored icon backgrounds (40dp rounded squares), Material 3 SegmentedButton (green tint, no checkmark), relative timestamps, status badges, improved empty state with icon container

## Test plan

- Home screen: chart shows smooth curves (not jagged lines) with 30+ days of data
- Receive payment via WoS → balance flashes green and scales up briefly
- Status messages appear in pill-shaped capsule with slide animation
- Drag balance bar → smooth 60fps, haptic tick when crossing $1 threshold, animated snap-back on release
- History tab → segmented control with green selected state, no checkmark icons
- Trade/payment rows show colored icon backgrounds (orange Buy, purple Sell, green Received, blue Sent)
- Empty state shows centered icon in rounded container with description text
