### PR TITLE
stable-channels-lsp: SC REST handlers, push notifications, and the stability brain

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -109,6 +109,8 @@ min_payment_size_msat        = 1000000
 proxy_address = "127.0.0.1:9050"
 ```
 
+For the LdkLog route to return content, set `[log] file = "/some/path/ldk-server.log"` in the same config so a file exists to tail.
+
 Comment out the `[bitcoind]`, `[electrum]`, and `[liquidity.lsps2_client]` blocks. The `[tor]` block must stay uncommented even if Tor isn't running.
 
 ### 3. Configure the SC daemon
@@ -126,6 +128,8 @@ config_path = "/absolute/path/to/ldk-server/contrib/ldk-server-config.toml"
 ```
 
 `config_path` is how the SC daemon discovers LDK Server's TLS cert and api_key.
+
+For push notifications, add an optional `[push]` section with `apns_*` and `fcm_service_account_path` fields. Each is optional. Missing credentials disable that sender and log a warning at startup, but `RegisterPush` keeps working. See `server/stable-channels-lsp/example-config.toml` for the full schema.
 
 ### 4. Configure the desktop wallet
 

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 stable-channels   = { path = "../.." }
 sc-protos         = { path = "../sc-protos" }
 ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "3f98b857abfa9bcf660fd14db35be17cf79e03c6", features = ["serde"], default-features = false }
+# ldk-node is pulled transitively by stable-channels but we need it as a direct
+# dep so we can name `ldk_node::lightning::ln::types::ChannelId` etc. in our
+# module path. The rev must match the root Cargo.toml.
+ldk-node          = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
+hex               = "0.4"
 
 # HTTP/REST stack
 axum             = "0.8"
@@ -18,6 +23,17 @@ tower-http       = { version = "0.6", features = ["trace"] }
 # Protobuf wire format
 prost            = "0.11"
 bytes            = "1"
+
+# APNs push notifications.
+a2 = "0.10"
+
+# FCM (Android) push notifications: HTTPS + OAuth2 JWT.
+reqwest    = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde_json = "1"
+openssl    = { version = "0.10", default-features = false, features = ["vendored"] }
+
+# sqlite for the push tokens store (declared explicitly even though stable-channels pulls it transitively).
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 # HMAC + TLS
 bitcoin_hashes   = "0.14"
@@ -40,3 +56,4 @@ thiserror        = "1"
 
 [dev-dependencies]
 getrandom        = "0.2"
+tempfile         = "3"

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -14,6 +14,10 @@ ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev
 ldk-node          = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
 hex               = "0.4"
 
+# Async trait support for &dyn LdkServerCalls (stable Rust async-fn-in-trait
+# does not yet support trait objects).
+async-trait       = "0.1"
+
 # HTTP/REST stack
 axum             = "0.8"
 axum-server      = { version = "0.7", features = ["tls-rustls"] }

--- a/server/stable-channels-lsp/example-config.toml
+++ b/server/stable-channels-lsp/example-config.toml
@@ -26,3 +26,16 @@ config_path = "/path/to/ldk-server-config.toml"
 # grpc_address = "127.0.0.1:3536"
 # cert_path    = "/path/to/ldk-server/tls.crt"
 # api_key_path = "/path/to/ldk-server/regtest/api_key"
+
+# Push notifications. All fields optional. If a credentials file is missing
+# at startup, that sender is disabled and RegisterPush still works.
+[push]
+# APNs (iOS)
+apns_key_path            = "/path/to/AuthKey.p8"
+apns_key_id              = "<10-char Apple key id>"
+apns_team_id             = "<10-char Apple team id>"
+apns_topic               = "com.stablechannels.app"
+apns_environment         = "sandbox"          # "sandbox" or "production"
+
+# FCM (Android)
+fcm_service_account_path = "/path/to/firebase-service-account.json"

--- a/server/stable-channels-lsp/src/config.rs
+++ b/server/stable-channels-lsp/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     pub node: NodeConfig,
     pub storage: StorageConfig,
     pub ldk_server: LdkServerSection,
+    #[serde(default)]
+    pub push: Option<PushConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -38,6 +40,17 @@ pub struct LdkServerSection {
     pub api_key_path: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct PushConfig {
+    pub apns_key_path: Option<String>,
+    pub apns_key_id: Option<String>,
+    pub apns_team_id: Option<String>,
+    pub apns_topic: Option<String>,
+    /// "sandbox" or "production". Defaults to "sandbox" if absent.
+    pub apns_environment: Option<String>,
+    pub fcm_service_account_path: Option<String>,
+}
+
 impl Config {
     pub fn load(path: &std::path::Path) -> Result<Self, String> {
         let contents = std::fs::read_to_string(path)
@@ -66,6 +79,16 @@ impl Config {
     /// SC daemon's audit log file.
     pub fn audit_log_path(&self) -> PathBuf {
         PathBuf::from(&self.storage.disk.dir_path).join("audit_log.txt")
+    }
+
+    /// Resolve LDK Server's configured log file path. None if no config_path or no [log] file.
+    pub fn resolve_ldk_log_file(&self) -> Option<PathBuf> {
+        let path_str = self.ldk_server.config_path.as_deref()?;
+        let raw = std::fs::read_to_string(path_str).ok()?;
+        let parsed: toml::Value = toml::from_str(&raw).ok()?;
+        let log_section = parsed.get("log")?.as_table()?;
+        let file = log_section.get("file")?.as_str()?;
+        Some(PathBuf::from(file))
     }
 }
 
@@ -119,5 +142,52 @@ mod tests {
         let cfg: Config = toml::from_str(toml_text).unwrap();
         assert!(cfg.ldk_server.config_path.is_none());
         assert_eq!(cfg.ldk_server.grpc_address.as_deref(), Some("10.0.0.1:3536"));
+    }
+
+    #[test]
+    fn parses_push_section() {
+        let toml_text = r#"
+            [node]
+            rest_service_address = "127.0.0.1:3002"
+            network              = "regtest"
+
+            [storage.disk]
+            dir_path = "/tmp/sc-data"
+
+            [ldk_server]
+            config_path = "/etc/ldk-server/config.toml"
+
+            [push]
+            apns_key_path            = "/etc/sc/AuthKey.p8"
+            apns_key_id              = "ABC123KEY1"
+            apns_team_id             = "TEAM123456"
+            apns_topic               = "com.stablechannels.app"
+            apns_environment         = "sandbox"
+            fcm_service_account_path = "/etc/sc/firebase.json"
+        "#;
+        let cfg: Config = toml::from_str(toml_text).unwrap();
+        let push = cfg.push.expect("push section parsed");
+        assert_eq!(push.apns_key_path.as_deref(), Some("/etc/sc/AuthKey.p8"));
+        assert_eq!(push.apns_key_id.as_deref(), Some("ABC123KEY1"));
+        assert_eq!(push.apns_topic.as_deref(), Some("com.stablechannels.app"));
+        assert_eq!(push.apns_environment.as_deref(), Some("sandbox"));
+        assert_eq!(push.fcm_service_account_path.as_deref(), Some("/etc/sc/firebase.json"));
+    }
+
+    #[test]
+    fn push_section_is_optional() {
+        let toml_text = r#"
+            [node]
+            rest_service_address = "127.0.0.1:3002"
+            network              = "regtest"
+
+            [storage.disk]
+            dir_path = "/tmp/sc-data"
+
+            [ldk_server]
+            config_path = "/etc/ldk-server/config.toml"
+        "#;
+        let cfg: Config = toml::from_str(toml_text).unwrap();
+        assert!(cfg.push.is_none());
     }
 }

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -1,0 +1,89 @@
+//! Long-running SubscribeEvents loop: connects to LDK Server's event stream, reconnects with exponential backoff, and dispatches each EventEnvelope to its handler.
+
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use ldk_server_client::ldk_server_grpc::events::event_envelope::Event as EventVariant;
+use ldk_server_client::ldk_server_grpc::events::{ChannelState, EventEnvelope};
+
+use crate::stable_manager::LdkServerCalls;
+use crate::state::AppState;
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move { run(state).await });
+}
+
+async fn run(state: AppState) {
+    let mut backoff = Duration::from_secs(1);
+    loop {
+        let mut stream = match state.ldk_server.subscribe_events().await {
+            Ok(s) => {
+                backoff = Duration::from_secs(1);
+                s
+            },
+            Err(e) => {
+                warn!(
+                    "[event_loop] subscribe_events failed: {}; retry in {:?}",
+                    e, backoff
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = std::cmp::min(backoff * 2, Duration::from_secs(60));
+                continue;
+            },
+        };
+        info!("[event_loop] subscribed");
+        while let Some(item) = stream.next_message().await {
+            dispatch(item, &state).await;
+        }
+        warn!("[event_loop] stream ended; reconnecting");
+    }
+}
+
+async fn dispatch(
+    item: Result<EventEnvelope, ldk_server_client::error::LdkServerError>,
+    state: &AppState,
+) {
+    let envelope = match item {
+        Ok(e) => e,
+        Err(e) => {
+            warn!("[event_loop] item error: {}", e);
+            return;
+        },
+    };
+    let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+    let mut mgr = state.stable_manager.lock().await;
+    let ldk = state.ldk_server.as_ref() as &dyn LdkServerCalls;
+    match envelope.event {
+        Some(EventVariant::ChannelStateChanged(e)) => {
+            if e.state == ChannelState::Ready as i32 {
+                mgr.handle_channel_ready(
+                    e.channel_id.clone(),
+                    e.user_channel_id.clone(),
+                    ldk,
+                    btc_price,
+                )
+                .await;
+            } else if e.state == ChannelState::Closed as i32 {
+                mgr.handle_channel_closed(e.user_channel_id.clone());
+            }
+        },
+        Some(EventVariant::PaymentReceived(_)) => {
+            // Upstream PaymentReceived has no channel_id, so run_tick + reconcile_from_grpc catch up instead.
+            debug!("[event_loop] PaymentReceived (no channel_id available, deferred to tick)");
+        },
+        Some(EventVariant::PaymentForwarded(e)) => {
+            if let Some(fp) = e.forwarded_payment {
+                mgr.handle_payment_forwarded(
+                    fp.prev_user_channel_id,
+                    fp.outbound_amount_forwarded_msat.unwrap_or(0),
+                    fp.total_fee_earned_msat.unwrap_or(0),
+                    ldk,
+                    btc_price,
+                )
+                .await;
+            }
+        },
+        _ => {},
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/ldk_log.rs
+++ b/server/stable-channels-lsp/src/handlers/ldk_log.rs
@@ -25,8 +25,20 @@ pub async fn ldk_log(State(state): State<AppState>, body: Bytes) -> Response {
         return ok_response(LogResponse { content: String::new() });
     };
 
-    let content = read_tail_lines(path, req.max_lines as usize);
+    let content = read_tail_lines(path, effective_max_lines(req.max_lines as usize));
     ok_response(LogResponse { content })
+}
+
+/// Default tail length when a client passes `max_lines == 0`.
+const DEFAULT_LDK_LOG_LINES: usize = 200;
+
+/// Resolve the effective tail length: a request of 0 means "use the default".
+fn effective_max_lines(requested: usize) -> usize {
+    if requested == 0 {
+        DEFAULT_LDK_LOG_LINES
+    } else {
+        requested
+    }
 }
 
 /// Read the last `max_lines` lines from `path`. Returns empty string on any error.
@@ -59,7 +71,15 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
-    fn empty_max_lines_returns_empty() {
+    fn max_lines_zero_defaults_to_200() {
+        // A client request of 0 means use the default.
+        assert_eq!(effective_max_lines(0), 200);
+        assert_eq!(effective_max_lines(7), 7);
+    }
+
+    #[test]
+    fn read_tail_lines_zero_is_pure_empty() {
+        // The low-level reader treats 0 literally. The 0 -> default coercion is at the request boundary.
         let mut tmp = NamedTempFile::new().unwrap();
         writeln!(tmp, "line1").unwrap();
         assert_eq!(read_tail_lines(tmp.path(), 0), "");

--- a/server/stable-channels-lsp/src/handlers/ldk_log.rs
+++ b/server/stable-channels-lsp/src/handlers/ldk_log.rs
@@ -1,0 +1,91 @@
+//! LdkLog handler: tails LDK Server's log file and returns the last N lines.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+use tracing::warn;
+
+use sc_protos::stable::{LogRequest, LogResponse};
+
+use crate::handlers::{decode_body, ok_response};
+use crate::state::AppState;
+
+pub async fn ldk_log(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: LogRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let Some(path) = state.ldk_log_file.as_ref() else {
+        return ok_response(LogResponse { content: String::new() });
+    };
+
+    let content = read_tail_lines(path, req.max_lines as usize);
+    ok_response(LogResponse { content })
+}
+
+/// Read the last `max_lines` lines from `path`. Returns empty string on any error.
+fn read_tail_lines(path: &Path, max_lines: usize) -> String {
+    if max_lines == 0 {
+        return String::new();
+    }
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("[ldk-log] cannot open {}: {}", path.display(), e);
+            return String::new();
+        }
+    };
+    let reader = BufReader::new(file);
+    let mut buf: VecDeque<String> = VecDeque::with_capacity(max_lines);
+    for line in reader.lines().map_while(Result::ok) {
+        if buf.len() == max_lines {
+            buf.pop_front();
+        }
+        buf.push_back(line);
+    }
+    buf.into_iter().collect::<Vec<_>>().join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn empty_max_lines_returns_empty() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "line1").unwrap();
+        assert_eq!(read_tail_lines(tmp.path(), 0), "");
+    }
+
+    #[test]
+    fn fewer_lines_than_requested_returns_all() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "line1").unwrap();
+        writeln!(tmp, "line2").unwrap();
+        let out = read_tail_lines(tmp.path(), 10);
+        assert_eq!(out, "line1\nline2");
+    }
+
+    #[test]
+    fn more_lines_than_requested_returns_tail() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        for i in 1..=20 {
+            writeln!(tmp, "line{}", i).unwrap();
+        }
+        let out = read_tail_lines(tmp.path(), 3);
+        assert_eq!(out, "line18\nline19\nline20");
+    }
+
+    #[test]
+    fn missing_file_returns_empty() {
+        assert_eq!(read_tail_lines(Path::new("/nope/does/not/exist.log"), 5), "");
+    }
+}

