### PR TITLE
feat(android): wire biometric auth gates into sends and seed viewing

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
@@ -4,34 +4,137 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.stablechannels.app.services.AppAccessPreferencesManager
+import com.stablechannels.app.services.BiometricService
 import com.stablechannels.app.ui.ContentView
 import com.stablechannels.app.ui.theme.StableChannelsTheme
+import kotlinx.coroutines.launch
 
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
 
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ -> }
+
+    private var isLocked by mutableStateOf(false)
+    private var isAuthenticating by mutableStateOf(false)
+    private var lastBackgroundedTime: Long = 0L
+    private var isFirstResume = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         requestNotificationPermission()
+
+        // Lock on launch if app unlock is enabled
+        if (AppAccessPreferencesManager.isAppUnlockEnabled(this)) {
+            isLocked = true
+        }
+
         setContent {
             StableChannelsTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    ContentView()
+                    if (isLocked) {
+                        AuthLockOverlay()
+                    } else {
+                        ContentView()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        lastBackgroundedTime = System.currentTimeMillis()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (isFirstResume) {
+            isFirstResume = false
+            return
+        }
+        if (AppAccessPreferencesManager.isAppUnlockEnabled(this)) {
+            val elapsed = System.currentTimeMillis() - lastBackgroundedTime
+            if (elapsed > 5000L) {
+                isLocked = true
+            }
+        }
+    }
+
+    @Composable
+    private fun AuthLockOverlay() {
+        val scope = rememberCoroutineScope()
+        var authError by remember { mutableStateOf<String?>(null) }
+
+        fun performAuth() {
+            if (isAuthenticating) return
+            isAuthenticating = true
+            authError = null
+            scope.launch {
+                val result = BiometricService.authenticate(this@MainActivity, "Unlock Stable Channels")
+                if (result == BiometricService.AuthResult.SUCCESS) {
+                    isLocked = false
+                } else {
+                    authError = "Authentication failed. Tap Unlock to try again."
+                }
+                isAuthenticating = false
+            }
+        }
+
+        // Auto-trigger auth on first composition
+        LaunchedEffect(Unit) {
+            performAuth()
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                "Stable Channels",
+                style = MaterialTheme.typography.headlineMedium
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Authentication required",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            authError?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            Spacer(Modifier.height(24.dp))
+            Button(
+                onClick = { performAuth() },
+                enabled = !isAuthenticating
+            ) {
+                if (isAuthenticating) {
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    Text("Unlock")
                 }
             }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
@@ -20,7 +20,7 @@ fun AppAccessView() {
         mutableStateOf(prefs.getBoolean("app_unlock_enabled", false))
     }
     var paymentConfirmEnabled by remember {
-        mutableStateOf(prefs.getBoolean("payment_confirm_enabled", false))
+        mutableStateOf(prefs.getBoolean("payment_confirmation_enabled", false))
     }
 
     val biometricManager = BiometricManager.from(context)
@@ -124,7 +124,7 @@ fun AppAccessView() {
                     onCheckedChange = { newValue ->
                         if (biometricsAvailable) {
                             paymentConfirmEnabled = newValue
-                            prefs.edit().putBoolean("payment_confirm_enabled", newValue).apply()
+                            prefs.edit().putBoolean("payment_confirmation_enabled", newValue).apply()
                         }
                     },
                     enabled = biometricsAvailable,

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/BackupView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/BackupView.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import com.stablechannels.app.AppState
+import com.stablechannels.app.services.BiometricService
 import com.stablechannels.app.util.ClipboardUtils
 import com.stablechannels.app.util.Constants
 import kotlinx.coroutines.Dispatchers
@@ -28,9 +30,11 @@ import org.lightningdevkit.ldknode.Network
 fun BackupView(appState: AppState) {
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
+    val activity = LocalContext.current as? FragmentActivity
     val scope = rememberCoroutineScope()
 
     var showSeedWords by remember { mutableStateOf(false) }
+    var seedAuthError by remember { mutableStateOf<String?>(null) }
     var showRestore by remember { mutableStateOf(false) }
     var restoreMnemonic by remember { mutableStateOf("") }
     var restoreError by remember { mutableStateOf<String?>(null) }
@@ -43,7 +47,28 @@ fun BackupView(appState: AppState) {
     ) {
         // Show/hide seed words
         Button(
-            onClick = { showSeedWords = !showSeedWords },
+            onClick = {
+                if (showSeedWords) {
+                    // Hiding seed words — no auth needed
+                    showSeedWords = false
+                    seedAuthError = null
+                } else {
+                    // Showing seed words — require biometric auth
+                    scope.launch {
+                        if (activity != null) {
+                            val authResult = BiometricService.authenticate(activity, "View seed phrase")
+                            if (authResult == BiometricService.AuthResult.SUCCESS) {
+                                showSeedWords = true
+                                seedAuthError = null
+                            } else {
+                                seedAuthError = "Authentication required"
+                            }
+                        } else {
+                            seedAuthError = "Authentication required"
+                        }
+                    }
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(
                 containerColor = Color(0xFF10B981),
@@ -51,6 +76,11 @@ fun BackupView(appState: AppState) {
             )
         ) {
             Text(if (showSeedWords) "Hide Seed Words" else "Backup Seed Words")
+        }
+
+        seedAuthError?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
         }
 
         if (showSeedWords) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -1,5 +1,6 @@
 package com.stablechannels.app.ui.transfer
 
+import android.content.ContextWrapper
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -19,11 +20,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import com.stablechannels.app.AppState
+import com.stablechannels.app.services.AppAccessPreferencesManager
+import com.stablechannels.app.services.BiometricService
 import com.stablechannels.app.ui.scanner.QRScannerScreen
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.QRCodeUtils
@@ -31,6 +35,7 @@ import com.stablechannels.app.util.btcSpacedFormatted
 import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.lightningdevkit.ldknode.Bolt11Invoice
 import org.lightningdevkit.ldknode.Offer
 
@@ -47,6 +52,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     var isExtractingQR by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+    val activity = context.findActivity()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
 
     val inputType = remember(input) {
@@ -272,67 +278,93 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                 onClick = {
                     isSending = true
                     error = null
-                    scope.launch(Dispatchers.IO) {
-                        try {
-                            appState.ensureLSPConnected()
-                            val trimmed = input.trim()
-                            val price = btcPrice
-                            when (inputType) {
-                                InputType.BOLT11 -> {
-                                    val invoice = Bolt11Invoice.fromStr(trimmed)
-                                    val invoiceMsat = invoice.amountMilliSatoshis()?.toLong() ?: 0L
-                                    val paymentId: String
-                                    val actualMsat: Long
-                                    if (invoiceMsat > 0) {
-                                        paymentId = appState.nodeService.sendPayment(invoice)
-                                        actualMsat = invoiceMsat
-                                    } else {
-                                        actualMsat = manualAmountMsat
-                                        paymentId = appState.nodeService.sendPaymentUsingAmount(invoice, actualMsat)
-                                    }
-                                    appState.databaseService?.recordPayment(
-                                        paymentId = paymentId, paymentType = "lightning",
-                                        direction = "sent", amountMsat = actualMsat, btcPrice = price
-                                    )
-                                    result = "Payment sent"
-                                }
-                                InputType.BOLT12 -> {
-                                    val sats = manualAmountSats
-                                    if (sats <= 0) throw Exception("Enter amount")
-                                    val offer = Offer.fromStr(trimmed)
-                                    val paymentId = appState.nodeService.sendBolt12UsingAmount(offer, sats * 1000)
-                                    appState.databaseService?.recordPayment(
-                                        paymentId = paymentId, paymentType = "bolt12",
-                                        direction = "sent", amountMsat = sats * 1000, btcPrice = price
-                                    )
-                                    result = "Bolt12 payment sent"
-                                }
-                                InputType.ONCHAIN -> {
-                                    val sats = manualAmountSats
-                                    if (sats <= 0) throw Exception("Enter amount")
-                                    val hasChannel = appState.nodeService.channels.any { it.isChannelReady }
-                                    if (hasChannel) {
-                                        if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
-                                        val sc = appState.stableChannel.value
-                                        appState.pendingSplice = com.stablechannels.app.models.PendingSplice("out", sats, trimmed)
-                                        appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
-                                        result = "Splice-out initiated"
-                                    } else {
-                                        val txid = appState.nodeService.sendOnchain(trimmed, sats)
-                                        appState.databaseService?.recordPayment(
-                                            paymentId = null, paymentType = "onchain",
-                                            direction = "sent", amountMsat = sats * 1000,
-                                            btcPrice = price, txid = txid, address = trimmed
-                                        )
-                                        result = "On-chain tx sent: $txid"
-                                    }
-                                }
-                                InputType.UNKNOWN -> throw Exception("Enter a valid invoice, offer, or address")
+                    scope.launch {
+                        // Auth gate: check if authentication is required
+                        val isOnChain = inputType == InputType.ONCHAIN
+                        val requiresAuth = AppAccessPreferencesManager.shouldRequireAuth(context, isOnChain)
+
+                        if (requiresAuth && activity != null) {
+                            val reason = if (isOnChain) {
+                                "Confirm on-chain withdrawal"
+                            } else {
+                                "Confirm payment of $displaySats sats"
                             }
-                        } catch (e: Exception) {
-                            error = e.message ?: "Send failed"
+                            val authResult = BiometricService.authenticate(activity, reason)
+                            if (authResult != BiometricService.AuthResult.SUCCESS) {
+                                error = "Authentication required to send"
+                                isSending = false
+                                return@launch
+                            }
+                        } else if (requiresAuth) {
+                            // Activity not available (e.g., inside bottom sheet) — block send
+                            error = "Authentication required to send"
+                            isSending = false
+                            return@launch
                         }
-                        isSending = false
+
+                        // Auth succeeded (or not required), proceed with send on IO thread
+                        withContext(Dispatchers.IO) {
+                            try {
+                                appState.ensureLSPConnected()
+                                val trimmed = input.trim()
+                                val price = btcPrice
+                                when (inputType) {
+                                    InputType.BOLT11 -> {
+                                        val invoice = Bolt11Invoice.fromStr(trimmed)
+                                        val invoiceMsat = invoice.amountMilliSatoshis()?.toLong() ?: 0L
+                                        val paymentId: String
+                                        val actualMsat: Long
+                                        if (invoiceMsat > 0) {
+                                            paymentId = appState.nodeService.sendPayment(invoice)
+                                            actualMsat = invoiceMsat
+                                        } else {
+                                            actualMsat = manualAmountMsat
+                                            paymentId = appState.nodeService.sendPaymentUsingAmount(invoice, actualMsat)
+                                        }
+                                        appState.databaseService?.recordPayment(
+                                            paymentId = paymentId, paymentType = "lightning",
+                                            direction = "sent", amountMsat = actualMsat, btcPrice = price
+                                        )
+                                        result = "Payment sent"
+                                    }
+                                    InputType.BOLT12 -> {
+                                        val sats = manualAmountSats
+                                        if (sats <= 0) throw Exception("Enter amount")
+                                        val offer = Offer.fromStr(trimmed)
+                                        val paymentId = appState.nodeService.sendBolt12UsingAmount(offer, sats * 1000)
+                                        appState.databaseService?.recordPayment(
+                                            paymentId = paymentId, paymentType = "bolt12",
+                                            direction = "sent", amountMsat = sats * 1000, btcPrice = price
+                                        )
+                                        result = "Bolt12 payment sent"
+                                    }
+                                    InputType.ONCHAIN -> {
+                                        val sats = manualAmountSats
+                                        if (sats <= 0) throw Exception("Enter amount")
+                                        val hasChannel = appState.nodeService.channels.any { it.isChannelReady }
+                                        if (hasChannel) {
+                                            if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
+                                            val sc = appState.stableChannel.value
+                                            appState.pendingSplice = com.stablechannels.app.models.PendingSplice("out", sats, trimmed)
+                                            appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
+                                            result = "Splice-out initiated"
+                                        } else {
+                                            val txid = appState.nodeService.sendOnchain(trimmed, sats)
+                                            appState.databaseService?.recordPayment(
+                                                paymentId = null, paymentType = "onchain",
+                                                direction = "sent", amountMsat = sats * 1000,
+                                                btcPrice = price, txid = txid, address = trimmed
+                                            )
+                                            result = "On-chain tx sent: $txid"
+                                        }
+                                    }
+                                    InputType.UNKNOWN -> throw Exception("Enter a valid invoice, offer, or address")
+                                }
+                            } catch (e: Exception) {
+                                error = e.message ?: "Send failed"
+                            }
+                            isSending = false
+                        }
                     }
                 },
                 enabled = !isSending && input.isNotBlank() && !needsAmount,
@@ -395,4 +427,18 @@ private fun InputTypeIndicator(inputType: InputType) {
             color = tint
         )
     }
+}
+
+
+/**
+ * Walks up the Context wrapper chain to find the hosting FragmentActivity.
+ * Works even inside ModalBottomSheet where LocalContext is a ContextThemeWrapper.
+ */
+private fun android.content.Context.findActivity(): FragmentActivity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is FragmentActivity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
## What

Wire the biometric auth infrastructure into actual user flows.

### Auth gates
- **On-chain sends** — always require biometric auth before confirming
- **Lightning sends** — require auth when Payment Confirmation toggle is enabled
- **Seed phrase viewing** — always require auth before revealing words

### Files
- `SendScreen.kt` — auth gate before send (on-chain always, Lightning when toggle on)
- `BackupView.kt` — auth gate before showing seed phrase

### Depends on
- Previous PR (biometric auth infrastructure — already merged)

### Testing
- [x] On-chain send requires auth
- [x] Lightning send respects Payment Confirmation toggle
- [x] Seed phrase viewing requires auth