### PR TITLE
feat(iOS): QR Infrastructure Overhaul + Receive UX Polish

### DIFF
--- a/ios/StableChannels/Package.resolved
+++ b/ios/StableChannels/Package.resolved
@@ -26,6 +26,33 @@
         "revision" : "68ab7f417e595f3997dd598ebe070dd5d1b5facf",
         "version" : "0.7.0"
       }
+    },
+    {
+      "identity" : "qrcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/QRCode.git",
+      "state" : {
+        "revision" : "49fec812bd70eb9417c9bbdfac8f2a4e0d7b9a06",
+        "version" : "28.0.2"
+      }
+    },
+    {
+      "identity" : "swift-qrcode-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/swift-qrcode-generator",
+      "state" : {
+        "revision" : "2b1980b825f08a81ccc762b0c4d17fcde9d5e953",
+        "version" : "2.0.2"
+      }
+    },
+    {
+      "identity" : "swiftimagereadwrite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/SwiftImageReadWrite",
+      "state" : {
+        "revision" : "42ace2412279f18bc264bc306e96b51c36e12a33",
+        "version" : "1.9.2"
+      }
     }
   ],
   "version" : 2

--- a/ios/StableChannels/Package.swift
+++ b/ios/StableChannels/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/lightningdevkit/ldk-node.git", exact: "0.7.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
         .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.0"),
-        .package(url: "https://github.com/dagronf/QRCode.git", from: "28.0.0")
+        .package(url: "https://github.com/dagronf/QRCode.git", exact: "28.0.2")
     ],
     targets: [
         .executableTarget(

--- a/ios/StableChannels/Package.swift
+++ b/ios/StableChannels/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/lightningdevkit/ldk-node.git", exact: "0.7.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
-        .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.0")
+        .package(url: "https://github.com/twostraws/CodeScanner.git", from: "2.5.0"),
+        .package(url: "https://github.com/dagronf/QRCode.git", from: "28.0.0")
     ],
     targets: [
         .executableTarget(
@@ -17,7 +18,8 @@ let package = Package(
             dependencies: [
                 .product(name: "LDKNode", package: "ldk-node"),
                 "KeychainAccess",
-                "CodeScanner"
+                "CodeScanner",
+                .product(name: "QRCode", package: "QRCode")
             ],
             path: "StableChannels"
         ),

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -740,7 +740,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
-				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StableChannels/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -787,7 +786,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
-				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StableChannels/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
+		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
@@ -102,6 +103,7 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
+		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
 				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
 				49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */,
 				4F22F6639A59D4B86A959586 /* Constants.swift */,
@@ -473,6 +476,7 @@
 				2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */,
 				96B467E3F04FC01EB23B8413 /* FundWalletView.swift in Sources */,
 				E7E816D3AF095B47E1F58407 /* HistoricalPrices.swift in Sources */,
+				4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */,
 				88769D82377C43BCF549A52C /* HistoryView.swift in Sources */,
 				1A54F909B027D90A0AADD1AF /* HomeView.swift in Sources */,
 				3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
+		4980E2882FCD0EB5009B5A3E /* ShareSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */; };
 		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
@@ -103,6 +104,7 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
+		4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetPresenter.swift; sourceTree = "<group>"; };
 		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
 				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
 				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
 				49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */,
@@ -485,6 +488,7 @@
 				49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */,
 				6B789335CAF664AC4DA75B1A /* PaymentDetailView.swift in Sources */,
 				8A8A0B0C2BA8736EC140DD0E /* PriceChartView.swift in Sources */,
+				4980E2882FCD0EB5009B5A3E /* ShareSheetPresenter.swift in Sources */,
 				05856856E6E8EF9E688EFA20 /* PriceService.swift in Sources */,
 				37DA6E9D4F5D4BF36DD86BC8 /* ReceiveView.swift in Sources */,
 				B4C85619D6A5506E1BD9FC11 /* SellView.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
 		496A44432FCD4F75005AF12F /* QRInputToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44422FCD4F75005AF12F /* QRInputToolbar.swift */; };
 		496A44442FCD4F75005AF12F /* QRCodeExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */; };
+		496A44462FCD5845005AF12F /* InputSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44452FCD5845005AF12F /* InputSanitizer.swift */; };
 		4980E2882FCD0EB5009B5A3E /* ShareSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */; };
 		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
@@ -108,6 +109,7 @@
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
 		496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeExtractor.swift; sourceTree = "<group>"; };
 		496A44422FCD4F75005AF12F /* QRInputToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRInputToolbar.swift; sourceTree = "<group>"; };
+		496A44452FCD5845005AF12F /* InputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSanitizer.swift; sourceTree = "<group>"; };
 		4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetPresenter.swift; sourceTree = "<group>"; };
 		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				496A44452FCD5845005AF12F /* InputSanitizer.swift */,
 				496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */,
 				496A44422FCD4F75005AF12F /* QRInputToolbar.swift */,
 				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
@@ -480,6 +483,7 @@
 				8A8C427CEEC2C65DD31A6E88 /* BuyView.swift in Sources */,
 				7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */,
 				DC5FA35343D89CB75FD4E402 /* ContentView.swift in Sources */,
+				496A44462FCD5845005AF12F /* InputSanitizer.swift in Sources */,
 				3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */,
 				4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */,
 				2770708ED911F0D15D5C3670 /* Extensions.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
+		496A44432FCD4F75005AF12F /* QRInputToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44422FCD4F75005AF12F /* QRInputToolbar.swift */; };
+		496A44442FCD4F75005AF12F /* QRCodeExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */; };
 		4980E2882FCD0EB5009B5A3E /* ShareSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */; };
 		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
@@ -104,6 +106,8 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
+		496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeExtractor.swift; sourceTree = "<group>"; };
+		496A44422FCD4F75005AF12F /* QRInputToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRInputToolbar.swift; sourceTree = "<group>"; };
 		4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetPresenter.swift; sourceTree = "<group>"; };
 		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -267,6 +271,8 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */,
+				496A44422FCD4F75005AF12F /* QRInputToolbar.swift */,
 				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
 				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
 				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
@@ -505,6 +511,8 @@
 				49F0B0E22FC0EF3A003A3B89 /* Colors.swift in Sources */,
 				49F0B0E32FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift in Sources */,
 				49E456812FCC596F00B0CA85 /* QRCodeUtility.swift in Sources */,
+				496A44432FCD4F75005AF12F /* QRInputToolbar.swift in Sources */,
+				496A44442FCD4F75005AF12F /* QRCodeExtractor.swift in Sources */,
 				49E456822FCC596F00B0CA85 /* FullscreenQRZoomView.swift in Sources */,
 				49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */,
 				49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
 		49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */; };
+		49E4567E2FCA3E8B00B0CA85 /* QRCode in Frameworks */ = {isa = PBXBuildFile; productRef = 49E4567D2FCA3E8B00B0CA85 /* QRCode */; };
+		49E456812FCC596F00B0CA85 /* QRCodeUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */; };
+		49E456822FCC596F00B0CA85 /* FullscreenQRZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */; };
 		49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */; };
 		49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */; };
 		49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */; };
@@ -103,6 +106,8 @@
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccessSettingsView.swift; sourceTree = "<group>"; };
+		49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenQRZoomView.swift; sourceTree = "<group>"; };
+		49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeUtility.swift; sourceTree = "<group>"; };
 		49F0B0D52FC0EF3A003A3B89 /* AboutSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSettingsView.swift; sourceTree = "<group>"; };
 		49F0B0D62FC0EF3A003A3B89 /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsView.swift; sourceTree = "<group>"; };
@@ -150,6 +155,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49E4567E2FCA3E8B00B0CA85 /* QRCode in Frameworks */,
 				BE362D96DB2063959BD092BC /* LDKNode in Frameworks */,
 				96F38A820CB6644940199C95 /* KeychainAccess in Frameworks */,
 				02EB2F2AFFACF5F588CF7912 /* CodeScanner in Frameworks */,
@@ -257,6 +263,8 @@
 		AD3E779FC98D09AA36FFCAE9 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
+				49E456802FCC596F00B0CA85 /* QRCodeUtility.swift */,
 				4F22F6639A59D4B86A959586 /* Constants.swift */,
 				AD425F9D6479B95B2258FCAE /* Extensions.swift */,
 				3B46630309755AE15EF291D4 /* HistoricalPrices.swift */,
@@ -363,8 +371,6 @@
 				08FE78FD6D230E0A01C11743 /* PBXTargetDependency */,
 			);
 			name = StableChannelsTests;
-			packageProductDependencies = (
-			);
 			productName = StableChannelsTests;
 			productReference = D34C08DCF6ACD28A3898859D /* StableChannelsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -388,6 +394,7 @@
 				925308E8B38E5B35C4AB30A4 /* LDKNode */,
 				79D34B41CFF9ABC3C914B624 /* KeychainAccess */,
 				C5B41595048B8AA9D3617B42 /* CodeScanner */,
+				49E4567D2FCA3E8B00B0CA85 /* QRCode */,
 			);
 			productName = StableChannels;
 			productReference = AAE0551124703F8BAA9C44C0 /* StableChannels.app */;
@@ -416,7 +423,9 @@
 				42173C82F7AE7108B707E5F8 /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				5C44A4ACEB5EFD7C2E78B8A6 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				70EEE76071EE59F64A24FD4F /* XCRemoteSwiftPackageReference "ldk-node" */,
+				49E4567C2FCA3E8B00B0CA85 /* XCRemoteSwiftPackageReference "QRCode" */,
 			);
+			productRefGroup = 052E4A6FC61BFB06E0A2A974 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -487,6 +496,8 @@
 				49F0B0E12FC0EF3A003A3B89 /* NotificationsSettingsView.swift in Sources */,
 				49F0B0E22FC0EF3A003A3B89 /* Colors.swift in Sources */,
 				49F0B0E32FC0EF3A003A3B89 /* PushConnectivitySettingsView.swift in Sources */,
+				49E456812FCC596F00B0CA85 /* QRCodeUtility.swift in Sources */,
+				49E456822FCC596F00B0CA85 /* FullscreenQRZoomView.swift in Sources */,
 				49F0B0E42FC0EF3A003A3B89 /* StablePositionView.swift in Sources */,
 				49F0B0E52FC0EF3A003A3B89 /* AboutSettingsView.swift in Sources */,
 				49F0B0E62FC0EF3A003A3B89 /* AppearanceSettingsView.swift in Sources */,
@@ -582,6 +593,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -663,6 +675,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -707,6 +720,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StableChannels/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -753,6 +767,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VJF3VBKXV9;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StableChannels/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -817,6 +832,14 @@
 				minimumVersion = 2.5.0;
 			};
 		};
+		49E4567C2FCA3E8B00B0CA85 /* XCRemoteSwiftPackageReference "QRCode" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/dagronf/QRCode.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 28.0.2;
+			};
+		};
 		5C44A4ACEB5EFD7C2E78B8A6 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess.git";
@@ -836,6 +859,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		49E4567D2FCA3E8B00B0CA85 /* QRCode */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 49E4567C2FCA3E8B00B0CA85 /* XCRemoteSwiftPackageReference "QRCode" */;
+			productName = QRCode;
+		};
 		74AB91D77B62D8BA24840317 /* LDKNode */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 70EEE76071EE59F64A24FD4F /* XCRemoteSwiftPackageReference "ldk-node" */;