--- a/server/stable-channels-lsp/src/handlers/mod.rs
+++ b/server/stable-channels-lsp/src/handlers/mod.rs
@@ -3,12 +3,14 @@
 pub mod audit_log;
 pub mod channels;
 pub mod graph;
+pub mod ldk_log;
 pub mod lightning;
 pub mod onchain;
 pub mod payments;
 pub mod peers;
 pub mod price;
 pub mod proxy;
+pub mod register_push;
 pub mod stable_channels;
 pub mod tools;
 

--- a/server/stable-channels-lsp/src/handlers/register_push.rs
+++ b/server/stable-channels-lsp/src/handlers/register_push.rs
@@ -1,0 +1,24 @@
+//! RegisterPush handler: wallets POST an APNs/FCM device token and Lightning node id, stored in push_tokens.db.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::response::Response;
+
+use sc_protos::stable::{RegisterPushRequest, RegisterPushResponse};
+
+use crate::handlers::{decode_body, ok_response};
+use crate::state::AppState;
+
+pub async fn register_push(State(state): State<AppState>, body: Bytes) -> Response {
+    let req: RegisterPushRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    {
+        let push = state.push.lock().await;
+        push.register_token(&req.token, &req.platform, &req.node_id, &req.environment);
+    }
+
+    ok_response(RegisterPushResponse { ok: true })
+}

--- a/server/stable-channels-lsp/src/handlers/stable_channels.rs
+++ b/server/stable-channels-lsp/src/handlers/stable_channels.rs
@@ -5,12 +5,14 @@ use axum::extract::State;
 use axum::response::Response;
 
 use sc_protos::stable::{
-    ListStableChannelsRequest, ListStableChannelsResponse, StableChannelInfo,
+    EditStableChannelRequest, EditStableChannelResponse, ListStableChannelsRequest,
+    ListStableChannelsResponse, StableChannelInfo,
 };
 use stable_channels::price_feeds::get_cached_price_no_fetch;
 use tracing::warn;
 
 use crate::handlers::{decode_body, error_response, ok_response};
+use crate::stable_manager::EditOutcome;
 use crate::state::AppState;
 use ldk_server_client::ldk_server_grpc::error::ErrorCode;
 
