### PR TITLE
feat(iOS): Partial backup

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -10,9 +10,14 @@
 		02EB2F2AFFACF5F588CF7912 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = C5B41595048B8AA9D3617B42 /* CodeScanner */; };
 		05856856E6E8EF9E688EFA20 /* PriceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0446A88D1E083A380EDC5436 /* PriceService.swift */; };
 		06C3B1697681F176DD44C146 /* StableChannelsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B785A33E02FD999CB62019AD /* StableChannelsApp.swift */; };
+		0CB88B7AD5C868A8BAB15AB7 /* ExportImportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */; };
+		10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */; };
 		1A54F909B027D90A0AADD1AF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95055FDBC76859CB74803660 /* HomeView.swift */; };
+		1A972F89DB503A5171D1525C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFF3730F0DCCB9662892DE /* KeychainService.swift */; };
 		1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */; };
 		2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD425F9D6479B95B2258FCAE /* Extensions.swift */; };
+		2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */; };
+		2FA17E14D9F4E24E05FF09E3 /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7BB840EC5C451056C5C21D /* CryptoService.swift */; };
 		37DA6E9D4F5D4BF36DD86BC8 /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */; };
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
@@ -54,6 +59,7 @@
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
 		62340228B969D280C66FD733 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC40949E35E9317ACA30E35 /* AppState.swift */; };
+		6410EE715C16CF8D006022EC /* MnemonicUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EFF29BD58A394274F50B96 /* MnemonicUtils.swift */; };
 		6929CC2C37EEDC6219317621 /* TradeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6EF4DE5A43647E46CAAD52B /* TradeService.swift */; };
 		6949A1E4AC3016EB41A5832A /* AuditService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */; };
 		6B789335CAF664AC4DA75B1A /* PaymentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6DE49D25B7A85291504E77 /* PaymentDetailView.swift */; };
@@ -65,19 +71,24 @@
 		88769D82377C43BCF549A52C /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A9339F75D1A3A7B5313C7 /* HistoryView.swift */; };
 		8A8A0B0C2BA8736EC140DD0E /* PriceChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B669FA976C4646AF0D206 /* PriceChartView.swift */; };
 		8A8C427CEEC2C65DD31A6E88 /* BuyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CB01DD108B12E75FFEAB11 /* BuyView.swift */; };
+		8C6EB05C5C93E0A887851D5D /* RateLimitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C253FF2C845BE12BC212FDB8 /* RateLimitService.swift */; };
 		8D7AA44935C2E984E70D42AE /* StabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF383D962C3260EA8D14692A /* StabilityService.swift */; };
 		96B467E3F04FC01EB23B8413 /* FundWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840E14EF06B6DF0135F2BE70 /* FundWalletView.swift */; };
 		96F38A820CB6644940199C95 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 79D34B41CFF9ABC3C914B624 /* KeychainAccess */; };
+		9EBF713364DF88022CB4F1D0 /* RestoreSeedSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */; };
+		A9F8B3821ACA38AD4DF869BD /* CloudBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */; };
 		B4C85619D6A5506E1BD9FC11 /* SellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955C6E8D6DB076A3B20A6F46 /* SellView.swift */; };
 		B58FDE639A431D2000E0F86D /* StableChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD82B198645873A6F492F2 /* StableChannel.swift */; };
 		BE362D96DB2063959BD092BC /* LDKNode in Frameworks */ = {isa = PBXBuildFile; productRef = 925308E8B38E5B35C4AB30A4 /* LDKNode */; };
 		C1911B3A7E4C92444F07A5C6 /* OnChainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9FF3A7A30FD6A84388868F3 /* OnChainView.swift */; };
+		C6695312119E768D5A04925A /* RestoreBackupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A322E98DBC403722CD1C6A /* RestoreBackupSheet.swift */; };
 		C6F3CDD0424F8A1BC7C7A1C9 /* LDKNode in Frameworks */ = {isa = PBXBuildFile; productRef = 74AB91D77B62D8BA24840317 /* LDKNode */; };
 		CF42CAD5BA55B3F759B62E22 /* Trade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3E864653E657FB0FCA3D2 /* Trade.swift */; };
 		DC5FA35343D89CB75FD4E402 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62A82EA774DC10F10A6574A /* ContentView.swift */; };
 		E7E816D3AF095B47E1F58407 /* HistoricalPrices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B46630309755AE15EF291D4 /* HistoricalPrices.swift */; };
 		E8C9430FF8920728747EF550 /* SendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0FAABBD08BCBF20220C850 /* SendView.swift */; };
 		F54F1E51D4AF15D8700AB399 /* NotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A2BA7D52F62DF17EFF532635 /* NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		FE2F09CF9E95112AC80D178F /* BackupPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,25 +166,35 @@
 		49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StablePositionView.swift; sourceTree = "<group>"; };
 		4F10632049E3C904E518EDD2 /* TradeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeDetailView.swift; sourceTree = "<group>"; };
 		4F22F6639A59D4B86A959586 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupService.swift; sourceTree = "<group>"; };
+		55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreSeedSheet.swift; sourceTree = "<group>"; };
+		5AFFF3730F0DCCB9662892DE /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		61BB0D1D623E0794FC1ED6ED /* NodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeService.swift; sourceTree = "<group>"; };
 		623F41D841B312F0C9AE01E6 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		6666E1947A119ECA89E2F4C2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6DCB92A88D9FEEAE6BF49737 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		6DDD82B198645873A6F492F2 /* StableChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableChannel.swift; sourceTree = "<group>"; };
+		6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupPromptView.swift; sourceTree = "<group>"; };
 		702A9339F75D1A3A7B5313C7 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		786B669FA976C4646AF0D206 /* PriceChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChartView.swift; sourceTree = "<group>"; };
 		7DB261201C1C656BAAED5283 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		7E0FAABBD08BCBF20220C850 /* SendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendView.swift; sourceTree = "<group>"; };
+		82EFF29BD58A394274F50B96 /* MnemonicUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MnemonicUtils.swift; sourceTree = "<group>"; };
 		840E14EF06B6DF0135F2BE70 /* FundWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FundWalletView.swift; sourceTree = "<group>"; };
 		8811E90D4B2B5C5C51093A95 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedWordGridView.swift; sourceTree = "<group>"; };
 		8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StabilityServiceTests.swift; sourceTree = "<group>"; };
 		95055FDBC76859CB74803660 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		955C6E8D6DB076A3B20A6F46 /* SellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellView.swift; sourceTree = "<group>"; };
 		A2BA7D52F62DF17EFF532635 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAE0551124703F8BAA9C44C0 /* StableChannels.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StableChannels.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModels.swift; sourceTree = "<group>"; };
 		AD425F9D6479B95B2258FCAE /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		B785A33E02FD999CB62019AD /* StableChannelsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableChannelsApp.swift; sourceTree = "<group>"; };
+		BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportImportSheet.swift; sourceTree = "<group>"; };
 		BE6DE49D25B7A85291504E77 /* PaymentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailView.swift; sourceTree = "<group>"; };
+		C253FF2C845BE12BC212FDB8 /* RateLimitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimitService.swift; sourceTree = "<group>"; };
+		CB7BB840EC5C451056C5C21D /* CryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoService.swift; sourceTree = "<group>"; };
 		CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditService.swift; sourceTree = "<group>"; };
 		D34C08DCF6ACD28A3898859D /* StableChannelsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StableChannelsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D62A82EA774DC10F10A6574A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -183,6 +204,7 @@
 		E6EF4DE5A43647E46CAAD52B /* TradeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeService.swift; sourceTree = "<group>"; };
 		E9358B0D20BFCDFAF7128834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceBarView.swift; sourceTree = "<group>"; };
+		F7A322E98DBC403722CD1C6A /* RestoreBackupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreBackupSheet.swift; sourceTree = "<group>"; };
 		FFC40949E35E9317ACA30E35 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -224,6 +246,7 @@
 			children = (
 				6DDD82B198645873A6F492F2 /* StableChannel.swift */,
 				45B3E864653E657FB0FCA3D2 /* Trade.swift */,
+				ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -314,6 +337,10 @@
 				0446A88D1E083A380EDC5436 /* PriceService.swift */,
 				DF383D962C3260EA8D14692A /* StabilityService.swift */,
 				E6EF4DE5A43647E46CAAD52B /* TradeService.swift */,
+				5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */,
+				CB7BB840EC5C451056C5C21D /* CryptoService.swift */,
+				5AFFF3730F0DCCB9662892DE /* KeychainService.swift */,
+				C253FF2C845BE12BC212FDB8 /* RateLimitService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -340,6 +367,11 @@
 				49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */,
 				49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */,
 				7DB261201C1C656BAAED5283 /* SettingsView.swift */,
+				6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */,
+				BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */,
+				F7A322E98DBC403722CD1C6A /* RestoreBackupSheet.swift */,
+				55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */,
+				88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -350,6 +382,7 @@
 				496A44452FCD5845005AF12F /* InputSanitizer.swift */,
 				4F22F6639A59D4B86A959586 /* Constants.swift */,
 				AD425F9D6479B95B2258FCAE /* Extensions.swift */,
+				82EFF29BD58A394274F50B96 /* MnemonicUtils.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -608,6 +641,17 @@
 				CF42CAD5BA55B3F759B62E22 /* Trade.swift in Sources */,
 				55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */,
 				6929CC2C37EEDC6219317621 /* TradeService.swift in Sources */,
+				2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */,
+				A9F8B3821ACA38AD4DF869BD /* CloudBackupService.swift in Sources */,
+				2FA17E14D9F4E24E05FF09E3 /* CryptoService.swift in Sources */,
+				1A972F89DB503A5171D1525C /* KeychainService.swift in Sources */,
+				8C6EB05C5C93E0A887851D5D /* RateLimitService.swift in Sources */,
+				6410EE715C16CF8D006022EC /* MnemonicUtils.swift in Sources */,
+				FE2F09CF9E95112AC80D178F /* BackupPromptView.swift in Sources */,
+				0CB88B7AD5C868A8BAB15AB7 /* ExportImportSheet.swift in Sources */,
+				C6695312119E768D5A04925A /* RestoreBackupSheet.swift in Sources */,
+				9EBF713364DF88022CB4F1D0 /* RestoreSeedSheet.swift in Sources */,
+				10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		499DBE782FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */; };
 		499DBE7B2FD2F06F003E89F9 /* TxidLinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */; };
 		499DBE7C2FD2F06F003E89F9 /* DepositRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */; };
+		49AD1B4B2FEE77F40015A7D9 /* SeedDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AD1B4A2FEE77F40015A7D9 /* SeedDisplayView.swift */; };
+		49AD1B512FEE812E0015A7D9 /* NativeTimerAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AD1B502FEE812E0015A7D9 /* NativeTimerAlert.swift */; };
 		49D4DB062FD02F400074ACD2 /* CloseTxidResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */; };
 		49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */; };
 		49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */; };
@@ -150,6 +152,8 @@
 		499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredTaskLauncherTests.swift; sourceTree = "<group>"; };
 		499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositRecorder.swift; sourceTree = "<group>"; };
 		499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxidLinkStore.swift; sourceTree = "<group>"; };
+		49AD1B4A2FEE77F40015A7D9 /* SeedDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedDisplayView.swift; sourceTree = "<group>"; };
+		49AD1B502FEE812E0015A7D9 /* NativeTimerAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTimerAlert.swift; sourceTree = "<group>"; };
 		49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolver.swift; sourceTree = "<group>"; };
 		49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolverTests.swift; sourceTree = "<group>"; };
 		49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseServiceTests.swift; sourceTree = "<group>"; };
@@ -376,11 +380,13 @@
 				49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */,
 				49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */,
 				BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */,
+				49AD1B502FEE812E0015A7D9 /* NativeTimerAlert.swift */,
 				49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */,
 				49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */,
 				49F0B0DC2FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift */,
 				F7A322E98DBC403722CD1C6A /* RestoreBackupSheet.swift */,
 				55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */,
+				49AD1B4A2FEE77F40015A7D9 /* SeedDisplayView.swift */,
 				88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */,
 				7DB261201C1C656BAAED5283 /* SettingsView.swift */,
 				49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */,
@@ -603,6 +609,8 @@
 				6949A1E4AC3016EB41A5832A /* AuditService.swift in Sources */,
 				49E4D8A62FED9FF3002AF338 /* BackupSettingsSupportBanner.swift in Sources */,
 				49E4D8A72FED9FF3002AF338 /* BackupSettingsICloudSection.swift in Sources */,
+				49AD1B4B2FEE77F40015A7D9 /* SeedDisplayView.swift in Sources */,
+				49AD1B512FEE812E0015A7D9 /* NativeTimerAlert.swift in Sources */,
 				581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */,
 				8A8C427CEEC2C65DD31A6E88 /* BuyView.swift in Sources */,
 				49E4D8A12FED848F002AF338 /* BackupError.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		1A54F909B027D90A0AADD1AF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95055FDBC76859CB74803660 /* HomeView.swift */; };
 		1A972F89DB503A5171D1525C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFF3730F0DCCB9662892DE /* KeychainService.swift */; };
 		1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */; };
-		1D8B3096714E8844A43983C3 /* BackupSettingsSupportBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */; };
 		2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD425F9D6479B95B2258FCAE /* Extensions.swift */; };
 		2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */; };
 		2FA17E14D9F4E24E05FF09E3 /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7BB840EC5C451056C5C21D /* CryptoService.swift */; };
@@ -48,6 +47,10 @@
 		49E4567E2FCA3E8B00B0CA85 /* QRCode in Frameworks */ = {isa = PBXBuildFile; productRef = 49E4567D2FCA3E8B00B0CA85 /* QRCode */; };
 		49E456812FCC596F00B0CA85 /* QRCodeUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */; };
 		49E456822FCC596F00B0CA85 /* FullscreenQRZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */; };
+		49E4D8A12FED848F002AF338 /* BackupError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4D8A02FED848F002AF338 /* BackupError.swift */; };
+		49E4D8A32FED84B7002AF338 /* BackupServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4D8A22FED84B7002AF338 /* BackupServiceProtocol.swift */; };
+		49E4D8A62FED9FF3002AF338 /* BackupSettingsSupportBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4D8A52FED9FF3002AF338 /* BackupSettingsSupportBanner.swift */; };
+		49E4D8A72FED9FF3002AF338 /* BackupSettingsICloudSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4D8A42FED9FF3002AF338 /* BackupSettingsICloudSection.swift */; };
 		49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */; };
 		49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */; };
 		49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */; };
@@ -57,7 +60,6 @@
 		49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */; };
 		49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */; };
 		49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */; };
-		4BF29DF506BBCCD9FC1ECE0B /* BackupSettingsICloudSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */; };
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
 		62340228B969D280C66FD733 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC40949E35E9317ACA30E35 /* AppState.swift */; };
@@ -157,6 +159,10 @@
 		49DAFB3B2FDB6587003BE0EB /* FeeRateServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeRateServiceTests.swift; sourceTree = "<group>"; };
 		49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenQRZoomView.swift; sourceTree = "<group>"; };
 		49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeUtility.swift; sourceTree = "<group>"; };
+		49E4D8A02FED848F002AF338 /* BackupError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupError.swift; sourceTree = "<group>"; };
+		49E4D8A22FED84B7002AF338 /* BackupServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceProtocol.swift; sourceTree = "<group>"; };
+		49E4D8A42FED9FF3002AF338 /* BackupSettingsICloudSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsICloudSection.swift; sourceTree = "<group>"; };
+		49E4D8A52FED9FF3002AF338 /* BackupSettingsSupportBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsSupportBanner.swift; sourceTree = "<group>"; };
 		49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettingsView.swift; sourceTree = "<group>"; };
 		49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
@@ -189,7 +195,6 @@
 		95055FDBC76859CB74803660 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		955C6E8D6DB076A3B20A6F46 /* SellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellView.swift; sourceTree = "<group>"; };
 		A2BA7D52F62DF17EFF532635 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackupSettingsSupportBanner.swift; path = StableChannels/Features/Settings/BackupSettingsSupportBanner.swift; sourceTree = "<group>"; };
 		AAE0551124703F8BAA9C44C0 /* StableChannels.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StableChannels.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModels.swift; sourceTree = "<group>"; };
 		AD425F9D6479B95B2258FCAE /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -204,7 +209,6 @@
 		D9FF3A7A30FD6A84388868F3 /* OnChainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainView.swift; sourceTree = "<group>"; };
 		DF383D962C3260EA8D14692A /* StabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StabilityService.swift; sourceTree = "<group>"; };
 		E2CB01DD108B12E75FFEAB11 /* BuyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyView.swift; sourceTree = "<group>"; };
-		E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackupSettingsICloudSection.swift; path = StableChannels/Features/Settings/BackupSettingsICloudSection.swift; sourceTree = "<group>"; };
 		E6EF4DE5A43647E46CAAD52B /* TradeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeService.swift; sourceTree = "<group>"; };
 		E9358B0D20BFCDFAF7128834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceBarView.swift; sourceTree = "<group>"; };
@@ -248,9 +252,9 @@
 		2788439C4BA338889A92627F /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */,
 				6DDD82B198645873A6F492F2 /* StableChannel.swift */,
 				45B3E864653E657FB0FCA3D2 /* Trade.swift */,
-				ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -262,8 +266,6 @@
 				674DEDB749CCE3FA348043D1 /* StableChannels */,
 				F11CF0F21D3319E86AF791B6 /* StableChannelsTests */,
 				052E4A6FC61BFB06E0A2A974 /* Products */,
-				A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */,
-				E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -281,12 +283,12 @@
 		49FC3EEC2FDC8B200054CD38 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */,
-				496A44422FCD4F75005AF12F /* QRInputToolbar.swift */,
-				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
-				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
 				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
+				496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */,
 				49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */,
+				496A44422FCD4F75005AF12F /* QRInputToolbar.swift */,
+				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
+				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -294,8 +296,8 @@
 		49FC3EED2FDC8C060054CD38 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				49FC3EEE2FDC8C160054CD38 /* Themes */,
 				3B46630309755AE15EF291D4 /* HistoricalPrices.swift */,
+				49FC3EEE2FDC8C160054CD38 /* Themes */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -329,24 +331,26 @@
 		7EE46C95963B6C9F86006346 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				49DAFB392FDB5FEB003BE0EB /* FeeRateService.swift */,
-				499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */,
-				499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */,
-				499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */,
-				499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */,
-				499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */,
-				49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */,
-				49D9C2E12FB6E52E00133509 /* BiometricService.swift */,
 				CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */,
-				3940DC5406ABC63AA090441A /* DatabaseService.swift */,
-				61BB0D1D623E0794FC1ED6ED /* NodeService.swift */,
-				0446A88D1E083A380EDC5436 /* PriceService.swift */,
-				DF383D962C3260EA8D14692A /* StabilityService.swift */,
-				E6EF4DE5A43647E46CAAD52B /* TradeService.swift */,
+				49E4D8A02FED848F002AF338 /* BackupError.swift */,
+				49E4D8A22FED84B7002AF338 /* BackupServiceProtocol.swift */,
+				49D9C2E12FB6E52E00133509 /* BiometricService.swift */,
+				49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */,
 				5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */,
 				CB7BB840EC5C451056C5C21D /* CryptoService.swift */,
+				3940DC5406ABC63AA090441A /* DatabaseService.swift */,
+				499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */,
+				49DAFB392FDB5FEB003BE0EB /* FeeRateService.swift */,
 				5AFFF3730F0DCCB9662892DE /* KeychainService.swift */,
+				61BB0D1D623E0794FC1ED6ED /* NodeService.swift */,
+				499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */,
+				0446A88D1E083A380EDC5436 /* PriceService.swift */,
 				C253FF2C845BE12BC212FDB8 /* RateLimitService.swift */,
+				499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */,
+				DF383D962C3260EA8D14692A /* StabilityService.swift */,
+				499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */,
+				E6EF4DE5A43647E46CAAD52B /* TradeService.swift */,
+				499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -364,20 +368,22 @@
 			isa = PBXGroup;
 			children = (
 				49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */,
+				49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */,
 				49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */,
+				6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */,
+				49E4D8A42FED9FF3002AF338 /* BackupSettingsICloudSection.swift */,
+				49E4D8A52FED9FF3002AF338 /* BackupSettingsSupportBanner.swift */,
 				49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */,
 				49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */,
+				BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */,
 				49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */,
 				49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */,
 				49F0B0DC2FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift */,
-				49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */,
-				49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */,
-				7DB261201C1C656BAAED5283 /* SettingsView.swift */,
-				6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */,
-				BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */,
 				F7A322E98DBC403722CD1C6A /* RestoreBackupSheet.swift */,
 				55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */,
 				88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */,
+				7DB261201C1C656BAAED5283 /* SettingsView.swift */,
+				49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -385,9 +391,9 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				496A44452FCD5845005AF12F /* InputSanitizer.swift */,
 				4F22F6639A59D4B86A959586 /* Constants.swift */,
 				AD425F9D6479B95B2258FCAE /* Extensions.swift */,
+				496A44452FCD5845005AF12F /* InputSanitizer.swift */,
 				82EFF29BD58A394274F50B96 /* MnemonicUtils.swift */,
 			);
 			path = Utilities;
@@ -595,8 +601,11 @@
 			files = (
 				62340228B969D280C66FD733 /* AppState.swift in Sources */,
 				6949A1E4AC3016EB41A5832A /* AuditService.swift in Sources */,
+				49E4D8A62FED9FF3002AF338 /* BackupSettingsSupportBanner.swift in Sources */,
+				49E4D8A72FED9FF3002AF338 /* BackupSettingsICloudSection.swift in Sources */,
 				581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */,
 				8A8C427CEEC2C65DD31A6E88 /* BuyView.swift in Sources */,
+				49E4D8A12FED848F002AF338 /* BackupError.swift in Sources */,
 				7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */,
 				DC5FA35343D89CB75FD4E402 /* ContentView.swift in Sources */,
 				499DBE702FD2DACF003E89F9 /* OnchainTxidResolver.swift in Sources */,
@@ -645,6 +654,7 @@
 				49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */,
 				49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */,
 				CF42CAD5BA55B3F759B62E22 /* Trade.swift in Sources */,
+				49E4D8A32FED84B7002AF338 /* BackupServiceProtocol.swift in Sources */,
 				55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */,
 				6929CC2C37EEDC6219317621 /* TradeService.swift in Sources */,
 				2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */,
@@ -658,8 +668,6 @@
 				C6695312119E768D5A04925A /* RestoreBackupSheet.swift in Sources */,
 				9EBF713364DF88022CB4F1D0 /* RestoreSeedSheet.swift in Sources */,
 				10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */,
-				1D8B3096714E8844A43983C3 /* BackupSettingsSupportBanner.swift in Sources */,
-				4BF29DF506BBCCD9FC1ECE0B /* BackupSettingsICloudSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1A54F909B027D90A0AADD1AF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95055FDBC76859CB74803660 /* HomeView.swift */; };
 		1A972F89DB503A5171D1525C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFF3730F0DCCB9662892DE /* KeychainService.swift */; };
 		1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */; };
+		1D8B3096714E8844A43983C3 /* BackupSettingsSupportBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */; };
 		2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD425F9D6479B95B2258FCAE /* Extensions.swift */; };
 		2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */; };
 		2FA17E14D9F4E24E05FF09E3 /* CryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7BB840EC5C451056C5C21D /* CryptoService.swift */; };
@@ -56,6 +57,7 @@
 		49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DD2FC0EF3A003A3B89 /* StablePositionView.swift */; };
 		49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */; };
 		49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */; };
+		4BF29DF506BBCCD9FC1ECE0B /* BackupSettingsICloudSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */; };
 		55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F10632049E3C904E518EDD2 /* TradeDetailView.swift */; };
 		581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */; };
 		62340228B969D280C66FD733 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC40949E35E9317ACA30E35 /* AppState.swift */; };
@@ -187,6 +189,7 @@
 		95055FDBC76859CB74803660 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		955C6E8D6DB076A3B20A6F46 /* SellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellView.swift; sourceTree = "<group>"; };
 		A2BA7D52F62DF17EFF532635 /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackupSettingsSupportBanner.swift; path = StableChannels/Features/Settings/BackupSettingsSupportBanner.swift; sourceTree = "<group>"; };
 		AAE0551124703F8BAA9C44C0 /* StableChannels.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StableChannels.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModels.swift; sourceTree = "<group>"; };
 		AD425F9D6479B95B2258FCAE /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -201,6 +204,7 @@
 		D9FF3A7A30FD6A84388868F3 /* OnChainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainView.swift; sourceTree = "<group>"; };
 		DF383D962C3260EA8D14692A /* StabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StabilityService.swift; sourceTree = "<group>"; };
 		E2CB01DD108B12E75FFEAB11 /* BuyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyView.swift; sourceTree = "<group>"; };
+		E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackupSettingsICloudSection.swift; path = StableChannels/Features/Settings/BackupSettingsICloudSection.swift; sourceTree = "<group>"; };
 		E6EF4DE5A43647E46CAAD52B /* TradeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeService.swift; sourceTree = "<group>"; };
 		E9358B0D20BFCDFAF7128834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EA3A67CDEA5F64D92ED8E602 /* BalanceBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceBarView.swift; sourceTree = "<group>"; };
@@ -258,6 +262,8 @@
 				674DEDB749CCE3FA348043D1 /* StableChannels */,
 				F11CF0F21D3319E86AF791B6 /* StableChannelsTests */,
 				052E4A6FC61BFB06E0A2A974 /* Products */,
+				A6CCC9964D2DE178082DA884 /* BackupSettingsSupportBanner.swift */,
+				E3F00B7A06F34D2BF8A066A6 /* BackupSettingsICloudSection.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -652,6 +658,8 @@
 				C6695312119E768D5A04925A /* RestoreBackupSheet.swift in Sources */,
 				9EBF713364DF88022CB4F1D0 /* RestoreSeedSheet.swift in Sources */,
 				10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */,
