### PR TITLE
stable-channels-lsp: vanilla LDK Server REST proxy routes

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -26,31 +26,22 @@ Clients (lsp-server-gui, iOS wallet, Android wallet)
 | `sc-protos/` | local | Hand written `prost` types for SC specific REST endpoints, plus route path constants. |
 | `sc-rest-client/` | local | REST client library, linked into the GUI and consumed by mobile wallet apps. WASM compatible. |
 | `lsp-server-gui/` | local | Native + WASM egui GUI. Talks to `stable-channels-lsp` over REST. |
-| `ldk-server-client` | LDK Server (`lightningdevkit/ldk-server`) | gRPC client used by `stable-channels-lsp` to dial LDK Server. Path dep on a sibling clone. |
-| `ldk-server-grpc` | LDK Server (`lightningdevkit/ldk-server`) | Wire types for LDK Server's gRPC surface (`GetNodeInfoRequest`, `Channel`, etc.). Re exported via `sc-rest-client`. |
+| `ldk-server-client` | LDK Server (`lightningdevkit/ldk-server`) | gRPC client used by `stable-channels-lsp` to dial LDK Server. Pinned to upstream via cargo git rev. |
+| `ldk-server-grpc` | LDK Server (`lightningdevkit/ldk-server`) | Wire types for LDK Server's gRPC surface (`GetNodeInfoRequest`, `Channel`, etc.). Pulled in transitively via `ldk-server-client`. |
 | `stable-channels` (root crate) | local | Shared utility lib (`db`, `audit`, `price_feeds`, `constants`). Path dep'd by the daemon. |
 
 ## Build & run
 
 The setup is **three terminals**: LDK Server, the SC daemon, and the GUI. All steps assume `bash`/`zsh`.
 
-### Step 1: Clone both repos as siblings
+### Step 1: Clone the repos
 
 ```bash
-cd /some/parent/path
 git clone https://github.com/toneloc/stable-channels.git
-git clone https://github.com/lightningdevkit/ldk-server.git ldk-server-upstream
+git clone https://github.com/lightningdevkit/ldk-server.git
 ```
 