@@ -49,4 +51,30 @@ pub async fn list_stable_channels(
         .collect::<Vec<_>>();
 
     ok_response(ListStableChannelsResponse { channels })
+}
+
+pub async fn edit_stable_channel(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Response {
+    let req: EditStableChannelRequest = match decode_body(&body) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+
+    let EditOutcome { ok, status } = {
+        let mut mgr = state.stable_manager.lock().await;
+        mgr.edit_stable_channel(
+            &req.channel_id,
+            req.expected_usd,
+            req.note,
+            state.ldk_server.as_ref(),
+            btc_price,
+        )
+        .await
+    };
+
+    ok_response(EditStableChannelResponse { ok, status })
 }

--- a/server/stable-channels-lsp/src/handlers/stable_channels.rs
+++ b/server/stable-channels-lsp/src/handlers/stable_channels.rs
@@ -1,4 +1,4 @@
-//! ListStableChannels handler. Reads from the SC daemon's sqlite store.
+//! ListStableChannels handler. Reads from the in-memory StableChannelManager.
 
 use axum::body::Bytes;
 use axum::extract::State;
@@ -9,12 +9,10 @@ use sc_protos::stable::{
     ListStableChannelsResponse, StableChannelInfo,
 };
 use stable_channels::price_feeds::get_cached_price_no_fetch;
-use tracing::warn;
 
-use crate::handlers::{decode_body, error_response, ok_response};
+use crate::handlers::{decode_body, ok_response};
 use crate::stable_manager::EditOutcome;
 use crate::state::AppState;
-use ldk_server_client::ldk_server_grpc::error::ErrorCode;
 
 pub async fn list_stable_channels(
     State(state): State<AppState>,
@@ -24,31 +22,23 @@ pub async fn list_stable_channels(
         return resp;
     }
 
-    let entries = match state.db.load_all_channels() {
-        Ok(e) => e,
-        Err(e) => {
-            warn!("load_all_channels failed: {}", e);
-            return error_response(
-                ErrorCode::InternalServerError,
-                format!("Failed to load stable channels: {}", e),
-            );
-        },
-    };
-
     let latest_price = get_cached_price_no_fetch();
 
-    let channels = entries
-        .into_iter()
-        .map(|e| StableChannelInfo {
-            channel_id: e.channel_id,
-            counterparty: String::new(),
-            expected_usd: e.expected_usd,
-            expected_msats: e.backing_sats.saturating_mul(1_000),
+    let mgr = state.stable_manager.lock().await;
+    let channels = mgr
+        .stable_channels
+        .iter()
+        .map(|sc| StableChannelInfo {
+            channel_id: sc.channel_id.to_string(),
+            counterparty: sc.counterparty.to_string(),
+            expected_usd: sc.expected_usd.0,
+            expected_msats: sc.backing_sats.saturating_mul(1_000),
             latest_price,
-            note: e.note.unwrap_or_default(),
-            is_stable_receiver: false,
+            note: sc.note.clone().unwrap_or_default(),
+            is_stable_receiver: sc.is_stable_receiver,
         })
         .collect::<Vec<_>>();
+    drop(mgr);
 
     ok_response(ListStableChannelsResponse { channels })
 }
@@ -70,7 +60,7 @@ pub async fn edit_stable_channel(
             &req.channel_id,
             req.expected_usd,
             req.note,
-            state.ldk_server.as_ref(),
+            state.ldk_server.as_ref() as &dyn crate::stable_manager::LdkServerCalls,
             btc_price,
         )
         .await

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -1,8 +1,10 @@
 mod auth;
 mod config;
+mod event_loop;
 mod handlers;
 mod price_task;
 mod push;
+mod stability_tick;
 mod stable_manager;
 mod state;
 mod tls;
@@ -120,6 +122,23 @@ async fn main() -> Result<()> {
     tokio::spawn(async move {
         price_task::run().await;
     });
+
+    // One-shot reconcile from gRPC to catch up snapshots changed while the daemon was down. Skipped if the price cache is cold.
+    {
+        let btc_price = stable_channels::price_feeds::get_cached_price();
+        if btc_price > 0.0 {
+            let mut mgr = state.stable_manager.lock().await;
+            mgr.reconcile_from_grpc(
+                state.ldk_server.as_ref() as &dyn crate::stable_manager::LdkServerCalls,
+                btc_price,
+            )
+            .await;
+        } else {
+            tracing::warn!("startup reconcile skipped: price cache cold");
+        }
+    }
+    event_loop::spawn(state.clone());
+    stability_tick::spawn(state.clone());
 
     let router = Router::new()
         .route("/GetNodeInfo", post(handlers::proxy::get_node_info))

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -2,6 +2,8 @@ mod auth;
 mod config;
 mod handlers;
 mod price_task;
+mod push;
+mod stable_manager;
 mod state;
 mod tls;
 
@@ -14,7 +16,10 @@ use axum::Router;
 use clap::Parser;
 use ldk_server_client::client::LdkServerClient;
 use ldk_server_client::config as ldk_config;
-use sc_protos::stable::{AUDIT_LOG_PATH, GET_PRICE_PATH, LIST_STABLE_CHANNELS_PATH};
+use sc_protos::stable::{
+    AUDIT_LOG_PATH, EDIT_STABLE_CHANNEL_PATH, GET_PRICE_PATH, LDK_LOG_PATH,
+    LIST_STABLE_CHANNELS_PATH, REGISTER_PUSH_PATH,
+};
 use ldk_server_client::ldk_server_grpc::endpoints::{
     BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
     CLOSE_CHANNEL_PATH, CONNECT_PEER_PATH, DISCONNECT_PEER_PATH, EXPORT_PATHFINDING_SCORES_PATH,
@@ -78,19 +83,38 @@ async fn main() -> Result<()> {
     let (ldk_server, ldk_addr) = build_ldk_server_client(&cfg)?;
     info!("LDK Server gRPC endpoint: {}", ldk_addr);
 
+    let ldk_log_file = cfg.resolve_ldk_log_file();
+    match &ldk_log_file {
+        Some(p) => info!("LDK Server log file path: {}", p.display()),
+        None => info!("LDK Server log file path not configured; /LdkLog will return empty"),
+    }
+
     let db = Database::open(&data_dir).map_err(|e| anyhow::anyhow!("DB open failed: {}", e))?;
     let channel_count = db
         .load_all_channels()
         .map_err(|e| anyhow::anyhow!("load_all_channels failed: {}", e))?
         .len();
     info!("loaded {} stable channel records from sqlite", channel_count);
+    let db_arc = Arc::new(db);
+
+    let push_cfg = cfg.push.clone().unwrap_or_default();
+    let push_service = crate::push::PushService::new(&push_cfg, &data_dir);
+    info!("push service initialized");
+
+    let stable_manager = crate::stable_manager::StableChannelManager::new(
+        Arc::clone(&db_arc),
+        data_dir.clone(),
+    );
 
     let state = AppState {
         ldk_server: Arc::new(ldk_server),
         api_key: Arc::new(api_key),
         data_dir: data_dir.clone(),
         network: cfg.node.network.clone(),
-        db: Arc::new(db),
+        db: db_arc,
+        push: Arc::new(tokio::sync::Mutex::new(push_service)),
+        stable_manager: Arc::new(tokio::sync::Mutex::new(stable_manager)),
+        ldk_log_file,
     };
 
     tokio::spawn(async move {
@@ -144,8 +168,20 @@ async fn main() -> Result<()> {
             post(handlers::stable_channels::list_stable_channels),
         )
         .route(
+            &format!("/{}", EDIT_STABLE_CHANNEL_PATH),
+            post(handlers::stable_channels::edit_stable_channel),
+        )
+        .route(
+            &format!("/{}", REGISTER_PUSH_PATH),
+            post(handlers::register_push::register_push),
+        )
+        .route(
             &format!("/{}", AUDIT_LOG_PATH),
             post(handlers::audit_log::audit_log),
+        )
+        .route(
+            &format!("/{}", LDK_LOG_PATH),
+            post(handlers::ldk_log::ldk_log),
         )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/server/stable-channels-lsp/src/push/apns.rs
+++ b/server/stable-channels-lsp/src/push/apns.rs
@@ -64,13 +64,18 @@ impl ApnsService {
     /// Send a wake-up notification to the device token. Direction ("incoming"/"outgoing") rides in the payload.
     pub async fn send(&self, device_token: &str, direction: &str, environment: &str) {
         let _ = environment;
-        let body = format!("Lightning {direction} payment pending");
+        let body = match direction {
+            "lsp_to_user" => "Receiving stability payment...",
+            "user_to_lsp" => "Sending stability payment...",
+            _ => "Processing payment...",
+        };
         let builder = DefaultNotificationBuilder::new()
-            .set_title("Stable Channels")
-            .set_body(&body)
+            .set_title("Stability Update")
+            .set_body(body)
+            .set_sound("default")
             .set_mutable_content()
             .set_content_available();
-        let payload = builder.build(
+        let mut payload = builder.build(
             device_token,
             NotificationOptions {
                 apns_topic: Some(&self.topic),
@@ -78,6 +83,9 @@ impl ApnsService {
                 ..Default::default()
             },
         );
+        let mut stability_data = std::collections::HashMap::new();
+        stability_data.insert("direction", direction);
+        let _ = payload.add_custom_data("stability", &stability_data);
         match self.client.send(payload).await {
             Ok(resp) => info!(
                 "[apns] Sent push to {} (code={})",

--- a/server/stable-channels-lsp/src/push/apns.rs
+++ b/server/stable-channels-lsp/src/push/apns.rs
@@ -1,0 +1,118 @@
+//! APNs (iOS) push sender. try_new returns None (send() then no-ops) when [push] credentials or AuthKey.p8 are missing.
+
+use a2::{
+    Client as ApnsClient, ClientConfig as ApnsClientConfig, DefaultNotificationBuilder,
+    NotificationBuilder, NotificationOptions, Priority,
+};
+use std::fs::File;
+use tracing::{info, warn};
+
+use crate::config::PushConfig;
+
+#[derive(Clone)]
+pub struct ApnsService {
+    client: ApnsClient,
+    topic: String,
+}
+
+impl ApnsService {
+    /// Build an APNs client from config. None if a required credential or the key file is missing.
+    pub fn try_new(cfg: &PushConfig) -> Option<Self> {
+        let key_path = cfg.apns_key_path.as_deref()?;
+        let key_id = cfg.apns_key_id.as_deref()?;
+        let team_id = cfg.apns_team_id.as_deref()?;
+        let topic = cfg.apns_topic.as_deref()?;
+        let env = cfg.apns_environment.as_deref().unwrap_or("sandbox");
+
+        let mut key_file = match File::open(key_path) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(
+                    "[apns] AuthKey file unreadable at {}: {}. APNs disabled.",
+                    key_path, e
+                );
+                return None;
+            }
+        };
+
+        let endpoint = if env == "production" {
+            a2::Endpoint::Production
+        } else {
+            a2::Endpoint::Sandbox
+        };
+
+        let client = match ApnsClient::token(
+            &mut key_file,
+            key_id,
+            team_id,
+            ApnsClientConfig::new(endpoint),
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("[apns] Failed to construct client: {}. APNs disabled.", e);
+                return None;
+            }
+        };
+
+        info!("[apns] enabled, topic={}, env={}", topic, env);
+        Some(Self {
+            client,
+            topic: topic.to_string(),
+        })
+    }
+
+    /// Send a wake-up notification to the device token. Direction ("incoming"/"outgoing") rides in the payload.
+    pub async fn send(&self, device_token: &str, direction: &str, environment: &str) {
+        let _ = environment;
+        let body = format!("Lightning {direction} payment pending");
+        let builder = DefaultNotificationBuilder::new()
+            .set_title("Stable Channels")
+            .set_body(&body)
+            .set_mutable_content()
+            .set_content_available();
+        let payload = builder.build(
+            device_token,
+            NotificationOptions {
+                apns_topic: Some(&self.topic),
+                apns_priority: Some(Priority::High),
+                ..Default::default()
+            },
+        );
+        match self.client.send(payload).await {
+            Ok(resp) => info!(
+                "[apns] Sent push to {} (code={})",
+                &device_token[..device_token.len().min(16)],
+                resp.code,
+            ),
+            Err(e) => warn!(
+                "[apns] Send failed for {}: {}",
+                &device_token[..device_token.len().min(16)],
+                e
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_new_returns_none_when_any_field_missing() {
+        let cfg = PushConfig::default();
+        assert!(ApnsService::try_new(&cfg).is_none());
+    }
+
+    #[test]
+    fn try_new_returns_none_when_key_file_missing() {
+        let cfg = PushConfig {
+            apns_key_path: Some("/nonexistent/AuthKey.p8".to_string()),
+            apns_key_id: Some("KEY123".to_string()),
+            apns_team_id: Some("TEAM123".to_string()),
+            apns_topic: Some("com.example.app".to_string()),
+            apns_environment: Some("sandbox".to_string()),
+            fcm_service_account_path: None,
+        };
+        assert!(ApnsService::try_new(&cfg).is_none());
+    }
+}

--- a/server/stable-channels-lsp/src/push/fcm.rs
+++ b/server/stable-channels-lsp/src/push/fcm.rs
@@ -1,0 +1,167 @@
+//! FCM (Android) push sender. try_new returns None when fcm_service_account_path is unset or the file is unreadable.
+
+use serde::Deserialize;
+use std::path::Path;
+use tracing::{error, info, warn};
+
+use crate::config::PushConfig;
+
+#[derive(Clone)]
+pub struct FcmService {
+    credentials: FcmCredentials,
+}
+
+#[derive(Clone, Deserialize)]
+struct FcmCredentials {
+    private_key: String,
+    client_email: String,
+    project_id: String,
+}
+
+impl FcmService {
+    pub fn try_new(cfg: &PushConfig) -> Option<Self> {
+        let path = cfg.fcm_service_account_path.as_deref()?;
+        if !Path::new(path).exists() {
+            warn!("[fcm] service account file missing at {}. FCM disabled.", path);
+            return None;
+        }
+        let contents = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("[fcm] failed to read {}: {}. FCM disabled.", path, e);
+                return None;
+            }
+        };
+        let credentials: FcmCredentials = match serde_json::from_str(&contents) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("[fcm] invalid service account JSON at {}: {}. FCM disabled.", path, e);
+                return None;
+            }
+        };
+        info!("[fcm] enabled, service_account_path={}", path);
+        Some(Self { credentials })
+    }
+
+    pub async fn send(&self, token: &str, direction: &str, node_id: &str) {
+        let creds = &self.credentials;
+
+        let access_token = match generate_access_token(creds).await {
+            Some(t) => t,
+            None => { error!("[fcm] Failed to generate access token"); return; }
+        };
+
+        let url = format!(
+            "https://fcm.googleapis.com/v1/projects/{}/messages:send",
+            creds.project_id
+        );
+
+        let body = serde_json::json!({
+            "message": {
+                "token": token,
+                "data": {
+                    "stability": serde_json::json!({
+                        "direction": direction,
+                        "node_id": node_id,
+                    }).to_string()
+                },
+                "android": {
+                    "priority": "high"
+                }
+            }
+        });
+
+        match reqwest::Client::new()
+            .post(&url)
+            .bearer_auth(&access_token)
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    info!("[fcm] Push sent to {}...", &token[..8.min(token.len())]);
+                } else {
+                    let text = resp.text().await.unwrap_or_default();
+                    error!("[fcm] Push failed ({}): {}", status, text);
+                }
+            }
+            Err(e) => error!("[fcm] Request failed: {}", e),
+        }
+    }
+}
+
+async fn generate_access_token(creds: &FcmCredentials) -> Option<String> {
+    use openssl::base64;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::sign::Signer;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+
+    let header = serde_json::json!({"alg": "RS256", "typ": "JWT"});
+    let claims = serde_json::json!({
+        "iss": creds.client_email,
+        "scope": "https://www.googleapis.com/auth/firebase.messaging",
+        "aud": "https://oauth2.googleapis.com/token",
+        "iat": now,
+        "exp": now + 3600,
+    });
+
+    let b64_encode = |data: &[u8]| -> String {
+        base64::encode_block(data)
+            .replace('+', "-")
+            .replace('/', "_")
+            .replace('=', "")
+    };
+
+    let header_b64 = b64_encode(header.to_string().as_bytes());
+    let claims_b64 = b64_encode(claims.to_string().as_bytes());
+    let signing_input = format!("{}.{}", header_b64, claims_b64);
+
+    let pkey = PKey::private_key_from_pem(creds.private_key.as_bytes()).ok()?;
+    let mut signer = Signer::new(MessageDigest::sha256(), &pkey).ok()?;
+    signer.update(signing_input.as_bytes()).ok()?;
+    let signature = signer.sign_to_vec().ok()?;
+    let sig_b64 = b64_encode(&signature);
+
+    let jwt = format!("{}.{}", signing_input, sig_b64);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", &jwt),
+        ])
+        .send()
+        .await
+        .ok()?;
+
+    let json: serde_json::Value = resp.json().await.ok()?;
+    json.get("access_token")?.as_str().map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_new_returns_none_when_path_missing() {
+        let cfg = PushConfig::default();
+        assert!(FcmService::try_new(&cfg).is_none());
+    }
+
+    #[test]
+    fn try_new_returns_none_when_file_does_not_exist() {
+        let cfg = PushConfig {
+            fcm_service_account_path: Some("/nonexistent/firebase.json".to_string()),
+            ..Default::default()
+        };
+        assert!(FcmService::try_new(&cfg).is_none());
+    }
+}

--- a/server/stable-channels-lsp/src/push/mod.rs
+++ b/server/stable-channels-lsp/src/push/mod.rs
@@ -1,0 +1,95 @@
+pub mod apns;
+pub mod fcm;
+pub mod tokens;
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Instant;
+
+use tracing::{info, warn};
+
+use crate::config::PushConfig;
+
+const PUSH_COOLDOWN_SECS: u64 = 600; // 10 minutes
+
+pub struct PushService {
+    apns: Option<apns::ApnsService>,
+    fcm: Option<fcm::FcmService>,
+    data_dir: String,
+    last_push_sent: HashMap<String, Instant>,
+}
+
+impl PushService {
+    pub fn new(cfg: &PushConfig, data_dir: &Path) -> Self {
+        tokens::init_db(data_dir);
+        Self {
+            apns: apns::ApnsService::try_new(cfg),
+            fcm: fcm::FcmService::try_new(cfg),
+            data_dir: data_dir.to_string_lossy().to_string(),
+            last_push_sent: HashMap::new(),
+        }
+    }
+
+    /// Persist a wallet's device token. Called by the RegisterPush handler.
+    pub fn register_token(&self, token: &str, platform: &str, node_id: &str, environment: &str) {
+        tokens::save_token(&self.data_dir, token, platform, node_id, environment);
+    }
+
+    /// Whether enough time has elapsed since the last push to this node.
+    pub fn should_notify(&self, node_id: &str) -> bool {
+        match self.last_push_sent.get(node_id) {
+            Some(last) => last.elapsed().as_secs() >= PUSH_COOLDOWN_SECS,
+            None => true,
+        }
+    }
+
+    fn mark_notified(&mut self, node_id: &str) {
+        self.last_push_sent.insert(node_id.to_string(), Instant::now());
+    }
+
+    /// Send a wake notification to the given Lightning node id.
+    pub fn notify(&mut self, node_id: &str, direction: &str) {
+        if !self.should_notify(node_id) {
+            info!("[push] Skipping notification for {} (cooldown)", node_id);
+            return;
+        }
+
+        let token_info = match tokens::load_token_for_node(&self.data_dir, node_id) {
+            Some(t) => t,
+            None => {
+                warn!("[push] No push token registered for node {}", node_id);
+                return;
+            }
+        };
+
+        self.mark_notified(node_id);
+
+        let token = token_info.token.clone();
+        let platform = token_info.platform.clone();
+        let environment = token_info.environment.clone();
+        let node_id_owned = node_id.to_string();
+        let direction_owned = direction.to_string();
+
+        if platform == "android" {
+            match self.fcm.clone() {
+                Some(fcm) => {
+                    tokio::spawn(async move {
+                        fcm.send(&token, &direction_owned, &node_id_owned).await;
+                    });
+                }
+                None => warn!("[push] android platform but FCM disabled, would have sent to {}", node_id),
+            }
+        } else {
+            match self.apns.clone() {
+                Some(apns) => {
+                    tokio::spawn(async move {
+                        apns.send(&token, &direction_owned, &environment).await;
+                    });
+                }
+                None => warn!("[push] ios platform but APNs disabled, would have sent to {}", node_id),
+            }
+        }
+
+        info!("[push] Sent {} notification to {} ({})", direction, node_id, platform);
+    }
+}

--- a/server/stable-channels-lsp/src/push/tokens.rs
+++ b/server/stable-channels-lsp/src/push/tokens.rs
@@ -1,0 +1,130 @@
+//! sqlite-backed device-token store for push notifications.
+
+use tracing::{error, info};
+use rusqlite::Connection;
+use std::path::Path;
+
+pub struct TokenInfo {
+    pub token: String,
+    pub platform: String,
+    pub environment: String,
+}
+
+fn db_path(data_dir: &str) -> String {
+    format!("{}/push_tokens.db", data_dir)
+}
+
+pub fn init_db(data_dir: &Path) {
+    let path = db_path(&data_dir.to_string_lossy());
+    let conn = match Connection::open(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("[push-tokens] Failed to open DB: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS push_tokens (
+            device_token  TEXT PRIMARY KEY,
+            platform      TEXT NOT NULL,
+            registered_at INTEGER,
+            node_id       TEXT,
+            environment   TEXT,
+            last_seen     INTEGER
+        )",
+    ) {
+        error!("[push-tokens] Failed to create table: {}", e);
+    }
+}
+
+pub fn save_token(data_dir: &str, token: &str, platform: &str, node_id: &str, environment: &str) {
+    let path = db_path(data_dir);
+    let conn = match Connection::open(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("[push-tokens] Failed to open DB: {}", e);
+            return;
+        }
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+
+    match conn.execute(
+        "INSERT OR REPLACE INTO push_tokens
+         (device_token, platform, registered_at, node_id, environment, last_seen)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![token, platform, now, node_id, environment, now],
+    ) {
+        Ok(_) => info!("[push-tokens] Saved token for node {} ({})", node_id, platform),
+        Err(e) => error!("[push-tokens] Failed to save token: {}", e),
+    }
+}
+
+pub fn load_token_for_node(data_dir: &str, node_id: &str) -> Option<TokenInfo> {
+    let path = db_path(data_dir);
+    let conn = Connection::open(&path).ok()?;
+
+    let cutoff = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+        - (30 * 86400);
+
+    conn.query_row(
+        "SELECT device_token, platform, environment FROM push_tokens
+         WHERE node_id = ?1 AND last_seen > ?2
+         ORDER BY last_seen DESC LIMIT 1",
+        rusqlite::params![node_id, cutoff],
+        |row| {
+            Ok(TokenInfo {
+                token: row.get(0)?,
+                platform: row.get(1)?,
+                environment: row
+                    .get::<_, Option<String>>(2)?
+                    .unwrap_or_else(|| "sandbox".to_string()),
+            })
+        },
+    )
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn save_then_load_returns_token() {
+        let dir = tempdir().unwrap();
+        init_db(dir.path());
+        let data_dir = dir.path().to_string_lossy().to_string();
+        save_token(&data_dir, "abc123", "ios", "node-pubkey", "sandbox");
+        let info = load_token_for_node(&data_dir, "node-pubkey").expect("token must exist");
+        assert_eq!(info.token, "abc123");
+        assert_eq!(info.platform, "ios");
+        assert_eq!(info.environment, "sandbox");
+    }
+
+    #[test]
+    fn replace_updates_token_and_environment() {
+        let dir = tempdir().unwrap();
+        init_db(dir.path());
+        let data_dir = dir.path().to_string_lossy().to_string();
+        save_token(&data_dir, "abc", "ios", "node-x", "sandbox");
+        save_token(&data_dir, "abc", "ios", "node-x", "production");
+        let info = load_token_for_node(&data_dir, "node-x").expect("token must exist");
+        assert_eq!(info.environment, "production");
+    }
+
+    #[test]
+    fn missing_node_returns_none() {
+        let dir = tempdir().unwrap();
+        init_db(dir.path());
+        let data_dir = dir.path().to_string_lossy().to_string();
+        assert!(load_token_for_node(&data_dir, "nope").is_none());
+    }
+}

--- a/server/stable-channels-lsp/src/stability_tick.rs
+++ b/server/stable-channels-lsp/src/stability_tick.rs
@@ -1,0 +1,35 @@
+//! Periodic stability tick: every STABILITY_CHECK_INTERVAL_SECS, run_tick detects USD drift and either sends a stability payment or wakes the offline peer.
+
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+use tracing::{info, warn};
+
+use crate::stable_manager::LdkServerCalls;
+use crate::state::AppState;
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move { run(state).await });
+}
+
+async fn run(state: AppState) {
+    let interval_secs = stable_channels::constants::STABILITY_CHECK_INTERVAL_SECS;
+    let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    info!("[stability_tick] running every {}s", interval_secs);
+    loop {
+        ticker.tick().await;
+        let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+        if btc_price <= 0.0 {
+            warn!("[stability_tick] price cache cold; skipping");
+            continue;
+        }
+        let mut mgr = state.stable_manager.lock().await;
+        mgr.run_tick(
+            state.ldk_server.as_ref() as &dyn LdkServerCalls,
+            &state.push,
+            btc_price,
+        )
+        .await;
+    }
+}

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -206,7 +206,9 @@ impl StableChannelManager {
         }
     }
 
-    /// Remove the stable_channel record from memory + DB when a channel closes.
+    /// Remove the stable_channel record from in-memory state when a channel
+    /// closes, and soft-close the DB row (preserved for forensics, excluded
+    /// from future reconcile/tick reads).
     pub fn handle_channel_closed(&mut self, user_channel_id: String) {
         let target = parse_user_channel_id(&user_channel_id);
         self.stable_channels.retain(|sc| {
@@ -216,9 +218,9 @@ impl StableChannelManager {
                 format!("{}", sc.user_channel_id) != user_channel_id
             }
         });
-        if let Err(e) = self.db.delete_channel(&user_channel_id) {
+        if let Err(e) = self.db.mark_channel_closed(&user_channel_id) {
             tracing::error!(
-                "[stable] handle_channel_closed: db.delete_channel failed for {}: {}",
+                "[stable] handle_channel_closed: db.mark_channel_closed failed for {}: {}",
                 user_channel_id, e
             );
         }
@@ -268,15 +270,18 @@ impl StableChannelManager {
                 .and_then(|uid| by_user_channel_id.get(&uid).map(|c| (uid, c)));
 
             let Some((user_channel_id_u128, c)) = live else {
-                // Channel closed while the daemon was down: drop from db, audit.
-                if let Err(e) = self.db.delete_channel(&record.user_channel_id) {
+                // Channel not in current live snapshot — soft-close in DB so
+                // forensics survive a transient gRPC blip. If the channel
+                // comes back on a future reconcile or save_channel call,
+                // closed_at is cleared automatically.
+                if let Err(e) = self.db.mark_channel_closed(&record.user_channel_id) {
                     tracing::error!(
-                        "[stable] reconcile: db.delete_channel({}) failed: {}",
+                        "[stable] reconcile: db.mark_channel_closed({}) failed: {}",
                         record.user_channel_id, e
                     );
                 }
                 stable_channels::audit::audit_event(
-                    "CHANNEL_DROPPED_AT_STARTUP",
+                    "CHANNEL_MARKED_CLOSED_AT_STARTUP",
                     serde_json::json!({ "user_channel_id": record.user_channel_id }),
                 );
                 continue;

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -1,0 +1,237 @@
+//! In-memory stable-channel manager, backed by the shared sqlite channels table.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ldk_server_client::client::LdkServerClient;
+use ldk_server_client::ldk_server_grpc::api::ListChannelsRequest;
+use ldk_server_client::ldk_server_grpc::types::Channel;
+use stable_channels::db::Database;
+use stable_channels::types::{Bitcoin, StableChannel, USD};
+use tracing::{error, info};
+
+/// In-memory list of stable channels plus a handle to the shared sqlite channels table.
+pub struct StableChannelManager {
+    pub stable_channels: Vec<StableChannel>,
+    db: Arc<Database>,
+    data_dir: PathBuf,
+}
+
+/// Outcome of an `edit_stable_channel` call.
+#[derive(Debug, PartialEq)]
+pub struct EditOutcome {
+    pub ok: bool,
+    pub status: String,
+}
+
+impl StableChannelManager {
+    pub fn new(db: Arc<Database>, data_dir: PathBuf) -> Self {
+        Self {
+            stable_channels: Vec::new(),
+            db,
+            data_dir,
+        }
+    }
+
+    /// Validate, patch expected_usd/note (Some sets, None keeps prior, both-None-no-prior rejected), persist, and update the cache.
+    pub async fn edit_stable_channel(
+        &mut self,
+        channel_id: &str,
+        expected_usd_in: Option<f64>,
+        note_in: Option<String>,
+        ldk_server: &LdkServerClient,
+        btc_price: f64,
+    ) -> EditOutcome {
+        let channels_resp = match ldk_server.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!("[stable] list_channels gRPC failed: {}", e);
+                return EditOutcome {
+                    ok: false,
+                    status: format!("list_channels failed: {}", e),
+                };
+            }
+        };
+
+        let Some(channel) = channels_resp
+            .channels
+            .into_iter()
+            .find(|c| c.channel_id == channel_id)
+        else {
+            return EditOutcome {
+                ok: false,
+                status: format!("No channel matching: {}", channel_id),
+            };
+        };
+
+        // Snapshot of any existing record for patch fallback.
+        let user_channel_id_str = channel.user_channel_id.clone();
+        let prior = self
+            .stable_channels
+            .iter()
+            .find(|sc| format!("{}", sc.user_channel_id) == user_channel_id_str);
+
+        let prior_target = prior.map(|p| p.expected_usd.0);
+        let prior_note = prior.and_then(|p| p.note.clone());
+
+        let expected_usd_f = match (expected_usd_in, prior_target) {
+            (Some(v), _) => v,
+            (None, Some(prev)) => prev,
+            (None, None) => 0.0,
+        };
+        let note = match (note_in.clone(), prior_note) {
+            (Some(s), _) => Some(s),
+            (None, Some(prev)) => Some(prev),
+            (None, None) => None,
+        };
+
+        if expected_usd_in.is_none() && note_in.is_none() && prior.is_none() {
+            return EditOutcome {
+                ok: false,
+                status: "No changes provided".to_string(),
+            };
+        }
+
+        let expected_usd = USD::from_f64(expected_usd_f);
+        let expected_btc = Bitcoin::from_usd(expected_usd, btc_price);
+
+        let unspendable = channel.unspendable_punishment_reserve.unwrap_or(0);
+        let our_balance_sats = (channel.outbound_capacity_msat / 1000) + unspendable;
+        let their_balance_sats = channel.channel_value_sats.saturating_sub(our_balance_sats);
+
+        let stable_provider_btc = Bitcoin::from_sats(our_balance_sats);
+        let stable_receiver_btc = Bitcoin::from_sats(their_balance_sats);
+        let stable_provider_usd = USD::from_bitcoin(stable_provider_btc, btc_price);
+        let stable_receiver_usd = USD::from_bitcoin(stable_receiver_btc, btc_price);
+
+        let backing_sats = if btc_price > 0.0 {
+            ((expected_usd_f / btc_price) * 100_000_000.0) as u64
+        } else {
+            0
+        };
+        let native_sats = their_balance_sats.saturating_sub(backing_sats);
+
+        let user_channel_id_u128 = u128::from_str_radix(
+            user_channel_id_str.trim_start_matches("0x"),
+            16,
+        )
+        .unwrap_or(0);
+
+        let new_sc = build_stable_channel(
+            &channel,
+            user_channel_id_u128,
+            expected_usd,
+            expected_btc,
+            stable_provider_btc,
+            stable_receiver_btc,
+            stable_provider_usd,
+            stable_receiver_usd,
+            backing_sats,
+            native_sats,
+            note.clone(),
+            btc_price,
+            self.data_dir.clone(),
+        );
+
+        if let Err(e) = self.db.save_channel(
+            &channel.channel_id,
+            &user_channel_id_str,
+            expected_usd_f,
+            backing_sats,
+            native_sats,
+            note.as_deref(),
+        ) {
+            return EditOutcome {
+                ok: false,
+                status: format!("DB write failed: {}", e),
+            };
+        }
+
+        self.stable_channels
+            .retain(|sc| format!("{}", sc.user_channel_id) != user_channel_id_str);
+        self.stable_channels.push(new_sc);
+
+        info!(
+            "[stable] edited channel={} user_channel_id={} expected_usd={}",
+            channel_id, user_channel_id_str, expected_usd_f
+        );
+
+        EditOutcome {
+            ok: true,
+            status: format!("Set expected_usd={} on channel {}", expected_usd_f, channel_id),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_stable_channel(
+    channel: &Channel,
+    user_channel_id: u128,
+    expected_usd: USD,
+    expected_btc: Bitcoin,
+    stable_provider_btc: Bitcoin,
+    stable_receiver_btc: Bitcoin,
+    stable_provider_usd: USD,
+    stable_receiver_usd: USD,
+    backing_sats: u64,
+    native_sats: u64,
+    note: Option<String>,
+    btc_price: f64,
+    sc_dir: PathBuf,
+) -> StableChannel {
+    let channel_id_bytes = parse_channel_id_hex(&channel.channel_id);
+    let counterparty = parse_pubkey_hex(&channel.counterparty_node_id);
+
+    StableChannel {
+        channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(channel_id_bytes),
+        user_channel_id,
+        counterparty,
+        is_stable_receiver: false,
+        expected_usd,
+        expected_btc,
+        stable_receiver_btc,
+        stable_receiver_usd,
+        stable_provider_btc,
+        stable_provider_usd,
+        latest_price: btc_price,
+        risk_level: 0,
+        payment_made: false,
+        timestamp: 0,
+        formatted_datetime: String::new(),
+        sc_dir: sc_dir.to_string_lossy().to_string(),
+        prices: String::new(),
+        onchain_btc: Bitcoin::from_sats(0),
+        onchain_usd: USD(0.0),
+        note,
+        native_channel_btc: Bitcoin::from_sats(0),
+        backing_sats,
+        native_sats,
+        last_stability_payment: 0,
+    }
+}
+
+fn parse_channel_id_hex(s: &str) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    if let Ok(bytes) = hex::decode(s) {
+        let n = bytes.len().min(32);
+        buf[..n].copy_from_slice(&bytes[..n]);
+    }
+    buf
+}
+
+fn parse_pubkey_hex(s: &str) -> ldk_node::bitcoin::secp256k1::PublicKey {
+    use std::str::FromStr;
+    ldk_node::bitcoin::secp256k1::PublicKey::from_str(s).unwrap_or_else(|_| {
+        let mut buf = [2u8; 33];
+        buf[1] = 0;
+        ldk_node::bitcoin::secp256k1::PublicKey::from_slice(&buf)
+            .expect("static dummy pubkey is valid")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // Unit-testing edit_stable_channel without a real LdkServerClient is awkward
+    // because LdkServerClient does not expose a trait we can mock. For Bucket 2
+    // we cover the patch semantics indirectly through Task 14's Mutinynet smoke test.
+}

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -3,12 +3,46 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use ldk_server_client::client::LdkServerClient;
-use ldk_server_client::ldk_server_grpc::api::ListChannelsRequest;
+use ldk_server_client::error::LdkServerError;
+use ldk_server_client::ldk_server_grpc::api::{
+    ListChannelsRequest, ListChannelsResponse, SpontaneousSendRequest,
+    SpontaneousSendResponse,
+};
 use ldk_server_client::ldk_server_grpc::types::Channel;
 use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
+
+/// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
+#[async_trait]
+pub trait LdkServerCalls: Send + Sync {
+    async fn list_channels(
+        &self,
+        req: ListChannelsRequest,
+    ) -> Result<ListChannelsResponse, LdkServerError>;
+    async fn spontaneous_send(
+        &self,
+        req: SpontaneousSendRequest,
+    ) -> Result<SpontaneousSendResponse, LdkServerError>;
+}
+
+#[async_trait]
+impl LdkServerCalls for LdkServerClient {
+    async fn list_channels(
+        &self,
+        req: ListChannelsRequest,
+    ) -> Result<ListChannelsResponse, LdkServerError> {
+        LdkServerClient::list_channels(self, req).await
+    }
+    async fn spontaneous_send(
+        &self,
+        req: SpontaneousSendRequest,
+    ) -> Result<SpontaneousSendResponse, LdkServerError> {
+        LdkServerClient::spontaneous_send(self, req).await
+    }
+}
 
 /// In-memory list of stable channels plus a handle to the shared sqlite channels table.
 pub struct StableChannelManager {
@@ -25,6 +59,10 @@ pub struct EditOutcome {
 }
 
 impl StableChannelManager {
+    pub fn data_dir(&self) -> &std::path::Path {
+        &self.data_dir
+    }
+
     pub fn new(db: Arc<Database>, data_dir: PathBuf) -> Self {
         Self {
             stable_channels: Vec::new(),
@@ -39,7 +77,7 @@ impl StableChannelManager {
         channel_id: &str,
         expected_usd_in: Option<f64>,
         note_in: Option<String>,
-        ldk_server: &LdkServerClient,
+        ldk_server: &dyn LdkServerCalls,
         btc_price: f64,
     ) -> EditOutcome {
         let channels_resp = match ldk_server.list_channels(ListChannelsRequest {}).await {
@@ -111,11 +149,7 @@ impl StableChannelManager {
         };
         let native_sats = their_balance_sats.saturating_sub(backing_sats);
 
-        let user_channel_id_u128 = u128::from_str_radix(
-            user_channel_id_str.trim_start_matches("0x"),
-            16,
-        )
-        .unwrap_or(0);
+        let user_channel_id_u128 = parse_user_channel_id(&user_channel_id_str).unwrap_or(0);
 
         let new_sc = build_stable_channel(
             &channel,
@@ -156,9 +190,583 @@ impl StableChannelManager {
             channel_id, user_channel_id_str, expected_usd_f
         );
 
+        stable_channels::audit::audit_event(
+            "STABLE_EDITED",
+            serde_json::json!({
+                "channel_id": channel_id,
+                "user_channel_id": user_channel_id_str,
+                "target_usd": expected_usd_f,
+                "note": note,
+            }),
+        );
+
         EditOutcome {
             ok: true,
             status: format!("Set expected_usd={} on channel {}", expected_usd_f, channel_id),
+        }
+    }
+
+    /// Remove the stable_channel record from memory + DB when a channel closes.
+    pub fn handle_channel_closed(&mut self, user_channel_id: String) {
+        let target = parse_user_channel_id(&user_channel_id);
+        self.stable_channels.retain(|sc| {
+            if let Some(t) = target {
+                sc.user_channel_id != t
+            } else {
+                format!("{}", sc.user_channel_id) != user_channel_id
+            }
+        });
+        if let Err(e) = self.db.delete_channel(&user_channel_id) {
+            tracing::error!(
+                "[stable] handle_channel_closed: db.delete_channel failed for {}: {}",
+                user_channel_id, e
+            );
+        }
+        stable_channels::audit::audit_event(
+            "CHANNEL_CLOSED",
+            serde_json::json!({ "user_channel_id": user_channel_id }),
+        );
+    }
+
+    /// Rebuild the in-memory stable-channel list at startup from sqlite joined with the live snapshot, dropping vanished channels.
+    pub async fn reconcile_from_grpc(
+        &mut self,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                tracing::error!("[stable] reconcile: list_channels failed: {}", e);
+                return;
+            }
+        };
+
+        // Map from u128 user_channel_id (parsed from decimal) -> Channel snapshot.
+        let mut by_user_channel_id: std::collections::HashMap<u128, Channel> =
+            std::collections::HashMap::new();
+        for c in &channels {
+            if let Some(uid) = parse_user_channel_id(&c.user_channel_id) {
+                by_user_channel_id.insert(uid, c.clone());
+            }
+        }
+
+        // Load persisted stable-channel records from sqlite.
+        let records = match self.db.load_all_channels() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("[stable] reconcile: db.load_all_channels failed: {}", e);
+                return;
+            }
+        };
+
+        // Rebuild the in-memory Vec from the persisted records joined with the live snapshot.
+        let mut rebuilt: Vec<StableChannel> = Vec::new();
+        for record in &records {
+            // Parse user_channel_id the same (decimal) way for db records and live channels so they match.
+            let live = parse_user_channel_id(&record.user_channel_id)
+                .and_then(|uid| by_user_channel_id.get(&uid).map(|c| (uid, c)));
+
+            let Some((user_channel_id_u128, c)) = live else {
+                // Channel closed while the daemon was down: drop from db, audit.
+                if let Err(e) = self.db.delete_channel(&record.user_channel_id) {
+                    tracing::error!(
+                        "[stable] reconcile: db.delete_channel({}) failed: {}",
+                        record.user_channel_id, e
+                    );
+                }
+                stable_channels::audit::audit_event(
+                    "CHANNEL_DROPPED_AT_STARTUP",
+                    serde_json::json!({ "user_channel_id": record.user_channel_id }),
+                );
+                continue;
+            };
+
+            // Balances come from the live channel. expected_usd/backing/native/note are the persisted intent.
+            let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
+            let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
+            let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+
+            let stable_provider_btc = Bitcoin::from_sats(our_sats);
+            let stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            let stable_provider_usd = USD::from_bitcoin(stable_provider_btc, btc_price);
+            let stable_receiver_usd = USD::from_bitcoin(stable_receiver_btc, btc_price);
+
+            let expected_usd = USD::from_f64(record.expected_usd);
+            let expected_btc = Bitcoin::from_usd(expected_usd, btc_price);
+
+            let mut sc = build_stable_channel(
+                c,
+                user_channel_id_u128,
+                expected_usd,
+                expected_btc,
+                stable_provider_btc,
+                stable_receiver_btc,
+                stable_provider_usd,
+                stable_receiver_usd,
+                record.backing_sats,
+                record.native_sats,
+                record.note.clone(),
+                btc_price,
+                self.data_dir.clone(),
+            );
+            stable_channels::stable::recompute_native(&mut sc);
+            rebuilt.push(sc);
+        }
+
+        self.stable_channels = rebuilt;
+        info!(
+            "[stable] reconciled {} stable channel(s) from sqlite",
+            self.stable_channels.len()
+        );
+    }
+
+    /// On ChannelStateChanged Ready, auto-register the channel as stable at expected_usd=0 if untracked (operator sets a target via EditStableChannel).
+    pub async fn handle_channel_ready(
+        &mut self,
+        channel_id: String,
+        user_channel_id: String,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let target_uid = parse_user_channel_id(&user_channel_id);
+        if let Some(uid) = target_uid {
+            if self.stable_channels.iter().any(|sc| sc.user_channel_id == uid) {
+                return;
+            }
+        }
+
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                tracing::error!(
+                    "[stable] handle_channel_ready: list_channels failed: {}",
+                    e
+                );
+                return;
+            }
+        };
+        let Some(c) = channels.into_iter().find(|c| c.channel_id == channel_id) else {
+            tracing::warn!(
+                "[stable] handle_channel_ready: channel {} not found in list_channels",
+                channel_id
+            );
+            return;
+        };
+
+        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
+        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
+        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+
+        let user_channel_id_u128 = parse_user_channel_id(&user_channel_id).unwrap_or(0);
+
+        let new_sc = StableChannel {
+            channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(
+                parse_channel_id_hex(&c.channel_id),
+            ),
+            user_channel_id: user_channel_id_u128,
+            counterparty: parse_pubkey_hex(&c.counterparty_node_id),
+            is_stable_receiver: false,
+            expected_usd: USD::from_f64(0.0),
+            expected_btc: Bitcoin::from_sats(0),
+            stable_receiver_btc: Bitcoin::from_sats(their_sats),
+            stable_receiver_usd: USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price),
+            stable_provider_btc: Bitcoin::from_sats(our_sats),
+            stable_provider_usd: USD::from_bitcoin(Bitcoin::from_sats(our_sats), btc_price),
+            latest_price: btc_price,
+            risk_level: 0,
+            payment_made: false,
+            timestamp: 0,
+            formatted_datetime: String::new(),
+            sc_dir: self.data_dir.to_string_lossy().to_string(),
+            prices: String::new(),
+            onchain_btc: Bitcoin::from_sats(0),
+            onchain_usd: USD(0.0),
+            note: None,
+            native_channel_btc: Bitcoin::from_sats(0),
+            backing_sats: 0,
+            native_sats: their_sats,
+            last_stability_payment: 0,
+        };
+
+        if let Err(e) = self.db.save_channel(
+            &c.channel_id,
+            &user_channel_id,
+            0.0,
+            0,
+            their_sats,
+            None,
+        ) {
+            tracing::error!(
+                "[stable] handle_channel_ready: db.save_channel failed: {}",
+                e
+            );
+            return;
+        }
+        self.stable_channels.push(new_sc);
+        stable_channels::audit::audit_event(
+            "CHANNEL_READY_TRACKED",
+            serde_json::json!({
+                "channel_id": channel_id,
+                "user_channel_id": user_channel_id,
+            }),
+        );
+    }
+
+    /// On PaymentReceived, refresh the channel's balances from a fresh ListChannels and recompute native/backing. Noop if untracked.
+    pub async fn handle_payment_received(
+        &mut self,
+        channel_id: String,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                tracing::error!(
+                    "[stable] handle_payment_received: list_channels failed: {}",
+                    e
+                );
+                return;
+            }
+        };
+        let Some(c) = channels.into_iter().find(|c| c.channel_id == channel_id) else {
+            return;
+        };
+
+        let Some(target_uid) = parse_user_channel_id(&c.user_channel_id) else {
+            return;
+        };
+
+        let Some(sc) = self
+            .stable_channels
+            .iter_mut()
+            .find(|sc| sc.user_channel_id == target_uid)
+        else {
+            return;
+        };
+
+        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
+        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
+        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+
+        sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
+        sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+        sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
+        sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+        sc.latest_price = btc_price;
+        stable_channels::stable::recompute_native(sc);
+
+        let expected_usd_f = sc.expected_usd.0;
+        let backing = sc.backing_sats;
+        let native = sc.native_sats;
+        let note = sc.note.clone();
+
+        if let Err(e) = self.db.save_channel(
+            &c.channel_id,
+            &c.user_channel_id,
+            expected_usd_f,
+            backing,
+            native,
+            note.as_deref(),
+        ) {
+            tracing::error!(
+                "[stable] handle_payment_received: db.save_channel failed: {}",
+                e
+            );
+        }
+        stable_channels::audit::audit_event(
+            "PAYMENT_RECEIVED_RECONCILED",
+            serde_json::json!({ "channel_id": channel_id }),
+        );
+    }
+
+    /// 60s tick: per stable channel, skip below threshold/cooldown/zero-target, then SpontaneousSend a connected peer or push an offline one.
+    pub async fn run_tick(
+        &mut self,
+        ldk: &dyn LdkServerCalls,
+        push: &std::sync::Arc<tokio::sync::Mutex<crate::push::PushService>>,
+        btc_price: f64,
+    ) {
+        if btc_price <= 0.0 {
+            return;
+        }
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                tracing::warn!("[stable] run_tick: list_channels failed: {}", e);
+                return;
+            }
+        };
+        let mut by_user_channel_id: std::collections::HashMap<u128, Channel> =
+            std::collections::HashMap::new();
+        for c in &channels {
+            if let Some(uid) = parse_user_channel_id(&c.user_channel_id) {
+                by_user_channel_id.insert(uid, c.clone());
+            }
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let percent_threshold = stable_channels::constants::STABILITY_THRESHOLD_PERCENT;
+        let dollar_threshold = stable_channels::constants::STABILITY_THRESHOLD_USD;
+        let cooldown = stable_channels::constants::STABILITY_PAYMENT_COOLDOWN_SECS as i64;
+
+        for sc in self.stable_channels.iter_mut() {
+            if sc.expected_usd.0 < 0.01 {
+                continue;
+            }
+            let Some(c) = by_user_channel_id.get(&sc.user_channel_id) else { continue; };
+
+            let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
+            let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
+            let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+            sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
+            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
+            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+            sc.latest_price = btc_price;
+
+            let stable_usd_value = if sc.backing_sats > 0 {
+                (sc.backing_sats as f64 / 100_000_000.0) * btc_price
+            } else {
+                sc.stable_receiver_usd.0
+            };
+            let target = sc.expected_usd.0;
+            let percent_from_par = (((stable_usd_value - target) / target) * 100.0).abs();
+            let dollars_from_par = (stable_usd_value - target).abs();
+
+            if percent_from_par < percent_threshold
+                || dollars_from_par < dollar_threshold
+            {
+                continue;
+            }
+            if now - sc.last_stability_payment < cooldown {
+                continue;
+            }
+
+            let is_receiver_below_expected = stable_usd_value < target;
+            let direction = if is_receiver_below_expected {
+                "lsp_to_user"
+            } else {
+                "user_to_lsp"
+            };
+            let amount_sats = ((dollars_from_par / btc_price) * 100_000_000.0) as u64;
+            let amount_msat = amount_sats.saturating_mul(1000);
+
+            if c.is_usable {
+                if is_receiver_below_expected {
+                    let send_req = SpontaneousSendRequest {
+                        amount_msat,
+                        node_id: sc.counterparty.to_string(),
+                        route_parameters: None,
+                    };
+                    let channel_id_clone = c.channel_id.clone();
+                    let user_channel_id_clone = c.user_channel_id.clone();
+                    let expected_usd_for_db = sc.expected_usd.0;
+                    let note_for_db = sc.note.clone();
+                    match ldk.spontaneous_send(send_req).await {
+                        Ok(resp) => {
+                            sc.last_stability_payment = now;
+                            // Reset backing_sats to equilibrium so the next tick doesn't re-pay the same drift forever. Native is recomputed on the next balance refresh.
+                            sc.backing_sats =
+                                ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
+                            let backing = sc.backing_sats;
+                            let native = sc.native_sats;
+                            if let Err(e) = self.db.save_channel(
+                                &channel_id_clone,
+                                &user_channel_id_clone,
+                                expected_usd_for_db,
+                                backing,
+                                native,
+                                note_for_db.as_deref(),
+                            ) {
+                                tracing::error!(
+                                    "[stable] run_tick: db.save_channel failed: {}",
+                                    e
+                                );
+                            }
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_SENT",
+                                serde_json::json!({
+                                    "channel_id": channel_id_clone,
+                                    "direction": direction,
+                                    "amount_msat": amount_msat,
+                                    "payment_id": resp.payment_id,
+                                    "counterparty": sc.counterparty.to_string(),
+                                    "expected_usd": expected_usd_for_db,
+                                    "new_backing_sats": sc.backing_sats,
+                                }),
+                            );
+                        },
+                        Err(e) => {
+                            tracing::warn!(
+                                "[stable] run_tick: spontaneous_send failed: {}",
+                                e
+                            );
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_FAILED",
+                                serde_json::json!({
+                                    "channel_id": channel_id_clone,
+                                    "direction": direction,
+                                    "error": e.to_string(),
+                                }),
+                            );
+                            // Do not bump last_stability_payment so retry can fire.
+                        },
+                    }
+                } else {
+                    // User above par: CHECK_ONLY. The LSP can only push value, not pull, so do nothing here (no cooldown bump).
+                    stable_channels::audit::audit_event(
+                        "STABILITY_CHECK_ONLY",
+                        serde_json::json!({
+                            "channel_id": c.channel_id,
+                            "direction": direction,
+                            "stable_usd_value": stable_usd_value,
+                            "expected_usd": target,
+                        }),
+                    );
+                }
+            } else {
+                let mut p = push.lock().await;
+                p.notify(&sc.counterparty.to_string(), direction);
+                drop(p);
+                stable_channels::audit::audit_event(
+                    "STABILITY_PUSH_QUEUED",
+                    serde_json::json!({
+                        "channel_id": c.channel_id,
+                        "node_id": sc.counterparty.to_string(),
+                        "direction": direction,
+                    }),
+                );
+            }
+        }
+    }
+
+    /// On a forward out of a stable channel, reconcile the spend: native BTC first, overflow reduces `expected_usd`.
+    pub async fn handle_payment_forwarded(
+        &mut self,
+        prev_user_channel_id: String,
+        outbound_amount_forwarded_msat: u64,
+        fee_msat: u64,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let total_sats = outbound_amount_forwarded_msat.saturating_add(fee_msat) / 1000;
+        stable_channels::audit::audit_event(
+            "PAYMENT_FORWARDED",
+            serde_json::json!({
+                "prev_user_channel_id": prev_user_channel_id,
+                "forwarded_msat": outbound_amount_forwarded_msat,
+                "fee_msat": fee_msat,
+                "total_sats": total_sats,
+            }),
+        );
+
+        let Some(target_uid) = parse_user_channel_id(&prev_user_channel_id) else {
+            return;
+        };
+        if !self
+            .stable_channels
+            .iter()
+            .any(|sc| sc.user_channel_id == target_uid)
+        {
+            return; // forward was not on a stable channel
+        }
+
+        // gRPC ForwardedPayment carries no balance, so reconstruct the pre-forward balance as live-post + total.
+        let live = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!("[forwarded] list_channels gRPC failed: {}", e);
+                return;
+            }
+        };
+        let Some(chan) = live
+            .channels
+            .into_iter()
+            .find(|c| parse_user_channel_id(&c.user_channel_id) == Some(target_uid))
+        else {
+            return; // channel vanished from the server
+        };
+        let unspendable = chan.unspendable_punishment_reserve.unwrap_or(0);
+        let lsp_sats = (chan.outbound_capacity_msat / 1000) + unspendable;
+        let post_user_sats = chan.channel_value_sats.saturating_sub(lsp_sats);
+        let channel_id_hex = chan.channel_id.clone();
+
+        let persisted = {
+            let Some(sc) = self
+                .stable_channels
+                .iter_mut()
+                .find(|sc| sc.user_channel_id == target_uid)
+            else {
+                return;
+            };
+            if sc.expected_usd.0 <= 0.0 || btc_price <= 0.0 {
+                return;
+            }
+
+            // Refresh tracked balance to the live value so native_channel_btc stays consistent with native_sats.
+            sc.stable_receiver_btc = Bitcoin::from_sats(post_user_sats);
+            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+
+            let native_before = sc.native_sats;
+            let old_expected = sc.expected_usd.0;
+            let user_sats_before = post_user_sats.saturating_add(total_sats);
+
+            if let Some(usd_deducted) = stable_channels::stable::reconcile_forwarded(
+                sc,
+                user_sats_before,
+                total_sats,
+                btc_price,
+            ) {
+                let stable_sats_spent = total_sats.saturating_sub(native_before);
+                stable_channels::audit::audit_event(
+                    "STABLE_SPEND_DEDUCTED",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", sc.user_channel_id),
+                        "total_sats_spent": total_sats,
+                        "native_sats_spent": native_before,
+                        "stable_sats_spent": stable_sats_spent,
+                        "usd_deducted": usd_deducted,
+                        "old_expected_usd": old_expected,
+                        "new_expected_usd": sc.expected_usd.0,
+                        "btc_price": btc_price,
+                    }),
+                );
+                info!(
+                    "[forwarded] channel user_id={} spent {} sats ({} native, {} stable), expected_usd ${:.2} -> ${:.2}",
+                    sc.user_channel_id, total_sats, native_before, stable_sats_spent,
+                    old_expected, sc.expected_usd.0
+                );
+            } else {
+                // Fully covered by native BTC: reflect the spend in the buffer.
+                sc.native_sats = post_user_sats.saturating_sub(sc.backing_sats);
+                stable_channels::stable::recompute_native(sc);
+            }
+
+            (
+                format!("{}", sc.user_channel_id),
+                sc.expected_usd.0,
+                sc.backing_sats,
+                sc.native_sats,
+                sc.note.clone(),
+            )
+        };
+
+        let (ucid_str, expected_usd_f, backing_sats, native_sats, note) = persisted;
+        if let Err(e) = self.db.save_channel(
+            &channel_id_hex,
+            &ucid_str,
+            expected_usd_f,
+            backing_sats,
+            native_sats,
+            note.as_deref(),
+        ) {
+            error!("[forwarded] db.save_channel failed: {}", e);
         }
     }
 }