+				1D8B3096714E8844A43983C3 /* BackupSettingsSupportBanner.swift in Sources */,
+				4BF29DF506BBCCD9FC1ECE0B /* BackupSettingsICloudSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -60,7 +60,7 @@ class AppState {
 
     // MARK: - Services
 
-    let nodeService = NodeService()
+    let nodeService = NodeService.shared
     let priceService = PriceService()
     let feeRateService = FeeRateService()
     var databaseService: DatabaseService?

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -152,6 +152,163 @@ class AppState {
     // Pending splice info
     var pendingSplice: PendingSplice?
 
+    enum WalletRestoreError: LocalizedError {
+        case invalidMnemonic
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidMnemonic:
+                return "Enter a valid 12 or 24-word seed phrase."
+            }
+        }
+    }
+
+    private func initializeDatabaseServices() throws {
+        databaseService = try DatabaseService(dataDir: Constants.userDataDir)
+        nodeService.databaseService = databaseService
+
+        let resolverConfig = URLSessionConfiguration.default
+        resolverConfig.timeoutIntervalForRequest = 5
+        resolverConfig.timeoutIntervalForResource = 10
+        let resolverSession = URLSession(configuration: resolverConfig)
+        closeTxidResolver = CloseTxidResolver(
+            chainURLs: Constants.esploraChainURLs,
+            onResolved: { [weak self] opId, closingTxid in
+                self?.handleCloseTxidResolved(opId: opId, closingTxid: closingTxid)
+            },
+            urlSession: resolverSession
+        )
+        onchainTxidResolver = OnchainTxidResolver(
+            chainURLs: Constants.esploraChainURLs,
+            onResolved: { [weak self] workId, txid in
+                // workId is "res-<resolutionId>"; recover the Int64.
+                guard let idStr = workId.split(separator: "-", maxSplits: 1).last,
+                      let resolutionId = Int64(idStr) else { return }
+                self?.handleOnchainReceiveResolved(resolutionId: resolutionId, txid: txid)
+            },
+            urlSession: resolverSession
+        )
+        // txidLinks (TxidLinkStore) restores its own lastClose/lastReceive
+        // from UserDefaults on init, with 7-day expiry.
+
+        tradeService = TradeService(nodeService: nodeService)
+
+        // Set audit log path
+        let auditPath = Constants.userDataDir.appendingPathComponent("audit_log.txt").path
+        AuditService.setLogPath(auditPath)
+    }
+
+    /// Replace the active wallet with a restored seed in one app-owned flow.
+    ///
+    /// Restore is destructive for the current local wallet state, so AppState
+    /// owns the full sequence: stop LDK, drop DB handles, wipe LDK + app DB
+    /// files, clear in-memory/app-group cache, then start the node fresh.
+    func restoreWalletFromMnemonic(_ mnemonic: String) async throws {
+        let words = MnemonicUtils.formatForDisplay(mnemonic)
+        guard MnemonicUtils.isValidWordCount(words),
+              MnemonicUtils.hasValidCharacterFormat(words) else {
+            throw WalletRestoreError.invalidMnemonic
+        }
+
+        phase = .syncing
+        isSyncing = true
+        statusMessage = "Restoring wallet..."
+        defer {
+            isSyncing = false
+        }
+
+        cancelBackgroundStop()
+        await waitForNSE()
+        stabilityTimer?.cancel()
+        stabilityTimer = nil
+        closeLauncher.cancelAll()
+        onchainLauncher.cancelAll()
+        nodeService.stop()
+
+        resetInMemoryWalletState()
+        dropDatabaseServices()
+        wipeWalletPersistence()
+
+        do {
+            try initializeDatabaseServices()
+            try await nodeService.start(
+                network: .bitcoin,
+                esploraURL: chainURL,
+                mnemonic: words
+            )
+
+            let nodeId = nodeService.nodeId
+            if !nodeId.isEmpty {
+                UserDefaults(suiteName: Constants.appGroupIdentifier)?
+                    .set(nodeId, forKey: "node_id")
+            }
+
+            phase = .wallet
+            refreshBalances()
+            updateStableBalances()
+            startStabilityTimer()
+            reregisterPushTokenIfNeeded()
+            statusMessage = ""
+        } catch {
+            phase = .error("Wallet restore failed: \(error.localizedDescription)")
+            statusMessage = ""
+            throw error
+        }
+    }
+
+    private func resetInMemoryWalletState() {
+        stableChannel = .default
+        statusMessage = ""
+        paymentFlash = false
+        isChannelClosing = false
+        isOpeningChannel = false
+        isSweeping = false
+        spliceTxid = nil
+        sweepOnchainStart = 0
+        prevOnchainSats = 0
+        fundingTxid = nil
+        onchainReceiveAddress = nil
+        lightningBalanceSats = 0
+        onchainBalanceSats = 0
+        hasReadyChannel = false
+        spendableOnchainSats = 0
+        pendingTradePayments.removeAll()
+        pendingSplice = nil
+        txidLinks.setClose(nil)
+        txidLinks.setReceive(nil)
+
+        let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        shared?.removeObject(forKey: "funding_txid")
+        shared?.removeObject(forKey: "node_id")
+        shared?.set(Int64(0), forKey: "cached_lightning_sats")
+        shared?.set(Int64(0), forKey: "cached_onchain_sats")
+        shared?.set(false, forKey: "pending_push_payment")
+    }
+
+    private func dropDatabaseServices() {
+        nodeService.databaseService = nil
+        nodeService.clearSavedMnemonic()
+        tradeService = nil
+        databaseService = nil
+        closeTxidResolver = nil
+        onchainTxidResolver = nil
+    }
+
+    private func wipeWalletPersistence() {
+        NodeService.wipeWalletData()
+
+        let dir = Constants.userDataDir
+        let filesToDelete = [
+            DatabaseService.dbFilename,
+            "\(DatabaseService.dbFilename)-wal",
+            "\(DatabaseService.dbFilename)-shm"
+        ]
+
+        for file in filesToDelete {
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(file))
+        }
+    }
+
     // MARK: - Startup
 
     func start() async {
@@ -166,45 +323,11 @@ class AppState {
 
         // Initialize database
         do {
-            databaseService = try DatabaseService(dataDir: Constants.userDataDir)
+            try initializeDatabaseServices()
         } catch {
             await MainActor.run { phase = .error("Database init failed: \(error.localizedDescription)") }
             return
         }
-
-        nodeService.databaseService = databaseService
-
-        if databaseService != nil {
-            let resolverConfig = URLSessionConfiguration.default
-            resolverConfig.timeoutIntervalForRequest = 5
-            resolverConfig.timeoutIntervalForResource = 10
-            let resolverSession = URLSession(configuration: resolverConfig)
-            closeTxidResolver = CloseTxidResolver(
-                chainURLs: Constants.esploraChainURLs,
-                onResolved: { [weak self] opId, closingTxid in
-                    await self?.handleCloseTxidResolved(opId: opId, closingTxid: closingTxid)
-                },
-                urlSession: resolverSession
-            )
-            onchainTxidResolver = OnchainTxidResolver(
-                chainURLs: Constants.esploraChainURLs,
-                onResolved: { [weak self] workId, txid in
-                    // workId is "res-<resolutionId>"; recover the Int64.
-                    guard let idStr = workId.split(separator: "-", maxSplits: 1).last,
-                          let resolutionId = Int64(idStr) else { return }
-                    await self?.handleOnchainReceiveResolved(resolutionId: resolutionId, txid: txid)
-                },
-                urlSession: resolverSession
-            )
-            // txidLinks (TxidLinkStore) restores its own lastClose/lastReceive
-            // from UserDefaults on init, with 7-day expiry.
-        }
-
-        tradeService = TradeService(nodeService: nodeService)
-
-        // Set audit log path
-        let auditPath = Constants.userDataDir.appendingPathComponent("audit_log.txt").path
-        AuditService.setLogPath(auditPath)
 
         // Load saved channel state from DB
         loadChannelFromDB()

--- a/ios/StableChannels/StableChannels/Domain/BackupModels.swift
+++ b/ios/StableChannels/StableChannels/Domain/BackupModels.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum BackupCipher: UInt8, Codable {
+    case aes256gcm = 0
+}
+
+enum BackupNetwork: UInt8, Codable {
+    case bitcoin = 0
+    case testnet = 1
+}
+
+struct BackupMetadata: Codable {
+    let version: UInt16
+    /// Hex-encoded SHA-256 checksum of encrypted payload
+    let checksum: String
+    let timestamp: Date
+    let network: BackupNetwork
+    let cipher: BackupCipher
+
+    static let currentVersion: UInt16 = 1
+}
+
+struct BackupFile: Codable {
+    let metadata: BackupMetadata
+    let mnemonic: String
+    let createdAt: Date
+}
+
+struct EncryptedBackup: Codable {
+    let version: UInt16
+    let mnemonic: String
+    let createdAt: Date
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct BackupPromptView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var errorMessage: String?
+    @State private var isAuthenticating = false
+    @State private var showSuccess = false
+
+    @ViewBuilder
+    private var prominentButton: some View {
+        if #available(iOS 26.0, *) {
+            Button {
+                Task { await enableBackup() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isAuthenticating {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "icloud.and.arrow.up")
+                    }
+                    Text(String(localized: "enable_icloud_backup", defaultValue: "Enable iCloud Backup"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+            }
+            .buttonStyle(.glassProminent)
+            .disabled(isAuthenticating)
+        } else {
+            Button {
+                Task { await enableBackup() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isAuthenticating {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "icloud.and.arrow.up")
+                    }
+                    Text(String(localized: "enable_icloud_backup", defaultValue: "Enable iCloud Backup"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(.blue)
+                .foregroundStyle(.white)
+                .clipShape(.rect(cornerRadius: 12))
+            }
+            .disabled(isAuthenticating)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer()
+
+                // Icon with soft glow
+                Image(systemName: "icloud.fill")
+                    .font(.system(size: 80))
+                    .foregroundStyle(.blue)
+                    .shadow(color: .blue.opacity(0.3), radius: 20, x: 0, y: 8)
+
+                // Title
+                Text(String(localized: "icloud_backup_title", defaultValue: "iCloud Seed Backup"))
+                    .font(.title.bold())
+                    .foregroundStyle(.primary)
+
+                // Subtitle
+                Text(String(
+                    localized: "icloud_backup_description",
+                    defaultValue: "Protect your wallet with encrypted cloud backup."
+                ))
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+                // Feature list
+                VStack(alignment: .leading, spacing: 16) {
+                    featureRow(icon: "lock.shield.fill", text: "Encrypted backup to your iCloud")
+                    featureRow(icon: "iphone.gen3", text: "Sync across all your devices")
+                    featureRow(icon: "key.fill", text: "AES-256 encryption")
+                }
+                .padding(.horizontal, 32)
+                .padding(.top, 8)
+
+                Spacer()
+
+                // Success state
+                if showSuccess {
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.green)
+                        Text("Backup enabled!")
+                            .font(.headline)
+                            .foregroundStyle(.green)
+                    }
+                    .padding(.vertical, 16)
+                }
+
+                // Buttons
+                VStack(spacing: 16) {
+                    prominentButton
+
+                    if let error = errorMessage {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    Button {
+                        dismiss()
+                        UserDefaults.standard.set(true, forKey: "backupPromptDismissed")
+                    } label: {
+                        Text(String(localized: "maybe_later", defaultValue: "Maybe Later"))
+                            .font(.subheadline)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .interactiveDismissDisabled()
+        }
+    }
+
+    private func featureRow(icon: String, text: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundStyle(.blue)
+                .frame(width: 24)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            Spacer()
+        }
+    }
+
+    private func enableBackup() async {
+        isAuthenticating = true
+        errorMessage = nil
+
+        await CloudBackupService.shared.checkAccountStatus()
+
+        if !CloudBackupService.shared.iCloudAvailable {
+            errorMessage = "Sign in to iCloud to enable backup"
+            isAuthenticating = false
+            return
+        }
+
+        do {
+            try await CloudBackupService.shared.generateAndStoreKey()
+            showSuccess = true
+            UserDefaults.standard.set(true, forKey: "backupEnabled")
+            UserDefaults.standard.set(true, forKey: "backupPromptDismissed")
+            try await Task.sleep(nanoseconds: 1_500_000_000)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+            isAuthenticating = false
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct BackupPromptView: View {
     let backupService: any BackupServiceProtocol
@@ -40,8 +41,6 @@ struct BackupPromptView: View {
                 .padding(.top, 8)
 
                 enableBackupWarning
-
-                Spacer()
 
                 if showSuccess {
                     VStack(spacing: 8) {
@@ -92,6 +91,7 @@ struct BackupPromptView: View {
                 .padding(.bottom, 24)
             }
             .navigationBarTitleDisplayMode(.inline)
+            .padding()
         }
         .nativeTimerAlert(isPresented: $showingOverwriteAlert, title: "Overwrite Existing Backup?") {
             await enableBackup()
@@ -111,32 +111,52 @@ struct BackupPromptView: View {
     }
 
     private var enableBackupWarning: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
+        HStack(spacing: 14) {
+            supportIconBadge
+            VStack(alignment: .leading, spacing: 4) {
                 Text("Important")
-                    .font(.headline)
-                Spacer()
-            }
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
 
-            Text(
-                "This backup contains only your seed phrase. Lightning channel state is NOT included. If you need to recover, you may lose access to any Lightning funds."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-
-            Text("Please withdraw Lightning funds before proceeding if you plan to use this backup for recovery.")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("This backup contains your seed phrase. Lightning channel state is NOT included.")
+                        + Text(" ")
+                        + Text("Please email")
+                        + Text(" ")
+                        + Text("support@stablechannels.com")
+                        .foregroundStyle(.blue)
+                        .underline()
+                        + Text(" ")
+                        + Text("for questions or assistance.")
+                }
                 .font(.caption)
-                .foregroundStyle(.orange)
-                .fontWeight(.medium)
-                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(Color(uiColor: .label).opacity(0.7))
+            }
+            Spacer()
         }
-        .padding()
-        .background(.orange.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(.red, lineWidth: 1)
+                )
+        )
+    }
+
+    private var supportIconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(.red)
+                .frame(width: 44, height: 44)
+                .shadow(color: .red.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "questionmark.circle.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
+        }
     }
 
     private func handleEnableTap() async {

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -42,6 +42,8 @@ struct BackupPromptView: View {
 
                 enableBackupWarning
 
+                Spacer()
+
                 if showSuccess {
                     VStack(spacing: 8) {
                         Image(systemName: "checkmark.circle.fill")

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -7,12 +7,22 @@ struct BackupPromptView: View {
     @State private var errorMessage: String?
     @State private var isAuthenticating = false
     @State private var showSuccess = false
+    @State private var showingOverwriteAlert = false
 
     @ViewBuilder
     private var prominentButton: some View {
         if #available(iOS 26.0, *) {
             Button {
-                Task { await enableBackup() }
+                Task {
+                    isAuthenticating = true
+                    let exists = await backupService.checkRemoteBackupExists()
+                    isAuthenticating = false
+                    if exists {
+                        showingOverwriteAlert = true
+                    } else {
+                        await enableBackup()
+                    }
+                }
             } label: {
                 HStack(spacing: 8) {
                     if isAuthenticating {
@@ -30,7 +40,16 @@ struct BackupPromptView: View {
             .disabled(isAuthenticating)
         } else {
             Button {
-                Task { await enableBackup() }
+                Task {
+                    isAuthenticating = true
+                    let exists = await backupService.checkRemoteBackupExists()
+                    isAuthenticating = false
+                    if exists {
+                        showingOverwriteAlert = true
+                    } else {
+                        await enableBackup()
+                    }
+                }
             } label: {
                 HStack(spacing: 8) {
                     if isAuthenticating {
@@ -124,6 +143,9 @@ struct BackupPromptView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .interactiveDismissDisabled()
+        }
+        .nativeTimerAlert(isPresented: $showingOverwriteAlert, title: "Overwrite Existing Backup?") {
+            await enableBackup()
         }
     }
 

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -9,84 +9,19 @@ struct BackupPromptView: View {
     @State private var showSuccess = false
     @State private var showingOverwriteAlert = false
 
-    @ViewBuilder
-    private var prominentButton: some View {
-        if #available(iOS 26.0, *) {
-            Button {
-                Task {
-                    isAuthenticating = true
-                    let exists = await backupService.checkRemoteBackupExists()
-                    isAuthenticating = false
-                    if exists {
-                        showingOverwriteAlert = true
-                    } else {
-                        await enableBackup()
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    if isAuthenticating {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "icloud.and.arrow.up")
-                    }
-                    Text(String(localized: "enable_icloud_backup", defaultValue: "Enable iCloud Backup"))
-                        .fontWeight(.semibold)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-            }
-            .buttonStyle(.glassProminent)
-            .disabled(isAuthenticating)
-        } else {
-            Button {
-                Task {
-                    isAuthenticating = true
-                    let exists = await backupService.checkRemoteBackupExists()
-                    isAuthenticating = false
-                    if exists {
-                        showingOverwriteAlert = true
-                    } else {
-                        await enableBackup()
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    if isAuthenticating {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "icloud.and.arrow.up")
-                    }
-                    Text(String(localized: "enable_icloud_backup", defaultValue: "Enable iCloud Backup"))
-                        .fontWeight(.semibold)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(.blue)
-                .foregroundStyle(.white)
-                .clipShape(.rect(cornerRadius: 12))
-            }
-            .disabled(isAuthenticating)
-        }
-    }
-
     var body: some View {
         NavigationStack {
             VStack(spacing: 32) {
                 Spacer()
 
-                // Icon with soft glow
                 Image(systemName: "icloud.fill")
                     .font(.system(size: 80))
                     .foregroundStyle(.blue)
                     .shadow(color: .blue.opacity(0.3), radius: 20, x: 0, y: 8)
 
-                // Title
                 Text(String(localized: "icloud_backup_title", defaultValue: "iCloud Seed Backup"))
                     .font(.title.bold())
-                    .foregroundStyle(.primary)
 
-                // Subtitle
                 Text(String(
                     localized: "icloud_backup_description",
                     defaultValue: "Protect your wallet with encrypted cloud backup."
@@ -96,7 +31,6 @@ struct BackupPromptView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
-                // Feature list
                 VStack(alignment: .leading, spacing: 16) {
                     featureRow(icon: "lock.shield.fill", text: "Encrypted backup to your iCloud")
                     featureRow(icon: "iphone.gen3", text: "Sync across all your devices")
@@ -107,7 +41,6 @@ struct BackupPromptView: View {
 
                 Spacer()
 
-                // Success state
                 if showSuccess {
                     VStack(spacing: 8) {
                         Image(systemName: "checkmark.circle.fill")
@@ -120,9 +53,24 @@ struct BackupPromptView: View {
                     .padding(.vertical, 16)
                 }
 
-                // Buttons
                 VStack(spacing: 16) {
-                    prominentButton
+                    Button {
+                        Task { await handleEnableTap() }
+                    } label: {
+                        HStack(spacing: 8) {
+                            if isAuthenticating {
+                                ProgressView()
+                            } else {
+                                Image(systemName: "icloud.and.arrow.up")
+                            }
+                            Text(String(localized: "enable_icloud_backup", defaultValue: "Enable iCloud Backup"))
+                                .fontWeight(.semibold)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isAuthenticating)
 
                     if let error = errorMessage {
                         Text(error)
@@ -157,8 +105,18 @@ struct BackupPromptView: View {
                 .frame(width: 24)
             Text(text)
                 .font(.subheadline)
-                .foregroundStyle(.primary)
             Spacer()
+        }
+    }
+
+    private func handleEnableTap() async {
+        isAuthenticating = true
+        let exists = await backupService.checkRemoteBackupExists()
+        isAuthenticating = false
+        if exists {
+            showingOverwriteAlert = true
+        } else {
+            await enableBackup()
         }
     }
 

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct BackupPromptView: View {
+    let backupService: any BackupServiceProtocol
+
     @Environment(\.dismiss) private var dismiss
     @State private var errorMessage: String?
     @State private var isAuthenticating = false
@@ -142,16 +144,16 @@ struct BackupPromptView: View {
         isAuthenticating = true
         errorMessage = nil
 
-        await CloudBackupService.shared.checkAccountStatus()
+        await backupService.checkAccountStatus()
 
-        if !CloudBackupService.shared.iCloudAvailable {
+        if !backupService.iCloudAvailable {
             errorMessage = "Sign in to iCloud to enable backup"
             isAuthenticating = false
             return
         }
 
         do {
-            try await CloudBackupService.shared.generateAndStoreKey()
+            try await backupService.generateAndStoreKey()
             showSuccess = true
             UserDefaults.standard.set(true, forKey: "backupEnabled")
             UserDefaults.standard.set(true, forKey: "backupPromptDismissed")

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupPromptView.swift
@@ -39,6 +39,8 @@ struct BackupPromptView: View {
                 .padding(.horizontal, 32)
                 .padding(.top, 8)
 
+                enableBackupWarning
+
                 Spacer()
 
                 if showSuccess {
@@ -90,7 +92,6 @@ struct BackupPromptView: View {
                 .padding(.bottom, 24)
             }
             .navigationBarTitleDisplayMode(.inline)
-            .interactiveDismissDisabled()
         }
         .nativeTimerAlert(isPresented: $showingOverwriteAlert, title: "Overwrite Existing Backup?") {
             await enableBackup()
@@ -107,6 +108,35 @@ struct BackupPromptView: View {
                 .font(.subheadline)
             Spacer()
         }
+    }
+
+    private var enableBackupWarning: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Important")
+                    .font(.headline)
+                Spacer()
+            }
+
+            Text(
+                "This backup contains only your seed phrase. Lightning channel state is NOT included. If you need to recover, you may lose access to any Lightning funds."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text("Please withdraw Lightning funds before proceeding if you plan to use this backup for recovery.")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fontWeight(.medium)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .background(.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 24)
     }
 
     private func handleEnableTap() async {

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
@@ -9,11 +9,12 @@ struct BackupSettingsICloudSection: View {
     @Binding var showingRestoreSheet: Bool
     @Binding var showBackupSuccess: Bool
     @Binding var backupError: String?
+    @Binding var isCheckingRemote: Bool
     let onBackupNow: () async -> Void
 
     var body: some View {
         Section {
-            if backupService.backupExists {
+            if backupService.hasLocalBackup {
                 icloudBackupEnabledSection
             } else {
                 icloudBackupDisabledSection
@@ -51,8 +52,12 @@ struct BackupSettingsICloudSection: View {
                 Task { await onBackupNow() }
             } label: {
                 HStack {
-                    Image(systemName: showBackupSuccess ? "checkmark.circle.fill" : "arrow.clockwise")
-                        .foregroundStyle(showBackupSuccess ? .green : .blue)
+                    if isCheckingRemote {
+                        ProgressView()
+                    } else {
+                        Image(systemName: showBackupSuccess ? "checkmark.circle.fill" : "arrow.clockwise")
+                            .foregroundStyle(showBackupSuccess ? .green : .blue)
+                    }
                     Text(showBackupSuccess
                         ? "Backup complete"
                         : String(localized: "backup_now", defaultValue: "Backup Now"))

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct BackupSettingsICloudSection: View {
-    let backupService: CloudBackupService
+    let backupService: any BackupServiceProtocol
     @Binding var showingBackupPrompt: Bool
     @Binding var showingExportSheet: Bool
     @Binding var showingImportSheet: Bool

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsICloudSection.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+struct BackupSettingsICloudSection: View {
+    let backupService: CloudBackupService
+    @Binding var showingBackupPrompt: Bool
+    @Binding var showingExportSheet: Bool
+    @Binding var showingImportSheet: Bool
+    @Binding var showingDeleteConfirmation: Bool
+    @Binding var showingRestoreSheet: Bool
+    @Binding var showBackupSuccess: Bool
+    @Binding var backupError: String?
+    let onBackupNow: () async -> Void
+
+    var body: some View {
+        Section {
+            if backupService.backupExists {
+                icloudBackupEnabledSection
+            } else {
+                icloudBackupDisabledSection
+            }
+        } header: {
+            Text(String(localized: "section_icloud_backup", defaultValue: "iCloud"))
+        }
+    }
+
+    private var icloudBackupEnabledSection: some View {
+        Group {
+            HStack {
+                Label(
+                    String(localized: "icloud_backup", defaultValue: "iCloud Backup"),
+                    systemImage: "icloud.fill"
+                )
+                .foregroundStyle(.blue)
+                Spacer()
+                Text(String(localized: "enabled", defaultValue: "Enabled"))
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
+            if let lastBackup = backupService.lastBackupDate {
+                HStack {
+                    Text(String(localized: "last_backup", defaultValue: "Last backup"))
+                    Spacer()
+                    Text(lastBackup, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Button {
+                Task { await onBackupNow() }
+            } label: {
+                HStack {
+                    Image(systemName: showBackupSuccess ? "checkmark.circle.fill" : "arrow.clockwise")
+                        .foregroundStyle(showBackupSuccess ? .green : .blue)
+                    Text(showBackupSuccess
+                        ? "Backup complete"
+                        : String(localized: "backup_now", defaultValue: "Backup Now"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            if let error = backupError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Button {
+                showingExportSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.up.on.square")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "export_to_files", defaultValue: "Export to Files"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button(role: .destructive) {
+                showingDeleteConfirmation = true
+            } label: {
+                HStack {
+                    Image(systemName: "trash.fill")
+                        .foregroundStyle(.red)
+                    Text(String(localized: "delete_backup", defaultValue: "Delete Backup"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Button {
+                showingRestoreSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.down.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "restore_backup", defaultValue: "Restore Backup"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+        }
+    }
+
+    private var icloudBackupDisabledSection: some View {
+        Group {
+            Button {
+                showingBackupPrompt = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.up.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "button_enable_icloud_backup", defaultValue: "Backup to iCloud"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button {
+                showingRestoreSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.down.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "button_restore_icloud", defaultValue: "Restore from iCloud"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button {
+                showingImportSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.down.on.square")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "button_import_backup", defaultValue: "Import from File"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsSupportBanner.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsSupportBanner.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct BackupSettingsSupportBanner: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            supportIconBadge
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "recovery_banner_title", defaultValue: "Need Help?"))
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(
+                        localized: "recovery_banner_text_prefix",
+                        defaultValue: "Please email"
+                    ))
+                        + Text(" ")
+                        + Text("support@stablechannels.com")
+                        .foregroundStyle(.blue)
+                        .underline()
+                        + Text(" ")
+                        + Text(String(
+                            localized: "recovery_banner_text_suffix",
+                            defaultValue: "for wallet recovery assistance."
+                        ))
+                }
+                .font(.caption)
+                .foregroundStyle(Color(uiColor: .label).opacity(0.7))
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(.orange, lineWidth: 1)
+                )
+        )
+    }
+
+    private var supportIconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(.orange)
+                .frame(width: 44, height: 44)
+                .shadow(color: .orange.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "questionmark.circle.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
@@ -2,17 +2,16 @@ import SwiftUI
 
 struct BackupSettingsView: View {
     @Environment(AppState.self) private var appState
-    private let backupService = CloudBackupService.shared
+    let backupService: any BackupServiceProtocol
 
     // MARK: - UI State
 
     @State private var showSeedWords = false
     @State private var showRestore = false
     @State private var restoreMnemonic = ""
+    @State private var restoreSourceIsCloud = false
     @State private var isRestoring = false
     @State private var restoreError: String?
-    @State private var copiedSeed = false
-    @State private var showCopyWarning = false
     @State private var showingBackupPrompt = false
     @State private var showingExportSheet = false
     @State private var showingImportSheet = false
@@ -23,14 +22,10 @@ struct BackupSettingsView: View {
     @State private var wordFields: [String] = Array(repeating: "", count: SeedConstants.maxWordCount)
     @State private var isWordFieldsReadOnly = false
     @State private var isImportingSeed = false
-    @State private var clipboardClearTask: Task<Void, Never>?
-    @State private var clipboardFadeTask: Task<Void, Never>?
+    @State private var showingOverwriteAlert = false
+    @State private var isCheckingRemote = false
 
     // MARK: - Computed Properties
-
-    private var detectedWordCount: Int {
-        MnemonicUtils.detectWordCount(restoreMnemonic)
-    }
 
     private var restoreValid: Bool {
         let filledCount = wordFields.filter { !$0.isEmpty }.count
@@ -49,8 +44,9 @@ struct BackupSettingsView: View {
         isWordFieldsReadOnly = false
     }
 
-    private func importMnemonic(_ mnemonic: String) {
+    private func importMnemonic(_ mnemonic: String, fromCloud: Bool = false) {
         isImportingSeed = true
+        restoreSourceIsCloud = fromCloud
         restoreMnemonic = ""
         wordFields = MnemonicUtils.wordsToFields(MnemonicUtils.parseMnemonic(mnemonic))
         isWordFieldsReadOnly = true
@@ -58,32 +54,19 @@ struct BackupSettingsView: View {
         showRestore = true
     }
 
-    private func copySeedToClipboard() {
-        guard let words = appState.nodeService.savedMnemonic else { return }
-        clipboardClearTask?.cancel()
-        clipboardFadeTask?.cancel()
-        UIPasteboard.general.string = words
-        withAnimation { copiedSeed = true }
-
-        clipboardClearTask = Task {
-            try? await Task.sleep(for: .seconds(SeedConstants.clipboardClearSeconds))
-            if UIPasteboard.general.string == words {
-                UIPasteboard.general.string = ""
-            }
-        }
-        clipboardFadeTask = Task {
-            try? await Task.sleep(for: .seconds(2))
-            withAnimation { self.copiedSeed = false }
-        }
-    }
-
-    private func cancelClipboardTasks() {
-        clipboardClearTask?.cancel()
-        clipboardFadeTask?.cancel()
-    }
-
     private func backupNow() async {
         guard appState.nodeService.savedMnemonic != nil else { return }
+        isCheckingRemote = true
+        let exists = await backupService.checkRemoteBackupExists()
+        isCheckingRemote = false
+        if exists {
+            showingOverwriteAlert = true
+        } else {
+            await executeBackup()
+        }
+    }
+
+    private func executeBackup() async {
         backupError = nil
         do {
             try await backupService.saveBackupToCloud()
@@ -115,7 +98,6 @@ struct BackupSettingsView: View {
         .listStyle(.insetGrouped)
         .navigationTitle(String(localized: "title_backup", defaultValue: "Backup"))
         .navigationBarTitleDisplayMode(.inline)
-        .onDisappear { cancelClipboardTasks() }
         .sheet(isPresented: $showRestore) {
             RestoreSeedSheet(
                 restoreMnemonic: $restoreMnemonic,
@@ -124,8 +106,12 @@ struct BackupSettingsView: View {
                 isImportingSeed: $isImportingSeed,
                 isRestoring: $isRestoring,
                 restoreError: $restoreError,
-                wordCount: detectedWordCount,
-                onCancel: { cancelRestore() }
+                onCancel: { cancelRestore() },
+                onSuccess: {
+                    if restoreSourceIsCloud {
+                        backupService.markLocalBackupAsEnabled()
+                    }
+                }
             )
         }
         .sheet(isPresented: $showingBackupPrompt) {
@@ -138,7 +124,7 @@ struct BackupSettingsView: View {
         }
         .sheet(isPresented: $showingRestoreSheet) {
             RestoreBackupSheet(backupService: backupService) { mnemonic in
-                importMnemonic(mnemonic)
+                importMnemonic(mnemonic, fromCloud: true)
             }
         }
         .sheet(isPresented: $showingExportSheet) {
@@ -156,6 +142,9 @@ struct BackupSettingsView: View {
             }
         } message: {
             Text("You'll need your seed phrase to restore. This cannot be undone.")
+        }
+        .nativeTimerAlert(isPresented: $showingOverwriteAlert, title: "Overwrite Existing Backup?") {
+            await executeBackup()
         }
     }
 
@@ -181,7 +170,7 @@ struct BackupSettingsView: View {
             .foregroundStyle(.primary)
 
             if showSeedWords, let words = appState.nodeService.savedMnemonic, !words.isEmpty {
-                seedWordsDisplay(words: words)
+                SeedDisplayView(words: words)
             }
         } header: {
             Text(String(localized: "section_backup_seed", defaultValue: "Backup"))
@@ -191,106 +180,6 @@ struct BackupSettingsView: View {
                 defaultValue: "Write these words down and store them safely. Anyone with these words can access your funds."
             ))
         }
-    }
-
-    private func seedWordsDisplay(words: String) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
-                Text(String(localized: "warning_seed", defaultValue: "Never share your seed words"))
-                    .font(.caption.bold())
-                    .foregroundStyle(.orange)
-            }
-
-            let wordList = words.split(separator: " ").map(String.init)
-            LazyVGrid(columns: [
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-                GridItem(.flexible())
-            ], spacing: 6) {
-                ForEach(Array(wordList.enumerated()), id: \.offset) { index, word in
-                    HStack(spacing: 4) {
-                        Text("\(index + 1).")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 18, alignment: .trailing)
-                        Text(word)
-                            .font(.system(.caption, design: .monospaced))
-                    }
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 6)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(uiColor: .secondarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
-            }
-
-            if !copiedSeed && !showCopyWarning {
-                Button {
-                    showCopyWarning = true
-                } label: {
-                    HStack {
-                        Image(systemName: "doc.on.doc")
-                        Text(String(localized: "button_copy_seed", defaultValue: "Copy to Clipboard"))
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .background(Color(uiColor: .secondarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                }
-            }
-
-            if copiedSeed {
-                HStack {
-                    Image(systemName: "checkmark")
-                    Text(String(localized: "button_copied", defaultValue: "Copied"))
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(Color.green.opacity(0.15))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-            }
-
-            if showCopyWarning {
-                VStack(spacing: 8) {
-                    Text(String(localized: "warning_copy_seed_title", defaultValue: "Copy Seed Words?"))
-                        .font(.caption.bold())
-
-                    Text(String(
-                        localized: "warning_copy_seed_message",
-                        defaultValue: "Clipboard is shared with other apps."
-                    ))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-
-                    HStack(spacing: 12) {
-                        Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
-                            showCopyWarning = false
-                        }
-                        .font(.caption)
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-
-                        Button(String(localized: "button_copy_anyway", defaultValue: "Copy Anyway")) {
-                            copySeedToClipboard()
-                            showCopyWarning = false
-                        }
-                        .font(.caption)
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                    }
-                }
-                .padding(12)
-                .frame(maxWidth: .infinity)
-                .background(Color(uiColor: .tertiarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .transition(.opacity.combined(with: .scale(scale: 0.95)))
-            }
-        }
-        .padding(.vertical, 4)
-        .animation(.easeInOut(duration: 0.2), value: showCopyWarning)
     }
 
     private var restoreSection: some View {
@@ -335,6 +224,7 @@ struct BackupSettingsView: View {
             showingRestoreSheet: $showingRestoreSheet,
             showBackupSuccess: $showBackupSuccess,
             backupError: $backupError,
+            isCheckingRemote: $isCheckingRemote,
             onBackupNow: { await backupNow() }
         )
     }

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
@@ -310,213 +310,23 @@ struct BackupSettingsView: View {
         }
     }
 
-    private var icloudSection: some View {
-        Section {
-            if backupService.backupExists {
-                icloudBackupEnabledSection
-            } else {
-                icloudBackupDisabledSection
-            }
-        } header: {
-            Text(String(localized: "section_icloud_backup", defaultValue: "iCloud"))
-        }
-    }
-
     private var supportBannerSection: some View {
         Section {
-            HStack(spacing: 14) {
-                supportIconBadge
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(String(localized: "recovery_banner_title", defaultValue: "Need Help?"))
-                        .font(.subheadline)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.primary)
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(
-                            localized: "recovery_banner_text_prefix",
-                            defaultValue: "Please email"
-                        ))
-                            + Text(" ")
-                            + Text("support@stablechannels.com")
-                            .foregroundStyle(.blue)
-                            .underline()
-                            + Text(" ")
-                            + Text(String(
-                                localized: "recovery_banner_text_suffix",
-                                defaultValue: "for wallet recovery assistance."
-                            ))
-                    }
-                    .font(.caption)
-                    .foregroundStyle(Color(uiColor: .label).opacity(0.7))
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .strokeBorder(.orange, lineWidth: 1)
-                    )
-            )
+            BackupSettingsSupportBanner()
         }
     }
 
-    private var supportIconBadge: some View {
-        ZStack {
-            Circle()
-                .fill(.orange)
-                .frame(width: 44, height: 44)
-                .shadow(color: .orange.opacity(0.3), radius: 8, x: 0, y: 4)
-            Image(systemName: "questionmark.circle.fill")
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(.white)
-        }
-    }
-
-    private var icloudBackupEnabledSection: some View {
-        Group {
-            HStack {
-                Label(
-                    String(localized: "icloud_backup", defaultValue: "iCloud Backup"),
-                    systemImage: "icloud.fill"
-                )
-                .foregroundStyle(.blue)
-                Spacer()
-                Text(String(localized: "enabled", defaultValue: "Enabled"))
-                    .font(.caption)
-                    .foregroundStyle(.green)
-            }
-
-            if let lastBackup = backupService.lastBackupDate {
-                HStack {
-                    Text(String(localized: "last_backup", defaultValue: "Last backup"))
-                    Spacer()
-                    Text(lastBackup, style: .relative)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Button {
-                Task { await backupNow() }
-            } label: {
-                HStack {
-                    Image(systemName: showBackupSuccess ? "checkmark.circle.fill" : "arrow.clockwise")
-                        .foregroundStyle(showBackupSuccess ? .green : .blue)
-                    Text(showBackupSuccess
-                        ? "Backup complete"
-                        : String(localized: "backup_now", defaultValue: "Backup Now"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-
-            if let error = backupError {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            Button {
-                showingExportSheet = true
-            } label: {
-                HStack {
-                    Image(systemName: "square.and.arrow.up.on.square")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "export_to_files", defaultValue: "Export to Files"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-
-            Button(role: .destructive) {
-                showingDeleteConfirmation = true
-            } label: {
-                HStack {
-                    Image(systemName: "trash.fill")
-                        .foregroundStyle(.red)
-                    Text(String(localized: "delete_backup", defaultValue: "Delete Backup"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Button {
-                showingRestoreSheet = true
-            } label: {
-                HStack {
-                    Image(systemName: "icloud.and.arrow.down.fill")
-                        .foregroundStyle(.blue)
-                    Text(String(localized: "restore_backup", defaultValue: "Restore Backup"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-        }
-    }
-
-    private var icloudBackupDisabledSection: some View {
-        Group {
-            Button {
-                showingBackupPrompt = true
-            } label: {
-                HStack {
-                    Image(systemName: "icloud.and.arrow.up.fill")
-                        .foregroundStyle(.blue)
-                    Text(String(localized: "button_enable_icloud_backup", defaultValue: "Backup to iCloud"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-
-            Button {
-                showingRestoreSheet = true
-            } label: {
-                HStack {
-                    Image(systemName: "icloud.and.arrow.down.fill")
-                        .foregroundStyle(.blue)
-                    Text(String(localized: "button_restore_icloud", defaultValue: "Restore from iCloud"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-
-            Button {
-                showingImportSheet = true
-            } label: {
-                HStack {
-                    Image(systemName: "square.and.arrow.down.on.square")
-                        .foregroundStyle(.green)
-                    Text(String(localized: "button_import_backup", defaultValue: "Import from File"))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .foregroundStyle(.primary)
-        }
+    private var icloudSection: some View {
+        BackupSettingsICloudSection(
+            backupService: backupService,
+            showingBackupPrompt: $showingBackupPrompt,
+            showingExportSheet: $showingExportSheet,
+            showingImportSheet: $showingImportSheet,
+            showingDeleteConfirmation: $showingDeleteConfirmation,
+            showingRestoreSheet: $showingRestoreSheet,
+            showBackupSuccess: $showBackupSuccess,
+            backupError: $backupError,
+            onBackupNow: { await backupNow() }
+        )
     }
 }

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
@@ -129,7 +129,7 @@ struct BackupSettingsView: View {
             )
         }
         .sheet(isPresented: $showingBackupPrompt) {
-            BackupPromptView()
+            BackupPromptView(backupService: backupService)
         }
         .onChange(of: showingBackupPrompt) { _, newValue in
             if !newValue {
@@ -137,7 +137,7 @@ struct BackupSettingsView: View {
             }
         }
         .sheet(isPresented: $showingRestoreSheet) {
-            RestoreBackupSheet { mnemonic in
+            RestoreBackupSheet(backupService: backupService) { mnemonic in
                 importMnemonic(mnemonic)
             }
         }

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct BackupSettingsView: View {
     @Environment(AppState.self) private var appState
+    private let backupService = CloudBackupService.shared
+
+    // MARK: - UI State
+
     @State private var showSeedWords = false
     @State private var showRestore = false
     @State private var restoreMnemonic = ""
@@ -9,139 +13,47 @@ struct BackupSettingsView: View {
     @State private var restoreError: String?
     @State private var copiedSeed = false
     @State private var showCopyWarning = false
+    @State private var showingBackupPrompt = false
+    @State private var showingExportSheet = false
+    @State private var showingImportSheet = false
+    @State private var showingDeleteConfirmation = false
+    @State private var showBackupSuccess = false
+    @State private var backupError: String?
+    @State private var showingRestoreSheet = false
+    @State private var wordFields: [String] = Array(repeating: "", count: SeedConstants.maxWordCount)
+    @State private var isWordFieldsReadOnly = false
+    @State private var isImportingSeed = false
 
-    var body: some View {
-        List {
-            // View Seed
-            Section {
-                Button {
-                    showSeedWords.toggle()
-                } label: {
-                    HStack {
-                        Image(systemName: showSeedWords ? "eye.slash.fill" : "eye.fill")
-                            .foregroundStyle(Color.stablePrimary)
-                        Text(showSeedWords
-                            ? String(localized: "button_hide_seed", defaultValue: "Hide Seed Words")
-                            : String(localized: "button_view_seed", defaultValue: "View Seed Words"))
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .foregroundStyle(.primary)
-            } header: {
-                Text(String(localized: "section_backup_seed", defaultValue: "Backup"))
-            } footer: {
-                Text(String(
-                    localized: "info_backup_seed",
-                    defaultValue: "Write these words down and store them safely. Anyone with these words can access your funds."
-                ))
-            }
+    // MARK: - Computed Properties
 
-            // Seed Words Display
-            if showSeedWords, let words = appState.nodeService.savedMnemonic, !words.isEmpty {
-                Section {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
-                            Text(String(localized: "warning_seed", defaultValue: "Never share your seed words"))
-                                .font(.caption.bold())
-                                .foregroundStyle(.orange)
-                        }
+    private var detectedWordCount: Int {
+        MnemonicUtils.detectWordCount(restoreMnemonic)
+    }
 
-                        let wordList = words.split(separator: " ").map(String.init)
-                        LazyVGrid(columns: [
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible())
-                        ], spacing: 6) {
-                            ForEach(Array(wordList.enumerated()), id: \.offset) { index, word in
-                                HStack(spacing: 4) {
-                                    Text("\(index + 1).")
-                                        .font(.caption2)
-                                        .foregroundStyle(.secondary)
-                                        .frame(width: 18, alignment: .trailing)
-                                    Text(word)
-                                        .font(.system(.caption, design: .monospaced))
-                                }
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 6)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .background(Color(uiColor: .secondarySystemGroupedBackground))
-                                .clipShape(RoundedRectangle(cornerRadius: 6))
-                            }
-                        }
+    private var restoreValid: Bool {
+        let filledCount = wordFields.filter { !$0.isEmpty }.count
+        let validCount = (filledCount == SeedConstants.wordCount12 || filledCount == SeedConstants.wordCount24)
+        guard validCount else { return false }
+        return MnemonicUtils.hasValidCharacterFormat(restoreMnemonic)
+    }
 
-                        Button {
-                            showCopyWarning = true
-                        } label: {
-                            HStack {
-                                Image(systemName: copiedSeed ? "checkmark" : "doc.on.doc")
-                                Text(copiedSeed
-                                    ? String(localized: "button_copied", defaultValue: "Copied")
-                                    : String(localized: "button_copy_seed", defaultValue: "Copy to Clipboard"))
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(Color(uiColor: .secondarySystemGroupedBackground))
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                        }
-                        .disabled(copiedSeed)
-                    }
-                    .padding(.vertical, 4)
-                } header: {
-                    Text(String(localized: "section_seed_phrase", defaultValue: "Seed Phrase"))
-                }
-            }
+    // MARK: - Actions
 
-            // Restore
-            Section {
-                Button {
-                    showRestore = true
-                } label: {
-                    HStack {
-                        Image(systemName: "arrow.uturn.backward.circle.fill")
-                            .foregroundStyle(.orange)
-                        Text(String(localized: "button_restore_seed", defaultValue: "Restore from Seed"))
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .foregroundStyle(.primary)
-            } header: {
-                Text(String(localized: "section_restore", defaultValue: "Restore"))
-            } footer: {
-                Text(String(
-                    localized: "info_restore",
-                    defaultValue: "Restore will stop your current node and start fresh."
-                ))
-            }
-        }
-        .listStyle(.insetGrouped)
-        .navigationTitle(String(localized: "title_backup", defaultValue: "Backup"))
-        .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $showRestore) {
-            restoreSheet
-        }
-        .confirmationDialog(
-            String(localized: "warning_copy_seed_title", defaultValue: "Copy Seed Words?"),
-            isPresented: $showCopyWarning,
-            titleVisibility: .visible
-        ) {
-            Button(String(localized: "button_copy_anyway", defaultValue: "Copy Anyway")) {
-                copySeedToClipboard()
-            }
-            Button(String(localized: "button_cancel", defaultValue: "Cancel"), role: .cancel) { }
-        } message: {
-            Text(String(
-                localized: "warning_copy_seed_message",
-                defaultValue: "Clipboard is shared with other apps. Consider writing down your seed instead."
-            ))
-        }
+    private func cancelRestore() {
+        restoreMnemonic = ""
+        showRestore = false
+        restoreError = nil
+        wordFields = Array(repeating: "", count: SeedConstants.maxWordCount)
+        isWordFieldsReadOnly = false
+    }
+
+    private func importMnemonic(_ mnemonic: String) {
+        isImportingSeed = true
+        restoreMnemonic = ""
+        wordFields = MnemonicUtils.wordsToFields(MnemonicUtils.parseMnemonic(mnemonic))
+        isWordFieldsReadOnly = true
+        restoreMnemonic = mnemonic
+        showRestore = true
     }
 
     private func copySeedToClipboard() {
@@ -149,119 +61,462 @@ struct BackupSettingsView: View {
         UIPasteboard.general.string = words
         withAnimation { copiedSeed = true }
 
-        // Clear clipboard after 60 seconds for security
-        DispatchQueue.main.asyncAfter(deadline: .now() + 60) {
+        Task {
+            try? await Task.sleep(for: .seconds(SeedConstants.clipboardClearSeconds))
             if UIPasteboard.general.string == words {
                 UIPasteboard.general.string = ""
             }
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            withAnimation { copiedSeed = false }
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation { self.copiedSeed = false }
         }
     }
 
-    private var restoreSheet: some View {
-        NavigationStack {
-            VStack(spacing: 24) {
-                Image(systemName: "arrow.uturn.backward.circle.fill")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.orange)
-                Text(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
-                    .font(.title2.bold())
-                Text(String(
-                    localized: "instruction_restore",
-                    defaultValue: "Enter your 12 or 24-word seed phrase."
-                ))
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+    private func backupNow() async {
+        guard appState.nodeService.savedMnemonic != nil else { return }
+        backupError = nil
+        do {
+            try await backupService.saveBackupToCloud()
+            showBackupSuccess = true
+            try await Task.sleep(for: .seconds(1.5))
+            showBackupSuccess = false
+        } catch {
+            backupError = error.localizedDescription
+        }
+    }
 
-                TextField(
-                    String(localized: "placeholder_seed", defaultValue: "word1 word2 word3 ..."),
-                    text: $restoreMnemonic,
-                    axis: .vertical
-                )
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .lineLimit(3...5)
-                .font(.system(.body, design: .monospaced))
-                .padding()
-                .background(Color(uiColor: .secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .padding(.horizontal)
+    private func deleteBackup() async {
+        do {
+            try await backupService.deleteBackup()
+        } catch {
+            print("Delete backup failed: \(error.localizedDescription)")
+        }
+    }
 
-                if let error = restoreError {
-                    Text(error)
+    // MARK: - Body
+
+    var body: some View {
+        List {
+            seedSection
+            restoreSection
+            icloudSection
+            supportBannerSection
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "title_backup", defaultValue: "Backup"))
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showRestore) {
+            RestoreSeedSheet(
+                restoreMnemonic: $restoreMnemonic,
+                wordFields: $wordFields,
+                isWordFieldsReadOnly: $isWordFieldsReadOnly,
+                isImportingSeed: $isImportingSeed,
+                isRestoring: $isRestoring,
+                restoreError: $restoreError,
+                wordCount: detectedWordCount,
+                restoreValid: restoreValid,
+                onCancel: { cancelRestore() }
+            )
+        }
+        .sheet(isPresented: $showingBackupPrompt) {
+            BackupPromptView()
+        }
+        .onChange(of: showingBackupPrompt) { _, newValue in
+            if !newValue {
+                backupService.refreshStatus()
+            }
+        }
+        .sheet(isPresented: $showingRestoreSheet) {
+            RestoreBackupSheet { mnemonic in
+                importMnemonic(mnemonic)
+            }
+        }
+        .sheet(isPresented: $showingExportSheet) {
+            ExportImportSheet(mode: .export)
+        }
+        .sheet(isPresented: $showingImportSheet) {
+            ExportImportSheet(mode: .importFile) { mnemonic in
+                importMnemonic(mnemonic)
+            }
+        }
+        .alert("Delete Backup?", isPresented: $showingDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task { await deleteBackup() }
+            }
+        } message: {
+            Text("You'll need your seed phrase to restore. This cannot be undone.")
+        }
+    }
+
+    // MARK: - Sections
+
+    private var seedSection: some View {
+        Section {
+            Button {
+                showSeedWords.toggle()
+            } label: {
+                HStack {
+                    Image(systemName: showSeedWords ? "eye.slash.fill" : "eye.fill")
+                        .foregroundStyle(Color.stablePrimary)
+                    Text(showSeedWords
+                        ? String(localized: "button_hide_seed", defaultValue: "Hide Seed Words")
+                        : String(localized: "button_view_seed", defaultValue: "View Seed Words"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
                         .font(.caption)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(.secondary)
                 }
+            }
+            .foregroundStyle(.primary)
 
+            if showSeedWords, let words = appState.nodeService.savedMnemonic, !words.isEmpty {
+                seedWordsDisplay(words: words)
+            }
+        } header: {
+            Text(String(localized: "section_backup_seed", defaultValue: "Backup"))
+        } footer: {
+            Text(String(
+                localized: "info_backup_seed",
+                defaultValue: "Write these words down and store them safely. Anyone with these words can access your funds."
+            ))
+        }
+    }
+
+    private func seedWordsDisplay(words: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(String(localized: "warning_seed", defaultValue: "Never share your seed words"))
+                    .font(.caption.bold())
+                    .foregroundStyle(.orange)
+            }
+
+            let wordList = words.split(separator: " ").map(String.init)
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 6) {
+                ForEach(Array(wordList.enumerated()), id: \.offset) { index, word in
+                    HStack(spacing: 4) {
+                        Text("\(index + 1).")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18, alignment: .trailing)
+                        Text(word)
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+
+            if !copiedSeed && !showCopyWarning {
                 Button {
-                    Task { await restoreWallet() }
+                    showCopyWarning = true
                 } label: {
-                    if isRestoring {
-                        ProgressView()
-                    } else {
-                        Text(String(localized: "button_restore", defaultValue: "Restore"))
+                    HStack {
+                        Image(systemName: "doc.on.doc")
+                        Text(String(localized: "button_copy_seed", defaultValue: "Copy to Clipboard"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+
+            if copiedSeed {
+                HStack {
+                    Image(systemName: "checkmark")
+                    Text(String(localized: "button_copied", defaultValue: "Copied"))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.green.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+
+            if showCopyWarning {
+                VStack(spacing: 8) {
+                    Text(String(localized: "warning_copy_seed_title", defaultValue: "Copy Seed Words?"))
+                        .font(.caption.bold())
+
+                    Text(String(
+                        localized: "warning_copy_seed_message",
+                        defaultValue: "Clipboard is shared with other apps."
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                    HStack(spacing: 12) {
+                        Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
+                            showCopyWarning = false
+                        }
+                        .font(.caption)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button(String(localized: "button_copy_anyway", defaultValue: "Copy Anyway")) {
+                            copySeedToClipboard()
+                            showCopyWarning = false
+                        }
+                        .font(.caption)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
                     }
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(isRestoring || restoreMnemonic.trimmingCharacters(in: .whitespaces).isEmpty)
+                .padding(12)
+                .frame(maxWidth: .infinity)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
+        }
+        .padding(.vertical, 4)
+        .animation(.easeInOut(duration: 0.2), value: showCopyWarning)
+    }
 
+    private var restoreSection: some View {
+        Section {
+            Button {
+                showRestore = true
+            } label: {
+                HStack {
+                    Image(systemName: "arrow.uturn.backward.circle.fill")
+                        .foregroundStyle(.orange)
+                    Text(String(localized: "button_restore_seed", defaultValue: "Restore from Seed"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+        } header: {
+            Text(String(localized: "section_restore", defaultValue: "Restore"))
+        } footer: {
+            Text(String(
+                localized: "info_restore",
+                defaultValue: "Restore will stop your current node and start fresh."
+            ))
+        }
+    }
+
+    private var icloudSection: some View {
+        Section {
+            if backupService.backupExists {
+                icloudBackupEnabledSection
+            } else {
+                icloudBackupDisabledSection
+            }
+        } header: {
+            Text(String(localized: "section_icloud_backup", defaultValue: "iCloud"))
+        }
+    }
+
+    private var supportBannerSection: some View {
+        Section {
+            HStack(spacing: 14) {
+                supportIconBadge
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(localized: "recovery_banner_title", defaultValue: "Need Help?"))
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(String(
+                            localized: "recovery_banner_text_prefix",
+                            defaultValue: "Please email"
+                        ))
+                            + Text(" ")
+                            + Text("support@stablechannels.com")
+                            .foregroundStyle(.blue)
+                            .underline()
+                            + Text(" ")
+                            + Text(String(
+                                localized: "recovery_banner_text_suffix",
+                                defaultValue: "for wallet recovery assistance."
+                            ))
+                    }
+                    .font(.caption)
+                    .foregroundStyle(Color(uiColor: .label).opacity(0.7))
+                }
                 Spacer()
             }
-            .padding()
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
-                        showRestore = false
-                        restoreMnemonic = ""
-                        restoreError = nil
-                    }
-                }
-            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .strokeBorder(.orange, lineWidth: 1)
+                    )
+            )
         }
     }
 
-    private func restoreWallet() async {
-        isRestoring = true
-        restoreError = nil
-
-        let input = restoreMnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
-        let wordCount = input.split(separator: " ").count
-        guard wordCount == 12 || wordCount == 24 else {
-            isRestoring = false
-            restoreError = String(
-                localized: "error_seed_word_count",
-                defaultValue: "Seed phrase must be 12 or 24 words"
-            )
-            return
+    private var supportIconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(.orange)
+                .frame(width: 44, height: 44)
+                .shadow(color: .orange.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "questionmark.circle.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
         }
+    }
 
-        // Validate mnemonic format before stopping node
-        do {
-            // Attempt initialization in isolated flow - if fails, node keeps running
-            try await appState.nodeService.start(
-                network: .bitcoin,
-                esploraURL: appState.chainURL,
-                mnemonic: input
-            )
-            await MainActor.run {
-                showRestore = false
-                restoreMnemonic = ""
-                appState.refreshBalances()
-                isRestoring = false
+    private var icloudBackupEnabledSection: some View {
+        Group {
+            HStack {
+                Label(
+                    String(localized: "icloud_backup", defaultValue: "iCloud Backup"),
+                    systemImage: "icloud.fill"
+                )
+                .foregroundStyle(.blue)
+                Spacer()
+                Text(String(localized: "enabled", defaultValue: "Enabled"))
+                    .font(.caption)
+                    .foregroundStyle(.green)
             }
-        } catch {
-            // Node start failed - old state preserved, user notified
-            await MainActor.run {
-                restoreError = String(
-                    localized: "error_restore_failed",
-                    defaultValue: "Restore failed: "
-                ) + error.localizedDescription
-                isRestoring = false
+
+            if let lastBackup = backupService.lastBackupDate {
+                HStack {
+                    Text(String(localized: "last_backup", defaultValue: "Last backup"))
+                    Spacer()
+                    Text(lastBackup, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
+
+            Button {
+                Task { await backupNow() }
+            } label: {
+                HStack {
+                    Image(systemName: showBackupSuccess ? "checkmark.circle.fill" : "arrow.clockwise")
+                        .foregroundStyle(showBackupSuccess ? .green : .blue)
+                    Text(showBackupSuccess
+                        ? "Backup complete"
+                        : String(localized: "backup_now", defaultValue: "Backup Now"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            if let error = backupError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Button {
+                showingExportSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.up.on.square")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "export_to_files", defaultValue: "Export to Files"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button(role: .destructive) {
+                showingDeleteConfirmation = true
+            } label: {
+                HStack {
+                    Image(systemName: "trash.fill")
+                        .foregroundStyle(.red)
+                    Text(String(localized: "delete_backup", defaultValue: "Delete Backup"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Button {
+                showingRestoreSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.down.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "restore_backup", defaultValue: "Restore Backup"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+        }
+    }
+
+    private var icloudBackupDisabledSection: some View {
+        Group {
+            Button {
+                showingBackupPrompt = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.up.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "button_enable_icloud_backup", defaultValue: "Backup to iCloud"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button {
+                showingRestoreSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "icloud.and.arrow.down.fill")
+                        .foregroundStyle(.blue)
+                    Text(String(localized: "button_restore_icloud", defaultValue: "Restore from iCloud"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
+
+            Button {
+                showingImportSheet = true
+            } label: {
+                HStack {
+                    Image(systemName: "square.and.arrow.down.on.square")
+                        .foregroundStyle(.green)
+                    Text(String(localized: "button_import_backup", defaultValue: "Import from File"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .foregroundStyle(.primary)
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/BackupSettingsView.swift
@@ -23,6 +23,8 @@ struct BackupSettingsView: View {
     @State private var wordFields: [String] = Array(repeating: "", count: SeedConstants.maxWordCount)
     @State private var isWordFieldsReadOnly = false
     @State private var isImportingSeed = false
+    @State private var clipboardClearTask: Task<Void, Never>?
+    @State private var clipboardFadeTask: Task<Void, Never>?
 
     // MARK: - Computed Properties
 
@@ -58,19 +60,26 @@ struct BackupSettingsView: View {
 
     private func copySeedToClipboard() {
         guard let words = appState.nodeService.savedMnemonic else { return }
+        clipboardClearTask?.cancel()
+        clipboardFadeTask?.cancel()
         UIPasteboard.general.string = words
         withAnimation { copiedSeed = true }
 
-        Task {
+        clipboardClearTask = Task {
             try? await Task.sleep(for: .seconds(SeedConstants.clipboardClearSeconds))
             if UIPasteboard.general.string == words {
                 UIPasteboard.general.string = ""
             }
         }
-        Task {
+        clipboardFadeTask = Task {
             try? await Task.sleep(for: .seconds(2))
             withAnimation { self.copiedSeed = false }
         }
+    }
+
+    private func cancelClipboardTasks() {
+        clipboardClearTask?.cancel()
+        clipboardFadeTask?.cancel()
     }
 
     private func backupNow() async {
@@ -106,6 +115,7 @@ struct BackupSettingsView: View {
         .listStyle(.insetGrouped)
         .navigationTitle(String(localized: "title_backup", defaultValue: "Backup"))
         .navigationBarTitleDisplayMode(.inline)
+        .onDisappear { cancelClipboardTasks() }
         .sheet(isPresented: $showRestore) {
             RestoreSeedSheet(
                 restoreMnemonic: $restoreMnemonic,
@@ -115,7 +125,6 @@ struct BackupSettingsView: View {
                 isRestoring: $isRestoring,
                 restoreError: $restoreError,
                 wordCount: detectedWordCount,
-                restoreValid: restoreValid,
                 onCancel: { cancelRestore() }
             )
         }

--- a/ios/StableChannels/StableChannels/Features/Settings/ExportImportSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/ExportImportSheet.swift
@@ -1,0 +1,456 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+    static var stableBackup: UTType {
+        UTType(filenameExtension: "stablebackup") ?? .data
+    }
+}
+
+struct ExportImportSheet: View {
+    enum Mode: String {
+        case export
+        case importFile
+    }
+
+    let mode: Mode
+    var onRestore: ((String) -> Void)?
+
+    init(mode: Mode, onRestore: ((String) -> Void)? = nil) {
+        self.mode = mode
+        self.onRestore = onRestore
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var passphrase = ""
+    @State private var confirmPassphrase = ""
+    @State private var isProcessing = false
+    @State private var errorMessage: String?
+    @State private var exportURL: URL?
+    @State private var showingShareSheet = false
+    @State private var showingFilePicker = false
+    @State private var selectedFileURL: URL?
+    @State private var selectedFileName: String?
+    @State private var animateFileSelection = false
+    @State private var isRateLimited = false
+    @State private var lockoutSeconds = 0
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    headerSection
+
+                    if mode == .export {
+                        exportContent
+                    } else {
+                        importContent
+                    }
+                }
+                .padding(20)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(mode == .export ? String(localized: "export_backup", defaultValue: "Export Backup") :
+                String(
+                    localized: "import_backup",
+                    defaultValue: "Import Backup"
+                ))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .sheet(isPresented: $showingShareSheet) {
+                if let url = exportURL {
+                    ShareSheet(items: [url])
+                }
+            }
+            .fileImporter(
+                isPresented: $showingFilePicker,
+                allowedContentTypes: [.stableBackup],
+                allowsMultipleSelection: false
+            ) { result in
+                handleFileSelection(result)
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(.ultraThinMaterial)
+                    .frame(width: 80, height: 80)
+
+                Image(systemName: mode == .export ? "square.and.arrow.up.fill" : "square.and.arrow.down.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.blue)
+            }
+
+            Text(mode == .export
+                ? String(localized: "export_title", defaultValue: "Export Your Backup")
+                : String(localized: "import_title", defaultValue: "Restore from Backup"))
+                .font(.title2.bold())
+                .foregroundStyle(.primary)
+
+            Text(mode == .export
+                ? String(
+                    localized: "export_description",
+                    defaultValue: "Add a passphrase to protect your exported backup. You'll need this to restore."
+                )
+                : String(
+                    localized: "import_description",
+                    defaultValue: "Select your .stablebackup file and enter the passphrase used when creating it."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, 8)
+    }
+
+    // MARK: - Export
+
+    private var exportContent: some View {
+        VStack(spacing: 16) {
+            passphraseCard(
+                label: String(localized: "passphrase", defaultValue: "Passphrase"),
+                placeholder: String(localized: "enter_passphrase", defaultValue: "Enter passphrase"),
+                text: $passphrase,
+                isNew: true
+            )
+
+            passphraseCard(
+                label: String(localized: "confirm_passphrase", defaultValue: "Confirm Passphrase"),
+                placeholder: String(localized: "confirm_passphrase_hint", defaultValue: "Confirm your passphrase"),
+                text: $confirmPassphrase,
+                isNew: true
+            )
+
+            if !passphrase.isEmpty && passphrase.count < 12 {
+                requirementBadge(
+                    text: String(localized: "passphrase_min_length", defaultValue: "At least 12 characters required"),
+                    isMet: false
+                )
+            }
+
+            if !passphrase.isEmpty && !confirmPassphrase.isEmpty && passphrase != confirmPassphrase {
+                requirementBadge(
+                    text: String(localized: "passphrase_mismatch", defaultValue: "Passphrases don't match"),
+                    isMet: false
+                )
+            }
+
+            errorBanner
+
+            Spacer(minLength: 20)
+
+            Button {
+                Task { await exportBackup() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isProcessing {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    Text(String(localized: "export", defaultValue: "Export"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(.ultraThinMaterial)
+                .foregroundStyle(isExportValid ? .blue : .secondary)
+                .clipShape(.rect(cornerRadius: 14))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(isExportValid ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+                )
+            }
+            .disabled(!isExportValid || isProcessing)
+        }
+    }
+
+    // MARK: - Import
+
+    private var importContent: some View {
+        VStack(spacing: 16) {
+            filePickerCard
+
+            if selectedFileURL != nil {
+                passphraseCard(
+                    label: String(localized: "passphrase", defaultValue: "Passphrase"),
+                    placeholder: String(localized: "enter_backup_passphrase", defaultValue: "Enter backup passphrase"),
+                    text: $passphrase,
+                    isNew: false
+                )
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            errorBanner
+
+            Spacer(minLength: 20)
+
+            Button {
+                Task { await importBackup() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isProcessing {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.down.circle.fill")
+                    }
+                    Text(String(localized: "import", defaultValue: "Import"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(.ultraThinMaterial)
+                .foregroundStyle(isImportValid ? .blue : .secondary)
+                .clipShape(.rect(cornerRadius: 14))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(isImportValid ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+                )
+            }
+            .disabled(!isImportValid || isProcessing)
+        }
+        .animation(.easeInOut(duration: 0.3), value: selectedFileURL != nil)
+    }
+
+    // MARK: - File Picker Card
+
+    private var filePickerCard: some View {
+        Button {
+            showingFilePicker = true
+        } label: {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(selectedFileURL != nil ? Color.green.opacity(0.1) : Color.blue.opacity(0.1))
+                        .frame(width: 52, height: 52)
+
+                    Image(systemName: selectedFileURL != nil ? "checkmark.circle.fill" : "doc.fill")
+                        .font(.title2)
+                        .foregroundStyle(selectedFileURL != nil ? .green : .blue)
+                        .scaleEffect(animateFileSelection ? 1.1 : 1.0)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(selectedFileURL != nil
+                        ? (selectedFileName ?? "File selected")
+                        : String(localized: "select_backup_file", defaultValue: "Select .stablebackup File"))
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    Text(selectedFileURL != nil
+                        ? String(localized: "file_ready", defaultValue: "File ready to restore")
+                        : String(localized: "tap_to_select", defaultValue: "Tap to browse your files"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(16)
+            .background(.ultraThinMaterial)
+            .clipShape(.rect(cornerRadius: 16))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(selectedFileURL != nil ? Color.green.opacity(0.3) : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Passphrase Card
+
+    private func passphraseCard(label: String, placeholder: String, text: Binding<String>, isNew: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            SecureField(placeholder, text: text)
+                .textContentType(isNew ? .newPassword : .password)
+                .padding(16)
+                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                .clipShape(.rect(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Requirement Badge
+
+    private func requirementBadge(text: String, isMet: Bool) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: isMet ? "checkmark.circle.fill" : "circle")
+                .font(.caption)
+                .foregroundStyle(isMet ? .green : .secondary)
+
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground).opacity(0.5))
+        .clipShape(.rect(cornerRadius: 8))
+    }
+
+    // MARK: - Error Banner
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let error = errorMessage {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+
+                Text(error)
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+
+                Spacer()
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity)
+            .background(Color.red.opacity(0.08))
+            .clipShape(.rect(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Validation
+
+    private var isExportValid: Bool {
+        !passphrase.isEmpty && passphrase.count >= 12 && passphrase == confirmPassphrase
+    }
+
+    private var isImportValid: Bool {
+        selectedFileURL != nil && !passphrase.isEmpty
+    }
+
+    // MARK: - Actions
+
+    private func handleFileSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            if let url = urls.first {
+                selectedFileURL = url
+                selectedFileName = url.lastPathComponent
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    animateFileSelection = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        animateFileSelection = false
+                    }
+                }
+            }
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func exportBackup() async {
+        isProcessing = true
+        defer { isProcessing = false }
+        errorMessage = nil
+
+        do {
+            guard let mnemonic = NodeService.shared.savedMnemonic else {
+                errorMessage = String(localized: "error_no_seed", defaultValue: "No seed available")
+                return
+            }
+            let encryptedData = try CryptoService.encrypt(mnemonic: mnemonic, passphrase: passphrase).data
+
+            let filename = "stablechannels-backup-\(Date().ISO8601Format()).stablebackup"
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+            try encryptedData.write(to: tempURL)
+            exportURL = tempURL
+            showingShareSheet = true
+        } catch {
+            errorMessage = String(localized: "error_export_failed", defaultValue: "Export failed")
+        }
+    }
+
+    private func importBackup() async {
+        guard let fileURL = selectedFileURL else {
+            errorMessage = String(localized: "error_no_file", defaultValue: "No file selected")
+            return
+        }
+
+        // Check rate limit before attempting decryption
+        if RateLimitService.shared.isLocked {
+            lockoutSeconds = RateLimitService.shared.lockoutRemainingSeconds
+            isRateLimited = true
+            errorMessage = "\(String(localized: "error_rate_limited", defaultValue: "Too many attempts. Try again in")) \(lockoutSeconds)s"
+            return
+        }
+
+        isProcessing = true
+        defer { isProcessing = false }
+        errorMessage = nil
+
+        do {
+            let accessing = fileURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessing {
+                    fileURL.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            let encryptedData = try Data(contentsOf: fileURL)
+            let backup = try CryptoService.decrypt(data: encryptedData, passphrase: passphrase)
+
+            // Success - reset rate limit
+            RateLimitService.shared.recordSuccessfulAttempt()
+            onRestore?(backup.mnemonic)
+            dismiss()
+        } catch let error as CryptoError {
+            RateLimitService.shared.recordFailedAttempt()
+
+            if case .invalidMagicBytes = error {
+                errorMessage = String(localized: "error_invalid_backup", defaultValue: "Invalid backup file")
+            } else if case .unsupportedVersion = error {
+                errorMessage = String(localized: "error_old_backup", defaultValue: "Backup version not supported")
+            } else {
+                // Wrong passphrase or decryption failed - show rate limit info
+                let remaining = RateLimitService.shared.attemptsRemaining
+                if RateLimitService.shared.isLocked {
+                    lockoutSeconds = RateLimitService.shared.lockoutRemainingSeconds
+                    errorMessage = "\(String(localized: "error_wrong_passphrase", defaultValue: "Wrong passphrase. \(remaining) attempts remaining")) "
+                        + "\(String(localized: "error_locked_for", defaultValue: "Locked for")) \(lockoutSeconds)s"
+                } else {
+                    errorMessage = "\(String(localized: "error_import_failed", defaultValue: "Decryption failed. Check passphrase.")) "
+                        + "(\(remaining) \(String(localized: "label_attempts_left", defaultValue: "attempts left")))"
+                }
+            }
+        } catch {
+            RateLimitService.shared.recordFailedAttempt()
+            errorMessage = String(
+                localized: "error_import_failed",
+                defaultValue: "Decryption failed. Check passphrase."
+            )
+        }
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context _: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/NativeTimerAlert.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/NativeTimerAlert.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import UIKit
+
+struct NativeTimerAlertModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let title: String
+    let onConfirm: () async -> Void
+
+    func body(content: Content) -> some View {
+        content.background(
+            NativeTimerAlertPresenter(
+                isPresented: $isPresented,
+                title: title,
+                onConfirm: onConfirm
+            )
+        )
+    }
+}
+
+extension View {
+    func nativeTimerAlert(isPresented: Binding<Bool>, title: String,
+                          onConfirm: @escaping () async -> Void) -> some View {
+        self.modifier(NativeTimerAlertModifier(isPresented: isPresented, title: title, onConfirm: onConfirm))
+    }
+}
+
+struct NativeTimerAlertPresenter: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let title: String
+    let onConfirm: () async -> Void
+
+    func makeUIViewController(context _: Context) -> UIViewController {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .clear
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        if isPresented && context.coordinator.alertController == nil {
+            context.coordinator.presentAlert(on: uiViewController)
+        } else if !isPresented && context.coordinator.alertController != nil {
+            context.coordinator.dismissAlert()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject {
+        var parent: NativeTimerAlertPresenter
+        var alertController: UIAlertController?
+        var timer: Timer?
+        var secondsRemaining = 10
+        var overwriteAction: UIAlertAction?
+
+        init(_ parent: NativeTimerAlertPresenter) {
+            self.parent = parent
+        }
+
+        func presentAlert(on viewController: UIViewController) {
+            secondsRemaining = 10
+
+            let alert = UIAlertController(
+                title: parent.title,
+                message: baseMessage + "\n\nPlease wait \(secondsRemaining) seconds...",
+                preferredStyle: .alert
+            )
+            self.alertController = alert
+
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { [weak self] _ in
+                self?.cleanup()
+            }
+
+            let overwrite = UIAlertAction(title: "Overwrite", style: .destructive) { [weak self] _ in
+                guard let self else { return }
+                self.stopTimer()
+                Task {
+                    await self.parent.onConfirm()
+                }
+                self.parent.isPresented = false
+                self.alertController = nil
+            }
+            overwrite.isEnabled = false
+            self.overwriteAction = overwrite
+
+            alert.addAction(cancelAction)
+            alert.addAction(overwrite)
+
+            viewController.present(alert, animated: true) { [weak self] in
+                self?.startTimer()
+            }
+        }
+
+        private var baseMessage: String {
+            "An existing backup from another device was found in iCloud. Overwriting it will permanently destroy the previous backup. Continue?"
+        }
+
+        func startTimer() {
+            timer?.invalidate()
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                self?.updateTimerMessage()
+            }
+        }
+
+        func updateTimerMessage() {
+            guard let alert = alertController else { return }
+
+            secondsRemaining -= 1
+            if secondsRemaining > 0 {
+                alert.message = baseMessage + "\n\nPlease wait \(secondsRemaining) seconds..."
+            } else {
+                alert.message = baseMessage
+                overwriteAction?.isEnabled = true
+                stopTimer()
+            }
+        }
+
+        func stopTimer() {
+            timer?.invalidate()
+            timer = nil
+        }
+
+        func dismissAlert() {
+            alertController?.dismiss(animated: true)
+            cleanup()
+        }
+
+        func cleanup() {
+            stopTimer()
+            alertController = nil
+            parent.isPresented = false
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct RestoreBackupSheet: View {
     let backupService: any BackupServiceProtocol
@@ -31,8 +32,6 @@ struct RestoreBackupSheet: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
-                icloudWarningBanner
-
                 VStack(alignment: .leading, spacing: 16) {
                     featureRow(icon: "key.fill", text: "AES-256 encrypted backup")
                     featureRow(icon: "arrow.clockwise", text: "Sync latest version")
@@ -41,7 +40,7 @@ struct RestoreBackupSheet: View {
                 .padding(.horizontal, 32)
                 .padding(.top, 8)
 
-                Spacer()
+                icloudWarningBanner
 
                 if showSuccess {
                     VStack(spacing: 8) {
@@ -63,16 +62,9 @@ struct RestoreBackupSheet: View {
                         .foregroundStyle(.red)
                         .padding(.horizontal, 24)
                 }
-
-                Spacer()
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-            }
         }
     }
 
@@ -110,32 +102,52 @@ struct RestoreBackupSheet: View {
     }
 
     private var icloudWarningBanner: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
-                Text("Partial Recovery Warning")
-                    .font(.headline)
-                Spacer()
-            }
+        HStack(spacing: 14) {
+            supportIconBadge
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Important")
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
 
-            Text(
-                "This backup contains only your seed phrase. Lightning channel state is NOT included. On-chain funds will be restored, but Lightning funds may be lost."
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-
-            Text("Contact support@stablechannels.com if you need help recovering Lightning funds.")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        "Restoring from iCloud will erase your existing wallet and all funds. Please withdraw all Bitcoin before proceeding."
+                    )
+                        + Text(" ")
+                        + Text("support@stablechannels.com")
+                        .foregroundStyle(.blue)
+                        .underline()
+                        + Text(" ")
+                        + Text("for questions or assistance.")
+                }
                 .font(.caption)
-                .foregroundStyle(.blue)
-                .fontWeight(.medium)
-                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(Color(uiColor: .label).opacity(0.7))
+            }
+            Spacer()
         }
-        .padding()
-        .background(.orange.opacity(0.1))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(.red, lineWidth: 1)
+                )
+        )
+    }
+
+    private var supportIconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(.red)
+                .frame(width: 44, height: 44)
+                .shadow(color: .red.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "questionmark.circle.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
+        }
     }
 
     private func performRestore() async {

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
@@ -31,6 +31,8 @@ struct RestoreBackupSheet: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
+                icloudWarningBanner
+
                 VStack(alignment: .leading, spacing: 16) {
                     featureRow(icon: "key.fill", text: "AES-256 encrypted backup")
                     featureRow(icon: "arrow.clockwise", text: "Sync latest version")
@@ -87,47 +89,53 @@ struct RestoreBackupSheet: View {
         }
     }
 
-    @ViewBuilder
     private var restoreButton: some View {
-        if #available(iOS 26.0, *) {
-            Button {
-                Task { await performRestore() }
-            } label: {
-                HStack(spacing: 8) {
-                    if isRestoring {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "arrow.down.circle")
-                    }
-                    Text(String(localized: "restore_action", defaultValue: "Restore Wallet"))
-                        .fontWeight(.semibold)
+        Button {
+            Task { await performRestore() }
+        } label: {
+            HStack(spacing: 8) {
+                if isRestoring {
+                    ProgressView()
+                } else {
+                    Image(systemName: "arrow.down.circle")
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
+                Text(String(localized: "restore_action", defaultValue: "Restore Wallet"))
+                    .fontWeight(.semibold)
             }
-            .buttonStyle(.glassProminent)
-            .disabled(isRestoring)
-        } else {
-            Button {
-                Task { await performRestore() }
-            } label: {
-                HStack(spacing: 8) {
-                    if isRestoring {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "arrow.down.circle")
-                    }
-                    Text(String(localized: "restore_action", defaultValue: "Restore Wallet"))
-                        .fontWeight(.semibold)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(.blue)
-                .foregroundStyle(.white)
-                .clipShape(.rect(cornerRadius: 12))
-            }
-            .disabled(isRestoring)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
         }
+        .buttonStyle(.borderedProminent)
+        .disabled(isRestoring)
+    }
+
+    private var icloudWarningBanner: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Partial Recovery Warning")
+                    .font(.headline)
+                Spacer()
+            }
+
+            Text(
+                "This backup contains only your seed phrase. Lightning channel state is NOT included. On-chain funds will be restored, but Lightning funds may be lost."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text("Contact support@stablechannels.com if you need help recovering Lightning funds.")
+                .font(.caption)
+                .foregroundStyle(.blue)
+                .fontWeight(.medium)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .background(.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 24)
     }
 
     private func performRestore() async {

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
@@ -42,6 +42,8 @@ struct RestoreBackupSheet: View {
 
                 icloudWarningBanner
 
+                Spacer()
+
                 if showSuccess {
                     VStack(spacing: 8) {
                         Image(systemName: "checkmark.circle.fill")
@@ -52,19 +54,22 @@ struct RestoreBackupSheet: View {
                             .foregroundStyle(.green)
                     }
                     .padding(.vertical, 16)
-                } else {
-                    restoreButton
                 }
 
-                if let error = errorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .padding(.horizontal, 24)
+                VStack(spacing: 16) {
+                    restoreButton
+
+                    if let error = errorMessage {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
                 }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
             }
-            .padding()
             .navigationBarTitleDisplayMode(.inline)
+            .padding()
         }
     }
 
@@ -76,7 +81,6 @@ struct RestoreBackupSheet: View {
                 .frame(width: 24)
             Text(text)
                 .font(.subheadline)
-                .foregroundStyle(.primary)
             Spacer()
         }
     }

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+struct RestoreBackupSheet: View {
+    let onRestore: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var isRestoring = false
+    @State private var showSuccess = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer()
+
+                Image(systemName: "icloud.and.arrow.down")
+                    .font(.system(size: 80))
+                    .foregroundStyle(.blue)
+                    .shadow(color: .blue.opacity(0.3), radius: 20, x: 0, y: 8)
+
+                Text(String(localized: "restore_from_icloud", defaultValue: "Restore from iCloud"))
+                    .font(.title.bold())
+
+                Text(String(
+                    localized: "restore_description",
+                    defaultValue: "Restore your wallet from backup."
+                ))
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+                VStack(alignment: .leading, spacing: 16) {
+                    featureRow(icon: "key.fill", text: "AES-256 encrypted backup")
+                    featureRow(icon: "arrow.clockwise", text: "Sync latest version")
+                    featureRow(icon: "checkmark.shield.fill", text: "Verified restore")
+                }
+                .padding(.horizontal, 32)
+                .padding(.top, 8)
+
+                Spacer()
+
+                if showSuccess {
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 48))
+                            .foregroundStyle(.green)
+                        Text("Wallet restored!")
+                            .font(.headline)
+                            .foregroundStyle(.green)
+                    }
+                    .padding(.vertical, 16)
+                } else {
+                    restoreButton
+                }
+
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal, 24)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func featureRow(icon: String, text: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundStyle(.blue)
+                .frame(width: 24)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var restoreButton: some View {
+        if #available(iOS 26.0, *) {
+            Button {
+                Task { await performRestore() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isRestoring {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.down.circle")
+                    }
+                    Text(String(localized: "restore_action", defaultValue: "Restore Wallet"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+            }
+            .buttonStyle(.glassProminent)
+            .disabled(isRestoring)
+        } else {
+            Button {
+                Task { await performRestore() }
+            } label: {
+                HStack(spacing: 8) {
+                    if isRestoring {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.down.circle")
+                    }
+                    Text(String(localized: "restore_action", defaultValue: "Restore Wallet"))
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(.blue)
+                .foregroundStyle(.white)
+                .clipShape(.rect(cornerRadius: 12))
+            }
+            .disabled(isRestoring)
+        }
+    }
+
+    private func performRestore() async {
+        isRestoring = true
+        errorMessage = nil
+
+        do {
+            let backup = try await CloudBackupService.shared.restoreFromCloud()
+            onRestore(backup.mnemonic)
+            showSuccess = true
+            try await Task.sleep(for: .seconds(1.5))
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+            isRestoring = false
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreBackupSheet.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct RestoreBackupSheet: View {
+    let backupService: any BackupServiceProtocol
     let onRestore: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -134,7 +135,7 @@ struct RestoreBackupSheet: View {
         errorMessage = nil
 
         do {
-            let backup = try await CloudBackupService.shared.restoreFromCloud()
+            let backup = try await backupService.restoreFromCloud()
             onRestore(backup.mnemonic)
             showSuccess = true
             try await Task.sleep(for: .seconds(1.5))

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
@@ -190,15 +190,10 @@ struct RestoreSeedSheet: View {
         }
 
         do {
-            try await appState.nodeService.start(
-                network: .bitcoin,
-                esploraURL: appState.chainURL,
-                mnemonic: input
-            )
+            try await appState.restoreWalletFromMnemonic(input)
             restoreMnemonic = ""
             wordFields = Array(repeating: "", count: SeedConstants.maxWordCount)
             isWordFieldsReadOnly = false
-            appState.refreshBalances()
             isRestoring = false
             onSuccess()
             dismiss()

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
@@ -10,8 +10,12 @@ struct RestoreSeedSheet: View {
     @Binding var isImportingSeed: Bool
     @Binding var isRestoring: Bool
     @Binding var restoreError: String?
-    let wordCount: Int
     let onCancel: () -> Void
+    let onSuccess: () -> Void
+
+    private var wordCount: Int {
+        MnemonicUtils.detectWordCount(restoreMnemonic)
+    }
 
     private var restoreValid: Bool {
         let filledCount = wordFields.filter { !$0.isEmpty }.count
@@ -166,6 +170,7 @@ struct RestoreSeedSheet: View {
             isWordFieldsReadOnly = false
             appState.refreshBalances()
             isRestoring = false
+            onSuccess()
             dismiss()
         } catch {
             restoreError = String(localized: "error_restore_failed") + error.localizedDescription

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
@@ -11,8 +11,12 @@ struct RestoreSeedSheet: View {
     @Binding var isRestoring: Bool
     @Binding var restoreError: String?
     let wordCount: Int
-    let restoreValid: Bool
     let onCancel: () -> Void
+
+    private var restoreValid: Bool {
+        let filledCount = wordFields.filter { !$0.isEmpty }.count
+        return filledCount == SeedConstants.wordCount12 || filledCount == SeedConstants.wordCount24
+    }
 
     var body: some View {
         NavigationStack {
@@ -157,19 +161,15 @@ struct RestoreSeedSheet: View {
                 esploraURL: appState.chainURL,
                 mnemonic: input
             )
-            await MainActor.run {
-                restoreMnemonic = ""
-                wordFields = Array(repeating: "", count: SeedConstants.maxWordCount)
-                isWordFieldsReadOnly = false
-                appState.refreshBalances()
-                isRestoring = false
-                dismiss()
-            }
+            restoreMnemonic = ""
+            wordFields = Array(repeating: "", count: SeedConstants.maxWordCount)
+            isWordFieldsReadOnly = false
+            appState.refreshBalances()
+            isRestoring = false
+            dismiss()
         } catch {
-            await MainActor.run {
-                restoreError = String(localized: "error_restore_failed") + error.localizedDescription
-                isRestoring = false
-            }
+            restoreError = String(localized: "error_restore_failed") + error.localizedDescription
+            isRestoring = false
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
@@ -96,13 +96,15 @@ struct RestoreSeedSheet: View {
     // MARK: - Subviews
 
     private var headerSection: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 16) {
             Image(systemName: "arrow.uturn.backward.circle.fill")
                 .font(.system(size: 48))
                 .foregroundStyle(.orange)
 
             Text(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
                 .font(.title2.bold())
+
+            warningBanner
 
             Text(String(
                 localized: "instruction_restore",
@@ -112,6 +114,34 @@ struct RestoreSeedSheet: View {
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
         }
+    }
+
+    private var warningBanner: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Partial Recovery Warning")
+                    .font(.headline)
+                Spacer()
+            }
+
+            Text(
+                "This recovery will restore on-chain funds but NOT Lightning channel state. Lightning funds will be lost and may require LSP force-close."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text("Please withdraw all BTC before proceeding. Existing wallet data will be completely overwritten.")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .fontWeight(.semibold)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .background(.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     private var seedTextField: some View {

--- a/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/RestoreSeedSheet.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+struct RestoreSeedSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(AppState.self) private var appState
+
+    @Binding var restoreMnemonic: String
+    @Binding var wordFields: [String]
+    @Binding var isWordFieldsReadOnly: Bool
+    @Binding var isImportingSeed: Bool
+    @Binding var isRestoring: Bool
+    @Binding var restoreError: String?
+    let wordCount: Int
+    let restoreValid: Bool
+    let onCancel: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    headerSection
+
+                    seedTextField
+                        .onTapGesture {
+                            UIApplication.shared.sendAction(
+                                #selector(UIResponder.resignFirstResponder),
+                                to: nil,
+                                from: nil,
+                                for: nil
+                            )
+                        }
+
+                    SeedWordGridView(
+                        wordFields: wordFields,
+                        isReadOnly: isWordFieldsReadOnly,
+                        isDisabled: isRestoring,
+                        wordCount: wordCount,
+                        onWordChanged: { index, word in
+                            wordFields[index] = word
+                            syncMnemonicFromFields()
+                        }
+                    )
+
+                    if let error = restoreError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    Button {
+                        Task { await restoreWallet() }
+                    } label: {
+                        if isRestoring {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                Text(String(localized: "restoring", defaultValue: "Restoring..."))
+                            }
+                        } else {
+                            Text(String(localized: "button_restore", defaultValue: "Restore"))
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(.ultraThinMaterial)
+                    .foregroundStyle(restoreValid ? .blue : .secondary)
+                    .clipShape(.rect(cornerRadius: 14))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .strokeBorder(restoreValid ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
+                    )
+                    .disabled(!restoreValid || isRestoring)
+
+                    Spacer()
+                }
+                .padding()
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
+                        onCancel()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var headerSection: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.uturn.backward.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange)
+
+            Text(String(localized: "title_restore_seed", defaultValue: "Restore from Seed"))
+                .font(.title2.bold())
+
+            Text(String(
+                localized: "instruction_restore",
+                defaultValue: "Enter your 12 or 24-word seed phrase."
+            ))
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+        }
+    }
+
+    private var seedTextField: some View {
+        TextField(
+            String(localized: "placeholder_seed", defaultValue: "Paste your seed phrase here"),
+            text: $restoreMnemonic,
+            axis: .vertical
+        )
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled()
+        .lineLimit(5...10)
+        .font(.system(.body, design: .monospaced))
+        .padding()
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .onChange(of: restoreMnemonic) { _, newValue in
+            if isImportingSeed {
+                isImportingSeed = false
+                return
+            }
+            syncWordFields(from: newValue)
+        }
+        .disabled(isRestoring)
+    }
+
+    private func syncWordFields(from text: String) {
+        wordFields = MnemonicUtils.wordsToFields(MnemonicUtils.parseMnemonic(text))
+        isWordFieldsReadOnly = true
+    }
+
+    private func syncMnemonicFromFields() {
+        isWordFieldsReadOnly = false
+        restoreMnemonic = wordFields.filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
+    private func restoreWallet() async {
+        isRestoring = true
+        restoreError = nil
+
+        let input = restoreMnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard MnemonicUtils.isValidWordCount(input) else {
+            isRestoring = false
+            restoreError = String(localized: "error_seed_word_count")
+            return
+        }
+
+        do {
+            try await appState.nodeService.start(
+                network: .bitcoin,
+                esploraURL: appState.chainURL,
+                mnemonic: input
+            )
+            await MainActor.run {
+                restoreMnemonic = ""
+                wordFields = Array(repeating: "", count: SeedConstants.maxWordCount)
+                isWordFieldsReadOnly = false
+                appState.refreshBalances()
+                isRestoring = false
+                dismiss()
+            }
+        } catch {
+            await MainActor.run {
+                restoreError = String(localized: "error_restore_failed") + error.localizedDescription
+                isRestoring = false
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/SeedDisplayView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/SeedDisplayView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct SeedDisplayView: View {
+    let words: String
+
+    @State private var copiedSeed = false
+    @State private var showCopyWarning = false
+    @State private var clipboardClearTask: Task<Void, Never>?
+    @State private var clipboardFadeTask: Task<Void, Never>?
+
+    private func copySeedToClipboard() {
+        clipboardClearTask?.cancel()
+        clipboardFadeTask?.cancel()
+        UIPasteboard.general.string = words
+        withAnimation { copiedSeed = true }
+
+        clipboardClearTask = Task {
+            try? await Task.sleep(for: .seconds(SeedConstants.clipboardClearSeconds))
+            if UIPasteboard.general.string == words {
+                UIPasteboard.general.string = ""
+            }
+        }
+        clipboardFadeTask = Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation { self.copiedSeed = false }
+        }
+    }
+
+    private func cancelClipboardTasks() {
+        clipboardClearTask?.cancel()
+        clipboardFadeTask?.cancel()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(String(localized: "warning_seed", defaultValue: "Never share your seed words"))
+                    .font(.caption.bold())
+                    .foregroundStyle(.orange)
+            }
+
+            let wordList = words.split(separator: " ").map(String.init)
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 6) {
+                ForEach(Array(wordList.enumerated()), id: \.offset) { index, word in
+                    HStack(spacing: 4) {
+                        Text("\(index + 1).")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18, alignment: .trailing)
+                        Text(word)
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+
+            if !copiedSeed && !showCopyWarning {
+                Button {
+                    showCopyWarning = true
+                } label: {
+                    HStack {
+                        Image(systemName: "doc.on.doc")
+                        Text(String(localized: "button_copy_seed", defaultValue: "Copy to Clipboard"))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+
+            if copiedSeed {
+                HStack {
+                    Image(systemName: "checkmark")
+                    Text(String(localized: "button_copied", defaultValue: "Copied"))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.green.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+
+            if showCopyWarning {
+                VStack(spacing: 8) {
+                    Text(String(localized: "warning_copy_seed_title", defaultValue: "Copy Seed Words?"))
+                        .font(.caption.bold())
+
+                    Text(String(
+                        localized: "warning_copy_seed_message",
+                        defaultValue: "Clipboard is shared with other apps."
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                    HStack(spacing: 12) {
+                        Button(String(localized: "button_cancel", defaultValue: "Cancel")) {
+                            showCopyWarning = false
+                        }
+                        .font(.caption)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button(String(localized: "button_copy_anyway", defaultValue: "Copy Anyway")) {
+                            copySeedToClipboard()
+                            showCopyWarning = false
+                        }
+                        .font(.caption)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .transition(.opacity.combined(with: .scale(scale: 0.95)))
+            }
+        }
+        .padding(.vertical, 4)
+        .animation(.easeInOut(duration: 0.2), value: showCopyWarning)
+        .onDisappear {
+            cancelClipboardTasks()
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/SeedWordGridView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/SeedWordGridView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct SeedWordGridView: View {
+    let wordFields: [String]
+    let isReadOnly: Bool
+    let isDisabled: Bool
+    let wordCount: Int
+    var onWordChanged: ((Int, String) -> Void)?
+
+    private var columns: [GridItem] {
+        wordCount == SeedConstants.wordCount12
+            ? [GridItem(.flexible()), GridItem(.flexible())]
+            : [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(0..<wordCount, id: \.self) { index in
+                wordCell(index: index)
+            }
+        }
+        .animation(.easeInOut, value: wordCount)
+    }
+
+    private func wordCell(index: Int) -> some View {
+        HStack(spacing: 4) {
+            Text("\(index + 1).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 18, alignment: .trailing)
+
+            if isReadOnly || isDisabled {
+                Text(wordFields[index])
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                TextField("", text: Binding(
+                    get: { wordFields[index] },
+                    set: { onWordChanged?(index, $0) }
+                ))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .font(.system(.caption, design: .monospaced))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/SettingsView.swift
@@ -35,7 +35,7 @@ struct SettingsView: View {
                         )
                     }
                     NavigationLink {
-                        BackupSettingsView()
+                        BackupSettingsView(backupService: CloudBackupService.shared)
                     } label: {
                         rowLabel(
                             icon: "lock.doc.fill",

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1,3541 +1,4082 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "%@" : {
-
+  "sourceLanguage": "en",
+  "strings": {
+    "%@": {},
+    "%@ BTC": {},
+    "%lld.": {},
+    "%lld%% USD  %lld%% BTC": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$lld%% USD  %2$lld%% BTC"
+          }
+        }
+      }
+    },
+    "Active": {},
+    "alert_close_channel_cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "alert_close_channel_confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Channel"
+          }
+        }
+      }
+    },
+    "alert_close_channel_message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to close this channel?"
+          }
+        }
+      }
+    },
+    "alert_close_channel_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Channel?"
+          }
+        }
+      }
+    },
+    "alert_no_qr": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No QR code found"
+          }
+        }
+      }
+    },
+    "alert_qr_error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error reading QR code"
+          }
+        }
+      }
+    },
+    "and_spending_account": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
+          }
+        }
+      }
+    },
+    "app_name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stable Channels"
+          }
+        }
+      }
+    },
+    "app_subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-custody Lightning wallet"
+          }
+        }
+      }
+    },
+    "auth_cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "auth_confirm_on_chain_send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authenticate to send onchain"
+          }
+        }
+      }
+    },
+    "auth_confirm_on_chain_withdrawal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authenticate to confirm onchain withdrawal"
+          }
+        }
+      }
+    },
+    "auth_disable_app_unlock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authenticate to disable App Unlock"
+          }
+        }
+      }
+    },
+    "auth_disable_payment_confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authenticate to disable Payment Confirmation"
+          }
+        }
+      }
+    },
+    "auth_required": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authentication required"
+          }
+        }
+      }
+    },
+    "auth_title_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authentication Failed"
+          }
+        }
+      }
+    },
+    "available_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available: "
+          }
+        }
+      }
+    },
+    "available_native_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available: "
+          }
+        }
+      }
+    },
+    "Bitcoin address QR code": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin address QR code"
+          }
+        }
+      }
+    },
+    "button_any_amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any Amount"
+          }
+        }
+      }
+    },
+    "button_backup_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup Seed"
+          }
+        }
+      }
+    },
+    "button_buy_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD → BTC"
+          }
+        }
+      }
+    },
+    "button_cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "button_close_channel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Channel"
+          }
+        }
+      }
+    },
+    "button_continue": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
+    "button_copied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        }
+      }
+    },
+    "button_copy_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Address"
+          }
+        }
+      }
+    },
+    "button_copy_anyway": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Anyway"
+          }
+        }
+      }
+    },
+    "button_copy_invoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Invoice"
+          }
+        }
+      }
+    },
+    "button_copy_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Seed"
+          }
+        }
+      }
+    },
+    "button_done": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        }
+      }
+    },
+    "button_enable_in_settings": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enable in Settings"
+          }
+        }
+      }
+    },
+    "button_enable_settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Settings"
+          }
+        }
+      }
+    },
+    "button_enlarge_qr": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enlarge QR"
+          }
+        }
+      }
+    },
+    "button_generate_invoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate Invoice"
+          }
+        }
+      }
+    },
+    "button_hide_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Seed"
+          }
+        }
+      }
+    },
+    "button_ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "button_open_settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        }
+      }
+    },
+    "button_pick_image": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Pick Image"
+          }
+        }
+      }
+    },
+    "button_receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive"
+          }
+        }
+      }
+    },
+    "button_restore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
+          }
+        }
+      }
     },
-    "%@ BTC" : {
-
+    "button_restore_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Seed"
+          }
+        }
+      }
     },
-    "%lld." : {
-
+    "button_retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        }
+      }
     },
-    "%lld%% USD  %lld%% BTC" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld%% USD  %2$lld%% BTC"
+    "button_scan_qr": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Scan QR"
           }
         }
       }
     },
-    "Active" : {
-
+    "button_sell_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC → USD"
+          }
+        }
+      }
     },
-    "alert_close_channel_cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "button_send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
           }
         }
       }
     },
-    "alert_close_channel_confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Channel"
+    "button_send_payment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
           }
         }
       }
     },
-    "alert_close_channel_message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to close this channel?"
+    "button_share_qr": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share QR"
           }
         }
       }
     },
-    "alert_close_channel_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Channel?"
+    "button_show_node_id": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Node ID"
           }
         }
       }
     },
-    "alert_no_qr" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No QR code found"
+    "button_swap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move"
           }
         }
       }
     },
-    "alert_qr_error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error reading QR code"
+    "button_view_seed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "View Seed Words"
           }
         }
       }
     },
-    "and_spending_account" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
+    "channel_status_pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opening"
           }
         }
       }
     },
-    "app_name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stable Channels"
+    "channel_status_ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready"
           }
         }
       }
     },
-    "app_subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Self-custody Lightning wallet"
+    "custody_self": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-custodial"
           }
         }
       }
     },
-    "auth_cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "disclaimer_custody_body": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
           }
         }
       }
     },
-    "auth_confirm_on_chain_send" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authenticate to send onchain"
+    "disclaimer_custody_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your keys, your coins."
           }
         }
       }
     },
-    "auth_confirm_on_chain_withdrawal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authenticate to confirm onchain withdrawal"
+    "empty_payments_desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No payments yet"
           }
         }
       }
     },
-    "auth_disable_app_unlock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authenticate to disable App Unlock"
+    "empty_payments_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Payments"
           }
         }
       }
     },
-    "auth_disable_payment_confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authenticate to disable Payment Confirmation"
+    "empty_trades_desc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convert BTC to see orders here"
           }
         }
       }
     },
-    "auth_required" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentication required"
+    "empty_trades_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Orders"
           }
         }
       }
     },
-    "auth_title_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentication Failed"
+    "error_biometric_cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authentication cancelled"
           }
         }
       }
     },
-    "available_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Available: "
+    "error_biometric_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authentication failed"
           }
         }
       }
     },
-    "available_native_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Available: "
+    "error_biometric_lockout": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometrics locked. Use passcode."
           }
         }
       }
     },
-    "Bitcoin address QR code" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitcoin address QR code"
+    "error_biometric_not_available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometrics not available"
           }
         }
       }
     },
-    "button_any_amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Any Amount"
+    "error_biometric_not_enrolled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biometrics not enrolled"
           }
         }
       }
     },
-    "button_backup_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Backup Seed"
+    "error_db_init": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to initialize database"
           }
         }
       }
     },
-    "button_buy_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD → BTC"
+    "error_exceeds_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exceeds available balance"
           }
         }
       }
     },
-    "button_cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "error_exceeds_limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount exceeds $"
           }
         }
       }
     },
-    "button_close_channel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Channel"
+    "error_exceeds_native": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exceeds native BTC balance"
           }
         }
       }
     },
-    "button_continue" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+    "error_insufficient_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insufficient balance"
           }
         }
       }
     },
-    "button_copied" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied"
+    "error_no_ready_channel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No ready channel"
           }
         }
       }
     },
-    "button_copy_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Address"
+    "error_node_start": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to start node"
           }
         }
       }
     },
-    "button_copy_anyway" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copy Anyway"
+    "error_not_enough_funds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not enough funds"
           }
         }
       }
     },
-    "button_copy_invoice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Invoice"
+    "error_open_channel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to open channel"
           }
         }
       }
     },
-    "button_copy_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copy Seed"
+    "error_passcode_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passcode failed"
           }
         }
       }
     },
-    "button_done" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Done"
+    "error_read_balances": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to read balances"
           }
         }
       }
     },
-    "button_enable_in_settings" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enable in Settings"
+    "error_restore_failed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore failed: "
           }
         }
       }
     },
-    "button_enable_settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Settings"
+    "error_seed_word_count": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seed phrase must be 12 or 24 words"
           }
         }
       }
     },
-    "button_enlarge_qr" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enlarge QR"
+    "error_seed_words": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid seed words"
           }
         }
       }
     },
-    "button_generate_invoice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate Invoice"
+    "error_splice_in_progress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A splice is already in progress — try again shortly"
           }
         }
       }
     },
-    "button_hide_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide Seed"
+    "error_sweep_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sweep failed"
           }
         }
       }
     },
-    "button_ok" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "error_title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
           }
         }
       }
     },
-    "button_open_settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+    "error_trade_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trade failed — check amount and try again"
           }
         }
       }
     },
-    "button_pick_image" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pick Image"
+    "error_unrecognized_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unrecognized invoice format"
           }
         }
       }
     },
-    "button_receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive"
+    "error_wallet_creation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create wallet"
           }
         }
       }
     },
-    "button_restore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore"
+    "header_amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         }
       }
     },
-    "button_restore_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore Seed"
+    "header_destination_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destination Address"
           }
         }
       }
     },
-    "button_retry" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry"
+    "header_invoice_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invoice Address"
           }
         }
       }
     },
-    "button_scan_qr" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Scan QR"
+    "header_onchain_subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move funds to any Bitcoin address"
           }
         }
       }
     },
-    "button_sell_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC → USD"
+    "headline_how_much_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How much BTC to convert to USD?"
           }
         }
       }
     },
-    "button_send" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send"
+    "headline_how_much_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How much USD to convert to BTC?"
           }
         }
       }
     },
-    "button_send_payment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send"
+    "hint_create_account": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive over Lightning to create your Stable Account"
           }
         }
       }
     },
-    "button_share_qr" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share QR"
+    "hint_scan_invoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
           }
         }
       }
     },
-    "button_show_node_id" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Node ID"
+    "home_header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stable Channels"
           }
         }
       }
     },
-    "button_swap" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move"
+    "home_hint_receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive sats via Lightning or onchain"
           }
         }
       }
     },
-    "button_view_seed" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "View Seed Words"
+    "home_syncing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing..."
           }
         }
       }
     },
-    "channel_status_pending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opening"
+    "Inactive": {},
+    "info_backup_seed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Write these words down and store them safely. Anyone with these words can access your funds."
           }
         }
       }
     },
-    "channel_status_ready" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ready"
+    "info_close_pending_confirmation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel closing - will appear on explorer after confirmation"
           }
         }
       }
     },
-    "custody_self" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Self-custodial"
+    "info_fee_approx": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee: ~"
           }
         }
       }
     },
-    "disclaimer_custody_body" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+    "info_first_payment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Make your first payment to activate the channel"
           }
         }
       }
     },
-    "disclaimer_custody_title" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your keys, your coins."
+    "info_funds_arrive_onchain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funds arrive after 1 onchain confirmation"
           }
         }
       }
     },
-    "empty_payments_desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No payments yet"
+    "info_no_channel": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No channel open yet."
           }
         }
       }
     },
-    "empty_payments_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Payments"
+    "info_node_id": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your node's public key. Share this to receive Lightning payments."
           }
         }
       }
     },
-    "empty_trades_desc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Convert BTC to see orders here"
+    "info_notifications_needed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable notifications to receive payment alerts"
           }
         }
       }
     },
-    "empty_trades_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Orders"
+    "info_pending_trade": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trade pending — check back soon"
           }
         }
       }
     },
-    "error_biometric_cancelled" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentication cancelled"
+    "info_push_connectivity": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Your device maintains a persistent connection to receive incoming payments and stability updates."
           }
         }
       }
     },
-    "error_biometric_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentication failed"
+    "info_push_description": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Background payments and stability updates"
           }
         }
       }
     },
-    "error_biometric_lockout" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biometrics locked. Use passcode."
+    "info_restore": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore will stop your current node and start fresh."
           }
         }
       }
     },
-    "error_biometric_not_available" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biometrics not available"
+    "info_seed_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seed unavailable"
           }
         }
       }
     },
-    "error_biometric_not_enrolled" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Biometrics not enrolled"
+    "info_self_custody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
           }
         }
       }
     },
-    "error_db_init" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to initialize database"
+    "info_splice_confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm splice-out of "
           }
         }
       }
     },
-    "error_exceeds_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exceeds available balance"
+    "info_splice_out": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice-out initiated"
           }
         }
       }
     },
-    "error_exceeds_limit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount exceeds $"
+    "info_splice_out_funds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funds will be sent via splice-out from your Lightning channel."
           }
         }
       }
     },
-    "error_exceeds_native" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exceeds native BTC balance"
+    "info_splice_out_note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note: Funds require onchain confirmation after splice completes."
           }
         }
       }
     },
-    "error_insufficient_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insufficient balance"
+    "info_theme_setting": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "System uses your device's appearance setting."
           }
         }
       }
     },
-    "error_no_ready_channel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No ready channel"
+    "instruction_restore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter your 12 or 24 word seed phrase"
           }
         }
       }
     },
-    "error_node_start" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to start node"
+    "invoice_description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invoice"
           }
         }
       }
     },
-    "error_not_enough_funds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not enough funds"
+    "label_action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action"
           }
         }
       }
     },
-    "error_open_channel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to open channel"
+    "label_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address"
           }
         }
       }
     },
-    "error_passcode_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passcode failed"
+    "label_all_available_funds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All available funds"
           }
         }
       }
     },
-    "error_read_balances" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to read balances"
+    "label_amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         }
       }
     },
-    "error_restore_failed" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restore failed: "
+    "label_amount_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC Amount"
           }
         }
       }
     },
-    "error_seed_word_count" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seed phrase must be 12 or 24 words"
+    "label_amount_row": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount"
           }
         }
       }
     },
-    "error_seed_words" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invalid seed words"
+    "label_amount_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD Amount"
           }
         }
       }
     },
-    "error_splice_in_progress" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A splice is already in progress — try again shortly"
+    "label_any_amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any Amount"
           }
         }
       }
     },
-    "error_sweep_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sweep failed"
+    "label_app_unlock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Unlock"
           }
         }
       }
     },
-    "error_title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
+    "label_auth_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authentication Failed"
           }
         }
       }
     },
-    "error_trade_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trade failed — check amount and try again"
+    "label_authenticate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authenticate"
           }
         }
       }
     },
-    "error_unrecognized_format" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unrecognized invoice format"
+    "label_background_service": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Background Service"
           }
         }
       }
     },
-    "error_wallet_creation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to create wallet"
+    "label_backing_sats": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backing Sats"
           }
         }
       }
     },
-    "header_amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+    "label_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balance"
           }
         }
       }
     },
-    "header_destination_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Destination Address"
+    "label_balance_pct": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "% USD % BTC"
           }
         }
       }
     },
-    "header_invoice_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invoice Address"
+    "label_bolt11": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bolt 11"
           }
         }
       }
     },
-    "header_onchain_subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move funds to any Bitcoin address"
+    "label_bolt12_offer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offer"
           }
         }
       }
     },
-    "headline_how_much_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How much BTC to convert to USD?"
+    "label_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC"
           }
         }
       }
     },
-    "headline_how_much_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "How much USD to convert to BTC?"
+    "label_btc_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC Balance"
           }
         }
       }
     },
-    "hint_create_account" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive over Lightning to create your Stable Account"
+    "label_btc_price": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC Price"
           }
         }
       }
     },
-    "hint_scan_invoice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
+    "label_build": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Build"
           }
         }
       }
     },
-    "home_header" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stable Channels"
+    "label_camera_denied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Camera access required. Enable in Settings."
           }
         }
       }
     },
-    "home_hint_receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive sats via Lightning or onchain"
+    "label_capacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capacity"
           }
         }
       }
     },
-    "home_syncing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing..."
+    "label_channel_info": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Channel Info"
           }
         }
       }
     },
-    "Inactive" : {
-
+    "label_close_tx": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Tx"
+          }
+        }
+      }
     },
-    "info_backup_seed" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Write these words down and store them safely. Anyone with these words can access your funds."
+    "label_confirmations": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmations"
           }
         }
       }
     },
-    "info_close_pending_confirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel closing - will appear on explorer after confirmation"
+    "label_connection": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connection"
           }
         }
       }
     },
-    "info_fee_approx" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee: ~"
+    "label_counterparty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Counterparty"
           }
         }
       }
     },
-    "info_first_payment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Make your first payment to activate the channel"
+    "label_custody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custody"
           }
         }
       }
     },
-    "info_funds_arrive_onchain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funds arrive after 1 onchain confirmation"
+    "label_dash": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
           }
         }
       }
     },
-    "info_no_channel" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No channel open yet."
+    "label_date": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
           }
         }
       }
     },
-    "info_node_id" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your node's public key. Share this to receive Lightning payments."
+    "label_device_token": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device Token"
           }
         }
       }
     },
-    "info_notifications_needed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable notifications to receive payment alerts"
+    "label_direction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direction"
           }
         }
       }
     },
-    "info_pending_trade" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trade pending — check back soon"
+    "label_distance_from_par": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distance from PAR"
           }
         }
       }
     },
-    "info_push_connectivity" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your device maintains a persistent connection to receive incoming payments and stability updates."
+    "label_dollar_sign": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "$"
           }
         }
       }
     },
-    "info_push_description" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Background payments and stability updates"
+    "label_expected_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expected USD"
           }
         }
       }
     },
-    "info_restore" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restore will stop your current node and start fresh."
+    "label_explorer": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Explorer"
           }
         }
       }
     },
-    "info_seed_unavailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seed unavailable"
+    "label_fee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         }
       }
     },
-    "info_self_custody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+    "label_fee_percent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee %"
           }
         }
       }
     },
-    "info_splice_confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm splice-out of "
+    "label_fee_row": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee"
           }
         }
       }
     },
-    "info_splice_out" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice-out initiated"
+    "label_fee_sats": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fee (sats)"
           }
         }
       }
     },
-    "info_splice_out_funds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funds will be sent via splice-out from your Lightning channel."
+    "label_funding_tx": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funding TX"
           }
         }
       }
     },
-    "info_splice_out_note" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note: Funds require onchain confirmation after splice completes."
+    "label_inbound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inbound"
           }
         }
       }
     },
-    "info_theme_setting" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "System uses your device's appearance setting."
+    "label_native_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Native BTC"
           }
         }
       }
     },
-    "instruction_restore" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter your 12 or 24 word seed phrase"
+    "label_network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
           }
         }
       }
     },
-    "invoice_description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invoice"
+    "label_network_fee": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Fee"
           }
         }
       }
     },
-    "label_action" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Action"
+    "label_no_camera": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No camera available. Paste invoice manually."
           }
         }
       }
     },
-    "label_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address"
+    "label_node_id": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Node ID"
           }
         }
       }
     },
-    "label_all_available_funds" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All available funds"
+    "label_node_identity": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Node Identity"
           }
         }
       }
     },
-    "label_amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+    "label_node_status": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Node Status"
           }
         }
       }
     },
-    "label_amount_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC Amount"
+    "label_none": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "None"
           }
         }
       }
     },
-    "label_amount_row" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount"
+    "label_notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         }
       }
     },
-    "label_amount_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD Amount"
+    "label_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain"
           }
         }
       }
     },
-    "label_any_amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Any Amount"
+    "label_on_chain_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain Address"
           }
         }
       }
     },
-    "label_app_unlock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Unlock"
+    "label_outbound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outbound"
           }
         }
       }
     },
-    "label_auth_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authentication Failed"
+    "label_payment_confirmation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Confirmation"
           }
         }
       }
     },
-    "label_authenticate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Authenticate"
+    "label_payment_id": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment ID"
           }
         }
       }
     },
-    "label_background_service" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Background Service"
+    "label_sats_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sats / BTC"
           }
         }
       }
     },
-    "label_backing_sats" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Backing Sats"
+    "label_status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         }
       }
     },
-    "label_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balance"
+    "label_theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Theme"
           }
         }
       }
     },
-    "label_balance_pct" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "% USD % BTC"
+    "label_total_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total Balance"
           }
         }
       }
     },
-    "label_bolt11" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolt 11"
+    "label_txid": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TXID"
           }
         }
       }
     },
-    "label_bolt12_offer" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offer"
+    "label_type": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
           }
         }
       }
     },
-    "label_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC"
+    "label_unrecognized_format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unrecognized format"
           }
         }
       }
     },
-    "label_btc_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC Balance"
+    "label_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD"
           }
         }
       }
     },
-    "label_btc_price" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC Price"
+    "label_usd_value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD Value"
           }
         }
       }
     },
-    "label_build" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Build"
+    "label_version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         }
       }
     },
-    "label_camera_denied" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Camera access required. Enable in Settings."
+    "label_you_receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You Receive"
           }
         }
       }
     },
-    "label_capacity" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capacity"
+    "label_your_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Bitcoin Address"
           }
         }
       }
     },
-    "label_channel_info" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Channel Info"
+    "label_your_invoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Lightning Invoice"
           }
         }
       }
     },
-    "label_close_tx" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close Tx"
+    "link_about": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
           }
         }
       }
     },
-    "label_confirmations" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmations"
+    "link_app_access": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "App Access"
           }
         }
       }
     },
-    "label_connection" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Connection"
+    "link_appearance": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Appearance"
           }
         }
       }
     },
-    "label_counterparty" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Counterparty"
+    "link_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup"
           }
         }
       }
     },
-    "label_custody" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custody"
+    "link_channel": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Channel"
           }
         }
       }
     },
-    "label_dash" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—"
+    "link_node": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Node"
           }
         }
       }
     },
-    "label_date" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date"
+    "link_notifications": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Notifications"
           }
         }
       }
     },
-    "label_device_token" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device Token"
+    "link_privacy_policy": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Privacy Policy"
           }
         }
       }
     },
-    "label_direction" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Direction"
+    "link_push_connectivity": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Push Connectivity"
           }
         }
       }
     },
-    "label_distance_from_par" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Distance from PAR"
+    "link_send_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Onchain"
           }
         }
       }
     },
-    "label_dollar_sign" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "$"
+    "link_stable_position": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stable Position"
           }
         }
       }
     },
-    "label_expected_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Expected USD"
+    "loading_balance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading balance..."
           }
         }
       }
     },
-    "label_explorer" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Explorer"
+    "max_channel_limit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum: $%lld"
           }
         }
       }
     },
-    "label_fee" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+    "Min": {},
+    "move_to_trading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Lightning Account"
           }
         }
       }
     },
-    "label_fee_percent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee %"
+    "notifications_disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications Disabled"
           }
         }
       }
     },
-    "label_fee_row" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee"
+    "notifications_disabled_subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable notifications to receive payment alerts"
           }
         }
       }
     },
-    "label_fee_sats" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fee (sats)"
+    "notifications_enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications Enabled"
           }
         }
       }
     },
-    "label_funding_tx" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funding TX"
+    "payment_received": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received"
           }
         }
       }
     },
-    "label_inbound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inbound"
+    "payment_sent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent"
           }
         }
       }
     },
-    "label_native_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Native BTC"
+    "payment_type_bolt12": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bolt 12"
           }
         }
       }
     },
-    "label_network" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network"
+    "payment_type_channel_close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel Close"
           }
         }
       }
     },
-    "label_network_fee" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network Fee"
+    "payment_type_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain"
           }
         }
       }
     },
-    "label_no_camera" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No camera available. Paste invoice manually."
+    "payment_type_settlement": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settlement"
           }
         }
       }
     },
-    "label_node_id" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Node ID"
+    "payment_type_splice_in": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice In"
           }
         }
       }
     },
-    "label_node_identity" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Node Identity"
+    "payment_type_splice_out": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice Out"
           }
         }
       }
     },
-    "label_node_status" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Node Status"
+    "payment_type_stability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stability"
           }
         }
       }
     },
-    "label_none" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "None"
+    "picker_history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History"
           }
         }
       }
     },
-    "label_notifications" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+    "placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.00"
           }
         }
       }
     },
-    "label_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain"
+    "placeholder_address": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bc1..."
           }
         }
       }
     },
-    "label_on_chain_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain Address"
+    "placeholder_amount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amount (USD)"
           }
         }
       }
     },
-    "label_outbound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Outbound"
+    "placeholder_amount_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.00"
           }
         }
       }
     },
-    "label_payment_confirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Confirmation"
+    "placeholder_invoice": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lnbc1..."
           }
         }
       }
     },
-    "label_payment_id" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment ID"
+    "placeholder_loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading..."
           }
         }
       }
     },
-    "label_sats_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sats / BTC"
+    "placeholder_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "word1 word2 word3..."
           }
         }
       }
     },
-    "label_status" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+    "Price": {},
+    "QR Code": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR Code"
           }
         }
       }
     },
-    "label_theme" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Theme"
+    "section_about": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
           }
         }
       }
     },
-    "label_total_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Total Balance"
+    "section_app_info": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "App Info"
           }
         }
       }
     },
-    "label_txid" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TXID"
+    "section_appearance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Appearance"
           }
         }
       }
     },
-    "label_type" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type"
+    "section_backup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup"
           }
         }
       }
     },
-    "label_unrecognized_format" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unrecognized format"
+    "section_backup_seed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup"
           }
         }
       }
     },
-    "label_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD"
+    "section_channel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel"
           }
         }
       }
     },
-    "label_usd_value" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD Value"
+    "section_custody": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Custody Model"
           }
         }
       }
     },
-    "label_version" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+    "section_metadata": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metadata"
           }
         }
       }
     },
-    "label_you_receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You Receive"
+    "section_network": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Network"
           }
         }
       }
     },
-    "label_your_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Bitcoin Address"
+    "section_node": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Node"
           }
         }
       }
     },
-    "label_your_invoice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Lightning Invoice"
+    "section_node_network": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Node & Network"
           }
         }
       }
     },
-    "link_about" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "About"
+    "section_notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
           }
         }
       }
     },
-    "link_app_access" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "App Access"
+    "section_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain"
           }
         }
       }
     },
-    "link_appearance" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
+    "section_payment_details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Details"
           }
         }
       }
     },
-    "link_backup" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Backup"
+    "section_preferences": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Preferences"
           }
         }
       }
     },
-    "link_channel" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Channel"
+    "section_privacy_security": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy & Security"
           }
         }
       }
     },
-    "link_node" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Node"
+    "section_restore": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore"
           }
         }
       }
     },
-    "link_notifications" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Notifications"
+    "section_seed_phrase": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Seed Phrase"
           }
         }
       }
     },
-    "link_privacy_policy" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Privacy Policy"
+    "section_stable_position": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stable Position"
           }
         }
       }
     },
-    "link_push_connectivity" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Push Connectivity"
+    "section_trade_details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Order Details"
           }
         }
       }
     },
-    "link_send_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send Onchain"
+    "section_wallet": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Wallet"
           }
         }
       }
     },
-    "link_stable_position" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stable Position"
+    "section_wallet_security": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wallet Security"
           }
         }
       }
     },
-    "loading_balance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading balance..."
+    "segment_payments": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payments"
           }
         }
       }
     },
-    "max_channel_limit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum: $%lld"
+    "segment_trades": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orders"
           }
         }
       }
     },
-    "Min" : {
-
+    "Selected": {},
+    "status_channel_closed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel Closed"
+          }
+        }
+      }
     },
-    "move_to_trading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move to Lightning Account"
+    "status_channel_closing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel closing..."
           }
         }
       }
     },
-    "notifications_disabled" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications Disabled"
+    "status_channel_opening": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel Opening"
           }
         }
       }
     },
-    "notifications_disabled_subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable notifications to receive payment alerts"
+    "status_channel_ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel Ready"
           }
         }
       }
     },
-    "notifications_enabled" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications Enabled"
+    "status_collecting_data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collecting price data..."
           }
         }
       }
     },
-    "payment_received" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Received"
+    "status_onchain_receiving": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receiving on-chain..."
           }
         }
       }
     },
-    "payment_sent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent"
+    "status_opening_channel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opening Channel"
           }
         }
       }
     },
-    "payment_type_bolt12" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolt 12"
+    "status_payment_confirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Confirmed"
           }
         }
       }
     },
-    "payment_type_channel_close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel Close"
+    "status_payment_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Failed"
           }
         }
       }
     },
-    "payment_type_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain"
+    "status_received_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received BTC"
           }
         }
       }
     },
-    "payment_type_settlement" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settlement"
+    "status_received_usd": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received USD"
           }
         }
       }
     },
-    "payment_type_splice_in" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice In"
+    "status_running": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running"
           }
         }
       }
     },
-    "payment_type_splice_out" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice Out"
+    "status_splice_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice Failed"
           }
         }
       }
     },
-    "payment_type_stability" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stability"
+    "status_splice_pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice Pending"
           }
         }
       }
     },
-    "picker_history" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "History"
+    "status_stopped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped"
           }
         }
       }
     },
-    "placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.00"
+    "status_sweeping": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
           }
         }
       }
     },
-    "placeholder_address" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "bc1..."
+    "status_syncing_moment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing Moment"
           }
         }
       }
     },
-    "placeholder_amount" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amount (USD)"
+    "status_syncing_wallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing Wallet"
           }
         }
       }
     },
-    "placeholder_amount_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "0.00"
+    "status_trade_confirmed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Order Confirmed"
           }
         }
       }
     },
-    "placeholder_invoice" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "lnbc1..."
+    "status_trade_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Order Failed"
           }
         }
       }
     },
-    "placeholder_loading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading..."
+    "status_waiting_lsp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for LSP"
           }
         }
       }
     },
-    "placeholder_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "word1 word2 word3..."
+    "subtitle_disable_app_unlock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable app lock requirement on launch and resume"
           }
         }
       }
     },
-    "Price" : {
-
+    "subtitle_disable_payment_confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Require auth before sending Lightning payments"
+          }
+        }
+      }
     },
-    "QR Code" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QR Code"
+    "subtitle_manage_exposure": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Manage your BTC exposure"
           }
         }
       }
     },
-    "section_about" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+    "success_sent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent!"
           }
         }
       }
     },
-    "section_app_info" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "App Info"
+    "success_splice_out": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Splice-out initiated!"
           }
         }
       }
     },
-    "section_appearance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
+    "tab_history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History"
           }
         }
       }
     },
-    "section_backup" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Backup"
+    "tab_home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
           }
         }
       }
     },
-    "section_backup_seed" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Backup"
+    "tab_settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         }
       }
     },
-    "section_channel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel"
+    "Tap to close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to close"
           }
         }
       }
     },
-    "section_custody" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Custody Model"
+    "Tap to enlarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to enlarge"
           }
         }
       }
     },
-    "section_metadata" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metadata"
+    "theme_dark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Dark"
           }
         }
       }
     },
-    "section_network" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Network"
+    "theme_light": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Light"
           }
         }
       }
     },
-    "section_node" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Node"
+    "theme_system": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "System"
           }
         }
       }
     },
-    "section_node_network" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Node & Network"
+    "Time": {},
+    "title_about": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "About"
           }
         }
       }
     },
-    "section_notifications" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
+    "title_app_access": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Access"
           }
         }
       }
     },
-    "section_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain"
+    "title_appearance": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Appearance"
           }
         }
       }
     },
-    "section_payment_details" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Details"
+    "title_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup"
           }
         }
       }
     },
-    "section_preferences" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preferences"
+    "title_buy_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD → BTC"
           }
         }
       }
     },
-    "section_privacy_security" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy & Security"
+    "title_cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "section_restore" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Restore"
+    "title_channel": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Channel"
           }
         }
       }
     },
-    "section_seed_phrase" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Seed Phrase"
+    "title_confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         }
       }
     },
-    "section_stable_position" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stable Position"
+    "title_confirm_buy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm USD → BTC"
           }
         }
       }
     },
-    "section_trade_details" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Order Details"
+    "title_confirm_sell": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm BTC → USD"
           }
         }
       }
     },
-    "section_wallet" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Wallet"
+    "title_fund_wallet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fund Wallet"
           }
         }
       }
     },
-    "section_wallet_security" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wallet Security"
+    "title_history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History"
           }
         }
       }
     },
-    "segment_payments" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payments"
+    "title_node": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Node"
           }
         }
       }
     },
-    "segment_trades" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Orders"
+    "title_notifications": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Notifications"
           }
         }
       }
     },
-    "Selected" : {
-
+    "title_on_chain_receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain Receive"
+          }
+        }
+      }
     },
-    "status_channel_closed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel Closed"
+    "title_payment_detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Payment Detail"
           }
         }
       }
     },
-    "status_channel_closing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel closing..."
+    "title_push_connectivity": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Push Connectivity"
           }
         }
       }
     },
-    "status_channel_opening" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel Opening"
+    "title_receive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive"
           }
         }
       }
     },
-    "status_channel_ready" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Channel Ready"
+    "title_restore_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Seed"
           }
         }
       }
     },
-    "status_collecting_data" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Collecting price data..."
+    "title_security": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security"
           }
         }
       }
     },
-    "status_onchain_receiving" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receiving on-chain..."
+    "title_sell_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC → USD"
           }
         }
       }
     },
-    "status_opening_channel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opening Channel"
+    "title_send_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Onchain"
           }
         }
       }
     },
-    "status_payment_confirmed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Confirmed"
+    "title_settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         }
       }
     },
-    "status_payment_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Failed"
+    "title_stable_position": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Stable Position"
           }
         }
       }
     },
-    "status_received_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Received BTC"
+    "title_trade_detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Order Detail"
           }
         }
       }
     },
-    "status_received_usd" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Received USD"
+    "toggle_send_all": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send All"
           }
         }
       }
     },
-    "status_running" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running"
+    "toolbar_on_chain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onchain"
           }
         }
       }
     },
-    "status_splice_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice Failed"
+    "trade_bought_btc_for": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converted "
           }
         }
       }
     },
-    "status_splice_pending" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice Pending"
+    "trade_buy_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USD → BTC"
           }
         }
       }
     },
-    "status_stopped" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stopped"
+    "trade_buying_btc_for": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converting "
           }
         }
       }
     },
-    "status_sweeping" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pending"
+    "trade_sell_btc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BTC → USD"
           }
         }
       }
     },
-    "status_syncing_moment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing Moment"
+    "trade_selling_btc_for": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converting "
           }
         }
       }
     },
-    "status_syncing_wallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Syncing Wallet"
+    "trade_sold_btc_for": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Converted "
           }
         }
       }
     },
-    "status_trade_confirmed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Order Confirmed"
+    "try_again": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
           }
         }
       }
     },
-    "status_trade_failed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Order Failed"
+    "view_on_explorer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View on Explorer"
           }
         }
       }
     },
-    "status_waiting_lsp" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for LSP"
+    "warning_copy_seed_message": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Clipboard is shared with other apps. Consider writing down your seed instead."
           }
         }
       }
     },
-    "subtitle_disable_app_unlock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable app lock requirement on launch and resume"
+    "warning_copy_seed_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Copy Seed Words?"
           }
         }
       }
     },
-    "subtitle_disable_payment_confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Require auth before sending Lightning payments"
+    "warning_seed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never share your seed phrase with anyone."
           }
         }
       }
     },
-    "subtitle_manage_exposure" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Manage your BTC exposure"
+    "": {},
+    " ": {},
+    "Backup enabled!": {},
+    "backup_now": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup Now"
           }
         }
       }
     },
-    "success_sent" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent!"
+    "button_enable_icloud_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup to iCloud"
           }
         }
       }
     },
-    "success_splice_out" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Splice-out initiated!"
+    "button_import_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import from File"
           }
         }
       }
     },
-    "tab_history" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "History"
+    "button_restore_icloud": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from iCloud"
           }
         }
       }
     },
-    "tab_home" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Home"
+    "Cancel": {},
+    "confirm_passphrase": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm Passphrase"
           }
         }
       }
     },
-    "tab_settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "confirm_passphrase_hint": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Confirm your passphrase"
           }
         }
       }
     },
-    "Tap to close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap to close"
+    "Delete": {},
+    "Delete Backup?": {},
+    "delete_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Delete Backup"
           }
         }
       }
     },
-    "Tap to enlarge" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap to enlarge"
+    "enable_icloud_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enable iCloud Backup"
           }
         }
       }
     },
-    "theme_dark" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dark"
+    "enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enabled"
           }
         }
       }
     },
-    "theme_light" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Light"
+    "enter_backup_passphrase": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter backup passphrase"
           }
         }
       }
     },
-    "theme_system" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "System"
+    "enter_passphrase": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enter passphrase"
           }
         }
       }
     },
-    "Time" : {
-
+    "error_export_failed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export failed"
+          }
+        }
+      }
     },
-    "title_about" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "About"
+    "error_import_failed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Decryption failed. Check passphrase."
           }
         }
       }
     },
-    "title_app_access" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Access"
+    "error_invalid_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Invalid backup file"
           }
         }
       }
     },
-    "title_appearance" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Appearance"
+    "error_locked_for": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Locked for"
           }
         }
       }
     },
-    "title_backup" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Backup"
+    "error_no_file": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No file selected"
           }
         }
       }
     },
-    "title_buy_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD → BTC"
+    "error_no_seed": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "No seed available"
           }
         }
       }
     },
-    "title_cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "error_old_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Backup version not supported"
           }
         }
       }
     },
-    "title_channel" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Channel"
+    "error_rate_limited": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Too many attempts. Try again in"
           }
         }
       }
     },
-    "title_confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+    "error_wrong_passphrase": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Wrong passphrase. %lld attempts remaining"
           }
         }
       }
     },
-    "title_confirm_buy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm USD → BTC"
+    "export": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export"
           }
         }
       }
     },
-    "title_confirm_sell" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm BTC → USD"
+    "export_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Backup"
           }
         }
       }
     },
-    "title_fund_wallet" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fund Wallet"
+    "export_description": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a passphrase to protect your exported backup. You'll need this to restore."
           }
         }
       }
     },
-    "title_history" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "History"
+    "export_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export Your Backup"
           }
         }
       }
     },
-    "title_node" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Node"
+    "export_to_files": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Export to Files"
           }
         }
       }
     },
-    "title_notifications" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Notifications"
+    "file_ready": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "File ready to restore"
           }
         }
       }
     },
-    "title_on_chain_receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain Receive"
+    "icloud_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud Backup"
           }
         }
       }
     },
-    "title_payment_detail" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Payment Detail"
+    "icloud_backup_description": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Protect your wallet with encrypted cloud backup."
           }
         }
       }
     },
-    "title_push_connectivity" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Push Connectivity"
+    "icloud_backup_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud Seed Backup"
           }
         }
       }
     },
-    "title_receive" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Receive"
+    "import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
           }
         }
       }
     },
-    "title_restore_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore Seed"
+    "import_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Import Backup"
           }
         }
       }
     },
-    "title_security" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Security"
+    "import_description": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select your .stablebackup file and enter the passphrase used when creating it."
           }
         }
       }
     },
-    "title_sell_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC → USD"
+    "import_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from Backup"
           }
         }
       }
     },
-    "title_send_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send Onchain"
+    "label_attempts_left": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "attempts left"
           }
         }
       }
     },
-    "title_settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "last_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Last backup"
           }
         }
       }
     },
-    "title_stable_position" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stable Position"
+    "maybe_later": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Maybe Later"
           }
         }
       }
     },
-    "title_trade_detail" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Order Detail"
+    "passphrase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passphrase"
           }
         }
       }
     },
-    "toggle_send_all" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send All"
+    "passphrase_min_length": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "At least 12 characters required"
           }
         }
       }
     },
-    "toolbar_on_chain" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onchain"
+    "passphrase_mismatch": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Passphrases don't match"
           }
         }
       }
     },
-    "trade_bought_btc_for" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converted "
+    "recovery_banner_text_prefix": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Please email"
           }
         }
       }
     },
-    "trade_buy_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USD → BTC"
+    "recovery_banner_text_suffix": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "for wallet recovery assistance."
           }
         }
       }
     },
-    "trade_buying_btc_for" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converting "
+    "recovery_banner_title": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Need Help?"
           }
         }
       }
     },
-    "trade_sell_btc" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BTC → USD"
+    "restore_action": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore Wallet"
           }
         }
       }
     },
-    "trade_selling_btc_for" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converting "
+    "restore_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore Backup"
           }
         }
       }
     },
-    "trade_sold_btc_for" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Converted "
+    "restore_description": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore your wallet from backup."
           }
         }
       }
     },
-    "try_again" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Try Again"
+    "restore_from_icloud": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restore from iCloud"
           }
         }
       }
     },
-    "view_on_explorer" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View on Explorer"
+    "restoring": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Restoring..."
           }
         }
       }
     },
-    "warning_copy_seed_message" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Clipboard is shared with other apps. Consider writing down your seed instead."
+    "section_icloud_backup": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "iCloud"
           }
         }
       }
     },
-    "warning_copy_seed_title" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copy Seed Words?"
+    "select_backup_file": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Select .stablebackup File"
           }
         }
       }
     },
-    "warning_seed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Never share your seed phrase with anyone."
+    "support@stablechannels.com": {},
+    "tap_to_select": {
+      "extractionState": "extracted_with_value",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tap to browse your files"
           }
         }
       }
-    }
+    },
+    "Wallet restored!": {},
+    "You'll need your seed phrase to restore. This cannot be undone.": {}
   },
-  "version" : "1.2"
+  "version": "1.2"
 }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1,4082 +1,4123 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "%@": {},
-    "%@ BTC": {},
-    "%lld.": {},
-    "%lld%% USD  %lld%% BTC": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld%% USD  %2$lld%% BTC"
-          }
-        }
-      }
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
     },
-    "Active": {},
-    "alert_close_channel_cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        }
-      }
+    " " : {
+
+    },
+    "%@" : {
+
     },
-    "alert_close_channel_confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close Channel"
+    "%@ BTC" : {
+
+    },
+    "%lld." : {
+
+    },
+    "%lld%% USD  %lld%% BTC" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld%% USD  %2$lld%% BTC"
           }
         }
       }
     },
-    "alert_close_channel_message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Are you sure you want to close this channel?"
+    "Active" : {
+
+    },
+    "alert_close_channel_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "alert_close_channel_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close Channel?"
+    "alert_close_channel_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel"
           }
         }
       }
     },
-    "alert_no_qr": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No QR code found"
+    "alert_close_channel_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to close this channel?"
           }
         }
       }
     },
-    "alert_qr_error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error reading QR code"
+    "alert_close_channel_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel?"
           }
         }
       }
     },
-    "and_spending_account": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ""
+    "alert_no_qr" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No QR code found"
           }
         }
       }
     },
-    "app_name": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stable Channels"
+    "alert_qr_error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error reading QR code"
           }
         }
       }
     },
-    "app_subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-custody Lightning wallet"
+    "and_spending_account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
           }
         }
       }
     },
-    "auth_cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "app_name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Channels"
           }
         }
       }
     },
-    "auth_confirm_on_chain_send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticate to send onchain"
+    "app_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-custody Lightning wallet"
           }
         }
       }
     },
-    "auth_confirm_on_chain_withdrawal": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticate to confirm onchain withdrawal"
+    "auth_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "auth_disable_app_unlock": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticate to disable App Unlock"
+    "auth_confirm_on_chain_send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to send onchain"
           }
         }
       }
     },
-    "auth_disable_payment_confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticate to disable Payment Confirmation"
+    "auth_confirm_on_chain_withdrawal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to confirm onchain withdrawal"
           }
         }
       }
     },
-    "auth_required": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication required"
+    "auth_disable_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to disable App Unlock"
           }
         }
       }
     },
-    "auth_title_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication Failed"
+    "auth_disable_payment_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to disable Payment Confirmation"
           }
         }
       }
     },
-    "available_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available: "
+    "auth_required" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication required"
           }
         }
       }
     },
-    "available_native_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available: "
+    "auth_title_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Failed"
           }
         }
       }
     },
-    "Bitcoin address QR code": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bitcoin address QR code"
+    "available_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available: "
           }
         }
       }
     },
-    "button_any_amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Any Amount"
+    "available_native_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available: "
           }
         }
       }
+    },
+    "Backup enabled!" : {
+
     },
-    "button_backup_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Backup Seed"
+    "backup_now" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup Now"
           }
         }
       }
     },
-    "button_buy_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD → BTC"
+    "Bitcoin address QR code" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitcoin address QR code"
           }
         }
       }
     },
-    "button_cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "button_any_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any Amount"
           }
         }
       }
     },
-    "button_close_channel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close Channel"
+    "button_backup_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup Seed"
           }
         }
       }
     },
-    "button_continue": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
+    "button_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD → BTC"
           }
         }
       }
     },
-    "button_copied": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied"
+    "button_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "button_copy_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Address"
+    "button_close_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Channel"
           }
         }
       }
     },
-    "button_copy_anyway": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Copy Anyway"
+    "button_continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
           }
         }
       }
     },
-    "button_copy_invoice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Invoice"
+    "button_copied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copied"
           }
         }
       }
     },
-    "button_copy_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Seed"
+    "button_copy_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Address"
           }
         }
       }
     },
-    "button_done": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+    "button_copy_anyway" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy Anyway"
           }
         }
       }
     },
-    "button_enable_in_settings": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enable in Settings"
+    "button_copy_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Invoice"
           }
         }
       }
     },
-    "button_enable_settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Settings"
+    "button_copy_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Seed"
           }
         }
       }
     },
-    "button_enlarge_qr": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enlarge QR"
+    "button_done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         }
       }
     },
-    "button_generate_invoice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generate Invoice"
+    "button_enable_icloud_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup to iCloud"
           }
         }
       }
     },
-    "button_hide_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide Seed"
+    "button_enable_in_settings" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable in Settings"
           }
         }
       }
     },
-    "button_ok": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "button_enable_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Settings"
           }
         }
       }
     },
-    "button_open_settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Settings"
+    "button_enlarge_qr" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enlarge QR"
           }
         }
       }
     },
-    "button_pick_image": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Pick Image"
+    "button_generate_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate Invoice"
           }
         }
       }
     },
-    "button_receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive"
+    "button_hide_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide Seed"
           }
         }
       }
     },
-    "button_restore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+    "button_import_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import from File"
           }
         }
       }
     },
-    "button_restore_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore Seed"
+    "button_ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
     },
-    "button_retry": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
+    "button_open_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
           }
         }
       }
     },
-    "button_scan_qr": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Scan QR"
+    "button_pick_image" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pick Image"
           }
         }
       }
     },
-    "button_sell_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC → USD"
+    "button_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive"
           }
         }
       }
     },
-    "button_send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send"
+    "button_restore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         }
       }
     },
-    "button_send_payment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send"
+    "button_restore_icloud" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore from iCloud"
           }
         }
       }
     },
-    "button_share_qr": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share QR"
+    "button_restore_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Seed"
           }
         }
       }
     },
-    "button_show_node_id": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Node ID"
+    "button_retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         }
       }
     },
-    "button_swap": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Move"
+    "button_scan_qr" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan QR"
           }
         }
       }
     },
-    "button_view_seed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "View Seed Words"
+    "button_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC → USD"
           }
         }
       }
     },
-    "channel_status_pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening"
+    "button_send" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
           }
         }
       }
     },
-    "channel_status_ready": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready"
+    "button_send_payment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send"
           }
         }
       }
     },
-    "custody_self": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-custodial"
+    "button_share_qr" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share QR"
           }
         }
       }
     },
-    "disclaimer_custody_body": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+    "button_show_node_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Node ID"
           }
         }
       }
     },
-    "disclaimer_custody_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Your keys, your coins."
+    "button_swap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move"
           }
         }
       }
     },
-    "empty_payments_desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No payments yet"
+    "button_view_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "View Seed Words"
           }
         }
       }
     },
-    "empty_payments_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Payments"
+    "Cancel" : {
+
+    },
+    "channel_status_pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opening"
           }
         }
       }
     },
-    "empty_trades_desc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convert BTC to see orders here"
+    "channel_status_ready" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ready"
           }
         }
       }
     },
-    "empty_trades_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Orders"
+    "confirm_passphrase" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm Passphrase"
           }
         }
       }
     },
-    "error_biometric_cancelled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication cancelled"
+    "confirm_passphrase_hint" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Confirm your passphrase"
           }
         }
       }
+    },
+    "Contact support@stablechannels.com if you need help recovering Lightning funds." : {
+
     },
-    "error_biometric_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication failed"
+    "custody_self" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-custodial"
           }
         }
       }
+    },
+    "Delete" : {
+
+    },
+    "Delete Backup?" : {
+
     },
-    "error_biometric_lockout": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometrics locked. Use passcode."
+    "delete_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Backup"
           }
         }
       }
     },
-    "error_biometric_not_available": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometrics not available"
+    "disclaimer_custody_body" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
           }
         }
       }
     },
-    "error_biometric_not_enrolled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Biometrics not enrolled"
+    "disclaimer_custody_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your keys, your coins."
           }
         }
       }
     },
-    "error_db_init": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to initialize database"
+    "empty_payments_desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No payments yet"
           }
         }
       }
     },
-    "error_exceeds_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exceeds available balance"
+    "empty_payments_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Payments"
           }
         }
       }
     },
-    "error_exceeds_limit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount exceeds $"
+    "empty_trades_desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convert BTC to see orders here"
           }
         }
       }
     },
-    "error_exceeds_native": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exceeds native BTC balance"
+    "empty_trades_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Orders"
           }
         }
       }
     },
-    "error_insufficient_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Insufficient balance"
+    "enable_icloud_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable iCloud Backup"
           }
         }
       }
     },
-    "error_no_ready_channel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No ready channel"
+    "enabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enabled"
           }
         }
       }
     },
-    "error_node_start": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to start node"
+    "enter_backup_passphrase" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter backup passphrase"
           }
         }
       }
     },
-    "error_not_enough_funds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not enough funds"
+    "enter_passphrase" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter passphrase"
           }
         }
       }
     },
-    "error_open_channel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to open channel"
+    "error_biometric_cancelled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication cancelled"
           }
         }
       }
     },
-    "error_passcode_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passcode failed"
+    "error_biometric_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication failed"
           }
         }
       }
     },
-    "error_read_balances": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to read balances"
+    "error_biometric_lockout" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics locked. Use passcode."
           }
         }
       }
     },
-    "error_restore_failed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore failed: "
+    "error_biometric_not_available" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics not available"
           }
         }
       }
     },
-    "error_seed_word_count": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seed phrase must be 12 or 24 words"
+    "error_biometric_not_enrolled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biometrics not enrolled"
           }
         }
       }
     },
-    "error_seed_words": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invalid seed words"
+    "error_db_init" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to initialize database"
           }
         }
       }
     },
-    "error_splice_in_progress": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A splice is already in progress — try again shortly"
+    "error_exceeds_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exceeds available balance"
           }
         }
       }
     },
-    "error_sweep_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sweep failed"
+    "error_exceeds_limit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount exceeds $"
           }
         }
       }
     },
-    "error_title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
+    "error_exceeds_native" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exceeds native BTC balance"
           }
         }
       }
     },
-    "error_trade_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trade failed — check amount and try again"
+    "error_export_failed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export failed"
           }
         }
       }
     },
-    "error_unrecognized_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unrecognized invoice format"
+    "error_import_failed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Decryption failed. Check passphrase."
           }
         }
       }
     },
-    "error_wallet_creation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to create wallet"
+    "error_insufficient_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insufficient balance"
           }
         }
       }
     },
-    "header_amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+    "error_invalid_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid backup file"
           }
         }
       }
     },
-    "header_destination_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destination Address"
+    "error_locked_for" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Locked for"
           }
         }
       }
     },
-    "header_invoice_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invoice Address"
+    "error_no_file" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No file selected"
           }
         }
       }
     },
-    "header_onchain_subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Move funds to any Bitcoin address"
+    "error_no_ready_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No ready channel"
           }
         }
       }
     },
-    "headline_how_much_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How much BTC to convert to USD?"
+    "error_no_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No seed available"
           }
         }
       }
     },
-    "headline_how_much_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How much USD to convert to BTC?"
+    "error_node_start" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to start node"
           }
         }
       }
     },
-    "hint_create_account": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive over Lightning to create your Stable Account"
+    "error_not_enough_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not enough funds"
           }
         }
       }
     },
-    "hint_scan_invoice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
+    "error_old_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup version not supported"
           }
         }
       }
     },
-    "home_header": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stable Channels"
+    "error_open_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to open channel"
           }
         }
       }
     },
-    "home_hint_receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive sats via Lightning or onchain"
+    "error_passcode_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passcode failed"
           }
         }
       }
     },
-    "home_syncing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing..."
+    "error_rate_limited" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Too many attempts. Try again in"
           }
         }
       }
     },
-    "Inactive": {},
-    "info_backup_seed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Write these words down and store them safely. Anyone with these words can access your funds."
+    "error_read_balances" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to read balances"
           }
         }
       }
     },
-    "info_close_pending_confirmation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel closing - will appear on explorer after confirmation"
+    "error_restore_failed" : {
+
+    },
+    "error_seed_word_count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed phrase must be 12 or 24 words"
           }
         }
       }
     },
-    "info_fee_approx": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee: ~"
+    "error_seed_words" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid seed words"
           }
         }
       }
     },
-    "info_first_payment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Make your first payment to activate the channel"
+    "error_splice_in_progress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A splice is already in progress — try again shortly"
           }
         }
       }
     },
-    "info_funds_arrive_onchain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funds arrive after 1 onchain confirmation"
+    "error_sweep_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sweep failed"
           }
         }
       }
     },
-    "info_no_channel": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "No channel open yet."
+    "error_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
           }
         }
       }
     },
-    "info_node_id": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Your node's public key. Share this to receive Lightning payments."
+    "error_trade_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade failed — check amount and try again"
           }
         }
       }
     },
-    "info_notifications_needed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable notifications to receive payment alerts"
+    "error_unrecognized_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unrecognized invoice format"
           }
         }
       }
     },
-    "info_pending_trade": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trade pending — check back soon"
+    "error_wallet_creation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to create wallet"
           }
         }
       }
     },
-    "info_push_connectivity": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Your device maintains a persistent connection to receive incoming payments and stability updates."
+    "error_wrong_passphrase" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Wrong passphrase. %lld attempts remaining"
           }
         }
       }
     },
-    "info_push_description": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Background payments and stability updates"
+    "export" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export"
           }
         }
       }
     },
-    "info_restore": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore will stop your current node and start fresh."
+    "export_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export Backup"
           }
         }
       }
     },
-    "info_seed_unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seed unavailable"
+    "export_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add a passphrase to protect your exported backup. You'll need this to restore."
           }
         }
       }
     },
-    "info_self_custody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
+    "export_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export Your Backup"
           }
         }
       }
     },
-    "info_splice_confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm splice-out of "
+    "export_to_files" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export to Files"
           }
         }
       }
     },
-    "info_splice_out": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice-out initiated"
+    "file_ready" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "File ready to restore"
           }
         }
       }
     },
-    "info_splice_out_funds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funds will be sent via splice-out from your Lightning channel."
+    "header_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         }
       }
     },
-    "info_splice_out_note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note: Funds require onchain confirmation after splice completes."
+    "header_destination_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination Address"
           }
         }
       }
     },
-    "info_theme_setting": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "System uses your device's appearance setting."
+    "header_invoice_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invoice Address"
           }
         }
       }
     },
-    "instruction_restore": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter your 12 or 24 word seed phrase"
+    "header_onchain_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move funds to any Bitcoin address"
           }
         }
       }
     },
-    "invoice_description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invoice"
+    "headline_how_much_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How much BTC to convert to USD?"
           }
         }
       }
     },
-    "label_action": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Action"
+    "headline_how_much_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How much USD to convert to BTC?"
           }
         }
       }
     },
-    "label_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address"
+    "hint_create_account" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive over Lightning to create your Stable Account"
           }
         }
       }
     },
-    "label_all_available_funds": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All available funds"
+    "hint_scan_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scan invoice (lnbc1…), offer (lno…), or Bitcoin address."
           }
         }
       }
     },
-    "label_amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+    "home_header" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Channels"
           }
         }
       }
     },
-    "label_amount_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC Amount"
+    "home_hint_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive sats via Lightning or onchain"
           }
         }
       }
     },
-    "label_amount_row": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount"
+    "home_syncing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing..."
           }
         }
       }
     },
-    "label_amount_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD Amount"
+    "icloud_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "iCloud Backup"
           }
         }
       }
     },
-    "label_any_amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Any Amount"
+    "icloud_backup_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Protect your wallet with encrypted cloud backup."
           }
         }
       }
     },
-    "label_app_unlock": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App Unlock"
+    "icloud_backup_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "iCloud Seed Backup"
           }
         }
       }
     },
-    "label_auth_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authentication Failed"
+    "import" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import"
           }
         }
       }
     },
-    "label_authenticate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Authenticate"
+    "import_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import Backup"
           }
         }
       }
     },
-    "label_background_service": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Background Service"
+    "import_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select your .stablebackup file and enter the passphrase used when creating it."
           }
         }
       }
     },
-    "label_backing_sats": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Backing Sats"
+    "import_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore from Backup"
           }
         }
       }
+    },
+    "Important" : {
+
+    },
+    "Inactive" : {
+
     },
-    "label_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Balance"
+    "info_backup_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Write these words down and store them safely. Anyone with these words can access your funds."
           }
         }
       }
     },
-    "label_balance_pct": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "% USD % BTC"
+    "info_close_pending_confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel closing - will appear on explorer after confirmation"
           }
         }
       }
     },
-    "label_bolt11": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bolt 11"
+    "info_fee_approx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee: ~"
           }
         }
       }
     },
-    "label_bolt12_offer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Offer"
+    "info_first_payment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Make your first payment to activate the channel"
           }
         }
       }
     },
-    "label_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC"
+    "info_funds_arrive_onchain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds arrive after 1 onchain confirmation"
           }
         }
       }
     },
-    "label_btc_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC Balance"
+    "info_no_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No channel open yet."
           }
         }
       }
     },
-    "label_btc_price": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC Price"
+    "info_node_id" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your node's public key. Share this to receive Lightning payments."
           }
         }
       }
     },
-    "label_build": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Build"
+    "info_notifications_needed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable notifications to receive payment alerts"
           }
         }
       }
     },
-    "label_camera_denied": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Camera access required. Enable in Settings."
+    "info_pending_trade" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trade pending — check back soon"
           }
         }
       }
     },
-    "label_capacity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Capacity"
+    "info_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your device maintains a persistent connection to receive incoming payments and stability updates."
           }
         }
       }
     },
-    "label_channel_info": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Channel Info"
+    "info_push_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Background payments and stability updates"
           }
         }
       }
     },
-    "label_close_tx": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close Tx"
+    "info_restore" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore will stop your current node and start fresh."
           }
         }
       }
     },
-    "label_confirmations": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirmations"
+    "info_seed_unavailable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed unavailable"
           }
         }
       }
     },
-    "label_connection": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connection"
+    "info_self_custody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Channels is a self-custodial wallet. You control your private keys. Third parties do not custody, access, or freeze your funds."
           }
         }
       }
     },
-    "label_counterparty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Counterparty"
+    "info_splice_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm splice-out of "
           }
         }
       }
     },
-    "label_custody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custody"
+    "info_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice-out initiated"
           }
         }
       }
     },
-    "label_dash": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—"
+    "info_splice_out_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funds will be sent via splice-out from your Lightning channel."
           }
         }
       }
     },
-    "label_date": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date"
+    "info_splice_out_note" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: Funds require onchain confirmation after splice completes."
           }
         }
       }
     },
-    "label_device_token": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Device Token"
+    "info_theme_setting" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System uses your device's appearance setting."
           }
         }
       }
     },
-    "label_direction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direction"
+    "instruction_restore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your 12 or 24 word seed phrase"
           }
         }
       }
     },
-    "label_distance_from_par": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Distance from PAR"
+    "invoice_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invoice"
           }
         }
       }
     },
-    "label_dollar_sign": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "$"
+    "label_action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action"
           }
         }
       }
     },
-    "label_expected_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expected USD"
+    "label_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
           }
         }
       }
     },
-    "label_explorer": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Explorer"
+    "label_all_available_funds" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All available funds"
           }
         }
       }
     },
-    "label_fee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+    "label_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         }
       }
     },
-    "label_fee_percent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee %"
+    "label_amount_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Amount"
           }
         }
       }
     },
-    "label_fee_row": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee"
+    "label_amount_row" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount"
           }
         }
       }
     },
-    "label_fee_sats": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fee (sats)"
+    "label_amount_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD Amount"
           }
         }
       }
     },
-    "label_funding_tx": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funding TX"
+    "label_any_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any Amount"
           }
         }
       }
     },
-    "label_inbound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inbound"
+    "label_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Unlock"
           }
         }
       }
     },
-    "label_native_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Native BTC"
+    "label_attempts_left" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "attempts left"
           }
         }
       }
     },
-    "label_network": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network"
+    "label_auth_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Failed"
           }
         }
       }
     },
-    "label_network_fee": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network Fee"
+    "label_authenticate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate"
           }
         }
       }
     },
-    "label_no_camera": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No camera available. Paste invoice manually."
+    "label_background_service" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Background Service"
           }
         }
       }
     },
-    "label_node_id": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Node ID"
+    "label_backing_sats" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backing Sats"
           }
         }
       }
     },
-    "label_node_identity": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Node Identity"
+    "label_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balance"
           }
         }
       }
     },
-    "label_node_status": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Node Status"
+    "label_balance_pct" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "% USD % BTC"
           }
         }
       }
     },
-    "label_none": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "None"
+    "label_bolt11" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolt 11"
           }
         }
       }
     },
-    "label_notifications": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications"
+    "label_bolt12_offer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offer"
           }
         }
       }
     },
-    "label_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain"
+    "label_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC"
           }
         }
       }
     },
-    "label_on_chain_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain Address"
+    "label_btc_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Balance"
           }
         }
       }
     },
-    "label_outbound": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outbound"
+    "label_btc_price" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC Price"
           }
         }
       }
     },
-    "label_payment_confirmation": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Confirmation"
+    "label_build" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Build"
           }
         }
       }
     },
-    "label_payment_id": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment ID"
+    "label_camera_denied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera access required. Enable in Settings."
           }
         }
       }
     },
-    "label_sats_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "sats / BTC"
+    "label_capacity" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capacity"
           }
         }
       }
     },
-    "label_status": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
+    "label_channel_info" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel Info"
           }
         }
       }
     },
-    "label_theme": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Theme"
+    "label_close_tx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Tx"
           }
         }
       }
     },
-    "label_total_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Total Balance"
+    "label_confirmations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmations"
           }
         }
       }
     },
-    "label_txid": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TXID"
+    "label_connection" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connection"
           }
         }
       }
     },
-    "label_type": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type"
+    "label_counterparty" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Counterparty"
           }
         }
       }
     },
-    "label_unrecognized_format": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unrecognized format"
+    "label_custody" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custody"
           }
         }
       }
     },
-    "label_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD"
+    "label_dash" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
           }
         }
       }
     },
-    "label_usd_value": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD Value"
+    "label_date" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
           }
         }
       }
     },
-    "label_version": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+    "label_device_token" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device Token"
           }
         }
       }
     },
-    "label_you_receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You Receive"
+    "label_direction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direction"
           }
         }
       }
     },
-    "label_your_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Bitcoin Address"
+    "label_distance_from_par" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distance from PAR"
           }
         }
       }
     },
-    "label_your_invoice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Lightning Invoice"
+    "label_dollar_sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "$"
           }
         }
       }
     },
-    "link_about": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "About"
+    "label_expected_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected USD"
           }
         }
       }
     },
-    "link_app_access": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "App Access"
+    "label_explorer" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Explorer"
           }
         }
       }
     },
-    "link_appearance": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Appearance"
+    "label_fee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         }
       }
     },
-    "link_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup"
+    "label_fee_percent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee %"
           }
         }
       }
     },
-    "link_channel": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Channel"
+    "label_fee_row" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee"
           }
         }
       }
     },
-    "link_node": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Node"
+    "label_fee_sats" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fee (sats)"
           }
         }
       }
     },
-    "link_notifications": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Notifications"
+    "label_funding_tx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funding TX"
           }
         }
       }
     },
-    "link_privacy_policy": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Privacy Policy"
+    "label_inbound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inbound"
           }
         }
       }
     },
-    "link_push_connectivity": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Push Connectivity"
+    "label_native_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Native BTC"
           }
         }
       }
     },
-    "link_send_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Onchain"
+    "label_network" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network"
           }
         }
       }
     },
-    "link_stable_position": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Stable Position"
+    "label_network_fee" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Fee"
           }
         }
       }
     },
-    "loading_balance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading balance..."
+    "label_no_camera" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No camera available. Paste invoice manually."
           }
         }
       }
     },
-    "max_channel_limit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maximum: $%lld"
+    "label_node_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Node ID"
           }
         }
       }
     },
-    "Min": {},
-    "move_to_trading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Move to Lightning Account"
+    "label_node_identity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node Identity"
           }
         }
       }
     },
-    "notifications_disabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications Disabled"
+    "label_node_status" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node Status"
           }
         }
       }
     },
-    "notifications_disabled_subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable notifications to receive payment alerts"
+    "label_none" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "None"
           }
         }
       }
     },
-    "notifications_enabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications Enabled"
+    "label_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
           }
         }
       }
     },
-    "payment_received": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received"
+    "label_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain"
           }
         }
       }
     },
-    "payment_sent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent"
+    "label_on_chain_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain Address"
           }
         }
       }
     },
-    "payment_type_bolt12": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bolt 12"
+    "label_outbound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outbound"
           }
         }
       }
     },
-    "payment_type_channel_close": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel Close"
+    "label_payment_confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Confirmation"
           }
         }
       }
     },
-    "payment_type_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain"
+    "label_payment_id" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment ID"
           }
         }
       }
     },
-    "payment_type_settlement": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settlement"
+    "label_sats_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sats / BTC"
           }
         }
       }
     },
-    "payment_type_splice_in": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice In"
+    "label_status" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         }
       }
     },
-    "payment_type_splice_out": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice Out"
+    "label_theme" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Theme"
           }
         }
       }
     },
-    "payment_type_stability": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stability"
+    "label_total_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Balance"
           }
         }
       }
     },
-    "picker_history": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History"
+    "label_txid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TXID"
           }
         }
       }
     },
-    "placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.00"
+    "label_type" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
           }
         }
       }
     },
-    "placeholder_address": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "bc1..."
+    "label_unrecognized_format" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unrecognized format"
           }
         }
       }
     },
-    "placeholder_amount": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Amount (USD)"
+    "label_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD"
           }
         }
       }
     },
-    "placeholder_amount_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "0.00"
+    "label_usd_value" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD Value"
           }
         }
       }
     },
-    "placeholder_invoice": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lnbc1..."
+    "label_version" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         }
       }
     },
-    "placeholder_loading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading..."
+    "label_you_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You Receive"
           }
         }
       }
     },
-    "placeholder_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "word1 word2 word3..."
+    "label_your_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Bitcoin Address"
           }
         }
       }
     },
-    "Price": {},
-    "QR Code": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "QR Code"
+    "label_your_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Lightning Invoice"
           }
         }
       }
     },
-    "section_about": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "About"
+    "last_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last backup"
           }
         }
       }
     },
-    "section_app_info": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "App Info"
+    "link_about" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "About"
           }
         }
       }
     },
-    "section_appearance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Appearance"
+    "link_app_access" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Access"
           }
         }
       }
     },
-    "section_backup": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Backup"
+    "link_appearance" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
           }
         }
       }
     },
-    "section_backup_seed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup"
+    "link_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
           }
         }
       }
     },
-    "section_channel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel"
+    "link_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel"
           }
         }
       }
     },
-    "section_custody": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Custody Model"
+    "link_node" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node"
           }
         }
       }
     },
-    "section_metadata": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Metadata"
+    "link_notifications" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Notifications"
           }
         }
       }
     },
-    "section_network": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Network"
+    "link_privacy_policy" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Privacy Policy"
           }
         }
       }
     },
-    "section_node": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Node"
+    "link_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Push Connectivity"
           }
         }
       }
     },
-    "section_node_network": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Node & Network"
+    "link_send_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send Onchain"
           }
         }
       }
     },
-    "section_notifications": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications"
+    "link_stable_position" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Position"
           }
         }
       }
     },
-    "section_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain"
+    "loading_balance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading balance..."
           }
         }
       }
     },
-    "section_payment_details": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Details"
+    "max_channel_limit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum: $%lld"
           }
         }
       }
     },
-    "section_preferences": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Preferences"
+    "maybe_later" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maybe Later"
           }
         }
       }
     },
-    "section_privacy_security": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy & Security"
+    "Min" : {
+
+    },
+    "move_to_trading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move to Lightning Account"
           }
         }
       }
     },
-    "section_restore": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore"
+    "notifications_disabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications Disabled"
           }
         }
       }
     },
-    "section_seed_phrase": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Seed Phrase"
+    "notifications_disabled_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable notifications to receive payment alerts"
           }
         }
       }
     },
-    "section_stable_position": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stable Position"
+    "notifications_enabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications Enabled"
           }
         }
       }
+    },
+    "Partial Recovery Warning" : {
+
     },
-    "section_trade_details": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Order Details"
+    "passphrase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passphrase"
           }
         }
       }
     },
-    "section_wallet": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Wallet"
+    "passphrase_min_length" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "At least 12 characters required"
           }
         }
       }
     },
-    "section_wallet_security": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wallet Security"
+    "passphrase_mismatch" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Passphrases don't match"
           }
         }
       }
     },
-    "segment_payments": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payments"
+    "payment_received" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received"
           }
         }
       }
     },
-    "segment_trades": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Orders"
+    "payment_sent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent"
           }
         }
       }
     },
-    "Selected": {},
-    "status_channel_closed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel Closed"
+    "payment_type_bolt12" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolt 12"
           }
         }
       }
     },
-    "status_channel_closing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel closing..."
+    "payment_type_channel_close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Close"
           }
         }
       }
     },
-    "status_channel_opening": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel Opening"
+    "payment_type_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain"
           }
         }
       }
     },
-    "status_channel_ready": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel Ready"
+    "payment_type_settlement" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settlement"
           }
         }
       }
     },
-    "status_collecting_data": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Collecting price data..."
+    "payment_type_splice_in" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice In"
           }
         }
       }
     },
-    "status_onchain_receiving": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receiving on-chain..."
+    "payment_type_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Out"
           }
         }
       }
     },
-    "status_opening_channel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opening Channel"
+    "payment_type_stability" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stability"
           }
         }
       }
     },
-    "status_payment_confirmed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Confirmed"
+    "picker_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
           }
         }
       }
     },
-    "status_payment_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Failed"
+    "placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00"
           }
         }
       }
     },
-    "status_received_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received BTC"
+    "placeholder_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "bc1..."
           }
         }
       }
     },
-    "status_received_usd": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received USD"
+    "placeholder_amount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amount (USD)"
           }
         }
       }
     },
-    "status_running": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running"
+    "placeholder_amount_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.00"
           }
         }
       }
     },
-    "status_splice_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice Failed"
+    "placeholder_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lnbc1..."
           }
         }
       }
     },
-    "status_splice_pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice Pending"
+    "placeholder_loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading..."
           }
         }
       }
     },
-    "status_stopped": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stopped"
+    "placeholder_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "word1 word2 word3..."
           }
         }
       }
+    },
+    "Please withdraw all BTC before proceeding. Existing wallet data will be completely overwritten." : {
+
+    },
+    "Please withdraw Lightning funds before proceeding if you plan to use this backup for recovery." : {
+
     },
-    "status_sweeping": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
+    "Price" : {
+
+    },
+    "QR Code" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR Code"
           }
         }
       }
     },
-    "status_syncing_moment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing Moment"
+    "recovery_banner_text_prefix" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please email"
           }
         }
       }
     },
-    "status_syncing_wallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Syncing Wallet"
+    "recovery_banner_text_suffix" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "for wallet recovery assistance."
           }
         }
       }
     },
-    "status_trade_confirmed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Order Confirmed"
+    "recovery_banner_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Need Help?"
           }
         }
       }
     },
-    "status_trade_failed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Order Failed"
+    "restore_action" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore Wallet"
           }
         }
       }
     },
-    "status_waiting_lsp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Waiting for LSP"
+    "restore_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore Backup"
           }
         }
       }
     },
-    "subtitle_disable_app_unlock": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable app lock requirement on launch and resume"
+    "restore_description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore your wallet from backup."
           }
         }
       }
     },
-    "subtitle_disable_payment_confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Require auth before sending Lightning payments"
+    "restore_from_icloud" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore from iCloud"
           }
         }
       }
     },
-    "subtitle_manage_exposure": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Manage your BTC exposure"
+    "restoring" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restoring..."
           }
         }
       }
     },
-    "success_sent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent!"
+    "section_about" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
           }
         }
       }
     },
-    "success_splice_out": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Splice-out initiated!"
+    "section_app_info" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "App Info"
           }
         }
       }
     },
-    "tab_history": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History"
+    "section_appearance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
           }
         }
       }
     },
-    "tab_home": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Home"
+    "section_backup" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backup"
           }
         }
       }
     },
-    "tab_settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings"
+    "section_backup_seed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
           }
         }
       }
     },
-    "Tap to close": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to close"
+    "section_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel"
           }
         }
       }
     },
-    "Tap to enlarge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to enlarge"
+    "section_custody" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custody Model"
           }
         }
       }
     },
-    "theme_dark": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Dark"
+    "section_icloud_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "iCloud"
           }
         }
       }
     },
-    "theme_light": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Light"
+    "section_metadata" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadata"
           }
         }
       }
     },
-    "theme_system": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "System"
+    "section_network" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Network"
           }
         }
       }
     },
-    "Time": {},
-    "title_about": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "About"
+    "section_node" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Node"
           }
         }
       }
     },
-    "title_app_access": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "App Access"
+    "section_node_network" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node & Network"
           }
         }
       }
     },
-    "title_appearance": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Appearance"
+    "section_notifications" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
           }
         }
       }
     },
-    "title_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup"
+    "section_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain"
           }
         }
       }
     },
-    "title_buy_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD → BTC"
+    "section_payment_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Details"
           }
         }
       }
     },
-    "title_cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "section_preferences" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferences"
           }
         }
       }
     },
-    "title_channel": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Channel"
+    "section_privacy_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy & Security"
           }
         }
       }
     },
-    "title_confirm": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm"
+    "section_restore" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Restore"
           }
         }
       }
     },
-    "title_confirm_buy": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm USD → BTC"
+    "section_stable_position" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable Position"
           }
         }
       }
     },
-    "title_confirm_sell": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Confirm BTC → USD"
+    "section_trade_details" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order Details"
           }
         }
       }
     },
-    "title_fund_wallet": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fund Wallet"
+    "section_wallet" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Wallet"
           }
         }
       }
     },
-    "title_history": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History"
+    "section_wallet_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallet Security"
           }
         }
       }
     },
-    "title_node": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Node"
+    "segment_payments" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payments"
           }
         }
       }
     },
-    "title_notifications": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Notifications"
+    "segment_trades" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orders"
           }
         }
       }
     },
-    "title_on_chain_receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain Receive"
+    "select_backup_file" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select .stablebackup File"
           }
         }
       }
+    },
+    "Selected" : {
+
     },
-    "title_payment_detail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payment Detail"
+    "status_channel_closed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Closed"
           }
         }
       }
     },
-    "title_push_connectivity": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Push Connectivity"
+    "status_channel_closing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel closing..."
           }
         }
       }
     },
-    "title_receive": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Receive"
+    "status_channel_opening" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Opening"
           }
         }
       }
     },
-    "title_restore_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore Seed"
+    "status_channel_ready" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel Ready"
           }
         }
       }
     },
-    "title_security": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Security"
+    "status_collecting_data" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collecting price data..."
           }
         }
       }
     },
-    "title_sell_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC → USD"
+    "status_onchain_receiving" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receiving on-chain..."
           }
         }
       }
     },
-    "title_send_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Onchain"
+    "status_opening_channel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opening Channel"
           }
         }
       }
     },
-    "title_settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings"
+    "status_payment_confirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Confirmed"
           }
         }
       }
     },
-    "title_stable_position": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Stable Position"
+    "status_payment_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Failed"
           }
         }
       }
     },
-    "title_trade_detail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Order Detail"
+    "status_received_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received BTC"
           }
         }
       }
     },
-    "toggle_send_all": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send All"
+    "status_received_usd" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Received USD"
           }
         }
       }
     },
-    "toolbar_on_chain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onchain"
+    "status_running" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running"
           }
         }
       }
     },
-    "trade_bought_btc_for": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converted "
+    "status_splice_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Failed"
           }
         }
       }
     },
-    "trade_buy_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "USD → BTC"
+    "status_splice_pending" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice Pending"
           }
         }
       }
     },
-    "trade_buying_btc_for": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converting "
+    "status_stopped" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopped"
           }
         }
       }
     },
-    "trade_sell_btc": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BTC → USD"
+    "status_sweeping" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
           }
         }
       }
     },
-    "trade_selling_btc_for": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converting "
+    "status_syncing_moment" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing Moment"
           }
         }
       }
     },
-    "trade_sold_btc_for": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Converted "
+    "status_syncing_wallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing Wallet"
           }
         }
       }
     },
-    "try_again": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
+    "status_trade_confirmed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order Confirmed"
           }
         }
       }
     },
-    "view_on_explorer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View on Explorer"
+    "status_trade_failed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order Failed"
           }
         }
       }
     },
-    "warning_copy_seed_message": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Clipboard is shared with other apps. Consider writing down your seed instead."
+    "status_waiting_lsp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for LSP"
           }
         }
       }
     },
-    "warning_copy_seed_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Copy Seed Words?"
+    "subtitle_disable_app_unlock" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable app lock requirement on launch and resume"
           }
         }
       }
     },
-    "warning_seed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Never share your seed phrase with anyone."
+    "subtitle_disable_payment_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require auth before sending Lightning payments"
           }
         }
       }
     },
-    "": {},
-    " ": {},
-    "Backup enabled!": {},
-    "backup_now": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup Now"
+    "subtitle_manage_exposure" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Manage your BTC exposure"
           }
         }
       }
     },
-    "button_enable_icloud_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup to iCloud"
+    "success_sent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent!"
           }
         }
       }
     },
-    "button_import_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Import from File"
+    "success_splice_out" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splice-out initiated!"
           }
         }
       }
     },
-    "button_restore_icloud": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore from iCloud"
+    "support@stablechannels.com" : {
+
+    },
+    "tab_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
           }
         }
       }
     },
-    "Cancel": {},
-    "confirm_passphrase": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Confirm Passphrase"
+    "tab_home" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
           }
         }
       }
     },
-    "confirm_passphrase_hint": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Confirm your passphrase"
+    "tab_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
           }
         }
       }
     },
-    "Delete": {},
-    "Delete Backup?": {},
-    "delete_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Delete Backup"
+    "Tap to close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to close"
           }
         }
       }
     },
-    "enable_icloud_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enable iCloud Backup"
+    "Tap to enlarge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to enlarge"
           }
         }
       }
     },
-    "enabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enabled"
+    "tap_to_select" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tap to browse your files"
           }
         }
       }
     },
-    "enter_backup_passphrase": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enter backup passphrase"
+    "theme_dark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dark"
           }
         }
       }
     },
-    "enter_passphrase": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enter passphrase"
+    "theme_light" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Light"
           }
         }
       }
     },
-    "error_export_failed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Export failed"
+    "theme_system" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "System"
           }
         }
       }
+    },
+    "This backup contains only your seed phrase. Lightning channel state is NOT included. If you need to recover, you may lose access to any Lightning funds." : {
+
     },
-    "error_import_failed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Decryption failed. Check passphrase."
+    "This backup contains only your seed phrase. Lightning channel state is NOT included. On-chain funds will be restored, but Lightning funds may be lost." : {
+
+    },
+    "This recovery will restore on-chain funds but NOT Lightning channel state. Lightning funds will be lost and may require LSP force-close." : {
+
+    },
+    "Time" : {
+
+    },
+    "title_about" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "About"
           }
         }
       }
     },
-    "error_invalid_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Invalid backup file"
+    "title_app_access" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Access"
           }
         }
       }
     },
-    "error_locked_for": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Locked for"
+    "title_appearance" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Appearance"
           }
         }
       }
     },
-    "error_no_file": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "No file selected"
+    "title_backup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Backup"
           }
         }
       }
     },
-    "error_no_seed": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "No seed available"
+    "title_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD → BTC"
           }
         }
       }
     },
-    "error_old_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Backup version not supported"
+    "title_cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "error_rate_limited": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Too many attempts. Try again in"
+    "title_channel" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Channel"
           }
         }
       }
     },
-    "error_wrong_passphrase": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Wrong passphrase. %lld attempts remaining"
+    "title_confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
           }
         }
       }
     },
-    "export": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export"
+    "title_confirm_buy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm USD → BTC"
           }
         }
       }
     },
-    "export_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Export Backup"
+    "title_confirm_sell" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm BTC → USD"
           }
         }
       }
     },
-    "export_description": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Add a passphrase to protect your exported backup. You'll need this to restore."
+    "title_fund_wallet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fund Wallet"
           }
         }
       }
     },
-    "export_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Export Your Backup"
+    "title_history" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
           }
         }
       }
     },
-    "export_to_files": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Export to Files"
+    "title_node" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Node"
           }
         }
       }
     },
-    "file_ready": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "File ready to restore"
+    "title_notifications" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Notifications"
           }
         }
       }
     },
-    "icloud_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "iCloud Backup"
+    "title_on_chain_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain Receive"
           }
         }
       }
     },
-    "icloud_backup_description": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Protect your wallet with encrypted cloud backup."
+    "title_payment_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment Detail"
           }
         }
       }
     },
-    "icloud_backup_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "iCloud Seed Backup"
+    "title_push_connectivity" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Push Connectivity"
           }
         }
       }
     },
-    "import": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import"
+    "title_receive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receive"
           }
         }
       }
     },
-    "import_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Import Backup"
+    "title_restore_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore Seed"
           }
         }
       }
     },
-    "import_description": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Select your .stablebackup file and enter the passphrase used when creating it."
+    "title_security" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security"
           }
         }
       }
     },
-    "import_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore from Backup"
+    "title_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC → USD"
           }
         }
       }
     },
-    "label_attempts_left": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "attempts left"
+    "title_send_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send Onchain"
           }
         }
       }
     },
-    "last_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Last backup"
+    "title_settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
           }
         }
       }
     },
-    "maybe_later": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Maybe Later"
+    "title_stable_position" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stable Position"
           }
         }
       }
     },
-    "passphrase": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passphrase"
+    "title_trade_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Order Detail"
           }
         }
       }
     },
-    "passphrase_min_length": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "At least 12 characters required"
+    "toggle_send_all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send All"
           }
         }
       }
     },
-    "passphrase_mismatch": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Passphrases don't match"
+    "toolbar_on_chain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onchain"
           }
         }
       }
     },
-    "recovery_banner_text_prefix": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Please email"
+    "trade_bought_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converted "
           }
         }
       }
     },
-    "recovery_banner_text_suffix": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "for wallet recovery assistance."
+    "trade_buy_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USD → BTC"
           }
         }
       }
     },
-    "recovery_banner_title": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Need Help?"
+    "trade_buying_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converting "
           }
         }
       }
     },
-    "restore_action": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore Wallet"
+    "trade_sell_btc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BTC → USD"
           }
         }
       }
     },
-    "restore_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore Backup"
+    "trade_selling_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converting "
           }
         }
       }
     },
-    "restore_description": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore your wallet from backup."
+    "trade_sold_btc_for" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converted "
           }
         }
       }
     },
-    "restore_from_icloud": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restore from iCloud"
+    "try_again" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
           }
         }
       }
     },
-    "restoring": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Restoring..."
+    "view_on_explorer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View on Explorer"
           }
         }
       }
+    },
+    "Wallet restored!" : {
+
     },
-    "section_icloud_backup": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "iCloud"
+    "warning_copy_seed_message" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clipboard is shared with other apps."
           }
         }
       }
     },
-    "select_backup_file": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Select .stablebackup File"
+    "warning_copy_seed_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy Seed Words?"
           }
         }
       }
     },
-    "support@stablechannels.com": {},
-    "tap_to_select": {
-      "extractionState": "extracted_with_value",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Tap to browse your files"
+    "warning_seed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Never share your seed phrase with anyone."
           }
         }
       }
     },
-    "Wallet restored!": {},
-    "You'll need your seed phrase to restore. This cannot be undone.": {}
+    "You'll need your seed phrase to restore. This cannot be undone." : {
+
+    }
   },
-  "version": "1.2"
+  "version" : "1.2"
 }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -684,9 +684,6 @@
         }
       }
     },
-    "Contact support@stablechannels.com if you need help recovering Lightning funds." : {
-
-    },
     "custody_self" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1256,6 +1253,9 @@
           }
         }
       }
+    },
+    "for questions or assistance." : {
+
     },
     "header_amount" : {
       "extractionState" : "manual",
@@ -2908,10 +2908,10 @@
         }
       }
     },
-    "Please withdraw all BTC before proceeding. Existing wallet data will be completely overwritten." : {
+    "Please email" : {
 
     },
-    "Please withdraw Lightning funds before proceeding if you plan to use this backup for recovery." : {
+    "Please withdraw all BTC before proceeding. Existing wallet data will be completely overwritten." : {
 
     },
     "Price" : {
@@ -3015,6 +3015,9 @@
           }
         }
       }
+    },
+    "Restoring from iCloud will erase your existing wallet and all funds. Please withdraw all Bitcoin before proceeding." : {
+
     },
     "section_about" : {
       "extractionState" : "manual",
@@ -3682,10 +3685,7 @@
         }
       }
     },
-    "This backup contains only your seed phrase. Lightning channel state is NOT included. If you need to recover, you may lose access to any Lightning funds." : {
-
-    },
-    "This backup contains only your seed phrase. Lightning channel state is NOT included. On-chain funds will be restored, but Lightning funds may be lost." : {
+    "This backup contains your seed phrase. Lightning channel state is NOT included." : {
 
     },
     "This recovery will restore on-chain funds but NOT Lightning channel state. Lightning funds will be lost and may require LSP force-close." : {

--- a/ios/StableChannels/StableChannels/Services/BackupError.swift
+++ b/ios/StableChannels/StableChannels/Services/BackupError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum BackupError: Error, LocalizedError {
     case backupCorrupted
+    case backupNotFound
     case checksumMismatch
     case iCloudNotSignedIn
     case invalidFormat
@@ -10,6 +11,7 @@ enum BackupError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .backupCorrupted: return "Backup is corrupted"
+        case .backupNotFound: return "Backup not found"
         case .checksumMismatch: return "Backup file is corrupted"
         case .iCloudNotSignedIn: return "Sign in to iCloud to enable backup"
         case .invalidFormat: return "Invalid backup file format"

--- a/ios/StableChannels/StableChannels/Services/BackupError.swift
+++ b/ios/StableChannels/StableChannels/Services/BackupError.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum BackupError: Error, LocalizedError {
+    case backupCorrupted
+    case checksumMismatch
+    case iCloudNotSignedIn
+    case invalidFormat
+    case rateLimitExceeded(remainingSeconds: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .backupCorrupted: return "Backup is corrupted"
+        case .checksumMismatch: return "Backup file is corrupted"
+        case .iCloudNotSignedIn: return "Sign in to iCloud to enable backup"
+        case .invalidFormat: return "Invalid backup file format"
+        case .rateLimitExceeded(let secs): return "Too many attempts. Try again in \(secs) seconds"
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
+++ b/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
@@ -9,6 +9,7 @@ enum SyncStatus: Equatable {
     case notSupported
 }
 
+@MainActor
 protocol BackupServiceProtocol {
     var backupExists: Bool { get }
     var hasLocalBackup: Bool { get }

--- a/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
+++ b/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum SyncStatus: Equatable {
+    case idle
+    case syncing
+    case synced
+    case error(String)
+    case iCloudNotAvailable
+    case notSupported
+}
+
+protocol BackupServiceProtocol {
+    var backupExists: Bool { get }
+    var syncStatus: SyncStatus { get }
+    var iCloudAvailable: Bool { get }
+    var lastBackupDate: Date? { get set }
+
+    func checkAccountStatus() async
+    func generateAndStoreKey() async throws
+    func saveBackupToCloud() async throws
+    func restoreFromCloud() async throws -> BackupFile
+    func deleteBackup() async throws
+    func refreshStatus()
+}

--- a/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
+++ b/ios/StableChannels/StableChannels/Services/BackupServiceProtocol.swift
@@ -11,14 +11,17 @@ enum SyncStatus: Equatable {
 
 protocol BackupServiceProtocol {
     var backupExists: Bool { get }
+    var hasLocalBackup: Bool { get }
     var syncStatus: SyncStatus { get }
     var iCloudAvailable: Bool { get }
     var lastBackupDate: Date? { get set }
 
     func checkAccountStatus() async
+    func checkRemoteBackupExists() async -> Bool
     func generateAndStoreKey() async throws
     func saveBackupToCloud() async throws
     func restoreFromCloud() async throws -> BackupFile
     func deleteBackup() async throws
     func refreshStatus()
+    func markLocalBackupAsEnabled()
 }

--- a/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
+++ b/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
@@ -1,0 +1,186 @@
+import Foundation
+import CloudKit
+import CryptoKit
+
+@MainActor
+@Observable
+final class CloudBackupService {
+    static let shared = CloudBackupService(nodeService: NodeService.shared)
+
+    private let recordType = "SeedBackup"
+    private let recordIDName = "latestSeedBackup"
+
+    private let keychain = KeychainService.shared
+    private let nodeService: NodeService
+
+    private(set) var backupExists: Bool = false
+    private(set) var syncStatus: SyncStatus = .idle
+    private(set) var iCloudAvailable: Bool = false
+
+    init(nodeService: NodeService) {
+        self.nodeService = nodeService
+        Task { await checkAccountStatus() }
+    }
+
+    enum SyncStatus: Equatable {
+        case idle
+        case syncing
+        case synced
+        case error(String)
+        case iCloudNotAvailable
+        case notSupported
+    }
+
+    // MARK: - iCloud Account
+
+    func checkAccountStatus() async {
+        do {
+            let container = CKContainer.default()
+            let status = try await container.accountStatus()
+            iCloudAvailable = status == .available
+            syncStatus = status == .available ? .idle : .iCloudNotAvailable
+        } catch {
+            iCloudAvailable = false
+            syncStatus = .notSupported
+        }
+    }
+
+    // MARK: - Key Generation (First Enable)
+
+    func generateAndStoreKey() async throws {
+        try throwIfUnavailable()
+        try keychain.generateAndStoreKey()
+        try await saveBackupToCloud()
+    }
+
+    private func throwIfUnavailable() throws {
+        if !iCloudAvailable {
+            throw BackupError.iCloudNotSignedIn
+        }
+    }
+
+    // MARK: - Backup Operations
+
+    func saveBackupToCloud() async throws {
+        try throwIfUnavailable()
+        syncStatus = .syncing
+
+        guard let mnemonic = getMnemonic() else {
+            syncStatus = .error("No mnemonic available")
+            throw BackupError.keychainUnavailable
+        }
+
+        let keyData = try keychain.loadKey()
+        let key = SymmetricKey(data: keyData)
+
+        let (encryptedData, checksum) = try CryptoService.encrypt(mnemonic: mnemonic, key: key)
+
+        let container = CKContainer.default()
+        let db = container.privateCloudDatabase
+
+        let recordID = CKRecord.ID(recordName: recordIDName)
+        let record: CKRecord
+        do {
+            record = try await db.record(for: recordID)
+        } catch {
+            record = CKRecord(recordType: recordType, recordID: recordID)
+        }
+
+        record["encryptedData"] = encryptedData as CKRecordValue
+        record["checksum"] = checksum as CKRecordValue
+        record["timestamp"] = Date() as CKRecordValue
+        record["version"] = 1 as CKRecordValue
+
+        try await db.save(record)
+
+        backupExists = true
+        lastBackupDate = Date()
+        syncStatus = .synced
+    }
+
+    // MARK: - Restore from iCloud
+
+    func restoreFromCloud() async throws -> BackupFile {
+        try throwIfUnavailable()
+        syncStatus = .syncing
+
+        let keyData = try keychain.loadKey()
+        let key = SymmetricKey(data: keyData)
+
+        let container = CKContainer.default()
+        let db = container.privateCloudDatabase
+
+        let recordID = CKRecord.ID(recordName: recordIDName)
+        let record: CKRecord
+        do {
+            record = try await db.record(for: recordID)
+        } catch let ckError as CKError where ckError.code == .unknownItem {
+            syncStatus = .error("Backup not found")
+            throw BackupError.backupCorrupted
+        }
+
+        guard let encryptedData = record["encryptedData"] as? Data,
+              let checksum = record["checksum"] as? String,
+              let timestamp = record["timestamp"] as? Date else {
+            syncStatus = .error("Invalid format")
+            throw BackupError.invalidFormat
+        }
+
+        let computed = SHA256.hash(data: encryptedData).compactMap { String(format: "%02x", $0) }.joined()
+        guard computed == checksum else {
+            syncStatus = .error("Checksum mismatch")
+            throw BackupError.checksumMismatch
+        }
+
+        let backup = try CryptoService.decrypt(data: encryptedData, key: key)
+        backupExists = true
+        syncStatus = .synced
+
+        // Return with CloudKit-specific data merged
+        return BackupFile(
+            metadata: BackupMetadata(
+                version: backup.metadata.version,
+                checksum: checksum,
+                timestamp: timestamp,
+                network: .bitcoin,
+                cipher: .aes256gcm
+            ),
+            mnemonic: backup.mnemonic,
+            createdAt: backup.createdAt
+        )
+    }
+
+    // MARK: - Delete
+
+    func deleteBackup() async throws {
+        keychain.deleteKey()
+
+        if iCloudAvailable {
+            let container = CKContainer.default()
+            let db = container.privateCloudDatabase
+            let recordID = CKRecord.ID(recordName: recordIDName)
+            do {
+                try await db.deleteRecord(withID: recordID)
+            } catch let ckError as CKError where ckError.code == .unknownItem {}
+        }
+
+        backupExists = false
+        lastBackupDate = nil
+        syncStatus = .idle
+    }
+
+    // MARK: - Helpers
+
+    private func getMnemonic() -> String? {
+        nodeService.savedMnemonic
+    }
+
+    func refreshStatus() {
+        Task { await checkAccountStatus() }
+    }
+
+    var lastBackupDate: Date? {
+        get { UserDefaults.standard.object(forKey: "lastBackupDate") as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: "lastBackupDate") }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
+++ b/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
@@ -19,6 +19,7 @@ final class CloudBackupService: BackupServiceProtocol {
     private let nodeService: NodeServiceProtocol
 
     private(set) var backupExists: Bool = false
+    private(set) var hasLocalBackup: Bool = UserDefaults.standard.bool(forKey: "backupEnabled")
     private(set) var syncStatus: SyncStatus = .idle
     private(set) var iCloudAvailable: Bool = false
 
@@ -38,9 +39,42 @@ final class CloudBackupService: BackupServiceProtocol {
             let status = try await container.accountStatus()
             iCloudAvailable = status == .available
             syncStatus = status == .available ? .idle : .iCloudNotAvailable
+
+            if iCloudAvailable {
+                await detectExistingBackup()
+            }
         } catch {
             iCloudAvailable = false
             syncStatus = .notSupported
+        }
+    }
+
+    private func detectExistingBackup() async {
+        let container = CKContainer.default()
+        let db = container.privateCloudDatabase
+        let recordID = CKRecord.ID(recordName: recordIDName)
+
+        do {
+            let record = try await db.record(for: recordID)
+            backupExists = true
+            if let timestamp = record["timestamp"] as? Date {
+                lastBackupDate = timestamp
+            }
+        } catch {
+            // Record does not exist or network failure
+        }
+    }
+
+    func checkRemoteBackupExists() async -> Bool {
+        let container = CKContainer.default()
+        let db = container.privateCloudDatabase
+        let recordID = CKRecord.ID(recordName: recordIDName)
+
+        do {
+            _ = try await db.record(for: recordID)
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -93,6 +127,8 @@ final class CloudBackupService: BackupServiceProtocol {
         try await db.save(record)
 
         backupExists = true
+        UserDefaults.standard.set(true, forKey: "backupEnabled")
+        hasLocalBackup = true
         lastBackupDate = Date()
         syncStatus = .synced
     }
@@ -133,7 +169,7 @@ final class CloudBackupService: BackupServiceProtocol {
 
         let backup = try CryptoService.decrypt(data: encryptedData, key: key)
         backupExists = true
-        syncStatus = .synced
+        syncStatus = .idle
 
         return BackupFile(
             metadata: BackupMetadata(
@@ -151,8 +187,6 @@ final class CloudBackupService: BackupServiceProtocol {
     // MARK: - Delete
 
     func deleteBackup() async throws {
-        keychain.deleteKey()
-
         if iCloudAvailable {
             let container = CKContainer.default()
             let db = container.privateCloudDatabase
@@ -162,7 +196,11 @@ final class CloudBackupService: BackupServiceProtocol {
             } catch let ckError as CKError where ckError.code == .unknownItem {}
         }
 
+        keychain.deleteKey()
+
         backupExists = false
+        UserDefaults.standard.set(false, forKey: "backupEnabled")
+        hasLocalBackup = false
         lastBackupDate = nil
         syncStatus = .idle
     }
@@ -180,5 +218,12 @@ final class CloudBackupService: BackupServiceProtocol {
     var lastBackupDate: Date? {
         get { UserDefaults.standard.object(forKey: "lastBackupDate") as? Date }
         set { UserDefaults.standard.set(newValue, forKey: "lastBackupDate") }
+    }
+
+    func markLocalBackupAsEnabled() {
+        backupExists = true
+        UserDefaults.standard.set(true, forKey: "backupEnabled")
+        hasLocalBackup = true
+        syncStatus = .synced
     }
 }

--- a/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
+++ b/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
@@ -19,6 +19,9 @@ final class CloudBackupService {
 
     init(nodeService: NodeService) {
         self.nodeService = nodeService
+    }
+
+    func initialize() {
         Task { await checkAccountStatus() }
     }
 

--- a/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
+++ b/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
@@ -1,37 +1,33 @@
 import Foundation
 import CloudKit
 import CryptoKit
+import LDKNode
 
 @MainActor
 @Observable
-final class CloudBackupService {
-    static let shared = CloudBackupService(nodeService: NodeService.shared)
+final class CloudBackupService: BackupServiceProtocol {
+    static let shared: BackupServiceProtocol = {
+        let service = CloudBackupService(nodeService: NodeService.shared)
+        service.initialize()
+        return service
+    }()
 
     private let recordType = "SeedBackup"
     private let recordIDName = "latestSeedBackup"
 
     private let keychain = KeychainService.shared
-    private let nodeService: NodeService
+    private let nodeService: NodeServiceProtocol
 
     private(set) var backupExists: Bool = false
     private(set) var syncStatus: SyncStatus = .idle
     private(set) var iCloudAvailable: Bool = false
 
-    init(nodeService: NodeService) {
+    init(nodeService: NodeServiceProtocol) {
         self.nodeService = nodeService
     }
 
     func initialize() {
         Task { await checkAccountStatus() }
-    }
-
-    enum SyncStatus: Equatable {
-        case idle
-        case syncing
-        case synced
-        case error(String)
-        case iCloudNotAvailable
-        case notSupported
     }
 
     // MARK: - iCloud Account
@@ -70,7 +66,7 @@ final class CloudBackupService {
 
         guard let mnemonic = getMnemonic() else {
             syncStatus = .error("No mnemonic available")
-            throw BackupError.keychainUnavailable
+            throw KeychainError.keychainUnavailable
         }
 
         let keyData = try keychain.loadKey()
@@ -139,7 +135,6 @@ final class CloudBackupService {
         backupExists = true
         syncStatus = .synced
 
-        // Return with CloudKit-specific data merged
         return BackupFile(
             metadata: BackupMetadata(
                 version: backup.metadata.version,

--- a/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
+++ b/ios/StableChannels/StableChannels/Services/CloudBackupService.swift
@@ -151,7 +151,7 @@ final class CloudBackupService: BackupServiceProtocol {
             record = try await db.record(for: recordID)
         } catch let ckError as CKError where ckError.code == .unknownItem {
             syncStatus = .error("Backup not found")
-            throw BackupError.backupCorrupted
+            throw BackupError.backupNotFound
         }
 
         guard let encryptedData = record["encryptedData"] as? Data,

--- a/ios/StableChannels/StableChannels/Services/CryptoService.swift
+++ b/ios/StableChannels/StableChannels/Services/CryptoService.swift
@@ -1,0 +1,208 @@
+import Foundation
+import CryptoKit
+import CommonCrypto
+
+enum CryptoError: Error, LocalizedError {
+    case keyDerivationFailed
+    case encryptionFailed
+    case decryptionFailed
+    case invalidChecksum
+    case invalidFormat
+    case invalidMagicBytes
+    case unsupportedVersion(UInt16)
+
+    var errorDescription: String? {
+        switch self {
+        case .keyDerivationFailed: return "Failed to derive encryption key"
+        case .encryptionFailed: return "Encryption failed"
+        case .decryptionFailed: return "Decryption failed"
+        case .invalidChecksum: return "Checksum mismatch"
+        case .invalidFormat: return "Invalid backup format"
+        case .invalidMagicBytes: return "Not a valid Stable Channels backup file"
+        case .unsupportedVersion(let v): return "Unsupported backup version: \(v)"
+        }
+    }
+}
+
+private struct EncryptedPayload: Codable {
+    let version: UInt16
+    let mnemonic: String
+    let createdAt: Date
+}
+
+private struct FileHeader {
+    static let magicBytes = "SBCKP001"
+    static let headerSize = 8 + 2 // magic (8) + version (2)
+    static let currentVersion: UInt16 = 1
+
+    let version: UInt16
+
+    func toData() -> Data {
+        var data = Data()
+        data.append(Self.magicBytes.data(using: .utf8)!)
+        withUnsafeBytes(of: version.bigEndian) { data.append(contentsOf: $0) }
+        return data
+    }
+
+    static func fromData(_ data: Data) -> FileHeader? {
+        guard data.count >= headerSize else { return nil }
+        let magic = String(data: data.prefix(8), encoding: .utf8)
+        guard magic == Self.magicBytes else { return nil }
+        // Safe byte-by-byte parsing (no alignment issues)
+        let b0 = UInt16(data[8])
+        let b1 = UInt16(data[9])
+        let version = (b0 << 8) | b1
+        return FileHeader(version: version)
+    }
+}
+
+enum CryptoService {
+    // MARK: - Key Derivation
+
+    static func deriveKey(passphrase: String, salt: Data) throws -> SymmetricKey {
+        guard let passphraseData = passphrase.data(using: .utf8) else {
+            throw CryptoError.keyDerivationFailed
+        }
+
+        var derivedKey = Data(count: 32)
+        let derivationResult = passphraseData.withUnsafeBytes { passphraseBytes -> Int32 in
+            salt.withUnsafeBytes { saltBytes -> Int32 in
+                derivedKey.withUnsafeMutableBytes { derivedKeyBytes -> Int32 in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passphraseBytes.baseAddress,
+                        passphraseData.count,
+                        saltBytes.baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        310_000,
+                        derivedKeyBytes.baseAddress,
+                        32
+                    )
+                }
+            }
+        }
+
+        guard derivationResult == kCCSuccess else {
+            throw CryptoError.keyDerivationFailed
+        }
+
+        return SymmetricKey(data: derivedKey)
+    }
+
+    // MARK: - Checksum
+
+    static func checksum(of data: Data) -> String {
+        SHA256.hash(data: data).compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - File Export Encryption (passphrase-based)
+
+    static func encrypt(mnemonic: String, passphrase: String) throws -> (data: Data, checksum: String) {
+        var salt = Data(count: 32)
+        let rngStatus = salt.withUnsafeMutableBytes { saltBytes in
+            SecRandomCopyBytes(kSecRandomDefault, 32, saltBytes.baseAddress!)
+        }
+        guard rngStatus == errSecSuccess else {
+            throw CryptoError.encryptionFailed
+        }
+
+        let key = try deriveKey(passphrase: passphrase, salt: salt)
+
+        let payload = EncryptedPayload(version: FileHeader.currentVersion, mnemonic: mnemonic, createdAt: Date())
+        let payloadData = try JSONEncoder().encode(payload)
+
+        let sealedBox = try AES.GCM.seal(payloadData, using: key)
+
+        guard let encrypted = sealedBox.combined else {
+            throw CryptoError.encryptionFailed
+        }
+
+        // Build file: header + salt + encrypted
+        var result = Data()
+        result.append(FileHeader(version: FileHeader.currentVersion).toData())
+        result.append(salt)
+        result.append(encrypted)
+
+        return (result, checksum(of: result))
+    }
+
+    static func decrypt(data: Data, passphrase: String) throws -> BackupFile {
+        // Parse header
+        guard data.count > FileHeader.headerSize + 32 else {
+            throw CryptoError.invalidFormat
+        }
+
+        guard let header = FileHeader.fromData(data) else {
+            throw CryptoError.invalidMagicBytes
+        }
+
+        guard header.version <= FileHeader.currentVersion else {
+            throw CryptoError.unsupportedVersion(header.version)
+        }
+
+        // Extract salt and encrypted data
+        let salt = data.subdata(in: FileHeader.headerSize..<(FileHeader.headerSize + 32))
+        let encrypted = data.dropFirst(FileHeader.headerSize + 32)
+
+        let key = try deriveKey(passphrase: passphrase, salt: salt)
+
+        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
+        let decryptedData = try AES.GCM.open(sealedBox, using: key)
+
+        let payload = try JSONDecoder().decode(EncryptedPayload.self, from: decryptedData)
+        return BackupFile(
+            metadata: BackupMetadata(version: payload.version, checksum: "", timestamp: payload.createdAt,
+                                     network: .bitcoin, cipher: .aes256gcm),
+            mnemonic: payload.mnemonic,
+            createdAt: payload.createdAt
+        )
+    }
+
+    // MARK: - iCloud Encryption (key-based)
+
+    static func encrypt(mnemonic: String, key: SymmetricKey) throws -> (data: Data, checksum: String) {
+        let payload = EncryptedPayload(version: FileHeader.currentVersion, mnemonic: mnemonic, createdAt: Date())
+        let payloadData = try JSONEncoder().encode(payload)
+
+        let sealedBox = try AES.GCM.seal(payloadData, using: key)
+
+        guard let combined = sealedBox.combined else {
+            throw CryptoError.encryptionFailed
+        }
+
+        // Build file: header + encrypted
+        var result = Data()
+        result.append(FileHeader(version: FileHeader.currentVersion).toData())
+        result.append(combined)
+
+        return (result, checksum(of: result))
+    }
+
+    static func decrypt(data: Data, key: SymmetricKey) throws -> BackupFile {
+        guard data.count > FileHeader.headerSize else {
+            throw CryptoError.invalidFormat
+        }
+
+        guard let header = FileHeader.fromData(data) else {
+            throw CryptoError.invalidMagicBytes
+        }
+
+        guard header.version <= FileHeader.currentVersion else {
+            throw CryptoError.unsupportedVersion(header.version)
+        }
+
+        let encrypted = data.dropFirst(FileHeader.headerSize)
+
+        let sealedBox = try AES.GCM.SealedBox(combined: encrypted)
+        let decryptedData = try AES.GCM.open(sealedBox, using: key)
+
+        let payload = try JSONDecoder().decode(EncryptedPayload.self, from: decryptedData)
+        return BackupFile(
+            metadata: BackupMetadata(version: payload.version, checksum: "", timestamp: payload.createdAt,
+                                     network: .bitcoin, cipher: .aes256gcm),
+            mnemonic: payload.mnemonic,
+            createdAt: payload.createdAt
+        )
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/KeychainService.swift
+++ b/ios/StableChannels/StableChannels/Services/KeychainService.swift
@@ -26,6 +26,8 @@ final class KeychainService {
     // MARK: - CRUD
 
     func generateAndStoreKey() throws {
+        if hasKey() { return }
+
         let keyData = try generateRandomBytes(count: 32)
         try storeKey(keyData)
     }

--- a/ios/StableChannels/StableChannels/Services/KeychainService.swift
+++ b/ios/StableChannels/StableChannels/Services/KeychainService.swift
@@ -1,6 +1,20 @@
 import Foundation
 import Security
 
+enum KeychainError: Error, LocalizedError {
+    case accessDenied
+    case keyNotFound
+    case keychainUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied: return "Access denied"
+        case .keyNotFound: return "Key not found"
+        case .keychainUnavailable: return "Keychain unavailable"
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class KeychainService {
@@ -30,7 +44,7 @@ final class KeychainService {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
         guard status == errSecSuccess, let keyData = result as? Data else {
-            throw BackupError.keyNotFound
+            throw KeychainError.keyNotFound
         }
         return keyData
     }
@@ -63,7 +77,7 @@ final class KeychainService {
         var bytes = [UInt8](repeating: 0, count: count)
         let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
         guard status == errSecSuccess else {
-            throw BackupError.keychainUnavailable
+            throw KeychainError.keychainUnavailable
         }
         return Data(bytes)
     }
@@ -90,7 +104,7 @@ final class KeychainService {
 
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
-            throw BackupError.keychainUnavailable
+            throw KeychainError.keychainUnavailable
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Services/KeychainService.swift
+++ b/ios/StableChannels/StableChannels/Services/KeychainService.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Security
+
+@MainActor
+@Observable
+final class KeychainService {
+    static let shared = KeychainService()
+
+    private let service = "com.stablechannels.backup"
+    private let account = "encryptionKey"
+
+    // MARK: - CRUD
+
+    func generateAndStoreKey() throws {
+        let keyData = try generateRandomBytes(count: 32)
+        try storeKey(keyData)
+    }
+
+    func loadKey() throws -> Data {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let keyData = result as? Data else {
+            throw BackupError.keyNotFound
+        }
+        return keyData
+    }
+
+    func deleteKey() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: true
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    func hasKey() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: false
+        ]
+        var result: AnyObject?
+        return SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess
+    }
+
+    // MARK: - Private
+
+    private func generateRandomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        guard status == errSecSuccess else {
+            throw BackupError.keychainUnavailable
+        }
+        return Data(bytes)
+    }
+
+    private func storeKey(_ keyData: Data) throws {
+        // Delete any existing key first to ensure clean state
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: true
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        // Now add the new key
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: true,
+            kSecValueData as String: keyData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw BackupError.keychainUnavailable
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -1,8 +1,17 @@
 import Foundation
 import LDKNode
 
+protocol NodeServiceProtocol {
+    var node: Node? { get }
+    var isRunning: Bool { get }
+    var nodeId: String { get }
+    var channels: [ChannelDetails] { get }
+    var savedMnemonic: String? { get }
+    func start(network: Network, esploraURL: String, mnemonic: String) async throws
+}
+
 @Observable
-class NodeService {
+class NodeService: NodeServiceProtocol {
     static let shared = NodeService()
 
     private(set) var node: Node?

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -38,6 +38,8 @@ class NodeService: NodeServiceProtocol {
     // MARK: - Lifecycle
 
     func start(network: Network, esploraURL: String, mnemonic: String) async throws {
+        guard !isRunning else { throw NodeServiceError.alreadyRunning }
+
         let dataDir = Constants.userDataDir.path
 
         // Ensure data directory exists
@@ -99,8 +101,8 @@ class NodeService: NodeServiceProtocol {
         // Determine which mnemonic to use
         let words: String
         if !mnemonic.isEmpty {
-            // Restore — wipe ALL wallet data so new seed takes effect
-            Self.wipeWalletData()
+            // Explicit restore callers must reset app + LDK state before
+            // starting with a replacement seed. NodeService only starts LDK.
             words = mnemonic.trimmingCharacters(in: .whitespacesAndNewlines)
         } else if let saved = try? String(contentsOfFile: seedPhrasePath.path, encoding: .utf8),
                   !saved.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -155,7 +157,14 @@ class NodeService: NodeServiceProtocol {
         eventTask?.cancel()
         eventTask = nil
         try? node?.stop()
+        node = nil
         isRunning = false
+        nodeId = ""
+        channels = []
+    }
+
+    func clearSavedMnemonic() {
+        savedMnemonic = nil
     }
 
     // MARK: - Event Loop
@@ -420,10 +429,12 @@ class NodeService: NodeServiceProtocol {
 
 enum NodeServiceError: LocalizedError {
     case notRunning
+    case alreadyRunning
 
     var errorDescription: String? {
         switch self {
         case .notRunning: return "Node is not running"
+        case .alreadyRunning: return "Node is already running"
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -3,6 +3,8 @@ import LDKNode
 
 @Observable
 class NodeService {
+    static let shared = NodeService()
+
     private(set) var node: Node?
     private(set) var isRunning = false
     private(set) var nodeId: String = ""

--- a/ios/StableChannels/StableChannels/Services/RateLimitService.swift
+++ b/ios/StableChannels/StableChannels/Services/RateLimitService.swift
@@ -30,7 +30,13 @@ final class RateLimitService {
 
     var isLocked: Bool {
         guard let until = lockedUntil else { return false }
-        return Date() < until
+        if Date() < until {
+            return true
+        }
+        // Lockout expired - reset attempts for a fresh session
+        attempts = 0
+        lockedUntil = nil
+        return false
     }
 
     var lockoutRemainingSeconds: Int {

--- a/ios/StableChannels/StableChannels/Services/RateLimitService.swift
+++ b/ios/StableChannels/StableChannels/Services/RateLimitService.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Rate limiting for iCloud backup restore attempts.
+/// - Max 5 attempts before lockout
+/// - 30s lockout after 3 consecutive failures
+/// - Counters reset on successful attempt or app restart
+@MainActor
+final class RateLimitService {
+    static let shared = RateLimitService()
+
+    private init() {}
+
+    private let maxAttempts = 5
+    private let lockoutDuration: TimeInterval = 30
+    private let lockoutThreshold = 3
+
+    private var attempts: Int {
+        get { UserDefaults.standard.integer(forKey: "backupRestoreAttempts") }
+        set { UserDefaults.standard.set(newValue, forKey: "backupRestoreAttempts") }
+    }
+
+    private var lockedUntil: Date? {
+        get { UserDefaults.standard.object(forKey: "backupRestoreLockedUntil") as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: "backupRestoreLockedUntil") }
+    }
+
+    var attemptsRemaining: Int {
+        max(0, maxAttempts - attempts)
+    }
+
+    var isLocked: Bool {
+        guard let until = lockedUntil else { return false }
+        return Date() < until
+    }
+
+    var lockoutRemainingSeconds: Int {
+        guard let until = lockedUntil else { return 0 }
+        return max(0, Int(until.timeIntervalSinceNow))
+    }
+
+    /// Records a failed restore attempt. Triggers lockout if threshold reached.
+    func recordFailedAttempt() {
+        attempts += 1
+        if attempts >= lockoutThreshold {
+            lockedUntil = Date().addingTimeInterval(lockoutDuration)
+        }
+    }
+
+    /// Records a successful restore attempt. Resets all counters.
+    func recordSuccessfulAttempt() {
+        attempts = 0
+        lockedUntil = nil
+    }
+
+    /// Checks current rate limit status. Throws if locked.
+    func checkRateLimit() throws {
+        if isLocked {
+            throw BackupError.rateLimitExceeded(remainingSeconds: lockoutRemainingSeconds)
+        }
+    }
+
+    /// Resets all rate limit counters.
+    func reset() {
+        attempts = 0
+        lockedUntil = nil
+    }
+}
+
+enum BackupError: Error, LocalizedError {
+    case iCloudNotSignedIn
+    case keychainUnavailable
+    case keyNotFound
+    case exportFailed(String)
+    case importFailed(String)
+    case invalidFormat
+    case checksumMismatch
+    case wrongPassphrase(attemptsRemaining: Int)
+    case rateLimitExceeded(remainingSeconds: Int)
+    case backupCorrupted
+    case migrationNotSupported
+    case invalidPassphrase
+
+    var errorDescription: String? {
+        switch self {
+        case .iCloudNotSignedIn: return "Sign in to iCloud to enable backup"
+        case .keychainUnavailable: return "iCloud Keychain unavailable"
+        case .keyNotFound: return "Backup encryption key not found"
+        case .exportFailed(let msg): return "Export failed: \(msg)"
+        case .importFailed(let msg): return "Import failed: \(msg)"
+        case .invalidFormat: return "Invalid backup file format"
+        case .checksumMismatch: return "Backup file is corrupted"
+        case .wrongPassphrase(let remaining): return "Wrong passphrase. \(remaining) attempts remaining"
+        case .rateLimitExceeded(let secs): return "Too many attempts. Try again in \(secs) seconds"
+        case .backupCorrupted: return "Backup is corrupted"
+        case .migrationNotSupported: return "Backup version not supported"
+        case .invalidPassphrase: return "Invalid passphrase"
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/RateLimitService.swift
+++ b/ios/StableChannels/StableChannels/Services/RateLimitService.swift
@@ -65,35 +65,3 @@ final class RateLimitService {
         lockedUntil = nil
     }
 }
-
-enum BackupError: Error, LocalizedError {
-    case iCloudNotSignedIn
-    case keychainUnavailable
-    case keyNotFound
-    case exportFailed(String)
-    case importFailed(String)
-    case invalidFormat
-    case checksumMismatch
-    case wrongPassphrase(attemptsRemaining: Int)
-    case rateLimitExceeded(remainingSeconds: Int)
-    case backupCorrupted
-    case migrationNotSupported
-    case invalidPassphrase
-
-    var errorDescription: String? {
-        switch self {
-        case .iCloudNotSignedIn: return "Sign in to iCloud to enable backup"
-        case .keychainUnavailable: return "iCloud Keychain unavailable"
-        case .keyNotFound: return "Backup encryption key not found"
-        case .exportFailed(let msg): return "Export failed: \(msg)"
-        case .importFailed(let msg): return "Import failed: \(msg)"
-        case .invalidFormat: return "Invalid backup file format"
-        case .checksumMismatch: return "Backup file is corrupted"
-        case .wrongPassphrase(let remaining): return "Wrong passphrase. \(remaining) attempts remaining"
-        case .rateLimitExceeded(let secs): return "Too many attempts. Try again in \(secs) seconds"
-        case .backupCorrupted: return "Backup is corrupted"
-        case .migrationNotSupported: return "Backup version not supported"
-        case .invalidPassphrase: return "Invalid passphrase"
-        }
-    }
-}

--- a/ios/StableChannels/StableChannels/StableChannels.entitlements
+++ b/ios/StableChannels/StableChannels/StableChannels.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.stablechannels.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.stablechannels.app</string>

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -135,3 +135,15 @@ struct PriceFeedConfig: Codable {
     let urlFormat: String
     let jsonPath: [String]
 }
+
+// MARK: - Seed Constants
+
+enum SeedConstants {
+    static let wordCount12 = 12
+    static let wordCount24 = 24
+    static let maxWordCount = 24
+    static let clipboardClearSeconds: TimeInterval = 60
+    static let defaultWordCount = 12
+    static let animationDuration: TimeInterval = 0.3
+    static let successDisplaySeconds: UInt64 = 1_500_000_000
+}

--- a/ios/StableChannels/StableChannels/Utilities/MnemonicUtils.swift
+++ b/ios/StableChannels/StableChannels/Utilities/MnemonicUtils.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Mnemonic word parsing utilities - full BIP39 validation handled by LDKNode
+enum MnemonicUtils {
+    /// Regex pattern for validating mnemonic word format (alphabetic only)
+    private static let wordPattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern: "^[a-z]+$",
+        options: .caseInsensitive
+    )
+
+    // MARK: - Word Parsing
+
+    /// Parse mnemonic string into array of words, trimmed, lowercased and filtered
+    static func parseMnemonic(_ input: String) -> [String] {
+        input
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(separator: " ")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+    }
+
+    /// Convert word array to filled array of maxWordCount (empty strings for unfilled)
+    static func wordsToFields(_ words: [String]) -> [String] {
+        var fields = Array(repeating: "", count: SeedConstants.maxWordCount)
+        for (index, word) in words.enumerated() where index < SeedConstants.maxWordCount {
+            fields[index] = word
+        }
+        return fields
+    }
+
+    // MARK: - Validation
+
+    /// Detect word count from mnemonic string (12 or 24, defaults based on input)
+    static func detectWordCount(_ mnemonic: String) -> Int {
+        let count = parseMnemonic(mnemonic).count
+        if count <= SeedConstants.wordCount12 {
+            return SeedConstants.wordCount12
+        }
+        return SeedConstants.wordCount24
+    }
+
+    /// Check if mnemonic has valid word count (12 or 24)
+    static func isValidWordCount(_ mnemonic: String) -> Bool {
+        let count = parseMnemonic(mnemonic).count
+        return count == SeedConstants.wordCount12 || count == SeedConstants.wordCount24
+    }
+
+    /// Check if all words contain only alphabetic characters (basic format check)
+    /// Note: Full BIP39 validation (wordlist + checksum) is handled by LDKNode
+    static func hasValidCharacterFormat(_ mnemonic: String) -> Bool {
+        let words = parseMnemonic(mnemonic)
+        guard !words.isEmpty else { return false }
+        return words.allSatisfy { word in
+            wordPattern?.firstMatch(
+                in: word,
+                options: [],
+                range: NSRange(word.startIndex..., in: word)
+            ) != nil
+        }
+    }
+
+    // MARK: - Display
+
+    /// Convert mnemonic to display format (space-separated, trimmed)
+    static func formatForDisplay(_ mnemonic: String) -> String {
+        parseMnemonic(mnemonic).joined(separator: " ")
+    }
+}


### PR DESCRIPTION
## Summary

Implemented partial backup system for iCloud Keychain and file export. Users can backup their seed phrase with AES-256-GCM encryption and restore via iCloud or file import.

## Screenshots

| Backup Home | Seed Display | iCloud Enable |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/0b58bdd1-8aee-446e-b166-03395ac2fe28" width="200"/> | <img src="https://github.com/user-attachments/assets/1b6d52c0-4c30-4941-9049-5a909ca9d159" width="200"/> | <img src="https://github.com/user-attachments/assets/93cf1182-719d-4013-86ed-f1bce61e881d" width="200"/> |

| Copy Confirmation | Word Grid | Import Backup |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/24cbd7ba-64a4-4d3a-b3ed-6ec789759051" width="200"/> | <img src="https://github.com/user-attachments/assets/14ad813c-c956-49ad-98b7-5971a1eb7c4e" width="200"/> | <img src="https://github.com/user-attachments/assets/3047e04b-9972-4865-a812-0de4bdb55989" width="200"/> |

## Architecture

```mermaid
flowchart TB
    subgraph Views["Views"]
        BV[BackupSettingsView]
        RS[RestoreSeedSheet]
        EI[ExportImportSheet]
        BP[BackupPromptView]
    end

    subgraph Services["Services"]
        CS[CloudBackupService]
        KS[KeychainService]
        CR[CryptoService]
        RL[RateLimitService]
    end

    subgraph Entities["Storage"]
        CK[(iCloud)]
        Files[(Files)]
        KC[(Keychain)]
    end

    BV --> CS
    BV --> RS
    BV --> EI
    BP --> CS

    CS --> KS
    CS --> CR
    CS --> CK

    KS --> KC

    EI --> CR
    EI --> RL
    EI --> Files

    RS --> LDK[LDKNode BIP39]

    style Views fill:#e3f2fd,stroke:#1976d2
    style Services fill:#f3e5f5,stroke:#7b1fa2
    style Entities fill:#e8f5e9,stroke:#388e3c
```

## File Format

```
+------------------+
| Magic: SBCKP001  |  8 bytes
+------------------+
| Version: 1       |  2 bytes (big-endian)
+------------------+
| Salt             | 32 bytes
+------------------+
| AES-GCM Blob     | variable
+------------------+
| Checksum (SHA256)| hex string
+------------------+
```

## Security

| Feature | Implementation |
|---------|-----------------|
| Encryption | AES-256-GCM via CryptoKit (authenticated) |
| Key Derivation | PBKDF2-HMAC-SHA256, 310,000 iterations |
| Key Storage | iCloud Keychain (kSecAttrSynchronizable) |
| File Format | Magic bytes + version header |
| Integrity | SHA256 checksum |
| Rate Limiting | 5 attempts, 30s lockout after 3 failures |
| Validation | BIP39 via LDKNode |


## Related

- Fixes #89 