--- a/ios/StableChannels/StableChannels.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e361f7d2296187aeb60e118ea09e178ee68bf4f796cc75de6a6b844098c93353",
+  "originHash" : "8425ecd3ab1390cff4e416ff9a1ee89186af666a99a5271053da5377b1094765",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -26,6 +26,33 @@
       "state" : {
         "revision" : "68ab7f417e595f3997dd598ebe070dd5d1b5facf",
         "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "qrcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/QRCode",
+      "state" : {
+        "revision" : "49fec812bd70eb9417c9bbdfac8f2a4e0d7b9a06",
+        "version" : "28.0.2"
+      }
+    },
+    {
+      "identity" : "swift-qrcode-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/swift-qrcode-generator",
+      "state" : {
+        "revision" : "2b1980b825f08a81ccc762b0c4d17fcde9d5e953",
+        "version" : "2.0.2"
+      }
+    },
+    {
+      "identity" : "swiftimagereadwrite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/SwiftImageReadWrite",
+      "state" : {
+        "revision" : "42ace2412279f18bc264bc306e96b51c36e12a33",
+        "version" : "1.9.2"
       }
     }
   ],

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -2133,7 +2133,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Maximum: $"
+            "value" : "Maximum: $%lld"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -2006,6 +2006,28 @@
         }
       }
     },
+    "label_your_address" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Bitcoin Address"
+          }
+        }
+      }
+    },
+    "label_your_invoice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Lightning Invoice"
+          }
+        }
+      }
+    },
     "link_about" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -2906,6 +2906,17 @@
         }
       }
     },
+    "Tap to enlarge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to enlarge"
+          }
+        }
+      }
+    },
     "theme_dark" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -221,6 +221,17 @@
         }
       }
     },
+    "Bitcoin address QR code" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitcoin address QR code"
+          }
+        }
+      }
+    },
     "button_any_amount" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -448,6 +459,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Restore Seed"
+          }
+        }
+      }
+    },
+    "button_retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         }
       }
@@ -2342,6 +2364,17 @@
     "Price" : {
 
     },
+    "QR Code" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QR Code"
+          }
+        }
+      }
+    },
     "section_about" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2902,6 +2935,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Settings"
+          }
+        }
+      }
+    },
+    "Tap to close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to close"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -364,17 +364,6 @@
         }
       }
     },
-    "button_enlarge_qr" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Enlarge QR"
-          }
-        }
-      }
-    },
     "button_enable_in_settings" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -393,6 +382,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enable Settings"
+          }
+        }
+      }
+    },
+    "button_enlarge_qr" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enlarge QR"
           }
         }
       }
@@ -441,6 +441,17 @@
         }
       }
     },
+    "button_pick_image" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pick Image"
+          }
+        }
+      }
+    },
     "button_receive" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -481,6 +492,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retry"
+          }
+        }
+      }
+    },
+    "button_scan_qr" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan QR"
           }
         }
       }
@@ -965,6 +987,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Invoice Address"
+          }
+        }
+      }
+    },
+    "header_onchain_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move funds to any Bitcoin address"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -507,6 +507,17 @@
         }
       }
     },
+    "button_share_qr" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share QR"
+          }
+        }
+      }
+    },
     "button_show_node_id" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -364,6 +364,17 @@
         }
       }
     },