@@ -210,6 +818,13 @@ fn build_stable_channel(
     }
 }
 
+/// Parse an LDK Server user_channel_id (decimal u128::to_string) to u128, with a hex fallback for legacy values.
+fn parse_user_channel_id(s: &str) -> Option<u128> {
+    s.parse::<u128>()
+        .ok()
+        .or_else(|| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+}
+
 fn parse_channel_id_hex(s: &str) -> [u8; 32] {
     let mut buf = [0u8; 32];
     if let Ok(bytes) = hex::decode(s) {
@@ -231,7 +846,610 @@ fn parse_pubkey_hex(s: &str) -> ldk_node::bitcoin::secp256k1::PublicKey {
 
 #[cfg(test)]
 mod tests {
-    // Unit-testing edit_stable_channel without a real LdkServerClient is awkward
-    // because LdkServerClient does not expose a trait we can mock. For Bucket 2
-    // we cover the patch semantics indirectly through Task 14's Mutinynet smoke test.
+    use super::*;
+    use ldk_server_client::error::LdkServerErrorCode;
+    use ldk_server_client::ldk_server_grpc::types::Channel as GrpcChannel;
+    use std::sync::Mutex as StdMutex;
+    use tempfile::tempdir;
+
+    pub struct FakeLdkServer {
+        pub channels: StdMutex<Vec<GrpcChannel>>,
+        pub sends: StdMutex<Vec<SpontaneousSendRequest>>,
+        pub send_should_fail: bool,
+    }
+
+    impl FakeLdkServer {
+        pub fn new(channels: Vec<GrpcChannel>) -> Self {
+            Self {
+                channels: StdMutex::new(channels),
+                sends: StdMutex::new(Vec::new()),
+                send_should_fail: false,
+            }
+        }
+        pub fn with_send_failure(mut self) -> Self {
+            self.send_should_fail = true;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl LdkServerCalls for FakeLdkServer {
+        async fn list_channels(
+            &self,
+            _req: ListChannelsRequest,
+        ) -> Result<ListChannelsResponse, LdkServerError> {
+            Ok(ListChannelsResponse {
+                channels: self.channels.lock().unwrap().clone(),
+            })
+        }
+        async fn spontaneous_send(
+            &self,
+            req: SpontaneousSendRequest,
+        ) -> Result<SpontaneousSendResponse, LdkServerError> {
+            if self.send_should_fail {
+                return Err(LdkServerError::new(
+                    LdkServerErrorCode::LightningError,
+                    "fake send failure".to_string(),
+                ));
+            }
+            self.sends.lock().unwrap().push(req);
+            Ok(SpontaneousSendResponse {
+                payment_id: "fake-payment-id".to_string(),
+            })
+        }
+    }
+
+    pub fn make_channel(
+        channel_id: &str,
+        user_channel_id: &str,
+        counterparty: &str,
+        value_sats: u64,
+        outbound_msat: u64,
+        is_usable: bool,
+    ) -> GrpcChannel {
+        GrpcChannel {
+            channel_id: channel_id.to_string(),
+            counterparty_node_id: counterparty.to_string(),
+            user_channel_id: user_channel_id.to_string(),
+            unspendable_punishment_reserve: Some(0),
+            channel_value_sats: value_sats,
+            outbound_capacity_msat: outbound_msat,
+            is_usable,
+            is_channel_ready: true,
+            is_outbound: true,
+            ..Default::default()
+        }
+    }
+
+    pub fn make_manager() -> StableChannelManager {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().to_path_buf();
+        // Keep the temp dir alive for the test process so sqlite isn't backed by a deleted directory.
+        std::mem::forget(dir);
+        let db = stable_channels::db::Database::open(&db_path).unwrap();
+        StableChannelManager::new(std::sync::Arc::new(db), db_path)
+    }
+
+    pub const COUNTERPARTY_HEX: &str =
+        "02465ed5be53d04fde66c9418ff14a5f2267723810176c9212b722e542dc1afb1b";
+    pub const USER_CHANNEL_ID_HEX: &str = "00000000000000000000000000000001";
+    // A realistic 39-digit decimal user_channel_id. Parsed as hex it overflows u128 (the bug this guards).
+    pub const USER_CHANNEL_ID_DECIMAL: &str = "189476124653200987495269098788434301048";
+    pub const CHANNEL_ID_HEX: &str =
+        "f9634c603646c60b0df9f07c3011708652125915c80300a9bb8fb37c9c0de05b";
+
+    #[tokio::test]
+    async fn handle_channel_closed_removes_record() {
+        let mut mgr = make_manager();
+        // Seed an existing record so handle_channel_closed has something to remove.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), Some("note".to_string()),
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+
+        mgr.handle_channel_closed(USER_CHANNEL_ID_HEX.to_string());
+        assert_eq!(mgr.stable_channels.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_drops_channels_no_longer_on_server() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), None,
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+
+        // LDK Server no longer reports the channel.
+        let empty_server = FakeLdkServer::new(vec![]);
+        mgr.reconcile_from_grpc(&empty_server as &dyn LdkServerCalls, 100_000.0).await;
+        assert_eq!(mgr.stable_channels.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_refreshes_known_channel() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), None,
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+
+        // Same channel, different balance: outbound drops from 50_000 to 30_000 sats.
+        let fake2 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 30_000_000, true,
+        )]);
+        mgr.reconcile_from_grpc(&fake2 as &dyn LdkServerCalls, 100_000.0).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+        // outbound dropped from 50_000 to 30_000 sats; receiver got 20_000 more.
+        assert_eq!(mgr.stable_channels[0].stable_receiver_btc.sats, 70_000);
+    }
+
+    #[tokio::test]
+    async fn reconcile_hydrates_fresh_manager_from_db() {
+        // Simulate a restart: empty in-memory Vec but a persisted stable channel row in sqlite.
+        let mut mgr = make_manager();
+        // Persist a row directly (bypass the in-memory Vec) to mimic a prior session.
+        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, 25.0, 40_000, 10_000, Some("persisted")).unwrap();
+        assert_eq!(mgr.stable_channels.len(), 0, "fresh manager starts empty");
+
+        // The live LDK Server still reports the channel.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert_eq!(mgr.stable_channels.len(), 1, "channel must be hydrated from db");
+        let sc = &mgr.stable_channels[0];
+        assert_eq!(sc.expected_usd.0, 25.0, "persisted expected_usd preserved");
+        assert_eq!(sc.backing_sats, 40_000, "persisted backing_sats preserved");
+        assert_eq!(sc.note.as_deref(), Some("persisted"), "persisted note preserved");
+        assert_eq!(sc.counterparty.to_string(), COUNTERPARTY_HEX, "counterparty resolved from live channel");
+    }
+
+    #[tokio::test]
+    async fn handle_channel_ready_auto_registers_new_channel() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_HEX.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+    }
+
+    #[tokio::test]
+    async fn handle_channel_ready_is_idempotent() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_HEX.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_HEX.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn handle_payment_received_refreshes_balances() {
+        let mut mgr = make_manager();
+        let fake_initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), None,
+            &fake_initial as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+
+        // After payment, outbound dropped from 50_000 sats to 30_000 sats.
+        let fake_after = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 30_000_000, true,
+        )]);
+        mgr.handle_payment_received(
+            CHANNEL_ID_HEX.to_string(),
+            &fake_after as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels[0].stable_receiver_btc.sats, 70_000);
+    }
+
+    #[tokio::test]
+    async fn handle_payment_received_untracked_channel_is_noop() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![]);
+        mgr.handle_payment_received(
+            CHANNEL_ID_HEX.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 0);
+    }
+
+    // Seed a stable channel: 100k value, 50k user side, $10 at $100k/BTC, giving backing 10k + native 40k.
+    async fn seed_forwarded_fixture() -> (StableChannelManager, FakeLdkServer) {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), None,
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(mgr.stable_channels[0].native_sats, 40_000);
+        (mgr, fake)
+    }
+
+    #[tokio::test]
+    async fn handle_payment_forwarded_deducts_stable_when_spend_exceeds_native() {
+        let (mut mgr, fake) = seed_forwarded_fixture().await;
+        // Forward 45k out: 40k native + 5k stable. Post-forward user side = 5_000 (LSP 95_000).
+        *fake.channels.lock().unwrap() = vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 95_000_000, true,
+        )];
+
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            45_000_000, // outbound_amount_forwarded_msat
+            0,          // fee_msat
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+
+        // 5_000 overflow sats * $100k / 1e8 = $5.00 deducted: $10 -> $5.
+        let exp = mgr.stable_channels[0].expected_usd.0;
+        assert!((exp - 5.0).abs() < 0.01, "expected_usd should drop to ~5.0, got {}", exp);
+        // native_sats and native_channel_btc must agree after reconcile.
+        assert_eq!(
+            mgr.stable_channels[0].native_channel_btc.sats,
+            mgr.stable_channels[0].native_sats,
+            "native_channel_btc must match native_sats after a forward",
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_payment_forwarded_covered_by_native_keeps_expected_usd() {
+        let (mut mgr, fake) = seed_forwarded_fixture().await;
+        // Forward 20k out, fully covered by the 40k native buffer. Post-forward user side = 30_000 (LSP 70_000).
+        *fake.channels.lock().unwrap() = vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 70_000_000, true,
+        )];
+
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            20_000_000,
+            0,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+
+        let exp = mgr.stable_channels[0].expected_usd.0;
+        assert!((exp - 10.0).abs() < 0.01, "expected_usd must stay ~10.0, got {}", exp);
+        // Native buffer shrank by the spend: 40_000 - 20_000 = 20_000.
+        assert_eq!(mgr.stable_channels[0].native_sats, 20_000);
+        // native_sats and native_channel_btc must agree after reconcile.
+        assert_eq!(
+            mgr.stable_channels[0].native_channel_btc.sats,
+            mgr.stable_channels[0].native_sats,
+            "native_channel_btc must match native_sats after a forward",
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_payment_forwarded_untracked_channel_is_noop() {
+        let mut mgr = make_manager();
+        // Untracked channel: a forward on an unknown channel must not panic or invent a record.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            45_000_000,
+            0,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        assert!(mgr.stable_channels.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_tick_skips_zero_target() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        // expected_usd defaulted to 0; tick must not attempt any send.
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_HEX.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        assert!(fake.sends.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_tick_skips_cooldown_active() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(10.0), None,
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+        // Pretend we just paid: bump last_stability_payment to "now".
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        mgr.stable_channels[0].last_stability_payment = now;
+
+        // Force a large drift by swapping in a channel with no outbound capacity.
+        let fake2 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 0, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+        mgr.run_tick(&fake2 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        assert!(
+            fake2.sends.lock().unwrap().is_empty(),
+            "cooldown should suppress send"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tick_sends_when_connected_and_drift_exceeds_threshold() {
+        let mut mgr = make_manager();
+        // Channel exists, set expected_usd = 50.
+        let fake_initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(50.0), None,
+            &fake_initial as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+
+        // Price drops 20% to 80_000 (receiver USD below 50), peer connected.
+        let fake_drift = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+
+        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0).await;
+
+        let sends = fake_drift.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1, "expected one stability payment");
+        assert_eq!(sends[0].node_id, COUNTERPARTY_HEX);
+        assert!(sends[0].amount_msat > 0);
+        assert!(mgr.stable_channels[0].last_stability_payment > 0,
+            "cooldown timestamp should be set");
+    }
+
+    #[tokio::test]
+    async fn run_tick_send_failure_keeps_cooldown_unset() {
+        let mut mgr = make_manager();
+        let fake_initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(50.0), None,
+            &fake_initial as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+        let fake_drift = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )])
+        .with_send_failure();
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+
+        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0).await;
+
+        assert_eq!(
+            mgr.stable_channels[0].last_stability_payment, 0,
+            "failed send must not start cooldown"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tick_pushes_when_offline_and_drift_exceeds_threshold() {
+        let mut mgr = make_manager();
+        let fake_initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(50.0), None,
+            &fake_initial as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+
+        // Peer disconnected: is_usable=false.
+        let fake_offline = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, false,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+
+        mgr.run_tick(&fake_offline as &dyn LdkServerCalls, &push, 80_000.0).await;
+
+        let sends = fake_offline.sends.lock().unwrap();
+        assert!(sends.is_empty(), "must not send when peer offline");
+        assert_eq!(
+            mgr.stable_channels[0].last_stability_payment, 0,
+            "must not bump cooldown when only pushing"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tick_check_only_when_connected_and_user_above_par() {
+        let mut mgr = make_manager();
+        let fake0 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        // expected_usd=50 at price 100k -> backing_sats = 50_000
+        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+
+        // Price RISES to 120k: stable_usd_value = 50_000/1e8*120k = $60 > $50 target -> user_to_lsp.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await;
+        assert!(fake.sends.lock().unwrap().is_empty(), "LSP must NOT send when user is above par (CHECK_ONLY)");
+    }
+
+    #[tokio::test]
+    async fn run_tick_resets_backing_to_equilibrium_after_send() {
+        let mut mgr = make_manager();
+        let fake0 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        // expected_usd=50 at price 100k -> backing_sats = 50_000
+        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+
+        // Price DROPS to 80k: stable_usd_value = 50_000/1e8*80k = $40 < $50 -> lsp_to_user -> send.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+
+        assert_eq!(fake.sends.lock().unwrap().len(), 1, "should send in lsp_to_user direction");
+        // backing reset to target/price = 50/80000*1e8 = 62_500 (NOT left at stale 50_000).
+        assert_eq!(mgr.stable_channels[0].backing_sats, 62_500, "backing must reset to equilibrium, preventing oscillation");
+    }
+
+    #[tokio::test]
+    async fn reconcile_hydrates_channel_with_decimal_user_channel_id() {
+        let mut mgr = make_manager();
+        // Persist a row whose user_channel_id is the realistic decimal form.
+        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 12.0, 30_000, 5_000, Some("dec")).unwrap();
+
+        // The live channel reports the SAME decimal user_channel_id (as real gRPC does).
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert_eq!(mgr.stable_channels.len(), 1, "decimal-id channel MUST hydrate (not be dropped)");
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 12.0);
+        // The in-memory u128 must equal the decimal parse, not a hex misparse.
+        assert_eq!(mgr.stable_channels[0].user_channel_id, 189476124653200987495269098788434301048u128);
+    }
+
+    #[test]
+    fn parse_user_channel_id_prefers_decimal() {
+        assert_eq!(parse_user_channel_id("189476124653200987495269098788434301048"),
+                   Some(189476124653200987495269098788434301048u128));
+        // hex fallback still works for 0x-prefixed values
+        assert_eq!(parse_user_channel_id("0x01"), Some(1));
+    }
+
+    #[tokio::test]
+    async fn edit_stable_channel_emits_audit_event() {
+        // Editing a USD target must leave a STABLE_EDITED entry in the audit log.
+        use stable_channels::audit::{get_audit_log_path, set_audit_log_path};
+        let dir = tempdir().unwrap();
+        let audit_path = dir.path().join("audit_log.txt");
+        // OnceLock: this wins if unset, otherwise we read whichever path is live.
+        set_audit_log_path(audit_path.to_str().unwrap());
+        let path = get_audit_log_path()
+            .expect("an audit log path is set")
+            .to_string();
+
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX, Some(7.5), None,
+            &fake as &dyn LdkServerCalls, 100_000.0,
+        ).await;
+
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        assert!(
+            contents.contains("STABLE_EDITED"),
+            "audit log should record STABLE_EDITED, got: {}",
+            contents
+        );
+        assert!(
+            contents.contains(USER_CHANNEL_ID_DECIMAL),
+            "STABLE_EDITED audit entry should include the user_channel_id"
+        );
+    }
 }