-Resulting layout:
-
-```
-parent/
-├── stable-channels/
-└── ldk-server-upstream/
-```
-
-(The SC daemon's `Cargo.toml` has a path dep at `../../../ldk-server-upstream/ldk-server-client`, so this exact sibling layout is required.)
+The two clones can live anywhere on disk, in any layout. Cargo pulls `ldk-server-client` directly from upstream at a pinned rev, so no sibling-directory layout is required.
 
 ### Step 2: Build everything
 
@@ -58,13 +49,13 @@ parent/
 cd stable-channels
 cargo build --workspace --release
 
-cd ../ldk-server-upstream
+cd /path/to/ldk-server
 cargo build --release -p ldk-server
 ```
 
 ### Step 3: Configure LDK Server
 
-Edit `ldk-server-upstream/contrib/ldk-server-config.toml`:
+Edit LDK Server's `contrib/ldk-server-config.toml`:
 
 - **`[node]`**: set `network = "regtest"` (or `"signet"` / `"bitcoin"` to match your chosen chain backend).
 - **Chain source**: leave exactly one of `[bitcoind]` / `[electrum]` / `[esplora]` active and comment the others out. If you don't have a local Bitcoin Core or Electrum server, the easiest path is:
@@ -76,7 +67,7 @@ Edit `ldk-server-upstream/contrib/ldk-server-config.toml`:
 ### Step 4: Run LDK Server (Terminal 1)
 
 ```bash
-cd ldk-server-upstream
+cd /path/to/ldk-server
 ./target/release/ldk-server ./contrib/ldk-server-config.toml
 ```
 
@@ -95,7 +86,7 @@ Edit `sc-config.toml`:
 - **`[ldk_server] config_path`**: absolute path to LDK Server's config file, e.g.:
 
   ```toml
-  config_path = "/some/parent/path/ldk-server-upstream/contrib/ldk-server-config.toml"
+  config_path = "/path/to/ldk-server/contrib/ldk-server-config.toml"
   ```
 
   (The SC daemon reads this to resolve LDK Server's TLS cert path and api_key file.)
@@ -104,18 +95,6 @@ Edit `sc-config.toml`:
 
 ```bash
 ./target/release/stable-channels-lsp ./sc-config.toml
-```
-
-Expected log lines:
-
-```
-loaded config from ./sc-config.toml
-generated new SC api_key at ./data/stable-channels-lsp/<network>/api_key   # first run only
-SC daemon api_key located at ./data/stable-channels-lsp/<network>/api_key
-LDK Server gRPC endpoint: 127.0.0.1:3536
-loaded 0 stable channel records from sqlite
-listening on https://127.0.0.1:3002
-initial BTC/USD price = $<live price>
 ```
 
 The daemon auto generates its own `tls.crt`, `tls.key`, and `<network>/api_key` under `./data/stable-channels-lsp/`.

--- a/server/README.md
+++ b/server/README.md
@@ -4,19 +4,65 @@ Cargo workspace for the **Stable Channels LSP** bidaemon architecture, under act
 
 ## Architecture
 
-```
-Clients (lsp-server-gui, iOS wallet, Android wallet)
-                │
-     REST :3002 (TLS + HMAC, protobuf body)
-                ▼
-    stable-channels-lsp   (sqlite, audit log, price feed)
-                │
-       gRPC :3536 (TLS + HMAC)
-                ▼
-       LDK Server (lightningdevkit/ldk-server, unmodified)
+```mermaid
+flowchart TD
+    Client["Client (operator GUI / wallet)"]
+
+    Client -->|"POST /Endpoint over TLS :3002<br/>protobuf body<br/>X-Auth = HMAC(SC api_key, body)"| SCVerify
+
+    subgraph SC ["stable-channels-lsp daemon"]
+        SCVerify{"HMAC verify<br/>SC api_key"} --> Route{"Route by path"}
+        Route -- "SC-owned<br/>/GetPrice, /ListStableChannels,<br/>/AuditLog" --> Local["Local handler"]
+        Route -- "Proxy<br/>/GetNodeInfo, /OpenChannel,<br/>/Bolt11Receive, ..." --> Grpc["ldk-server-client<br/>(gRPC wrapper)"]
+        Local --> SCData[("sqlite + price feed<br/>+ audit log")]
+    end
+
+    Grpc -->|"gRPC over TLS :3536<br/>protobuf body<br/>X-Auth = HMAC(LDK Server api_key, body)"| LDKVerify
+
+    subgraph LDK ["LDK Server (vanilla, no SC code)"]
+        LDKVerify{"HMAC verify<br/>LDK Server api_key"} --> LDKDispatch["gRPC service<br/>dispatch"]
+        LDKDispatch --> Node["LDK Node<br/>(channels, payments,<br/>graph, peer manager)"]
+        LDKDispatch --> Bdk["BDK on-chain wallet"]
+        LDKDispatch --> Lsps2["LSPS2 service<br/>(JIT channels)"]
+        Node --> Store[("LDK + BDK state<br/>on disk")]
+        Bdk --> Store
+    end
+
+    Node <-->|"Lightning p2p<br/>BOLT-8 Noise · :9735"| Peers["Lightning peers<br/>(faucet, wallets via JIT, ...)"]
+    Bdk <-->|"esplora REST"| Esplora["Chain source<br/>(mutinynet.com/api)"]
 ```
 
-`stable-channels-lsp` proxies node level calls to LDK Server over gRPC and serves SC specific data (price feed, stable channel records, audit log) directly.
+`stable-channels-lsp` proxies node-level calls to LDK Server over gRPC and serves SC-specific data (price feed, stable channel records, audit log) directly. LDK Server stays vanilla.
+
+### Clients
+
+Two parallel client classes talk to the SC daemon's REST API:
+
+- **Operator GUI** (`lsp-server-gui`) for admin tasks: channel management, on-chain funds, audit log.
+- **Wallet apps** (desktop, iOS, Android) for end-user receive/send.
+
+They are **peers, not chained**. Both are equal clients of the same REST surface. The operator GUI is not "in front of" the wallet apps.
+
+### Auth model
+
+Each connection (client → SC daemon, *and* SC daemon → LDK Server) is secured by three pieces of provisioning data:
+
+| Item | Role |
+|---|---|
+| **API URL** | Where the listener is (`https://127.0.0.1:3002` for the SC daemon, `127.0.0.1:3536` for LDK Server gRPC). |
+| **api_key** | 32-byte shared secret. Used as the key in `HMAC-SHA256(api_key, request_body)`. The resulting HMAC goes in the `X-Auth` header on every request. **The key itself never travels on the wire after provisioning.** This is what authenticates the **client to the server**. |
+| **TLS certificate** | The server's self-signed cert, **pinned** by the client. Authenticates the **server to the client** and encrypts the channel. |
+
+So three jobs, three mechanisms: HMAC proves who's calling, cert pinning proves who's answering, TLS encrypts the bytes in between.
+
+The two hops use **independent pairs** of (api_key, TLS cert):
+
+- Hop 1 (client → SC daemon): the SC daemon's api_key + the SC daemon's TLS cert.
+- Hop 2 (SC daemon → LDK Server): **LDK Server's own** api_key + **LDK Server's own** TLS cert.
+
+A leak on either hop is contained. A leaked SC daemon api_key (on a wallet, on the operator GUI host, anywhere) gives the attacker access only to the SC daemon, not to LDK Server, because LDK Server only trusts its own key. Symmetrically, leaking LDK Server's key (e.g., off the host running both daemons) reveals nothing about any wallet's traffic.
+
+**How the SC daemon obtains LDK Server's secrets**: at startup the SC daemon reads LDK Server's own config file (path set in `sc-config.toml` under `[ldk_server] config_path`), derives the api_key file and TLS cert paths from it, and loads both into memory. Both daemons therefore need read access to a shared filesystem, usually the same host (Umbrel, VM, etc.). To split them across hosts, those two files have to be shipped over a separate secure channel, or the transport upgraded to mTLS.
 
 ## Crates
 
@@ -30,87 +76,111 @@ Clients (lsp-server-gui, iOS wallet, Android wallet)
 | `ldk-server-grpc` | LDK Server (`lightningdevkit/ldk-server`) | Wire types for LDK Server's gRPC surface (`GetNodeInfoRequest`, `Channel`, etc.). Pulled in transitively via `ldk-server-client`. |
 | `stable-channels` (root crate) | local | Shared utility lib (`db`, `audit`, `price_feeds`, `constants`). Path dep'd by the daemon. |
 
-## Build & run
+## Run the stack on Mutinynet (signet)
 
-The setup is **three terminals**: LDK Server, the SC daemon, and the GUI. All steps assume `bash`/`zsh`.
+[Mutinynet](https://mutinynet.com/) is a public signet variant with ~30s blocks and a faucet at <https://faucet.mutinynet.com/>. It's the recommended way to bring up the full stack (LDK Server + SC daemon + operator GUI + desktop wallet) end to end without spending real bitcoin. The setup is **four terminals**. All commands assume `bash`/`zsh`.
 
-### Step 1: Clone the repos
+### 1. Clone both repos
 
 ```bash
 git clone https://github.com/toneloc/stable-channels.git
 git clone https://github.com/lightningdevkit/ldk-server.git
 ```
 
-The two clones can live anywhere on disk, in any layout. Cargo pulls `ldk-server-client` directly from upstream at a pinned rev, so no sibling-directory layout is required.
+They can live anywhere on disk in any layout. Cargo pulls `ldk-server-client` from upstream at a pinned rev, so no sibling-directory requirement.
 
-### Step 2: Build everything
+### 2. Configure LDK Server
+
+In `ldk-server/contrib/ldk-server-config.toml`:
+
+```toml
+[node]
+network = "signet"
+
+[esplora]
+server_url = "https://mutinynet.com/api"
+
+[liquidity.lsps2_service]
+channel_opening_fee_ppm      = 0
+min_channel_opening_fee_msat = 0
+min_payment_size_msat        = 1000000
+
+[tor]
+proxy_address = "127.0.0.1:9050"
+```
+
+Comment out the `[bitcoind]`, `[electrum]`, and `[liquidity.lsps2_client]` blocks. The `[tor]` block must stay uncommented even if Tor isn't running.
+
+### 3. Configure the SC daemon
 
 ```bash
 cd stable-channels
-cargo build --workspace --release
-
-cd /path/to/ldk-server
-cargo build --release -p ldk-server
-```
-
-### Step 3: Configure LDK Server
-
-Edit LDK Server's `contrib/ldk-server-config.toml`:
-
-- **`[node]`**: set `network = "regtest"` (or `"signet"` / `"bitcoin"` to match your chosen chain backend).
-- **Chain source**: leave exactly one of `[bitcoind]` / `[electrum]` / `[esplora]` active and comment the others out. If you don't have a local Bitcoin Core or Electrum server, the easiest path is:
-  - Comment out `[bitcoind]` and `[electrum]`.
-  - Leave `[esplora]` with `server_url = "https://mempool.space/api"` and set `[node] network = "bitcoin"` (the default esplora endpoint is mainnet).
-- **`[tor]`**: uncomment `proxy_address = "127.0.0.1:9050"` (the field must be present in the TOML even if Tor isn't running).
-- **`[liquidity.lsps2_client]`**: comment out the entire section (its default placeholder values fail validation).
-
-### Step 4: Run LDK Server (Terminal 1)
-
-```bash
-cd /path/to/ldk-server
-./target/release/ldk-server ./contrib/ldk-server-config.toml
-```
-
-Wait for the log line `gRPC service listening on 127.0.0.1:3536`. LDK Server will auto generate its own `tls.crt`, `tls.key`, and `<network>/api_key` under its `[storage.disk] dir_path`.
-
-### Step 5: Configure the SC daemon (Terminal 2)
-
-```bash
-cd ../stable-channels
 cp server/stable-channels-lsp/example-config.toml ./sc-config.toml
 ```
 
 Edit `sc-config.toml`:
 
-- **`[node] network`**: must match LDK Server's network.
-- **`[ldk_server] config_path`**: absolute path to LDK Server's config file, e.g.:
-
-  ```toml
-  config_path = "/path/to/ldk-server/contrib/ldk-server-config.toml"
-  ```
-
-  (The SC daemon reads this to resolve LDK Server's TLS cert path and api_key file.)
-
-### Step 6: Run the SC daemon (Terminal 2)
-
-```bash
-./target/release/stable-channels-lsp ./sc-config.toml
+```toml
+network = "signet"
+config_path = "/absolute/path/to/ldk-server/contrib/ldk-server-config.toml"
 ```
 
-The daemon auto generates its own `tls.crt`, `tls.key`, and `<network>/api_key` under `./data/stable-channels-lsp/`.
+`config_path` is how the SC daemon discovers LDK Server's TLS cert and api_key.
 
-### Step 7: Run the GUI (Terminal 3)
+### 4. Configure the desktop wallet
 
-```bash
-./target/release/lsp-server-gui
+In `stable-channels/src/constants.rs`:
+
+```rust
+pub const DEFAULT_NETWORK: &str = "signet";
+pub const DEFAULT_CHAIN_URL: &str = "https://mutinynet.com/api";
+pub const FALLBACK_CHAIN_URL: &str = "https://mutinynet.com/api";
+pub const DEFAULT_LSP_PUBKEY: &str = "<LSP_NODE_ID>";   // fill in after step 5
+pub const DEFAULT_LSP_ADDRESS: &str = "127.0.0.1:9735";
 ```
 
-### Step 8: Connect
+`<LSP_NODE_ID>` comes from LDK Server's startup log line `Starting up LDK Node with node ID ...`. Launch the LSP first (step 5, terminal 1), copy the ID, paste it here, then build the wallet (terminal 4).
 
-In the GUI window:
+### 5. Launch the four services
 
-1. Click **Load Config**. The GUI auto discovers `sc-config.toml` in the current directory and populates Server URL (`127.0.0.1:3002`), API key (hex of the SC daemon's api_key file), and TLS cert path.
-2. Click **Connect**. The status indicator turns green and reads "Connected".
-3. **Node Info** tab: real `node_id`, best block hash and height, sync timestamps.
-4. **Channels** tab: renders "No channels found." on a fresh node.
-5. **Stable** tab: live BTC/USD price, empty stable channels table.
+```bash
+# Terminal 1: LDK Server (LSPS2 service feature is required for JIT channels)
+cd /path/to/ldk-server
+cargo run --release -p ldk-server --features experimental-lsps2-support -- contrib/ldk-server-config.toml
+
+# Terminal 2: SC daemon
+cd /path/to/stable-channels
+cargo run --release -p stable-channels-lsp -- sc-config.toml
+
+# Terminal 3: Operator GUI
+cargo run --release -p lsp-server-gui
+
+# Terminal 4: Desktop wallet (after pasting the LSP node ID into src/constants.rs)
+cargo run --release --bin stable-channels
+```
+
+First builds take a few minutes. Subsequent runs are seconds.
+
+### 6. Run the full Lightning flow
+
+In the operator GUI, then the wallet:
+
+1. **Load Config** → **Connect** (status turns green).
+2. **Onchain** tab → **Get Address** → copy the `tb1q...` address.
+3. <https://faucet.mutinynet.com/> → on-chain section → paste address → request ≥ 100,000 sats → wait ~1 block.
+4. The faucet's Lightning node URI is in the form `<pubkey>@<host:port>`. As of writing:
+   - **Node ID (pubkey):** `02465ed5be53d04fde66c9418ff14a5f2267723810176c9212b722e542dc1afb1b`
+   - **Address:** `45.79.52.207:9735`
+
+   If the faucet has rotated keys since, grab the current values from the faucet site.
+5. **Channels** tab → Connect Peer → paste the Node ID and Address from step 4 → **Connect**.
+6. **Channels** tab → Open Channel → same Node ID and Address, channel amount `50000` sats → **Open Channel** → wait ~90s for `is_channel_ready = true`.
+7. **Lightning** tab → **Spontaneous Payment (Keysend)** → Recipient = faucet Node ID, Amount = `30000000` **msat** (= 30,000 sats, multiply sats by 1,000 since the field is in msat) → **Send**. This pushes sats to the faucet's side of the channel so the LSP has inbound capacity.
+8. In the **wallet** onboarding screen: **Add Bitcoin** → **Fixed amount** (use Fixed on Mutinynet, enter ≥ 1000 sats) → **Receive**.
+9. Copy the `lntbs1...` invoice from the wallet's QR screen.
+10. Faucet site → Lightning section → paste invoice → **Pay**.
+11. The LSP opens a JIT channel to the wallet on the fly and forwards the HTLC. Verify in the operator GUI: **Channels** now shows two channels (faucet + wallet), and **Forwarded Payments** shows the routed HTLC. The wallet balance updates.
+
+### Other networks
+
+For regtest or mainnet, the same shape applies: swap `network = "signet"` in both config files, swap the esplora URL (or activate `[bitcoind]` / `[electrum]` instead) in LDK Server's config, and update `DEFAULT_CHAIN_URL` + `FALLBACK_CHAIN_URL` in `src/constants.rs`. Drop the zero-fee LSPS2 values when you're not just testing.

--- a/server/sc-rest-client/Cargo.toml
+++ b/server/sc-rest-client/Cargo.toml
@@ -10,7 +10,7 @@ serde = ["sc-protos/serde"]
 
 [dependencies]
 sc-protos = { path = "../sc-protos" }
-ldk-server-client = { path = "../../../ldk-server-upstream/ldk-server-client", features = ["serde"], default-features = false }
+ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "3f98b857abfa9bcf660fd14db35be17cf79e03c6", features = ["serde"], default-features = false }
 prost = { version = "0.11.6", default-features = false, features = ["std", "prost-derive"] }
 bitcoin_hashes = "0.14"
 

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # Workspace crates
 stable-channels   = { path = "../.." }
 sc-protos         = { path = "../sc-protos" }
-ldk-server-client = { path = "../../../ldk-server-upstream/ldk-server-client", features = ["serde"], default-features = false }
+ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "3f98b857abfa9bcf660fd14db35be17cf79e03c6", features = ["serde"], default-features = false }
 
 # HTTP/REST stack
 axum             = "0.8"

--- a/server/stable-channels-lsp/example-config.toml
+++ b/server/stable-channels-lsp/example-config.toml
@@ -20,7 +20,7 @@ dir_path = "./data/stable-channels-lsp"
 [ldk_server]
 # Path to LDK Server's own config.toml. The SC daemon uses LDK Server's config
 # helpers to find its TLS cert and api_key.
-config_path = "../ldk-server-upstream/ldk-server-config.toml"
+config_path = "/path/to/ldk-server-config.toml"
 
 # Optional explicit overrides. Each takes priority over what config_path resolves.
 # grpc_address = "127.0.0.1:3536"

--- a/server/stable-channels-lsp/src/auth.rs
+++ b/server/stable-channels-lsp/src/auth.rs
@@ -42,7 +42,13 @@ pub fn validate_auth(
     let expected = Hmac::<sha256::Hash>::from_engine(eng);
     let expected_hex = format!("{:x}", expected);
 
-    if expected_hex == hex_str {
+    // Constant-time comparison to avoid timing-leak HMAC recovery.
+    if ring::constant_time::verify_slices_are_equal(
+        expected_hex.as_bytes(),
+        hex_str.as_bytes(),
+    )
+    .is_ok()
+    {
         Ok(())
     } else {
         Err(AuthError::HmacMismatch)

--- a/server/stable-channels-lsp/src/handlers/channels.rs
+++ b/server/stable-channels-lsp/src/handlers/channels.rs
@@ -1,0 +1,79 @@
+//! REST proxies for LDK Server channel-management endpoints (open/close/splice/config).
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    CloseChannelRequest, ForceCloseChannelRequest, OpenChannelRequest, SpliceInRequest,
+    SpliceOutRequest, UpdateChannelConfigRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn open_channel(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: OpenChannelRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.open_channel(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn close_channel(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: CloseChannelRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.close_channel(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn force_close_channel(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ForceCloseChannelRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.force_close_channel(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn splice_in(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: SpliceInRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.splice_in(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn splice_out(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: SpliceOutRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.splice_out(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn update_channel_config(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: UpdateChannelConfigRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.update_channel_config(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/graph.rs
+++ b/server/stable-channels-lsp/src/handlers/graph.rs
@@ -1,0 +1,56 @@
+//! REST proxies for LDK Server network-graph endpoints.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    GraphGetChannelRequest, GraphGetNodeRequest, GraphListChannelsRequest, GraphListNodesRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn graph_list_channels(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: GraphListChannelsRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.graph_list_channels(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn graph_get_channel(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: GraphGetChannelRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.graph_get_channel(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn graph_list_nodes(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: GraphListNodesRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.graph_list_nodes(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn graph_get_node(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: GraphGetNodeRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.graph_get_node(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/lightning.rs
+++ b/server/stable-channels-lsp/src/handlers/lightning.rs
@@ -1,0 +1,68 @@
+//! REST proxies for LDK Server Lightning send/receive endpoints (Bolt11, Bolt12, spontaneous).
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    Bolt11ReceiveRequest, Bolt11SendRequest, Bolt12ReceiveRequest, Bolt12SendRequest,
+    SpontaneousSendRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn bolt11_receive(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: Bolt11ReceiveRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.bolt11_receive(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn bolt11_send(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: Bolt11SendRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.bolt11_send(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn bolt12_receive(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: Bolt12ReceiveRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.bolt12_receive(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn bolt12_send(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: Bolt12SendRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.bolt12_send(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn spontaneous_send(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: SpontaneousSendRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.spontaneous_send(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/mod.rs
+++ b/server/stable-channels-lsp/src/handlers/mod.rs
@@ -1,9 +1,16 @@
 //! REST handler infrastructure: error mapping, response encoding.
 
 pub mod audit_log;
+pub mod channels;
+pub mod graph;
+pub mod lightning;
+pub mod onchain;
+pub mod payments;
+pub mod peers;
 pub mod price;
 pub mod proxy;
 pub mod stable_channels;
+pub mod tools;
 
 use axum::body::Bytes;
 use axum::http::{header, StatusCode};

--- a/server/stable-channels-lsp/src/handlers/onchain.rs
+++ b/server/stable-channels-lsp/src/handlers/onchain.rs
@@ -1,0 +1,32 @@
+//! REST proxies for LDK Server on-chain send/receive endpoints.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{OnchainReceiveRequest, OnchainSendRequest};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn onchain_receive(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: OnchainReceiveRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.onchain_receive(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn onchain_send(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: OnchainSendRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.onchain_send(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/payments.rs
+++ b/server/stable-channels-lsp/src/handlers/payments.rs
@@ -1,0 +1,45 @@
+//! REST proxies for LDK Server payment-history endpoints.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    GetPaymentDetailsRequest, ListForwardedPaymentsRequest, ListPaymentsRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn list_payments(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ListPaymentsRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.list_payments(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn get_payment_details(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: GetPaymentDetailsRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.get_payment_details(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn list_forwarded_payments(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ListForwardedPaymentsRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.list_forwarded_payments(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/peers.rs
+++ b/server/stable-channels-lsp/src/handlers/peers.rs
@@ -1,0 +1,45 @@
+//! REST proxies for LDK Server peer-management endpoints.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    ConnectPeerRequest, DisconnectPeerRequest, ListPeersRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn list_peers(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ListPeersRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.list_peers(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn connect_peer(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ConnectPeerRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.connect_peer(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn disconnect_peer(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: DisconnectPeerRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.disconnect_peer(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/tools.rs
+++ b/server/stable-channels-lsp/src/handlers/tools.rs
@@ -1,0 +1,45 @@
+//! REST proxies for LDK Server signing / verification / scores-export endpoints.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use ldk_server_client::ldk_server_grpc::api::{
+    ExportPathfindingScoresRequest, SignMessageRequest, VerifySignatureRequest,
+};
+
+use crate::handlers::{decode_body, map_grpc_error, ok_response};
+use crate::state::AppState;
+
+pub async fn sign_message(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: SignMessageRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.sign_message(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn verify_signature(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: VerifySignatureRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.verify_signature(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}
+
+pub async fn export_pathfinding_scores(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: ExportPathfindingScoresRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match state.ldk_server.export_pathfinding_scores(req).await {
+        Ok(resp) => ok_response(resp),
+        Err(e) => map_grpc_error(e),
+    }
+}

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -15,6 +15,15 @@ use clap::Parser;
 use ldk_server_client::client::LdkServerClient;
 use ldk_server_client::config as ldk_config;
 use sc_protos::stable::{AUDIT_LOG_PATH, GET_PRICE_PATH, LIST_STABLE_CHANNELS_PATH};
+use ldk_server_client::ldk_server_grpc::endpoints::{
+    BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
+    CLOSE_CHANNEL_PATH, CONNECT_PEER_PATH, DISCONNECT_PEER_PATH, EXPORT_PATHFINDING_SCORES_PATH,
+    FORCE_CLOSE_CHANNEL_PATH, GET_PAYMENT_DETAILS_PATH, GRAPH_GET_CHANNEL_PATH,
+    GRAPH_GET_NODE_PATH, GRAPH_LIST_CHANNELS_PATH, GRAPH_LIST_NODES_PATH,
+    LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH, LIST_PEERS_PATH, ONCHAIN_RECEIVE_PATH,
+    ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, SIGN_MESSAGE_PATH, SPLICE_IN_PATH, SPLICE_OUT_PATH,
+    SPONTANEOUS_SEND_PATH, UPDATE_CHANNEL_CONFIG_PATH, VERIFY_SIGNATURE_PATH,
+};
 use stable_channels::audit::set_audit_log_path;
 use stable_channels::db::Database;
 use tower_http::trace::TraceLayer;
@@ -92,6 +101,40 @@ async fn main() -> Result<()> {
         .route("/GetNodeInfo", post(handlers::proxy::get_node_info))
         .route("/GetBalances", post(handlers::proxy::get_balances))
         .route("/ListChannels", post(handlers::proxy::list_channels))
+        // peers
+        .route(&format!("/{}", LIST_PEERS_PATH), post(handlers::peers::list_peers))
+        .route(&format!("/{}", CONNECT_PEER_PATH), post(handlers::peers::connect_peer))
+        .route(&format!("/{}", DISCONNECT_PEER_PATH), post(handlers::peers::disconnect_peer))
+        // payments
+        .route(&format!("/{}", LIST_PAYMENTS_PATH), post(handlers::payments::list_payments))
+        .route(&format!("/{}", GET_PAYMENT_DETAILS_PATH), post(handlers::payments::get_payment_details))
+        .route(&format!("/{}", LIST_FORWARDED_PAYMENTS_PATH), post(handlers::payments::list_forwarded_payments))
+        // lightning
+        .route(&format!("/{}", BOLT11_RECEIVE_PATH), post(handlers::lightning::bolt11_receive))
+        .route(&format!("/{}", BOLT11_SEND_PATH), post(handlers::lightning::bolt11_send))
+        .route(&format!("/{}", BOLT12_RECEIVE_PATH), post(handlers::lightning::bolt12_receive))
+        .route(&format!("/{}", BOLT12_SEND_PATH), post(handlers::lightning::bolt12_send))
+        .route(&format!("/{}", SPONTANEOUS_SEND_PATH), post(handlers::lightning::spontaneous_send))
+        // onchain
+        .route(&format!("/{}", ONCHAIN_RECEIVE_PATH), post(handlers::onchain::onchain_receive))
+        .route(&format!("/{}", ONCHAIN_SEND_PATH), post(handlers::onchain::onchain_send))
+        // channels
+        .route(&format!("/{}", OPEN_CHANNEL_PATH), post(handlers::channels::open_channel))
+        .route(&format!("/{}", CLOSE_CHANNEL_PATH), post(handlers::channels::close_channel))
+        .route(&format!("/{}", FORCE_CLOSE_CHANNEL_PATH), post(handlers::channels::force_close_channel))
+        .route(&format!("/{}", SPLICE_IN_PATH), post(handlers::channels::splice_in))
+        .route(&format!("/{}", SPLICE_OUT_PATH), post(handlers::channels::splice_out))
+        .route(&format!("/{}", UPDATE_CHANNEL_CONFIG_PATH), post(handlers::channels::update_channel_config))
+        // graph
+        .route(&format!("/{}", GRAPH_LIST_CHANNELS_PATH), post(handlers::graph::graph_list_channels))
+        .route(&format!("/{}", GRAPH_GET_CHANNEL_PATH), post(handlers::graph::graph_get_channel))
+        .route(&format!("/{}", GRAPH_LIST_NODES_PATH), post(handlers::graph::graph_list_nodes))
+        .route(&format!("/{}", GRAPH_GET_NODE_PATH), post(handlers::graph::graph_get_node))
+        // tools
+        .route(&format!("/{}", SIGN_MESSAGE_PATH), post(handlers::tools::sign_message))
+        .route(&format!("/{}", VERIFY_SIGNATURE_PATH), post(handlers::tools::verify_signature))
+        .route(&format!("/{}", EXPORT_PATHFINDING_SCORES_PATH), post(handlers::tools::export_pathfinding_scores))
+        // SC-specific
         .route(
             &format!("/{}", GET_PRICE_PATH),
             post(handlers::price::get_price),

--- a/src/user.rs
+++ b/src/user.rs
@@ -221,6 +221,9 @@ pub struct UserApp {
 
     // UI fields
     pub invoice_amount: String,
+    pub jit_amount_input: String,
+    pub jit_choice_open: bool,
+    pub jit_fixed_mode: bool,
     pub invoice_result: String,
     pub invoice_to_pay: String,
     pub on_chain_address: String,
@@ -534,6 +537,9 @@ impl UserApp {
             background_started: false,
             btc_price,
             invoice_amount: "0".to_string(),
+            jit_amount_input: String::new(),
+            jit_choice_open: false,
+            jit_fixed_mode: false,
             invoice_to_pay: String::new(),
             on_chain_address: String::new(),
             on_chain_amount: "0".to_string(),
@@ -817,8 +823,8 @@ impl UserApp {
         self.background_started = true;
     }
 
-    fn get_jit_invoice(&mut self, ctx: &egui::Context) {
-        println!("[DEBUG] get_jit_invoice called");
+    fn get_jit_invoice(&mut self, ctx: &egui::Context, amount_sats: Option<u64>) {
+        println!("[DEBUG] get_jit_invoice called (amount_sats={:?})", amount_sats);
         let description = ldk_node::lightning_invoice::Bolt11InvoiceDescription::Direct(
             ldk_node::lightning_invoice::Description::new(
                 "Stable Channel Wallet onboarding".to_string(),
@@ -826,23 +832,34 @@ impl UserApp {
             .unwrap(),
         );
 
-        // Variable amount invoice - user pays any amount they want
-        println!("[DEBUG] Calling receive_variable_amount_via_jit_channel");
-        let result = self
-            .node
-            .bolt11_payment()
-            .receive_variable_amount_via_jit_channel(
-                &description,
-                INVOICE_EXPIRY_SECS,
-                Some(MAX_PROPORTIONAL_LSP_FEE_LIMIT_PPM_MSAT),
-            );
+        let result = match amount_sats {
+            Some(sats) => {
+                let amount_msat = sats * 1000;
+                let max_lsp_fee_msat = (amount_msat * 80 / 100).max(20_000_000);
+                self.node.bolt11_payment().receive_via_jit_channel(
+                    amount_msat,
+                    &description,
+                    INVOICE_EXPIRY_SECS,
+                    Some(max_lsp_fee_msat),
+                )
+            }
+            None => self
+                .node
+                .bolt11_payment()
+                .receive_variable_amount_via_jit_channel(
+                    &description,
+                    INVOICE_EXPIRY_SECS,
+                    Some(MAX_PROPORTIONAL_LSP_FEE_LIMIT_PPM_MSAT),
+                ),
+        };
         println!("[DEBUG] JIT invoice result: {:?}", result.is_ok());
 
         audit_event(
             "JIT_INVOICE_ATTEMPT",
-            json!({
-                "type": "variable_amount"
-            }),
+            match amount_sats {
+                Some(s) => json!({"type": "fixed_amount", "amount_sats": s}),
+                None => json!({"type": "variable_amount"}),
+            },
         );
 
         match result {
@@ -3461,21 +3478,135 @@ impl UserApp {
 
                     ui.add_space(40.0);
 
-                    let btn = egui::Button::new(
-                        egui::RichText::new("Add Bitcoin")
-                            .color(egui::Color32::WHITE)
-                            .strong()
-                            .size(18.0),
-                    )
-                    .min_size(egui::vec2(200.0, 55.0))
-                    .fill(egui::Color32::BLACK)
-                    .corner_radius(theme::RADIUS_PILL);
-
                     ui.add_space(50.0);
 
-                    if ui.add(btn).clicked() {
-                        self.status_message = "Creating your wallet...".to_string();
-                        self.get_jit_invoice(ctx);
+                    if !self.jit_choice_open {
+                        let btn = egui::Button::new(
+                            egui::RichText::new("Add Bitcoin")
+                                .color(egui::Color32::WHITE)
+                                .strong()
+                                .size(18.0),
+                        )
+                        .min_size(egui::vec2(200.0, 55.0))
+                        .fill(egui::Color32::BLACK)
+                        .corner_radius(theme::RADIUS_PILL);
+                        if ui.add(btn).clicked() {
+                            self.jit_choice_open = true;
+                            self.jit_fixed_mode = false;
+                            self.jit_amount_input.clear();
+                        }
+                    } else if !self.jit_fixed_mode {
+                        ui.label(
+                            egui::RichText::new("Choose how to receive:")
+                                .size(15.0)
+                                .color(egui::Color32::BLACK),
+                        );
+                        ui.add_space(14.0);
+
+                        let var_btn = egui::Button::new(
+                            egui::RichText::new("Variable amount")
+                                .color(egui::Color32::WHITE)
+                                .strong()
+                                .size(16.0),
+                        )
+                        .min_size(egui::vec2(220.0, 48.0))
+                        .fill(egui::Color32::BLACK)
+                        .corner_radius(theme::RADIUS_PILL);
+                        if ui.add(var_btn).clicked() {
+                            self.status_message = "Creating your wallet...".to_string();
+                            self.get_jit_invoice(ctx, None);
+                            self.jit_choice_open = false;
+                            self.jit_fixed_mode = false;
+                        }
+
+                        ui.add_space(10.0);
+
+                        let fixed_btn = egui::Button::new(
+                            egui::RichText::new("Fixed amount")
+                                .color(egui::Color32::BLACK)
+                                .strong()
+                                .size(16.0),
+                        )
+                        .min_size(egui::vec2(220.0, 48.0))
+                        .fill(theme::SUBTLE_BG)
+                        .corner_radius(theme::RADIUS_PILL);
+                        if ui.add(fixed_btn).clicked() {
+                            self.jit_fixed_mode = true;
+                        }
+
+                        ui.add_space(12.0);
+                        if ui
+                            .link(
+                                egui::RichText::new("Cancel")
+                                    .size(13.0)
+                                    .color(egui::Color32::DARK_GRAY),
+                            )
+                            .clicked()
+                        {
+                            self.jit_choice_open = false;
+                        }
+                    } else {
+                        const JIT_MIN_SATS: u64 = 1_000;
+                        ui.label(
+                            egui::RichText::new("Enter amount (sats):")
+                                .size(15.0)
+                                .color(egui::Color32::BLACK),
+                        );
+                        ui.add_space(4.0);
+                        ui.label(
+                            egui::RichText::new(format!("Minimum {} sats", JIT_MIN_SATS))
+                                .size(12.0)
+                                .color(egui::Color32::DARK_GRAY),
+                        );
+                        ui.add_space(8.0);
+                        let amt_edit =
+                            egui::TextEdit::singleline(&mut self.jit_amount_input)
+                                .hint_text("e.g. 25000")
+                                .desired_width(200.0);
+                        ui.add(amt_edit);
+                        ui.add_space(12.0);
+                        let gen_btn = egui::Button::new(
+                            egui::RichText::new("Receive")
+                                .color(egui::Color32::WHITE)
+                                .strong()
+                                .size(15.0),
+                        )
+                        .min_size(egui::vec2(200.0, 40.0))
+                        .fill(egui::Color32::BLACK)
+                        .corner_radius(theme::RADIUS_PILL);
+                        if ui.add(gen_btn).clicked() {
+                            match self.jit_amount_input.trim().parse::<u64>() {
+                                Ok(sats) if sats >= JIT_MIN_SATS => {
+                                    self.status_message =
+                                        format!("Creating invoice for {} sats...", sats);
+                                    self.get_jit_invoice(ctx, Some(sats));
+                                    self.jit_choice_open = false;
+                                    self.jit_fixed_mode = false;
+                                }
+                                Ok(_) => {
+                                    self.status_message = format!(
+                                        "Amount must be at least {} sats",
+                                        JIT_MIN_SATS
+                                    );
+                                }
+                                Err(_) => {
+                                    self.status_message =
+                                        "Enter a positive number of sats".to_string();
+                                }
+                            }
+                        }
+
+                        ui.add_space(12.0);
+                        if ui
+                            .link(
+                                egui::RichText::new("Back")
+                                    .size(13.0)
+                                    .color(egui::Color32::DARK_GRAY),
+                            )
+                            .clicked()
+                        {
+                            self.jit_fixed_mode = false;
+                        }
                     }
 
                     // Show transfer option if user has onchain funds
@@ -7689,7 +7820,7 @@ impl App for UserApp {
                 // No channel — JIT invoice to open one
                 println!("[DEBUG] Fund wallet triggered, calling get_jit_invoice");
                 self.status_message = "Getting JIT channel invoice...".to_string();
-                self.get_jit_invoice(ctx);
+                self.get_jit_invoice(ctx, None);
             }
         }
 


### PR DESCRIPTION
## Summary

  - 26 LDK Server gRPC endpoints exposed via the stable-channels-lsp REST proxy (peers, payments, lightning, onchain, channels, graph, tools handlers).
  - `ldk-server-client` switched from sibling-path dep to a git rev pin on upstream main, so `cargo check --workspace` builds from a fresh clone.
  - Wallet onboarding "Add Bitcoin" now offers a Variable or Fixed amount JIT receive choice.
  - `auth.rs`: constant-time HMAC comparison via `ring::constant_time` (fixes timing-leak finding from automated security review).

See `server/README.md` for the full end-to-end replication recipe (configs → build → run → lightning flow)