+    "button_enlarge_qr" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enlarge QR"
+          }
+        }
+      }
+    },
     "button_enable_in_settings" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -18,6 +18,12 @@ enum Constants {
 
     static let primaryChainURL = "https://blockstream.info/api"
     static let fallbackChainURL = "https://mempool.space/api"
+    static let txExplorerURL = "https://mempool.space/tx"
+
+    static func txExplorerLink(for txid: String) -> URL? {
+        URL(string: "\(txExplorerURL)/\(txid)")
+    }
+
     static let defaultLSPPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
     static let defaultLSPAddress = "34.198.44.89:9735"
     static let defaultGatewayPubkey = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"

--- a/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
+++ b/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct FullscreenQRZoomView: View {
     private let horizontalPadding: CGFloat = 48
@@ -9,14 +10,17 @@ struct FullscreenQRZoomView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
-            Image(uiImage: qrImage)
-                .interpolation(.none)
-                .resizable()
-                .scaledToFit()
-                .frame(maxWidth: UIScreen.main.bounds.width - horizontalPadding,
-                       maxHeight: UIScreen.main.bounds.width - horizontalPadding)
-                .accessibilityLabel(String(localized: "QR Code", defaultValue: "QR Code"))
-                .accessibilityHint(String(localized: "Tap to close", defaultValue: "Tap to close"))
+            GeometryReader { geo in
+                let side = min(geo.size.width, geo.size.height) - horizontalPadding
+                Image(uiImage: qrImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: side, height: side)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .accessibilityLabel(String(localized: "QR Code", defaultValue: "QR Code"))
+            .accessibilityHint(String(localized: "Tap to close", defaultValue: "Tap to close"))
 
             VStack {
                 Spacer()

--- a/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
+++ b/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct FullscreenQRZoomView: View {
+    private let horizontalPadding: CGFloat = 48
+    let qrImage: UIImage
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            Image(uiImage: qrImage)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: UIScreen.main.bounds.width - horizontalPadding,
+                       maxHeight: UIScreen.main.bounds.width - horizontalPadding)
+                .accessibilityLabel("QR Code")
+                .accessibilityHint(String(localized: "Tap to close", defaultValue: "Tap to close"))
+
+            VStack {
+                Spacer()
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark.circle")
+                        .font(.caption)
+                    Text(String(localized: "Tap to close", defaultValue: "Tap to close"))
+                        .font(.caption)
+                }
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.bottom, 48)
+            }
+        }
+        .onTapGesture {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                isPresented = false
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
+++ b/ios/StableChannels/StableChannels/Utilities/FullscreenQRZoomView.swift
@@ -15,7 +15,7 @@ struct FullscreenQRZoomView: View {
                 .scaledToFit()
                 .frame(maxWidth: UIScreen.main.bounds.width - horizontalPadding,
                        maxHeight: UIScreen.main.bounds.width - horizontalPadding)
-                .accessibilityLabel("QR Code")
+                .accessibilityLabel(String(localized: "QR Code", defaultValue: "QR Code"))
                 .accessibilityHint(String(localized: "Tap to close", defaultValue: "Tap to close"))
 
             VStack {

--- a/ios/StableChannels/StableChannels/Utilities/InputSanitizer.swift
+++ b/ios/StableChannels/StableChannels/Utilities/InputSanitizer.swift
@@ -1,0 +1,28 @@
+enum InputSanitizer {
+    /// Keeps digits + at most one dot, trims excess decimals, strips leading zeros.
+    /// `"00012.3a."` with `maxDecimals: 2` -> `"12.3"`, `"."` -> `"0."`, `""` -> `""`.
+    static func decimal(_ raw: String, maxDecimals: Int = 2) -> String {
+        var s = raw
+        while s.hasPrefix("0") && s.count > 1 && !s.hasPrefix("0.") {
+            s.removeFirst()
+        }
+        var result = ""
+        var seenDot = false
+        var decimals = 0
+        for ch in s {
+            if ch.isNumber {
+                if seenDot {
+                    decimals += 1
+                    if decimals > maxDecimals { continue }
+                }
+                result.append(ch)
+            } else if ch == "." && !seenDot {
+                seenDot = true
+                result.append(ch)
+            }
+        }
+        if result.isEmpty { return "" }
+        if result == "." { return "0." }
+        return result
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/QRCodeExtractor.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRCodeExtractor.swift
@@ -1,0 +1,68 @@
+import UIKit
+import Vision
+
+enum QRCodeExtractor {
+    /// Cap the longest edge of the input image. Vision can detect a QR in a
+    /// few hundred pixels; full-resolution photos waste memory + CPU.
+    private static let maxEdge: CGFloat = 1024
+
+    static func extract(from image: UIImage) -> String? {
+        guard let cgImage = downscaledCGImage(from: image) else { return nil }
+        let request = VNDetectBarcodesRequest()
+        request.symbologies = [.qr]
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try? handler.perform([request])
+        return request.results?
+            .compactMap(\.payloadStringValue)
+            .first(where: { !$0.isEmpty })
+    }
+
+    private static func downscaledCGImage(from image: UIImage) -> CGImage? {
+        guard let original = image.cgImage else { return nil }
+        let w = original.width
+        let h = original.height
+        let longest = max(w, h)
+        guard longest > Int(maxEdge) else { return original }
+        let scale = maxEdge / CGFloat(longest)
+        let newW = Int(CGFloat(w) * scale)
+        let newH = Int(CGFloat(h) * scale)
+        let colorSpace = original.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+        let bitsPerComponent = original.bitsPerComponent > 0 ? original.bitsPerComponent : 8
+        guard let ctx = CGContext(
+            data: nil,
+            width: newW,
+            height: newH,
+            bitsPerComponent: bitsPerComponent,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
+        ) else { return original }
+        ctx.interpolationQuality = .high
+        ctx.draw(original, in: CGRect(x: 0, y: 0, width: newW, height: newH))
+        return ctx.makeImage() ?? original
+    }
+
+    static func sanitizeAddress(_ raw: String) -> String {
+        sanitizePaymentURI(raw, scheme: "bitcoin:")
+    }
+
+    static func sanitizeLightningInput(_ raw: String) -> String {
+        sanitizePaymentURI(raw, scheme: "lightning:")
+    }
+
+    /// Strips both `lightning:` and `bitcoin:` URI schemes (case-insensitive prefix).
+    static func sanitizePaymentInput(_ raw: String) -> String {
+        sanitizeLightningInput(sanitizeAddress(raw))
+    }
+
+    private static func sanitizePaymentURI(_ raw: String, scheme: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.range(of: scheme, options: [.caseInsensitive, .anchored]) != nil {
+            s.removeFirst(scheme.count)
+        }
+        if let q = s.firstIndex(of: "?") {
+            s = String(s[..<q])
+        }
+        return s
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
@@ -7,12 +7,12 @@ enum QRCodeUtility {
     private static let cache: NSCache<NSString, UIImage> = {
         let c = NSCache<NSString, UIImage>()
         c.countLimit = 100
-        // 512x512x4 = ~1MB per image. 10MB limit allows ~10 cached QR codes (wallet use case).
-        c.totalCostLimit = 10_000_000
+        // 1024x1024x4 = ~4MB per image. 40MB limit allows ~10 cached QR codes (wallet use case).
+        c.totalCostLimit = 40_000_000
         return c
     }()
 
-    static func generate(from string: String, size: CGFloat = 512) -> UIImage? {
+    static func generate(from string: String, size: CGFloat = 1024) -> UIImage? {
         let cacheKey = NSString(string: "\(string)_\(Int(size))")
         if let cached = cache.object(forKey: cacheKey) {
             return cached

--- a/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
@@ -11,7 +11,7 @@ enum QRCodeUtility {
         return c
     }()
 
-    static func generate(from string: String, size: CGFloat = 2048) -> UIImage? {
+    static func generate(from string: String, size: CGFloat = 512) -> UIImage? {
         let cacheKey = NSString(string: "\(string)_\(Int(size))")
         if let cached = cache.object(forKey: cacheKey) {
             return cached
@@ -28,7 +28,7 @@ enum QRCodeUtility {
 
     /// Async variant for SwiftUI .task compatibility
     @MainActor
-    static func generateAsync(from string: String, size: CGFloat = 2048) async -> UIImage? {
+    static func generateAsync(from string: String, size: CGFloat = 512) async -> UIImage? {
         generate(from: string, size: size)
     }
 

--- a/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+import QRCode
+
+enum QRCodeUtility {
+    // NSCache auto-evicts under memory pressure with configured limits
+    private static let cache: NSCache<NSString, UIImage> = {
+        let c = NSCache<NSString, UIImage>()
+        c.countLimit = 100
+        c.totalCostLimit = 50_000_000 // 50MB limit
+        return c
+    }()
+
+    static func generate(from string: String, size: CGFloat = 2048) -> UIImage? {
+        let cacheKey = NSString(string: "\(string)_\(Int(size))")
+        if let cached = cache.object(forKey: cacheKey) {
+            return cached
+        }
+
+        guard let image = generateQRImage(from: string, size: size) else {
+            return nil
+        }
+
+        let cost = Int(size * size * 4) // Approximate bytes (RGBA)
+        cache.setObject(image, forKey: cacheKey, cost: cost)
+        return image
+    }
+
+    /// Async variant for SwiftUI .task compatibility
+    @MainActor
+    static func generateAsync(from string: String, size: CGFloat = 2048) async -> UIImage? {
+        generate(from: string, size: size)
+    }
+
+    static func clearCache() {
+        cache.removeAllObjects()
+    }
+
+    // BIP-21 URI helper for on-chain addresses
+    static func generateBitcoinURI(from address: String, amount: String? = nil) -> String {
+        var uri = "bitcoin:\(address)"
+        if let amount, !amount.isEmpty {
+            uri += "?amount=\(amount)"
+        }
+        return uri
+    }
+
+    private static func generateQRImage(from string: String, size: CGFloat) -> UIImage? {
+        do {
+            let doc = try QRCode.Document(utf8String: string)
+
+            // Eye style: Peacock corners
+            doc.design.shape.eye = QRCode.EyeShape.Peacock()
+
+            // Pixel style
+            doc.design.shape.onPixels = QRCode.PixelShape.RoundedPath()
+            doc.design.shape.offPixels = QRCode.PixelShape.RoundedPath()
+
+            let cgImage = try doc.cgImage(width: size, height: size)
+            return UIImage(cgImage: cgImage)
+        } catch {
+            // CoreImage fallback
+            let context = CIContext()
+            let filter = CIFilter.qrCodeGenerator()
+            filter.message = Data(string.utf8)
+            guard let outputImage = filter.outputImage else { return nil }
+            let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: 40, y: 40))
+            guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
+            return UIImage(cgImage: cgImage)
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRCodeUtility.swift
@@ -7,7 +7,8 @@ enum QRCodeUtility {
     private static let cache: NSCache<NSString, UIImage> = {
         let c = NSCache<NSString, UIImage>()
         c.countLimit = 100
-        c.totalCostLimit = 50_000_000 // 50MB limit
+        // 512x512x4 = ~1MB per image. 10MB limit allows ~10 cached QR codes (wallet use case).
+        c.totalCostLimit = 10_000_000
         return c
     }()
 
@@ -24,12 +25,6 @@ enum QRCodeUtility {
         let cost = Int(size * size * 4) // Approximate bytes (RGBA)
         cache.setObject(image, forKey: cacheKey, cost: cost)
         return image
-    }
-
-    /// Async variant for SwiftUI .task compatibility
-    @MainActor
-    static func generateAsync(from string: String, size: CGFloat = 512) async -> UIImage? {
-        generate(from: string, size: size)
     }
 
     static func clearCache() {

--- a/ios/StableChannels/StableChannels/Utilities/QRInputToolbar.swift
+++ b/ios/StableChannels/StableChannels/Utilities/QRInputToolbar.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import PhotosUI
+
+struct QRInputToolbar: ViewModifier {
+    @Binding var text: String
+    var sanitize: (String) -> String
+
+    @State private var showScanner = false
+    @State private var showPhotoPicker = false
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var showQRAlert = false
+    @State private var qrAlertMessage = ""
+
+    private let qrErrorMessage = String(
+        localized: "alert_qr_error",
+        defaultValue: "Selected image doesn't contain a QR code."
+    )
+    private let qrAlertTitle = String(
+        localized: "alert_no_qr",
+        defaultValue: "No QR Code Found"
+    )
+
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    HStack(spacing: 16) {
+                        Button { showPhotoPicker = true } label: {
+                            Image(systemName: "photo.on.rectangle")
+                        }
+                        .accessibilityLabel(String(localized: "button_pick_image", defaultValue: "Pick Image"))
+
+                        Button { showScanner = true } label: {
+                            Image(systemName: "qrcode.viewfinder")
+                        }
+                        .accessibilityLabel(String(localized: "button_scan_qr", defaultValue: "Scan QR"))
+                    }
+                }
+            }
+            .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
+            .onChange(of: selectedPhotoItem) { _, newItem in
+                guard let item = newItem else { return }
+                Task.detached(priority: .userInitiated) {
+                    let data = try? await item.loadTransferable(type: Data.self)
+                    let code: String? = await {
+                        guard let data, let image = UIImage(data: data) else { return nil }
+                        return QRCodeExtractor.extract(from: image)
+                    }()
+                    await MainActor.run {
+                        if let code {
+                            text = sanitize(code)
+                        } else {
+                            qrAlertMessage = qrErrorMessage
+                            showQRAlert = true
+                        }
+                        selectedPhotoItem = nil
+                    }
+                }
+            }
+            .sheet(isPresented: $showScanner) {
+                InvoiceScanView(
+                    onScan: { scanned in
+                        text = sanitize(scanned)
+                        showScanner = false
+                    },
+                    onCancel: { showScanner = false }
+                )
+            }
+            .alert(qrAlertTitle, isPresented: $showQRAlert) {
+                Button(String(localized: "button_ok", defaultValue: "OK"), role: .cancel) {}
+            } message: {
+                Text(qrAlertMessage)
+            }
+    }
+}
+
+extension View {
+    func qrInputToolbar(
+        text: Binding<String>,
+        sanitize: @escaping (String) -> String = { $0 }
+    ) -> some View {
+        modifier(QRInputToolbar(text: text, sanitize: sanitize))
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
+++ b/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
@@ -7,20 +7,25 @@ enum ShareSheetPresenter {
             applicationActivities: nil
         )
 
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive }),
-            let rootVC = windowScene.windows
-            .first(where: \.isKeyWindow)?
-            .rootViewController else {
-            assertionFailure("ShareSheetPresenter: no active foreground window scene with rootViewController")
+        guard let topVC = topMostViewController() else {
+            assertionFailure("ShareSheetPresenter: no view controller in any window scene")
             return
         }
 
-        var topVC = rootVC
-        while let presented = topVC.presentedViewController {
-            topVC = presented
-        }
         topVC.present(activityVC, animated: true)
+    }
+
+    private static func topMostViewController() -> UIViewController? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows where window.isKeyWindow {
+                guard var top = window.rootViewController else { continue }
+                while let presented = top.presentedViewController {
+                    top = presented
+                }
+                return top
+            }
+        }
+        return nil
     }
 }

--- a/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
+++ b/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
@@ -13,6 +13,7 @@ enum ShareSheetPresenter {
             let rootVC = windowScene.windows
             .first(where: \.isKeyWindow)?
             .rootViewController else {
+            assertionFailure("ShareSheetPresenter: no active foreground window scene with rootViewController")
             return
         }
 

--- a/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
+++ b/ios/StableChannels/StableChannels/Utilities/ShareSheetPresenter.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+enum ShareSheetPresenter {
+    static func present(items: [Any]) {
+        let activityVC = UIActivityViewController(
+            activityItems: items,
+            applicationActivities: nil
+        )
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+            let rootVC = windowScene.windows
+            .first(where: \.isKeyWindow)?
+            .rootViewController else {
+            return
+        }
+
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+        topVC.present(activityVC, animated: true)
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/ShareableQRGenerator.swift
+++ b/ios/StableChannels/StableChannels/Utilities/ShareableQRGenerator.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+import UIKit
+
+enum ShareableQRGenerator {
+    // Image dimensions
+    private static let imgWidth: CGFloat = 1080
+    private static let imgHeight: CGFloat = 1920
+
+    // QR code
+    private static let qrSize: CGFloat = 720
+
+    // Header elements
+    private static let iconSize: CGFloat = 126
+    private static let iconCornerRadius: CGFloat = 18
+    private static let textLineHeight: CGFloat = 61
+    private static let headerBottomPadding: CGFloat = 62
+    private static let headerGap: CGFloat = 0
+
+    // Footer elements
+    private static let footerGap: CGFloat = 110
+    private static let invoiceToCopyrightGap: CGFloat = 100
+    private static let labelToInvoiceGap: CGFloat = 20
+
+    // Lightning invoice truncation
+    private static let LN_CHARS_LEFT = 14
+    private static let LN_CHARS_RIGHT = 14
+    private static let LN_DOTS = "......." // 7 dots
+
+    private static func loadAppIcon() -> UIImage? {
+        return UIImage(named: "SplashIcon")
+    }
+
+    private static func calculateInvoiceFontSize(for text: String, availableWidth: CGFloat) -> CGFloat {
+        let charRatio: CGFloat = 0.6
+        let charCount = CGFloat(text.count)
+        return floor(availableWidth / (charCount * charRatio))
+    }
+
+    private static func calculateOnChainFontSize(for text: String, availableWidth: CGFloat) -> CGFloat {
+        var fontSize: CGFloat = 60
+        let step: CGFloat = 2
+        var font = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        while text.size(withAttributes: [.font: font]).width > availableWidth && fontSize > 10 {
+            fontSize -= step
+            font = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        }
+        return fontSize
+    }
+
+    static func generateShareImage(qrImage: UIImage, invoice: String, amount: String?,
+                                   isOnChain: Bool = false) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: imgWidth, height: imgHeight))
+
+        return renderer.image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: imgWidth, height: imgHeight))
+
+            let headerHeight = iconSize + textLineHeight + headerBottomPadding
+            let qrY = imgHeight / 2 - qrSize / 2
+            let iconY = qrY - headerHeight - headerGap
+            let footerStartY = qrY + qrSize + footerGap
+
+            let textFont = UIFont.systemFont(ofSize: 50, weight: .bold)
+            let stableWidth = "Stable".size(withAttributes: [.font: textFont]).width
+            let channelsWidth = "Channels".size(withAttributes: [.font: textFont]).width
+            let headerTextWidth = max(stableWidth, channelsWidth)
+            let textGap: CGFloat = 11
+            let totalWidth = iconSize + textGap + headerTextWidth
+            let blockCenterX = imgWidth / 2
+            let blockStartX = blockCenterX - totalWidth / 2
+
+            // Draw icon
+            let icon = loadAppIcon()
+            let iconRect = CGRect(
+                x: blockStartX,
+                y: iconY,
+                width: iconSize,
+                height: iconSize
+            )
+            if let loadedIcon = icon {
+                let path = UIBezierPath(roundedRect: iconRect, cornerRadius: iconCornerRadius)
+                context.cgContext.addPath(path.cgPath)
+                context.cgContext.clip()
+                loadedIcon.draw(in: iconRect)
+                context.cgContext.resetClip()
+            } else {
+                let path = UIBezierPath(roundedRect: iconRect, cornerRadius: iconCornerRadius)
+                UIColor.systemBlue.setFill()
+                path.fill()
+            }
+
+            // Draw header text
+            let textStartX = blockStartX + iconSize + textGap
+            let textCenterX = textStartX + headerTextWidth / 2
+            let textAttrs: [NSAttributedString.Key: Any] = [.font: textFont, .foregroundColor: UIColor.black]
+            "Stable".draw(at: CGPoint(x: textCenterX - stableWidth / 2, y: iconY), withAttributes: textAttrs)
+            "Channels".draw(
+                at: CGPoint(x: textCenterX - channelsWidth / 2, y: iconY + textLineHeight),
+                withAttributes: textAttrs
+            )
+
+            // Draw QR
+            let qrRect = CGRect(x: (imgWidth - qrSize) / 2, y: qrY, width: qrSize, height: qrSize)
+            qrImage.draw(in: qrRect)
+
+            // Draw footer
+            var contentY = footerStartY
+
+            if let amountText = amount {
+                let amountFont = UIFont.systemFont(ofSize: 58, weight: .bold)
+                let amountAttrs: [NSAttributedString.Key: Any] = [.font: amountFont, .foregroundColor: UIColor.black]
+                let amountSize = amountText.size(withAttributes: amountAttrs)
+                let amountRect = CGRect(
+                    x: (imgWidth - amountSize.width) / 2,
+                    y: contentY,
+                    width: amountSize.width,
+                    height: amountSize.height
+                )
+                amountText.draw(in: amountRect, withAttributes: amountAttrs)
+                contentY += amountSize.height + footerGap
+            }
+
+            let labelFont = UIFont.systemFont(ofSize: 36, weight: .semibold)
+            let labelText = isOnChain ? "Bitcoin Address" : "Lightning Payment"
+
+            if isOnChain {
+                let btcSymbol = "₿"
+                let btcFont = UIFont.systemFont(ofSize: 36, weight: .semibold)
+                let textPortion = "itcoin Address"
+
+                let btcSize = btcSymbol.size(withAttributes: [.font: btcFont])
+                let textSize = textPortion.size(withAttributes: [.font: labelFont])
+                let totalWidth = btcSize.width + textSize.width
+
+                let btcAttrs: [NSAttributedString.Key: Any] = [
+                    .font: btcFont,
+                    .foregroundColor: UIColor(red: 1.0, green: 0.6, blue: 0.0, alpha: 1.0)
+                ]
+                let textAttrs: [NSAttributedString.Key: Any] = [
+                    .font: labelFont,
+                    .foregroundColor: UIColor.black
+                ]
+
+                let startX = (imgWidth - totalWidth) / 2
+                btcSymbol.draw(at: CGPoint(x: startX, y: contentY), withAttributes: btcAttrs)
+                textPortion.draw(at: CGPoint(x: startX + btcSize.width, y: contentY), withAttributes: textAttrs)
+            } else {
+                let labelAttrs: [NSAttributedString.Key: Any] = [
+                    .font: labelFont,
+                    .foregroundColor: UIColor(red: 1.0, green: 0.6, blue: 0.0, alpha: 1.0)
+                ]
+                let labelSize = labelText.size(withAttributes: labelAttrs)
+                let labelRect = CGRect(
+                    x: (imgWidth - labelSize.width) / 2,
+                    y: contentY,
+                    width: labelSize.width,
+                    height: 36
+                )
+                labelText.draw(in: labelRect, withAttributes: labelAttrs)
+            }
+
+            contentY += 36 + labelToInvoiceGap
+
+            // Draw invoice
+            let availableWidth = qrSize
+            let displayInvoice: String
+            let invoiceFont: UIFont
+
+            if isOnChain {
+                let fontSize = calculateOnChainFontSize(for: invoice, availableWidth: availableWidth)
+                invoiceFont = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+                displayInvoice = invoice
+            } else {
+                let leftPart = String(invoice.prefix(LN_CHARS_LEFT))
+                let rightPart = String(invoice.suffix(LN_CHARS_RIGHT))
+                displayInvoice = leftPart + LN_DOTS + rightPart
+
+                let fontSize = calculateInvoiceFontSize(for: displayInvoice, availableWidth: availableWidth)
+                invoiceFont = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+            }
+
+            let invoiceAttrs: [NSAttributedString.Key: Any] = [.font: invoiceFont, .foregroundColor: UIColor.black]
+            let invoiceSize = displayInvoice.size(withAttributes: invoiceAttrs)
+            let invoiceRect = CGRect(
+                x: (imgWidth - invoiceSize.width) / 2,
+                y: contentY,
+                width: invoiceSize.width,
+                height: invoiceSize.height
+            )
+            displayInvoice.draw(in: invoiceRect, withAttributes: invoiceAttrs)
+
+            contentY += invoiceSize.height + invoiceToCopyrightGap
+
+            // Draw copyright
+            let copyFont = UIFont.systemFont(ofSize: 22, weight: .medium)
+            let copyText = "© StableChannels.com"
+            let copyAttrs: [NSAttributedString.Key: Any] = [
+                .font: copyFont,
+                .foregroundColor: UIColor(white: 0.4, alpha: 1.0)
+            ]
+            let copySize = copyText.size(withAttributes: copyAttrs)
+            let copyRect = CGRect(
+                x: (imgWidth - copySize.width) / 2,
+                y: contentY,
+                width: copySize.width,
+                height: copySize.height
+            )
+            copyText.draw(in: copyRect, withAttributes: copyAttrs)
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -45,6 +45,7 @@ struct FundWalletView: View {
                 FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
             }
         }
+        .onDisappear { copyResetTask?.cancel() }
     }
 
     // MARK: - Subviews

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -8,6 +8,7 @@ struct FundWalletView: View {
     @State private var isCopied = false
     @State private var showFullscreenQR = false
     @State private var loadError: Error?
+    @State private var copyResetTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
@@ -120,12 +121,7 @@ struct FundWalletView: View {
                 .contentShape(Rectangle())
                 .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isCopied)
                 .onTapGesture {
-                    UIPasteboard.general.string = address
-                    isCopied = true
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        isCopied = false
-                    }
+                    copyAddress(address)
                 }
         }
     }
@@ -133,12 +129,7 @@ struct FundWalletView: View {
     private func actionButtons(address: String) -> some View {
         HStack(spacing: 12) {
             Button {
-                UIPasteboard.general.string = address
-                isCopied = true
-                Task {
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    isCopied = false
-                }
+                copyAddress(address)
             } label: {
                 Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
                     .font(.system(size: 17, weight: .semibold))
@@ -211,5 +202,16 @@ struct FundWalletView: View {
             .buttonStyle(.bordered)
         }
         .padding()
+    }
+
+    private func copyAddress(_ address: String) {
+        UIPasteboard.general.string = address
+        isCopied = true
+        copyResetTask?.cancel()
+        copyResetTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
+            isCopied = false
+        }
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -8,9 +8,6 @@ struct FundWalletView: View {
     @State private var isCopied = false
     @State private var showFullscreenQR = false
     @State private var loadError: Error?
-    @State private var showShareSheet = false
-    @State private var shareImage: UIImage?
-    @State private var isSharing = false
 
     var body: some View {
         ScrollView {
@@ -45,23 +42,6 @@ struct FundWalletView: View {
             if let uri = bitcoinURI,
                let qrImage = QRCodeUtility.generate(from: uri) {
                 FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
-            }
-        }
-        .onChange(of: showShareSheet) { _, newValue in
-            if newValue, let img = shareImage, let uriStr = bitcoinURI {
-                let addressToShare = uriStr.replacingOccurrences(of: "bitcoin:", with: "")
-                let activityVC = UIActivityViewController(
-                    activityItems: [img, addressToShare],
-                    applicationActivities: nil
-                )
-                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let rootVC = windowScene.windows.first?.rootViewController {
-                    var topVC = rootVC
-                    while let presented = topVC.presentedViewController {
-                        topVC = presented
-                    }
-                    topVC.present(activityVC, animated: true)
-                }
             }
         }
     }
@@ -143,11 +123,12 @@ struct FundWalletView: View {
 
     private func shareQR() {
         guard let uri = bitcoinURI,
-              let qrImage = QRCodeUtility.generate(from: uri) else { return }
+              let qrImage = QRCodeUtility.generate(from: uri),
+              let addr = address else { return }
 
-        shareImage = ShareableQRGenerator.generateShareImage(
+        let shareImage = ShareableQRGenerator.generateShareImage(
             qrImage: qrImage,
-            invoice: address ?? uri,
+            invoice: addr,
             amount: nil,
             isOnChain: true
         )
@@ -156,23 +137,8 @@ struct FundWalletView: View {
             showFullscreenQR = false
             try? await Task.sleep(nanoseconds: 100_000_000)
 
-            guard let img = shareImage, let uriStr = bitcoinURI else { return }
-            let addressToShare = uriStr.replacingOccurrences(of: "bitcoin:", with: "")
-            let activityVC = UIActivityViewController(
-                activityItems: [img, addressToShare],
-                applicationActivities: nil
-            )
-            activityVC.completionWithItemsHandler = { _, _, _, _ in
-            }
-
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let rootVC = windowScene.windows.first?.rootViewController {
-                var topVC = rootVC
-                while let presented = topVC.presentedViewController {
-                    topVC = presented
-                }
-                topVC.present(activityVC, animated: true)
-            }
+            let addressToShare = uri.replacingOccurrences(of: "bitcoin:", with: "")
+            ShareSheetPresenter.present(items: [shareImage, addressToShare])
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -17,7 +17,7 @@ struct FundWalletView: View {
 
                     addressDisplay(address: address)
 
-                    copyButton(address: address)
+                    actionButtons(address: address)
                 } else if let error = loadError {
                     errorView(error: error)
                 } else {
@@ -87,8 +87,8 @@ struct FundWalletView: View {
             .textSelection(.enabled)
     }
 
-    private func copyButton(address: String) -> some View {
-        VStack(spacing: 12) {
+    private func actionButtons(address: String) -> some View {
+        HStack(spacing: 12) {
             Button {
                 UIPasteboard.general.string = address
                 isCopied = true
@@ -97,27 +97,37 @@ struct FundWalletView: View {
                     isCopied = false
                 }
             } label: {
-                Label(
-                    isCopied
-                        ? String(localized: "button_copied", defaultValue: "Copied")
-                        : String(localized: "button_copy_address", defaultValue: "Copy Address"),
-                    systemImage: isCopied ? "checkmark" : "doc.on.doc"
-                )
+                Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(width: 44, height: 44)
+                    .background(.ultraThinMaterial, in: Circle())
             }
-            .buttonStyle(.borderedProminent)
-            .accessibilityLabel(isCopied
-                ? String(localized: "button_copied", defaultValue: "Copied")
-                : String(localized: "button_copy_address", defaultValue: "Copy Address"))
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "button_copy_address", defaultValue: "Copy Address"))
 
             Button {
                 shareQR()
             } label: {
-                Label(
-                    String(localized: "button_share_qr", defaultValue: "Share QR"),
-                    systemImage: "square.and.arrow.up"
-                )
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(width: 44, height: 44)
+                    .background(.ultraThinMaterial, in: Circle())
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "button_share_qr", defaultValue: "Share QR"))
+
+            Button {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                    showFullscreenQR = true
+                }
+            } label: {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(width: 44, height: 44)
+                    .background(.ultraThinMaterial, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "button_enlarge_qr", defaultValue: "Enlarge QR"))
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct FundWalletView: View {
     @Environment(AppState.self) private var appState
@@ -7,6 +8,9 @@ struct FundWalletView: View {
     @State private var isCopied = false
     @State private var showFullscreenQR = false
     @State private var loadError: Error?
+    @State private var showShareSheet = false
+    @State private var shareImage: UIImage?
+    @State private var isSharing = false
 
     var body: some View {
         ScrollView {
@@ -41,6 +45,23 @@ struct FundWalletView: View {
             if let uri = bitcoinURI,
                let qrImage = QRCodeUtility.generate(from: uri) {
                 FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
+            }
+        }
+        .onChange(of: showShareSheet) { _, newValue in
+            if newValue, let img = shareImage, let uriStr = bitcoinURI {
+                let addressToShare = uriStr.replacingOccurrences(of: "bitcoin:", with: "")
+                let activityVC = UIActivityViewController(
+                    activityItems: [img, addressToShare],
+                    applicationActivities: nil
+                )
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let rootVC = windowScene.windows.first?.rootViewController {
+                    var topVC = rootVC
+                    while let presented = topVC.presentedViewController {
+                        topVC = presented
+                    }
+                    topVC.present(activityVC, animated: true)
+                }
             }
         }
     }
@@ -87,25 +108,72 @@ struct FundWalletView: View {
     }
 
     private func copyButton(address: String) -> some View {
-        Button {
-            UIPasteboard.general.string = address
-            isCopied = true
-            Task {
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                isCopied = false
+        VStack(spacing: 12) {
+            Button {
+                UIPasteboard.general.string = address
+                isCopied = true
+                Task {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    isCopied = false
+                }
+            } label: {
+                Label(
+                    isCopied
+                        ? String(localized: "button_copied", defaultValue: "Copied")
+                        : String(localized: "button_copy_address", defaultValue: "Copy Address"),
+                    systemImage: isCopied ? "checkmark" : "doc.on.doc"
+                )
             }
-        } label: {
-            Label(
-                isCopied
-                    ? String(localized: "button_copied", defaultValue: "Copied")
-                    : String(localized: "button_copy_address", defaultValue: "Copy Address"),
-                systemImage: isCopied ? "checkmark" : "doc.on.doc"
-            )
+            .buttonStyle(.borderedProminent)
+            .accessibilityLabel(isCopied
+                ? String(localized: "button_copied", defaultValue: "Copied")
+                : String(localized: "button_copy_address", defaultValue: "Copy Address"))
+
+            Button {
+                shareQR()
+            } label: {
+                Label(
+                    String(localized: "button_share_qr", defaultValue: "Share QR"),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+            .buttonStyle(.bordered)
         }
-        .buttonStyle(.borderedProminent)
-        .accessibilityLabel(isCopied
-            ? String(localized: "button_copied", defaultValue: "Copied")
-            : String(localized: "button_copy_address", defaultValue: "Copy Address"))
+    }
+
+    private func shareQR() {
+        guard let uri = bitcoinURI,
+              let qrImage = QRCodeUtility.generate(from: uri) else { return }
+
+        shareImage = ShareableQRGenerator.generateShareImage(
+            qrImage: qrImage,
+            invoice: address ?? uri,
+            amount: nil,
+            isOnChain: true
+        )
+
+        Task { @MainActor in
+            showFullscreenQR = false
+            try? await Task.sleep(nanoseconds: 100_000_000)
+
+            guard let img = shareImage, let uriStr = bitcoinURI else { return }
+            let addressToShare = uriStr.replacingOccurrences(of: "bitcoin:", with: "")
+            let activityVC = UIActivityViewController(
+                activityItems: [img, addressToShare],
+                applicationActivities: nil
+            )
+            activityVC.completionWithItemsHandler = { _, _, _, _ in
+            }
+
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let rootVC = windowScene.windows.first?.rootViewController {
+                var topVC = rootVC
+                while let presented = topVC.presentedViewController {
+                    topVC = presented
+                }
+                topVC.present(activityVC, animated: true)
+            }
+        }
     }
 
     private func errorView(error: Error) -> some View {

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -1,51 +1,35 @@
 import SwiftUI
-import CoreImage.CIFilterBuiltins
 
 struct FundWalletView: View {
     @Environment(AppState.self) private var appState
     @State private var address: String?
+    @State private var bitcoinURI: String?
     @State private var isCopied = false
+    @State private var showFullscreenQR = false
+    @State private var loadError: Error?
 
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
                 if let address {
-                    VStack(spacing: 16) {
-                        // QR Code
-                        if let qrImage = generateQRCode(from: "bitcoin:\(address)") {
-                            Image(uiImage: qrImage)
-                                .interpolation(.none)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 200, height: 200)
-                        }
+                    qrCodeSection(address: address)
 
-                        Text(address)
-                            .font(.system(.caption, design: .monospaced))
-                            .padding()
-                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
-                            .textSelection(.enabled)
+                    addressDisplay(address: address)
 
-                        Button {
-                            UIPasteboard.general.string = address
-                            isCopied = true
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCopied = false }
-                        } label: {
-                            Label(
-                                isCopied
-                                    ? String(localized: "button_copied", defaultValue: "Copied")
-                                    : String(localized: "button_copy_address", defaultValue: "Copy Address"),
-                                systemImage: isCopied ? "checkmark" : "doc.on.doc"
-                            )
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
+                    copyButton(address: address)
+                } else if let error = loadError {
+                    errorView(error: error)
                 } else {
                     ProgressView()
                         .task {
-                            let addr = try? appState.nodeService.newOnchainAddress()
-                            address = addr
-                            appState.onchainReceiveAddress = addr
+                            do {
+                                let addr = try await appState.nodeService.newOnchainAddress()
+                                address = addr
+                                bitcoinURI = QRCodeUtility.generateBitcoinURI(from: addr)
+                                appState.onchainReceiveAddress = addr
+                            } catch {
+                                loadError = error
+                            }
                         }
                 }
             }
@@ -53,16 +37,89 @@ struct FundWalletView: View {
         }
         .navigationTitle(String(localized: "title_on_chain_receive", defaultValue: "On-chain Receive"))
         .navigationBarTitleDisplayMode(.inline)
+        .fullScreenCover(isPresented: $showFullscreenQR) {
+            if let uri = bitcoinURI,
+               let qrImage = QRCodeUtility.generate(from: uri) {
+                FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
+            }
+        }
     }
 
-    private func generateQRCode(from string: String) -> UIImage? {
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(string.uppercased().utf8)
+    // MARK: - Subviews
 
-        guard let outputImage = filter.outputImage else { return nil }
-        let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
-        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-        return UIImage(cgImage: cgImage)
+    private func qrCodeSection(address _: String) -> some View {
+        VStack(spacing: 4) {
+            if let uri = bitcoinURI,
+               let qrImage = QRCodeUtility.generate(from: uri) {
+                Image(uiImage: qrImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+                    .accessibilityLabel("Bitcoin address QR code")
+                    .accessibilityHint(String(localized: "Tap to enlarge", defaultValue: "Tap to enlarge"))
+                    .onTapGesture {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                            showFullscreenQR = true
+                        }
+                    }
+
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption2)
+                    Text(String(localized: "Tap to enlarge", defaultValue: "Tap to enlarge"))
+                        .font(.caption2)
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func addressDisplay(address: String) -> some View {
+        Text(address)
+            .font(.system(.caption, design: .monospaced))
+            .padding()
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+            .textSelection(.enabled)
+    }
+
+    private func copyButton(address: String) -> some View {
+        Button {
+            UIPasteboard.general.string = address
+            isCopied = true
+            Task {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                isCopied = false
+            }
+        } label: {
+            Label(
+                isCopied
+                    ? String(localized: "button_copied", defaultValue: "Copied")
+                    : String(localized: "button_copy_address", defaultValue: "Copy Address"),
+                systemImage: isCopied ? "checkmark" : "doc.on.doc"
+            )
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityLabel(isCopied
+            ? String(localized: "button_copied", defaultValue: "Copied")
+            : String(localized: "button_copy_address", defaultValue: "Copy Address"))
+    }
+
+    private func errorView(error: Error) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(error.localizedDescription)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button(String(localized: "button_retry", defaultValue: "Retry")) {
+                loadError = nil
+                address = nil
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -56,7 +56,10 @@ struct FundWalletView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 200, height: 200)
-                    .accessibilityLabel("Bitcoin address QR code")
+                    .accessibilityLabel(String(
+                        localized: "Bitcoin address QR code",
+                        defaultValue: "Bitcoin address QR code"
+                    ))
                     .accessibilityHint(String(localized: "Tap to enlarge", defaultValue: "Tap to enlarge"))
                     .onTapGesture {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {

--- a/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/FundWalletView.swift
@@ -80,11 +80,54 @@ struct FundWalletView: View {
     }
 
     private func addressDisplay(address: String) -> some View {
-        Text(address)
-            .font(.system(.caption, design: .monospaced))
-            .padding()
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
-            .textSelection(.enabled)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "label_your_address", defaultValue: "Your Bitcoin Address"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(address)
+                .font(.system(.caption, design: .monospaced))
+                .lineLimit(3)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.ultraThinMaterial)
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(isCopied ? Color.green.opacity(0.25) : Color.clear)
+                    }
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isCopied ? Color.green : Color.primary.opacity(0.1), lineWidth: 1)
+                )
+                .overlay(alignment: .center) {
+                    if isCopied {
+                        Label(
+                            String(localized: "button_copied", defaultValue: "Copied"),
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.green)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(.regularMaterial, in: Capsule())
+                        .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                .contentShape(Rectangle())
+                .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isCopied)
+                .onTapGesture {
+                    UIPasteboard.general.string = address
+                    isCopied = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        isCopied = false
+                    }
+                }
+        }
     }
 
     private func actionButtons(address: String) -> some View {

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -402,14 +402,16 @@ struct HomeView: View {
                 .foregroundStyle(.secondary)
             Spacer()
             if let txid, !txid.isEmpty {
-                Link(destination: URL(string: "https://mempool.space/tx/\(txid)")!) {
-                    HStack(spacing: 2) {
-                        Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
-                            .font(.caption2)
-                        Image(systemName: "arrow.up.right.square")
-                            .font(.caption2)
+                if let url = Constants.txExplorerLink(for: txid) {
+                    Link(destination: url) {
+                        HStack(spacing: 2) {
+                            Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
+                                .font(.caption2)
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.caption2)
+                        }
+                        .foregroundStyle(.blue)
                     }
-                    .foregroundStyle(.blue)
                 }
             }
         }

--- a/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
@@ -46,7 +46,7 @@ struct ChannelSettingsView: View {
                                 .font(.system(.caption, design: .monospaced))
                                 .foregroundStyle(.secondary)
                         }
-                        if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                        if let url = Constants.txExplorerLink(for: txid) {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
                                     Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -3,7 +3,6 @@ import UIKit
 
 struct OnChainSendView: View {
     @Environment(AppState.self) private var appState
-    @Environment(\.dismiss) private var dismiss
     @State private var address = ""
     @State private var amountUSDStr = ""
     @State private var sendAll = false
@@ -23,105 +22,276 @@ struct OnChainSendView: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section(String(localized: "header_destination_address", defaultValue: "Destination Address")) {
-                    TextField(String(localized: "placeholder_address", defaultValue: "bc1..."), text: $address)
-                        .font(.system(.body, design: .monospaced))
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                }
-
-                Section(String(localized: "header_amount", defaultValue: "Amount")) {
-                    if sendAll {
-                        Text(String(localized: "label_all_available_funds", defaultValue: "All available funds"))
-                            .foregroundStyle(.secondary)
-                    } else {
-                        HStack {
-                            Text(String(localized: "label_dollar_sign", defaultValue: "$"))
-                                .foregroundStyle(.secondary)
-                            TextField(
-                                String(localized: "placeholder_amount_usd", defaultValue: "0.00"),
-                                text: $amountUSDStr
+            ScrollView {
+                VStack(spacing: 20) {
+                    addressCard
+                    amountCard
+                    if hasReadyChannel {
+                        infoCard(
+                            icon: "arrow.up.arrow.down",
+                            text: String(
+                                localized: "info_splice_out_funds",
+                                defaultValue: "Funds will be sent via splice-out from your Lightning channel."
                             )
-                            .keyboardType(.decimalPad)
-                        }
-                        if let sats = amountSats, sats > 0 {
-                            Text("\(sats.btcSpacedFormatted) BTC")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    Toggle(String(localized: "toggle_send_all", defaultValue: "Send All"), isOn: $sendAll)
-                }
-
-                if hasReadyChannel {
-                    Section {
-                        Text(String(
-                            localized: "info_splice_out_funds",
-                            defaultValue: "Funds will be sent via splice-out from your Lightning channel."
-                        ))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    }
-                }
-
-                Section {
-                    Button {
-                        Task { await send() }
-                    } label: {
-                        if isSending {
-                            ProgressView().frame(maxWidth: .infinity)
-                        } else {
-                            Text(String(localized: "button_send_payment", defaultValue: "Send"))
-                                .frame(maxWidth: .infinity)
-                        }
-                    }
-                    .disabled(address.isEmpty || (!sendAll && (amountSats ?? 0) == 0) || isSending)
-                }
-
-                if let txid {
-                    Section {
-                        Label(
-                            String(localized: "success_sent", defaultValue: "Sent!"),
-                            systemImage: "checkmark.circle.fill"
                         )
-                        .foregroundStyle(.green)
-                        Text(String(localized: "label_txid", defaultValue: "TXID") + ": \(txid)")
-                            .font(.caption)
-                            .textSelection(.enabled)
                     }
-                }
-
-                if spliceSuccess {
-                    Section {
-                        Label(
-                            String(localized: "success_splice_out", defaultValue: "Splice-out initiated!"),
-                            systemImage: "checkmark.circle.fill"
+                    if let txid {
+                        successCard(
+                            icon: "checkmark.circle.fill",
+                            title: String(localized: "success_sent", defaultValue: "Sent!"),
+                            detail: String(localized: "label_txid", defaultValue: "TXID") + ": " + txid,
+                            monospaced: true,
+                            linkStyle: true
                         )
-                        .foregroundStyle(.green)
-                        Text(String(
-                            localized: "info_funds_arrive_onchain",
-                            defaultValue: "Funds will arrive on-chain after confirmation."
-                        ))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                     }
-                }
-
-                if let error = errorMessage {
-                    Section {
-                        Text(error).foregroundStyle(.red)
+                    if spliceSuccess {
+                        successCard(
+                            icon: "checkmark.circle.fill",
+                            title: String(localized: "success_splice_out", defaultValue: "Splice-out initiated!"),
+                            detail: String(
+                                localized: "info_funds_arrive_onchain",
+                                defaultValue: "Funds will arrive on-chain after confirmation."
+                            ),
+                            monospaced: false
+                        )
                     }
+                    if let error = errorMessage {
+                        errorCard(error)
+                    }
+                    sendButton
+                    Spacer(minLength: 12)
                 }
+                .padding(20)
             }
+            .scrollDismissesKeyboard(.interactively)
+            .background(Color(.systemGroupedBackground))
             .navigationTitle(String(localized: "title_send_on_chain", defaultValue: "Send On-Chain"))
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "button_cancel", defaultValue: "Cancel")) { dismiss() }
+            .qrInputToolbar(text: $address, sanitize: QRCodeExtractor.sanitizeAddress)
+        }
+    }
+
+    private var addressCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "wallet.bifold")
+                    .foregroundStyle(.secondary)
+                Text(String(localized: "header_destination_address", defaultValue: "Destination Address"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            TextField(String(localized: "placeholder_address", defaultValue: "bc1..."), text: $address)
+                .font(.system(.body, design: .monospaced))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(12)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
+                .onChange(of: address) { _, new in
+                    address = QRCodeExtractor.sanitizeAddress(new)
+                }
+        }
+        .padding(16)
+        .glassCard()
+    }
+
+    private var amountCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Image(systemName: "dollarsign.circle")
+                    .foregroundStyle(.secondary)
+                Text(String(localized: "header_amount", defaultValue: "Amount"))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            if sendAll {
+                Label(
+                    String(localized: "label_all_available_funds", defaultValue: "All available funds"),
+                    systemImage: "infinity"
+                )
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(String(localized: "label_dollar_sign", defaultValue: "$"))
+                        .font(.system(size: 36, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.secondary)
+                    TextField(
+                        String(localized: "placeholder_amount_usd", defaultValue: "0.00"),
+                        text: $amountUSDStr
+                    )
+                    .keyboardType(.decimalPad)
+                    .font(.system(size: 36, weight: .semibold, design: .rounded))
+                    .onChange(of: amountUSDStr) { _, new in
+                        amountUSDStr = Self.sanitizeAmount(new)
+                    }
+                }
+                if let sats = amountSats, sats > 0 {
+                    HStack(spacing: 6) {
+                        Image(systemName: "bitcoinsign.circle.fill")
+                            .foregroundStyle(.primary)
+                        Text("\(sats.btcSpacedFormatted) BTC")
+                            .font(.subheadline.weight(.medium))
+                            .contentTransition(.numericText())
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .animation(.snappy, value: sats)
                 }
             }
+
+            Toggle(isOn: $sendAll) {
+                Label(
+                    String(localized: "toggle_send_all", defaultValue: "Send All"),
+                    systemImage: "infinity.circle"
+                )
+                .font(.subheadline)
+            }
+            .tint(.green)
         }
+        .padding(16)
+        .glassCard()
+    }
+
+    private func infoCard(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassCard()
+    }
+
+    private func successCard(icon: String, title: String, detail: String, monospaced: Bool,
+                             linkStyle: Bool = false) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.green)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                if linkStyle {
+                    Text(makeTxidAttributed(label: "TXID: ", txid: detail.replacingOccurrences(of: "TXID: ", with: "")))
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                } else {
+                    Text(detail)
+                        .font(monospaced ? .system(.caption, design: .monospaced) : .caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            Spacer()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.green.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.green.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private func errorCard(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundStyle(.red)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.red)
+            Spacer()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.red.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.red.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var sendButton: some View {
+        Button {
+            Task { await send() }
+        } label: {
+            HStack(spacing: 8) {
+                if isSending {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.body.weight(.semibold))
+                    Text(String(localized: "button_send_payment", defaultValue: "Send"))
+                        .fontWeight(.semibold)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.blue)
+        .disabled(address.isEmpty || (!sendAll && (amountSats ?? 0) == 0) || isSending)
+        .scaleEffect(isSending ? 0.97 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSending)
+        .animation(.easeInOut(duration: 0.2), value: address.isEmpty)
+        .animation(.easeInOut(duration: 0.2), value: amountSats)
+    }
+
+    private func makeTxidAttributed(label: String, txid: String) -> AttributedString {
+        var s = AttributedString(label)
+        s.foregroundColor = .secondary
+        var t = AttributedString(txid)
+        t.foregroundColor = .blue
+        t.underlineStyle = .single
+        t.link = URL(string: "https://mempool.space/tx/\(txid)")
+        return s + t
+    }
+
+    private static func sanitizeAmount(_ raw: String) -> String {
+        var s = raw
+        while s.hasPrefix("0") && s.count > 1 && !s.hasPrefix("0.") {
+            s.removeFirst()
+        }
+        var result = ""
+        var seenDot = false
+        var decimals = 0
+        for ch in s {
+            if ch.isNumber {
+                if seenDot {
+                    decimals += 1
+                    if decimals > 2 { continue }
+                }
+                result.append(ch)
+            } else if ch == "." && !seenDot {
+                seenDot = true
+                result.append(ch)
+            }
+        }
+        if result.isEmpty { return "" }
+        if result == "." { return "0." }
+        return result
     }
 
     private func send() async {
@@ -132,6 +302,7 @@ struct OnChainSendView: View {
             from: nil,
             for: nil
         )
+
         // Always require auth for on-chain sends — highest risk, drains to external wallet
         let authReason = sendAll ? "Confirm on-chain withdrawal" : "Confirm on-chain send"
         let authPassed = await appState.authenticate(reason: authReason)
@@ -206,4 +377,22 @@ struct OnChainSendView: View {
             errorMessage = error.localizedDescription
         }
     }
+}
+
+private struct GlassCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+    }
+}
+
+private extension View {
+    func glassCard() -> some View { modifier(GlassCardModifier()) }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -265,7 +265,7 @@ struct OnChainSendView: View {
         var t = AttributedString(txid)
         t.foregroundColor = .blue
         t.underlineStyle = .single
-        t.link = URL(string: "https://mempool.space/tx/\(txid)")
+        t.link = Constants.txExplorerLink(for: txid)
         return s + t
     }
 

--- a/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/OnChainView.swift
@@ -131,7 +131,7 @@ struct OnChainSendView: View {
                     .keyboardType(.decimalPad)
                     .font(.system(size: 36, weight: .semibold, design: .rounded))
                     .onChange(of: amountUSDStr) { _, new in
-                        amountUSDStr = Self.sanitizeAmount(new)
+                        amountUSDStr = InputSanitizer.decimal(new)
                     }
                 }
                 if let sats = amountSats, sats > 0 {
@@ -267,31 +267,6 @@ struct OnChainSendView: View {
         t.underlineStyle = .single
         t.link = URL(string: "https://mempool.space/tx/\(txid)")
         return s + t
-    }
-
-    private static func sanitizeAmount(_ raw: String) -> String {
-        var s = raw
-        while s.hasPrefix("0") && s.count > 1 && !s.hasPrefix("0.") {
-            s.removeFirst()
-        }
-        var result = ""
-        var seenDot = false
-        var decimals = 0
-        for ch in s {
-            if ch.isNumber {
-                if seenDot {
-                    decimals += 1
-                    if decimals > 2 { continue }
-                }
-                result.append(ch)
-            } else if ch == "." && !seenDot {
-                seenDot = true
-                result.append(ch)
-            }
-        }
-        if result.isEmpty { return "" }
-        if result == "." { return "0." }
-        return result
     }
 
     private func send() async {

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -81,6 +81,9 @@ struct ReceiveView: View {
                 .keyboardType(.decimalPad)
                 .font(.system(size: 32, weight: .bold, design: .rounded))
                 .multilineTextAlignment(.center)
+                .onChange(of: amountUSD) { _, new in
+                    amountUSD = Self.sanitizeAmount(new)
+                }
                 .overlay(alignment: .leading) {
                     if !amountUSD.isEmpty {
                         GeometryReader { geo in
@@ -193,12 +196,55 @@ struct ReceiveView: View {
                 }
             }
 
-            Text(invoiceStr)
-                .font(.system(.caption2, design: .monospaced))
-                .lineLimit(3)
-                .truncationMode(.middle)
-                .padding(.horizontal)
-                .textSelection(.enabled)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(String(localized: "label_your_invoice", defaultValue: "Your Lightning Invoice"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(invoiceStr)
+                    .font(.system(.caption2, design: .monospaced))
+                    .lineLimit(3)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(.ultraThinMaterial)
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(isCopied ? Color.green.opacity(0.25) : Color.clear)
+                        }
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(isCopied ? Color.green : Color.primary.opacity(0.1), lineWidth: 1)
+                    )
+                    .overlay(alignment: .center) {
+                        if isCopied {
+                            Label(
+                                String(localized: "button_copied", defaultValue: "Copied"),
+                                systemImage: "checkmark.circle.fill"
+                            )
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.green)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(.regularMaterial, in: Capsule())
+                            .transition(.scale.combined(with: .opacity))
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isCopied)
+                    .onTapGesture {
+                        UIPasteboard.general.string = invoiceStr
+                        isCopied = true
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            isCopied = false
+                        }
+                    }
+            }
+            .padding(.horizontal)
 
             HStack(spacing: 12) {
                 Button {
@@ -307,5 +353,30 @@ struct ReceiveView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private static func sanitizeAmount(_ raw: String) -> String {
+        var s = raw
+        while s.hasPrefix("0") && s.count > 1 && !s.hasPrefix("0.") {
+            s.removeFirst()
+        }
+        var result = ""
+        var seenDot = false
+        var decimals = 0
+        for ch in s {
+            if ch.isNumber {
+                if seenDot {
+                    decimals += 1
+                    if decimals > 2 { continue }
+                }
+                result.append(ch)
+            } else if ch == "." && !seenDot {
+                seenDot = true
+                result.append(ch)
+            }
+        }
+        if result.isEmpty { return "" }
+        if result == "." { return "0." }
+        return result
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -54,8 +54,9 @@ struct ReceiveView: View {
                     Button {
                         showOnChain = true
                     } label: {
-                        Label(String(localized: "toolbar_on_chain", defaultValue: "On-Chain"), systemImage: "link")
+                        Image(systemName: "link")
                     }
+                    .accessibilityLabel(String(localized: "toolbar_on_chain", defaultValue: "On-Chain"))
                 }
             }
             .navigationDestination(isPresented: $showOnChain) {
@@ -199,30 +200,47 @@ struct ReceiveView: View {
                 .padding(.horizontal)
                 .textSelection(.enabled)
 
-            Button {
-                UIPasteboard.general.string = invoiceStr
-                isCopied = true
-                Task {
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    isCopied = false
+            HStack(spacing: 12) {
+                Button {
+                    UIPasteboard.general.string = invoiceStr
+                    isCopied = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        isCopied = false
+                    }
+                } label: {
+                    Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(width: 44, height: 44)
+                        .background(.ultraThinMaterial, in: Circle())
                 }
-            } label: {
-                Label(isCopied
-                    ? String(localized: "button_copied", defaultValue: "Copied")
-                    : String(localized: "button_copy_invoice", defaultValue: "Copy Invoice"),
-                    systemImage: isCopied ? "checkmark" : "doc.on.doc")
-            }
-            .buttonStyle(.borderedProminent)
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "button_copy_invoice", defaultValue: "Copy Invoice"))
 
-            Button {
-                shareQR()
-            } label: {
-                Label(
-                    String(localized: "button_share_qr", defaultValue: "Share QR"),
-                    systemImage: "square.and.arrow.up"
-                )
+                Button {
+                    shareQR()
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(width: 44, height: 44)
+                        .background(.ultraThinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "button_share_qr", defaultValue: "Share QR"))
+
+                Button {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                        showFullscreenQR = true
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(width: 44, height: 44)
+                        .background(.ultraThinMaterial, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "button_enlarge_qr", defaultValue: "Enlarge QR"))
             }
-            .buttonStyle(.bordered)
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import LDKNode
+import UIKit
 
 struct ReceiveView: View {
     @Environment(AppState.self) private var appState
@@ -11,6 +12,8 @@ struct ReceiveView: View {
     @State private var isCopied = false
     @State private var showOnChain = false
     @State private var showFullscreenQR = false
+    @State private var showShareSheet = false
+    @State private var shareImage: UIImage?
 
     private var hasChannel: Bool {
         appState.nodeService.channels.contains { $0.isChannelReady }
@@ -63,6 +66,22 @@ struct ReceiveView: View {
             .fullScreenCover(isPresented: $showFullscreenQR) {
                 if let invoice, let qrImage = QRCodeUtility.generate(from: invoice) {
                     FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
+                }
+            }
+            .onChange(of: showShareSheet) { _, newValue in
+                if newValue, let img = shareImage, let invoiceStr = invoice {
+                    let activityVC = UIActivityViewController(
+                        activityItems: [img, invoiceStr],
+                        applicationActivities: nil
+                    )
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let rootVC = windowScene.windows.first?.rootViewController {
+                        var topVC = rootVC
+                        while let presented = topVC.presentedViewController {
+                            topVC = presented
+                        }
+                        topVC.present(activityVC, animated: true)
+                    }
                 }
             }
         }
@@ -211,6 +230,57 @@ struct ReceiveView: View {
                     systemImage: isCopied ? "checkmark" : "doc.on.doc")
             }
             .buttonStyle(.borderedProminent)
+
+            Button {
+                shareQR()
+            } label: {
+                Label(
+                    String(localized: "button_share_qr", defaultValue: "Share QR"),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func shareQR() {
+        guard let invoiceStr = invoice,
+              let qrImage = QRCodeUtility.generate(from: invoiceStr) else { return }
+
+        let amountText: String?
+        if let sats = invoiceAmountSats, sats > 0 {
+            amountText = "\(sats.btcSpacedFormatted) BTC"
+        } else {
+            amountText = nil
+        }
+
+        shareImage = ShareableQRGenerator.generateShareImage(
+            qrImage: qrImage,
+            invoice: invoiceStr,
+            amount: amountText,
+            isOnChain: false
+        )
+
+        Task { @MainActor in
+            showFullscreenQR = false
+            try? await Task.sleep(nanoseconds: 100_000_000)
+
+            guard let img = shareImage, let invoiceStr = invoice else { return }
+            let activityVC = UIActivityViewController(
+                activityItems: [img, invoiceStr],
+                applicationActivities: nil
+            )
+            activityVC.completionWithItemsHandler = { _, _, _, _ in
+            }
+
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let rootVC = windowScene.windows.first?.rootViewController {
+                var topVC = rootVC
+                while let presented = topVC.presentedViewController {
+                    topVC = presented
+                }
+                topVC.present(activityVC, animated: true)
+            }
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -82,7 +82,7 @@ struct ReceiveView: View {
                 .font(.system(size: 32, weight: .bold, design: .rounded))
                 .multilineTextAlignment(.center)
                 .onChange(of: amountUSD) { _, new in
-                    amountUSD = Self.sanitizeAmount(new)
+                    amountUSD = InputSanitizer.decimal(new)
                 }
                 .overlay(alignment: .leading) {
                     if !amountUSD.isEmpty {
@@ -353,30 +353,5 @@ struct ReceiveView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-    }
-
-    private static func sanitizeAmount(_ raw: String) -> String {
-        var s = raw
-        while s.hasPrefix("0") && s.count > 1 && !s.hasPrefix("0.") {
-            s.removeFirst()
-        }
-        var result = ""
-        var seenDot = false
-        var decimals = 0
-        for ch in s {
-            if ch.isNumber {
-                if seenDot {
-                    decimals += 1
-                    if decimals > 2 { continue }
-                }
-                result.append(ch)
-            } else if ch == "." && !seenDot {
-                seenDot = true
-                result.append(ch)
-            }
-        }
-        if result.isEmpty { return "" }
-        if result == "." { return "0." }
-        return result
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -12,6 +12,7 @@ struct ReceiveView: View {
     @State private var isCopied = false
     @State private var showOnChain = false
     @State private var showFullscreenQR = false
+    @State private var copyResetTask: Task<Void, Never>?
 
     private var hasChannel: Bool {
         appState.nodeService.channels.contains { $0.isChannelReady }
@@ -236,24 +237,14 @@ struct ReceiveView: View {
                     .contentShape(Rectangle())
                     .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isCopied)
                     .onTapGesture {
-                        UIPasteboard.general.string = invoiceStr
-                        isCopied = true
-                        Task {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            isCopied = false
-                        }
+                        copyInvoice(invoiceStr)
                     }
             }
             .padding(.horizontal)
 
             HStack(spacing: 12) {
                 Button {
-                    UIPasteboard.general.string = invoiceStr
-                    isCopied = true
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        isCopied = false
-                    }
+                    copyInvoice(invoiceStr)
                 } label: {
                     Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
                         .font(.system(size: 17, weight: .semibold))
@@ -339,6 +330,17 @@ struct ReceiveView: View {
             invoice = inv.description
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func copyInvoice(_ invoice: String) {
+        UIPasteboard.general.string = invoice
+        isCopied = true
+        copyResetTask?.cancel()
+        copyResetTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
+            isCopied = false
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import CoreImage.CIFilterBuiltins
 import LDKNode
 
 struct ReceiveView: View {
@@ -11,6 +10,7 @@ struct ReceiveView: View {
     @State private var errorMessage: String?
     @State private var isCopied = false
     @State private var showOnChain = false
+    @State private var showFullscreenQR = false
 
     private var hasChannel: Bool {
         appState.nodeService.channels.contains { $0.isChannelReady }
@@ -60,6 +60,11 @@ struct ReceiveView: View {
             .navigationDestination(isPresented: $showOnChain) {
                 FundWalletView()
             }
+            .fullScreenCover(isPresented: $showFullscreenQR) {
+                if let invoice, let qrImage = QRCodeUtility.generate(from: invoice) {
+                    FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
+                }
+            }
         }
     }
 
@@ -104,14 +109,17 @@ struct ReceiveView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
-                Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $") +
-                    "\(Int(Constants.maxChannelUSD))")
+                Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $\(Int(Constants.maxChannelUSD))"))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
             if !hasChannel && enteredUSDValue > Constants.maxChannelUSD {
-                let limitStr = String(localized: "error_exceeds_limit", defaultValue: "Amount exceeds $") + "\(Int(Constants.maxChannelUSD)) channel limit"
+                let maxAmount = Int(Constants.maxChannelUSD)
+                let limitStr = String(
+                    localized: "error_exceeds_limit",
+                    defaultValue: "Amount exceeds $\(maxAmount) channel limit"
+                )
                 Text(limitStr)
                     .font(.caption)
                     .foregroundStyle(.red)
@@ -158,16 +166,30 @@ struct ReceiveView: View {
             }
 
             // QR Code
-            if let qrImage = generateQRCode(from: invoiceStr) {
-                Image(uiImage: qrImage)
-                    .interpolation(.none)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 220, height: 220)
-                    .padding()
+            if let qrImage = QRCodeUtility.generate(from: invoiceStr) {
+                VStack(spacing: 4) {
+                    Image(uiImage: qrImage)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 220, height: 220)
+                        .padding()
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                                showFullscreenQR = true
+                            }
+                        }
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.caption2)
+                        Text(String(localized: "Tap to enlarge", defaultValue: "Tap to enlarge"))
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.secondary)
+                }
             }
 
-            // Invoice text
             Text(invoiceStr)
                 .font(.system(.caption2, design: .monospaced))
                 .lineLimit(3)
@@ -178,7 +200,10 @@ struct ReceiveView: View {
             Button {
                 UIPasteboard.general.string = invoiceStr
                 isCopied = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCopied = false }
+                Task {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    isCopied = false
+                }
             } label: {
                 Label(isCopied
                     ? String(localized: "button_copied", defaultValue: "Copied")
@@ -227,16 +252,5 @@ struct ReceiveView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-    }
-
-    private func generateQRCode(from string: String) -> UIImage? {
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(string.uppercased().utf8)
-
-        guard let outputImage = filter.outputImage else { return nil }
-        let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
-        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-        return UIImage(cgImage: cgImage)
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -69,6 +69,7 @@ struct ReceiveView: View {
                 }
             }
         }
+        .onDisappear { copyResetTask?.cancel() }
     }
 
     // MARK: - Amount Input

--- a/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/ReceiveView.swift
@@ -12,8 +12,6 @@ struct ReceiveView: View {
     @State private var isCopied = false
     @State private var showOnChain = false
     @State private var showFullscreenQR = false
-    @State private var showShareSheet = false
-    @State private var shareImage: UIImage?
 
     private var hasChannel: Bool {
         appState.nodeService.channels.contains { $0.isChannelReady }
@@ -68,22 +66,6 @@ struct ReceiveView: View {
                     FullscreenQRZoomView(qrImage: qrImage, isPresented: $showFullscreenQR)
                 }
             }
-            .onChange(of: showShareSheet) { _, newValue in
-                if newValue, let img = shareImage, let invoiceStr = invoice {
-                    let activityVC = UIActivityViewController(
-                        activityItems: [img, invoiceStr],
-                        applicationActivities: nil
-                    )
-                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                       let rootVC = windowScene.windows.first?.rootViewController {
-                        var topVC = rootVC
-                        while let presented = topVC.presentedViewController {
-                            topVC = presented
-                        }
-                        topVC.present(activityVC, animated: true)
-                    }
-                }
-            }
         }
     }
 
@@ -128,9 +110,12 @@ struct ReceiveView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
-                Text(String(localized: "max_channel_limit", defaultValue: "Maximum: $\(Int(Constants.maxChannelUSD))"))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                Text(String(
+                    format: NSLocalizedString("max_channel_limit", comment: ""),
+                    Int64(Constants.maxChannelUSD)
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
             }
 
             if !hasChannel && enteredUSDValue > Constants.maxChannelUSD {
@@ -165,7 +150,6 @@ struct ReceiveView: View {
 
     private func invoiceDisplay(_ invoiceStr: String) -> some View {
         VStack(spacing: 16) {
-            // Amount summary
             if let sats = invoiceAmountSats, sats > 0 {
                 VStack(spacing: 2) {
                     let price = appState.btcPrice
@@ -184,7 +168,6 @@ struct ReceiveView: View {
                     .foregroundStyle(.secondary)
             }
 
-            // QR Code
             if let qrImage = QRCodeUtility.generate(from: invoiceStr) {
                 VStack(spacing: 4) {
                     Image(uiImage: qrImage)
@@ -254,7 +237,7 @@ struct ReceiveView: View {
             amountText = nil
         }
 
-        shareImage = ShareableQRGenerator.generateShareImage(
+        let shareImage = ShareableQRGenerator.generateShareImage(
             qrImage: qrImage,
             invoice: invoiceStr,
             amount: amountText,
@@ -265,22 +248,7 @@ struct ReceiveView: View {
             showFullscreenQR = false
             try? await Task.sleep(nanoseconds: 100_000_000)
 
-            guard let img = shareImage, let invoiceStr = invoice else { return }
-            let activityVC = UIActivityViewController(
-                activityItems: [img, invoiceStr],
-                applicationActivities: nil
-            )
-            activityVC.completionWithItemsHandler = { _, _, _, _ in
-            }
-
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let rootVC = windowScene.windows.first?.rootViewController {
-                var topVC = rootVC
-                while let presented = topVC.presentedViewController {
-                    topVC = presented
-                }
-                topVC.present(activityVC, animated: true)
-            }
+            ShareSheetPresenter.present(items: [shareImage, invoiceStr])
         }
     }
 
@@ -298,7 +266,6 @@ struct ReceiveView: View {
                     description: "Stable Channels payment"
                 )
             } else {
-                // No channel yet — use JIT channel via LSPS2
                 inv = try appState.nodeService.receiveViaJitChannel(
                     amountMsat: sats * 1000,
                     description: "Stable Channels payment"

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 import UIKit
 import LDKNode
-import PhotosUI
-import Vision
 import CoreImage
 
 struct SendView: View {
@@ -15,10 +13,6 @@ struct SendView: View {
     @State private var errorMessage: String?
     @State private var success = false
     @State private var sentAmountSats: UInt64 = 0
-    @State private var showScanner = false
-    @State private var showPhotoPicker = false
-    @State private var selectedPhotoItem: PhotosPickerItem?
-    @State private var showQRAlert = false
     @State private var qrAlertMessage = ""
 
     private enum InputType {
@@ -313,53 +307,8 @@ struct SendView: View {
                         defaultValue: "Cancel"
                     )) { dismiss() }
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    HStack(spacing: 16) {
-                        Button {
-                            showPhotoPicker = true
-                        } label: {
-                            Image(systemName: "photo.on.rectangle")
-                        }
-                        Button {
-                            showScanner = true
-                        } label: {
-                            Image(systemName: "qrcode.viewfinder")
-                        }
-                    }
-                }
             }
-            .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
-            .onChange(of: selectedPhotoItem) { _, newItem in
-                guard let item = newItem else { return }
-                Task {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data),
-                       let code = extractQRCode(from: image) {
-                        input = code
-                    } else {
-                        qrAlertMessage = String(
-                            localized: "alert_qr_error",
-                            defaultValue: "Selected image doesn't contain a Lightning invoice or Bitcoin address QR code."
-                        )
-                        showQRAlert = true
-                    }
-                    selectedPhotoItem = nil
-                }
-            }
-            .sheet(isPresented: $showScanner) {
-                InvoiceScanView(
-                    onScan: { scanned in
-                        input = scanned
-                        showScanner = false
-                    },
-                    onCancel: { showScanner = false }
-                )
-            }
-            .alert(String(localized: "alert_no_qr", defaultValue: "No QR Code Found"), isPresented: $showQRAlert) {
-                Button(String(localized: "button_ok", defaultValue: "OK"), role: .cancel) {}
-            } message: {
-                Text(qrAlertMessage)
-            }
+            .qrInputToolbar(text: $input, sanitize: QRCodeExtractor.sanitizePaymentInput)
         }
     }
 
@@ -520,23 +469,5 @@ struct SendView: View {
         } catch {
             errorMessage = error.localizedDescription
         }
-    }
-
-    private func extractQRCode(from image: UIImage) -> String? {
-        guard let cgImage = image.cgImage else { return nil }
-
-        let request = VNDetectBarcodesRequest()
-        request.symbologies = [.qr]
-
-        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-        try? handler.perform([request])
-
-        guard let results = request.results,
-              let qrCode = results.first,
-              let value = qrCode.payloadStringValue,
-              !value.isEmpty
-        else { return nil }
-
-        return value
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Views/Transfer/SendView.swift
@@ -29,7 +29,10 @@ struct SendView: View {
     }
 
     private var detectedType: InputType {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if trimmed.hasPrefix("bitcoin:") {
+            trimmed = String(trimmed.dropFirst(8))
+        }
         if trimmed.hasPrefix("lnbc") || trimmed.hasPrefix("lntb") || trimmed.hasPrefix("lnts") {
             return .bolt11
         } else if trimmed.hasPrefix("lno") {


### PR DESCRIPTION
## Summary

Replaces scattered, duplicated QR code logic across `SendView`, `ReceiveView`, and `FundWalletView` with a centralized utility layer. Simultaneously upgrades the receive flow UX with fullscreen zoom, share sheet generation, and a properly cancellable copy-feedback system.

---

## Motivation

Three views each owned their own `generateQRCode(from:)` implementation (all slightly different), their own `VNDetectBarcodesRequest` setup, and their own `DispatchQueue.main.asyncAfter` copy-feedback timers. Any fix had to be applied three times. This PR makes QR a first-class concern.

---

## New Files

| File | Role |
|---|---|
| `QRCodeUtility.swift` | Styled QR generation via `dagronf/QRCode` with `NSCache` (40 MB / 100-item limit), CoreImage fallback, BIP-21 URI helper |
| `QRCodeExtractor.swift` | Vision-based QR reading from `UIImage`, downscales to 1024 px before request, URI-scheme sanitizers for `bitcoin:` / `lightning:` |
| `QRInputToolbar.swift` | `ViewModifier` adding scan + pick-from-photo toolbar buttons to any `TextField`; accepts a `sanitize` closure |
| `InputSanitizer.swift` | Pure decimal string sanitizer — strips non-numeric chars, trims extra decimals, collapses leading zeros |
| `FullscreenQRZoomView.swift` | Full-screen black overlay with pixel-perfect QR render, spring-animated dismiss on tap |
| `ShareableQRGenerator.swift` | `UIGraphicsImageRenderer`-based 1080×1920 share card with app icon, amount, truncated invoice, and `© StableChannels.com` footer |
| `ShareSheetPresenter.swift` | UIKit helper — walks the connected scenes to find the topmost `UIViewController` and presents `UIActivityViewController` |

---

## Changed Files

| File | What changed |
|---|---|
| `ReceiveView.swift` | Removed inline `generateQRCode`, wired `QRCodeUtility`, added fullscreen zoom + share action, `copyResetTask` replaces `asyncAfter` |
| `FundWalletView.swift` | Same QR/copy refactor, added error state with retry, `try/catch` on address fetch, BIP-21 URI passed to QR generator |
| `SendView.swift` | Deleted local `extractQRCode` + `PhotosPickerItem` state; replaced with `.qrInputToolbar(text:sanitize:)` — ~65 lines removed |
| `OnChainView.swift` | Full UI overhaul to card layout, removed `@Environment(\.dismiss)`, added `QRInputToolbar`, `InputSanitizer`, TXID mempool.space link |
| `HomeView.swift` | Replaced hardcoded `https://mempool.space/tx/{txid}` link with `Constants.txExplorerLink(for:)` |
| `ChannelSettingsView.swift` | Same `Constants.txExplorerLink(for:)` swap on the channel-txid link |
| `Constants.swift` | Added `txExplorerURL` constant and `txExplorerLink(for:)` helper to centralize the explorer host |
| `Localizable.xcstrings` | New keys: `qr_code`, `tap_to_close`, `tap_to_enlarge`, `bitcoin_address_qr_code`, `share_qr`, `enlarge_qr`, plus receive/send toolbar copy variants |
| `project.pbxproj` | Added 7 new files to the project tree |
| `Package.swift` / `Package.resolved` | Added `dagronf/QRCode 28.0.2` (brings in `swift-qrcode-generator` + `SwiftImageReadWrite` as transitive deps) |

---
## Screenshots

| Receive — Invoice QR | Receive — Tap to Enlarge | Receive — Fullscreen QR | Receive — Copy Feedback |
|----------|----------|----------|----------|
| <img width="250" src="https://github.com/user-attachments/assets/c3e7a0c4-2011-4a39-8e67-3269655b666a"> | <img width="250" src="https://github.com/user-attachments/assets/dab45fe4-ce94-45e6-957f-93ab89a1cbed"> | <img width="250" src="https://github.com/user-attachments/assets/09496a80-67de-452c-bef6-ccf139b519b2"> | <img width="250" src="https://github.com/user-attachments/assets/9d7cbce1-124c-45df-ac55-b07a3037831d"> |
| Invoice generated with styled QR. | "Tap to enlarge" hint below QR. | Fullscreen QR overlay with pixel-perfect rendering. | Green flash + "Copied" confirmation pill. |

| Receive — Share Sheet | Receive — Share Card | Fund Wallet — On-chain QR | Fund Wallet — Fullscreen QR |
|----------|----------|----------|----------|
| <img width="250" src="https://github.com/user-attachments/assets/221d7e40-3786-4338-b64c-addbec0eae76"> | <img width="250" src="https://github.com/user-attachments/assets/9d90e8df-0954-4ddb-972f-8924dbdfb019"> | <img width="250" src="https://github.com/user-attachments/assets/6e07b43b-5bcc-4743-ad6d-3fa7e2a55f3d"> | <img width="250" src="https://github.com/user-attachments/assets/d936fde8-8e3b-4505-b0fe-7c5795ba9d5a"> |
| System share sheet. | Branded Lightning share card. | BIP-21 URI QR code. | Fullscreen QR view. |

| Fund Wallet — Copy Feedback | Fund Wallet — Share Card | Fund Wallet — Share Sheet | Send — QR Toolbar |
|----------|----------|----------|----------|
| <img width="250" src="https://github.com/user-attachments/assets/2609ff65-78f3-4e10-94b4-68810a6b33e0"> | <img width="250" src="https://github.com/user-attachments/assets/01e5cced-2973-45a2-8c37-71e86d7444d1"> | <img width="250" src="https://github.com/user-attachments/assets/ca25c529-75c5-4e9f-ad5f-4de50a481404"> | <img width="250" src="https://github.com/user-attachments/assets/17eceb3a-cf78-42ef-a971-9a2de2fcbb50"> |
| Address copied with visual feedback. | Bitcoin Address share card. | System share sheet for the on-chain address. | Photo picker + QR scanner toolbar. |

| Send — Photo QR Scan | On-chain Send — Card Layout | On-chain Send — Send All | On-chain Send — Success Card |
|----------|----------|----------|----------|
| <img width="250" src="https://github.com/user-attachments/assets/c02fedec-e56e-4f3b-85ad-6f29c1b1cd51"> | <img width="250" src="https://github.com/user-attachments/assets/3293209b-69d7-49a6-a8cb-655f28f22b8d"> | <img width="250" src="https://github.com/user-attachments/assets/781a945d-206f-480f-b130-fbd61d79b475"> | <img width="250" src="https://github.com/user-attachments/assets/f05d0b54-e286-4064-b7ca-1851ff487eeb"> |
| QR extracted from photo and sanitized. | Glass-card based send UI. | All available funds mode. | Success card with tappable TXID link. |

---

## Architecture Diagram

<img width="8192" height="5404" src="https://github.com/user-attachments/assets/d2abee70-929d-49c6-90f9-8bfbe30b3a7f" />

---

## Architecture Notes

### Caching strategy
`QRCodeUtility` uses `NSCache<NSString, UIImage>` with a 40 MB cost limit. Each image's cost is `size × size × 4` bytes (RGBA). At 1024 px this is ~4 MB per entry, so the cache holds ~10 QR codes before eviction — appropriate for a wallet that shows at most 2-3 distinct addresses per session.

### Async copy-feedback
`copyResetTask` is a `Task<Void, Never>` stored as `@State`. On every copy action:
1. Cancel the previous task (prevents double-reset race).
2. Spawn a new task with `Task.sleep(nanoseconds: 2_000_000_000)`.
3. Check `Task.isCancelled` before resetting `isCopied`.

This is correct under view lifecycle — `onDisappear` cancels the task so no state mutation happens on a deallocated view.

### QRInputToolbar
The modifier is generic: any view can call `.qrInputToolbar(text: $foo, sanitize: SomeExtractor.sanitizeBar)`. `SendView` passes `QRCodeExtractor.sanitizePaymentInput` (strips both `bitcoin:` and `lightning:`). `OnChainView` passes `QRCodeExtractor.sanitizeAddress` (strips `bitcoin:` only).


---

## Dependencies Added

```
dagronf/QRCode 28.0.2
  └── dagronf/swift-qrcode-generator 2.0.2
  └── dagronf/SwiftImageReadWrite 1.9.2
```

No new permissions required. `NSPhotoLibraryUsageDescription` was already present for the existing photo picker in `SendView`.

---

## Related
Closes #95 