--- a/server/stable-channels-lsp/src/state.rs
+++ b/server/stable-channels-lsp/src/state.rs
@@ -5,6 +5,10 @@ use std::sync::Arc;
 
 use ldk_server_client::client::LdkServerClient;
 use stable_channels::db::Database;
+use tokio::sync::Mutex;
+
+use crate::push::PushService;
+use crate::stable_manager::StableChannelManager;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -18,4 +22,10 @@ pub struct AppState {
     pub network: String,
     /// sqlite handle to the SC daemon's stable channels database.
     pub db: Arc<Database>,
+    /// Push notification service. Wrapped in a tokio mutex because `notify` mutates the cooldown map.
+    pub push: Arc<Mutex<PushService>>,
+    /// In-memory + sqlite-backed stable channel manager.
+    pub stable_manager: Arc<Mutex<StableChannelManager>>,
+    /// LDK Server's log file path, resolved at daemon startup. None if not configured.
+    pub ldk_log_file: Option<PathBuf>,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -105,6 +105,12 @@ impl Database {
             [],
         ); // Ignore error if column already exists
 
+        // Migration: Add closed_at column. NULL = active, unix timestamp = soft-closed.
+        // We never hard-delete channel rows from reconcile / handle_channel_closed —
+        // they're marked closed so closed-channel forensics survive transient gRPC blips.
+        let _ = conn.execute("ALTER TABLE channels ADD COLUMN closed_at INTEGER", []);
+        // Ignore error if column already exists
+
         // Price history table - stores historical prices for charts
         conn.execute(
             "CREATE TABLE IF NOT EXISTS price_history (
@@ -219,7 +225,12 @@ impl Database {
     // Channel Operations
     // =========================================================================
 
-    /// Save or update channel settings
+    /// Save or update channel settings.
+    ///
+    /// Calling this is an active assertion that the channel is live, so any
+    /// prior `closed_at` is cleared on UPDATE. This way a channel that was
+    /// marked closed in error (e.g. a transient gRPC blip during reconcile)
+    /// re-activates the next time we save it.
     pub fn save_channel(
         &self,
         channel_id: &str,
@@ -234,6 +245,7 @@ impl Database {
         let updated = conn.execute(
             "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
                                  note = ?4, user_channel_id = ?5, native_sats = ?6,
+                                 closed_at = NULL,
                                  updated_at = strftime('%s', 'now')
              WHERE user_channel_id = ?5",
             params![
@@ -256,6 +268,7 @@ impl Database {
                     stable_sats = ?4,
                     native_sats = ?5,
                     note = ?6,
+                    closed_at = NULL,
                     updated_at = strftime('%s', 'now')",
                 params![channel_id, user_channel_id, expected_usd, backing_sats as i64, native_sats as i64, note],
             )?;
@@ -263,11 +276,28 @@ impl Database {
         Ok(())
     }
 
-    /// Delete channel settings (e.g. after channel close)
+    /// Hard-delete a channel row. Reserved for explicit admin purge; reconcile
+    /// and channel-close paths should call `mark_channel_closed` instead so the
+    /// row survives for forensics.
     pub fn delete_channel(&self, user_channel_id: &str) -> SqliteResult<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "DELETE FROM channels WHERE user_channel_id = ?1",
+            params![user_channel_id],
+        )?;
+        Ok(())
+    }
+
+    /// Soft-close a channel row: set `closed_at` to now if not already set.
+    /// Idempotent — preserves the original close time on subsequent calls so
+    /// the audit trail stays meaningful.
+    pub fn mark_channel_closed(&self, user_channel_id: &str) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE channels
+             SET closed_at = strftime('%s', 'now'),
+                 updated_at = strftime('%s', 'now')
+             WHERE user_channel_id = ?1 AND closed_at IS NULL",
             params![user_channel_id],
         )?;
         Ok(())
@@ -299,8 +329,40 @@ impl Database {
         }
     }
 
-    /// Load all channel records from the database
+    /// Load all *active* channel records (closed_at IS NULL). This is the
+    /// load called by reconcile and the stability tick — closed channels are
+    /// excluded so we never act on them.
     pub fn load_all_channels(&self) -> SqliteResult<Vec<ChannelRecord>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, native_sats
+             FROM channels
+             WHERE closed_at IS NULL",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            let backing_sats: i64 = row.get(3).unwrap_or(0);
+            let native_sats: i64 = row.get(5).unwrap_or(0);
+            Ok(ChannelRecord {
+                channel_id: row.get(0)?,
+                user_channel_id: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                expected_usd: row.get(1)?,
+                note: row.get(2)?,
+                backing_sats: backing_sats as u64,
+                native_sats: native_sats as u64,
+            })
+        })?;
+
+        let mut channels = Vec::new();
+        for row in rows {
+            channels.push(row?);
+        }
+        Ok(channels)
+    }
+
+    /// Load every channel row, active or closed. Use this for forensics /
+    /// closed-channel history views, never for reconcile.
+    pub fn load_all_channels_including_closed(&self) -> SqliteResult<Vec<ChannelRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, native_sats FROM channels",
@@ -931,6 +993,74 @@ mod tests {
         assert!((loaded.expected_usd - 100.0).abs() < 0.001);
         assert_eq!(loaded.backing_sats, 100_000);
         assert_eq!(loaded.native_sats, 20_000);
+    }
+
+    #[test]
+    fn test_mark_channel_closed_excludes_from_load_all() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("ch_a", "uch_a", 10.0, 1000, 0, None).unwrap();
+        db.save_channel("ch_b", "uch_b", 20.0, 2000, 0, None).unwrap();
+        assert_eq!(db.load_all_channels().unwrap().len(), 2);
+
+        db.mark_channel_closed("uch_a").unwrap();
+
+        let active = db.load_all_channels().unwrap();
+        assert_eq!(active.len(), 1, "closed channel must be excluded from load_all_channels");
+        assert_eq!(active[0].user_channel_id, "uch_b");
+
+        let all = db.load_all_channels_including_closed().unwrap();
+        assert_eq!(all.len(), 2, "closed channel must still exist in DB");
+    }
+
+    #[test]
+    fn test_save_channel_reactivates_closed_row() {
+        // A row marked closed by mistake (e.g. transient gRPC blip) must
+        // re-activate the next time we save it.
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("ch_x", "uch_x", 50.0, 5000, 0, None).unwrap();
+        db.mark_channel_closed("uch_x").unwrap();
+        assert!(db.load_all_channels().unwrap().is_empty());
+
+        db.save_channel("ch_x", "uch_x", 75.0, 7500, 0, Some("revived")).unwrap();
+
+        let active = db.load_all_channels().unwrap();
+        assert_eq!(active.len(), 1, "save_channel must clear closed_at");
+        assert!((active[0].expected_usd - 75.0).abs() < 0.001);
+        assert_eq!(active[0].note.as_deref(), Some("revived"));
+    }
+
+    #[test]
+    fn test_mark_channel_closed_is_idempotent() {
+        // Calling mark_channel_closed twice must preserve the original
+        // close timestamp, not overwrite it.
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("ch_y", "uch_y", 10.0, 1000, 0, None).unwrap();
+
+        db.mark_channel_closed("uch_y").unwrap();
+        // Read the closed_at value directly so we can compare across calls.
+        let conn = db.conn.lock().unwrap();
+        let first_ts: i64 = conn
+            .query_row(
+                "SELECT closed_at FROM channels WHERE user_channel_id = ?1",
+                params!["uch_y"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        drop(conn);
+
+        // Sleep a beat so the wall clock advances past 1s resolution, then mark closed again.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        db.mark_channel_closed("uch_y").unwrap();
+
+        let conn = db.conn.lock().unwrap();
+        let second_ts: i64 = conn
+            .query_row(
+                "SELECT closed_at FROM channels WHERE user_channel_id = ?1",
+                params!["uch_y"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(first_ts, second_ts, "closed_at must not be overwritten");
     }
 
     #[test]


### PR DESCRIPTION
Adds the Stable Channels REST surface and the autonomous stability logic to the `stable-channels-lsp` daemon. Runs against vanilla upstream `main`, no LDK Server changes needed.

  **SC handlers + push**
  - `EditStableChannel` (set/update a channel's USD target, patch semantics)
  - `RegisterPush` (wallets register APNs/FCM device tokens)
  - `PushService` over APNs + FCM, config-driven, disables gracefully when creds are absent
  - `LdkLog` (tails LDK Server's log file)

  **Stability brain**
  - `SubscribeEvents` consumer with backoff, plus a 60s tick that keysends a top-up on USD drift (only `lsp_to_user`) or wakes offline peers via push
  - Startup hydration from sqlite joined with the live channel snapshot, so it survives restarts
  - Lifecycle handlers for channel ready/closed and forwarded-payment stable-spend reconcile
  - `LdkServerCalls` trait for mockable gRPC, plus 51 unit tests