### PR TITLE
stable-channels-lsp: TLV trade/sync protocol, splice reconcile, and RegisterPush hardening

### DIFF
--- a/server/lsp-server-gui/src/app.rs
+++ b/server/lsp-server-gui/src/app.rs
@@ -774,6 +774,7 @@ impl LspServerApp {
 						amount_msat,
 						node_id,
 						route_parameters: None,
+						custom_tlvs: vec![],
 					})
 					.await
 					.map_err(|e| e.to_string())

--- a/server/lsp-server-gui/src/app.rs
+++ b/server/lsp-server-gui/src/app.rs
@@ -18,7 +18,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	VerifySignatureRequest,
 };
 use sc_rest_client::sc_protos::stable::{
-	EditStableChannelRequest, GetPriceRequest, ListStableChannelsRequest,
+	EditStableChannelRequest, GetPriceRequest, ListStableChannelsRequest, LogRequest,
 };
 use sc_rest_client::ldk_server_grpc::types::{
 	bolt11_invoice_description, Bolt11InvoiceDescription, ChannelConfig,
@@ -237,6 +237,19 @@ impl LspServerApp {
 					.list_forwarded_payments(ListForwardedPaymentsRequest { page_token })
 					.await
 					.map_err(|e| e.to_string())
+			}));
+		}
+	}
+
+	pub fn fetch_ldk_log(&mut self) {
+		if self.state.tasks.ldk_log.is_some() {
+			return;
+		}
+		let max_lines = self.state.forms.ldk_log.max_lines.parse::<u32>().unwrap_or(200);
+		if let Some(client) = &self.state.client {
+			let client = client.clone();
+			self.state.tasks.ldk_log = Some(self.spawn_task(async move {
+				client.ldk_log(LogRequest { max_lines }).await.map_err(|e| e.to_string())
 			}));
 		}
 	}
@@ -961,6 +974,10 @@ impl LspServerApp {
 			self.state.forwarded_payments = Some(v);
 		});
 
+		poll_task!(self.state.tasks.ldk_log => |v| {
+			self.state.ldk_log = Some(v);
+		});
+
 		poll_task!(self.state.tasks.payment_details => |v| {
 			self.state.payment_details = Some(v);
 		});
@@ -1173,6 +1190,7 @@ impl App for LspServerApp {
 				(ActiveTab::StableChannels, "Stable"),
 				(ActiveTab::Tools, "Tools"),
 				(ActiveTab::NetworkGraph, "Graph"),
+				(ActiveTab::Logs, "Logs"),
 			];
 
 			for (tab, label) in tabs {
@@ -1218,6 +1236,7 @@ impl App for LspServerApp {
 			ActiveTab::StableChannels => ui::stable_channels::render(ui, self),
 			ActiveTab::Tools => ui::tools::render(ui, self),
 			ActiveTab::NetworkGraph => ui::network_graph::render(ui, self),
+			ActiveTab::Logs => ui::ldk_log::render(ui, self),
 		});
 
 		ui::channels::render_dialogs(ctx, self);

--- a/server/lsp-server-gui/src/state.rs
+++ b/server/lsp-server-gui/src/state.rs
@@ -18,7 +18,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	VerifySignatureResponse,
 };
 use sc_rest_client::sc_protos::stable::{
-	EditStableChannelResponse, GetPriceResponse, ListStableChannelsResponse,
+	EditStableChannelResponse, GetPriceResponse, ListStableChannelsResponse, LogResponse,
 };
 use sc_rest_client::ldk_server_grpc::types::PageToken;
 
@@ -44,6 +44,7 @@ pub enum ActiveTab {
 	StableChannels,
 	Tools,
 	NetworkGraph,
+	Logs,
 }
 
 #[derive(Default, Clone)]
@@ -161,6 +162,17 @@ pub struct GraphGetNodeForm {
 	pub node_id: String,
 }
 
+#[derive(Clone)]
+pub struct LogForm {
+	pub max_lines: String,
+}
+
+impl Default for LogForm {
+	fn default() -> Self {
+		Self { max_lines: "200".to_string() }
+	}
+}
+
 /// Editable chain source configuration (used on native only)
 #[allow(dead_code)]
 #[derive(Default, Clone)]
@@ -236,6 +248,7 @@ pub struct Forms {
 	pub verify_signature: VerifySignatureForm,
 	pub graph_get_channel: GraphGetChannelForm,
 	pub graph_get_node: GraphGetNodeForm,
+	pub ldk_log: LogForm,
 	#[allow(dead_code)]
 	pub chain_source: ChainSourceForm,
 }
@@ -308,6 +321,7 @@ pub struct AsyncTasks {
 	pub get_price: Option<ChannelTaskHandle<GetPriceResponse>>,
 	pub list_stable_channels: Option<ChannelTaskHandle<ListStableChannelsResponse>>,
 	pub edit_stable_channel: Option<ChannelTaskHandle<EditStableChannelResponse>>,
+	pub ldk_log: Option<ChannelTaskHandle<LogResponse>>,
 }
 
 impl Default for AsyncTasks {
@@ -345,6 +359,7 @@ impl Default for AsyncTasks {
 			get_price: None,
 			list_stable_channels: None,
 			edit_stable_channel: None,
+			ldk_log: None,
 		}
 	}
 }
@@ -383,6 +398,7 @@ impl AsyncTasks {
 			|| self.get_price.is_some()
 			|| self.list_stable_channels.is_some()
 			|| self.edit_stable_channel.is_some()
+			|| self.ldk_log.is_some()
 	}
 }
 
@@ -416,6 +432,7 @@ pub struct AppState {
 	pub payment_details: Option<GetPaymentDetailsResponse>,
 	pub price: Option<GetPriceResponse>,
 	pub stable_channels: Option<ListStableChannelsResponse>,
+	pub ldk_log: Option<LogResponse>,
 
 	// Operation results
 	pub onchain_address: Option<String>,
@@ -502,6 +519,7 @@ impl Default for AppState {
 			payment_details: None,
 			price: None,
 			stable_channels: None,
+			ldk_log: None,
 
 			onchain_address: None,
 			generated_invoice: None,

--- a/server/lsp-server-gui/src/ui/ldk_log.rs
+++ b/server/lsp-server-gui/src/ui/ldk_log.rs
@@ -1,0 +1,55 @@
+use eframe::egui;
+
+use crate::app::LspServerApp;
+
+pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
+	ui.heading("LDK Server Logs");
+	ui.add_space(5.0);
+
+	ui.horizontal(|ui| {
+		ui.label("Lines:");
+		ui.add(
+			egui::TextEdit::singleline(&mut app.state.forms.ldk_log.max_lines)
+				.desired_width(80.0),
+		);
+		let loading = app.state.tasks.ldk_log.is_some();
+		if ui.add_enabled(!loading, egui::Button::new("Refresh")).clicked() {
+			app.fetch_ldk_log();
+		}
+		if loading {
+			ui.spinner();
+		}
+	});
+
+	ui.add_space(10.0);
+
+	match &app.state.ldk_log {
+		Some(resp) if resp.content.is_empty() => {
+			ui.label("Empty response.");
+			ui.label(
+				egui::RichText::new(
+					"LDK Server may not have `[log] file = \"...\"` set in its config. \
+					 Uncomment that line and restart LDK Server, then refresh.",
+				)
+				.italics()
+				.weak(),
+			);
+		},
+		Some(resp) => {
+			egui::ScrollArea::both().auto_shrink([false, false]).stick_to_bottom(true).show(
+				ui,
+				|ui| {
+					ui.add(
+						egui::TextEdit::multiline(&mut resp.content.as_str())
+							.font(egui::TextStyle::Monospace)
+							.desired_width(f32::INFINITY)
+							.desired_rows(30),
+					);
+				},
+			);
+		},
+		None => {
+			ui.label("Click Refresh to load.");
+		},
+	}
+}

--- a/server/lsp-server-gui/src/ui/mod.rs
+++ b/server/lsp-server-gui/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod balances;
 pub mod channels;
 pub mod connection;
 pub mod forwarded_payments;
+pub mod ldk_log;
 pub mod lightning;
 pub mod network_graph;
 pub mod node_info;

--- a/server/sc-protos/src/stable.rs
+++ b/server/sc-protos/src/stable.rs
@@ -73,6 +73,10 @@ pub struct RegisterPushRequest {
 	pub node_id: ::prost::alloc::string::String,
 	#[prost(string, tag = "4")]
 	pub environment: ::prost::alloc::string::String,
+	#[prost(string, tag = "5")]
+	pub signature: ::prost::alloc::string::String,
+	#[prost(uint64, tag = "6")]
+	pub timestamp: u64,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/server/sc-rest-client/Cargo.toml
+++ b/server/sc-rest-client/Cargo.toml
@@ -10,7 +10,7 @@ serde = ["sc-protos/serde"]
 
 [dependencies]
 sc-protos = { path = "../sc-protos" }
-ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "3f98b857abfa9bcf660fd14db35be17cf79e03c6", features = ["serde"], default-features = false }
+ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "e975689b0b8332c3ace1e7272c2fd0c4153144b7", features = ["serde"], default-features = false }
 prost = { version = "0.11.6", default-features = false, features = ["std", "prost-derive"] }
 bitcoin_hashes = "0.14"
 

--- a/server/sc-rest-client/src/client.rs
+++ b/server/sc-rest-client/src/client.rs
@@ -43,8 +43,8 @@ use ldk_server_client::ldk_server_grpc::endpoints::{
 use ldk_server_client::ldk_server_grpc::error::{ErrorCode, ErrorResponse};
 use sc_protos::stable::{
 	EditStableChannelRequest, EditStableChannelResponse, GetPriceRequest, GetPriceResponse,
-	ListStableChannelsRequest, ListStableChannelsResponse, EDIT_STABLE_CHANNEL_PATH,
-	GET_PRICE_PATH, LIST_STABLE_CHANNELS_PATH,
+	ListStableChannelsRequest, ListStableChannelsResponse, LogRequest, LogResponse,
+	EDIT_STABLE_CHANNEL_PATH, GET_PRICE_PATH, LDK_LOG_PATH, LIST_STABLE_CHANNELS_PATH,
 };
 use prost::Message;
 use reqwest::header::CONTENT_TYPE;
@@ -500,6 +500,12 @@ impl LspRestClient {
 		&self, request: EditStableChannelRequest,
 	) -> Result<EditStableChannelResponse, LspRestError> {
 		let url = self.build_url(EDIT_STABLE_CHANNEL_PATH);
+		self.post_request(&request, &url).await
+	}
+
+	/// Tail LDK Server's log file via the SC daemon.
+	pub async fn ldk_log(&self, request: LogRequest) -> Result<LogResponse, LspRestError> {
+		let url = self.build_url(LDK_LOG_PATH);
 		self.post_request(&request, &url).await
 	}
 

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -32,9 +32,9 @@ bytes            = "1"
 a2 = "0.10"
 
 # FCM (Android) push notifications: HTTPS + OAuth2 JWT.
-reqwest    = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-serde_json = "1"
-openssl    = { version = "0.10", default-features = false, features = ["vendored"] }
+reqwest      = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde_json   = "1"
+jsonwebtoken = "9"
 
 # sqlite for the push tokens store (declared explicitly even though stable-channels pulls it transitively).
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # Workspace crates
 stable-channels   = { path = "../.." }
 sc-protos         = { path = "../sc-protos" }
-ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "3f98b857abfa9bcf660fd14db35be17cf79e03c6", features = ["serde"], default-features = false }
+ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "e975689b0b8332c3ace1e7272c2fd0c4153144b7", features = ["serde"], default-features = false }
 # ldk-node is pulled transitively by stable-channels but we need it as a direct
 # dep so we can name `ldk_node::lightning::ln::types::ChannelId` etc. in our
 # module path. The rev must match the root Cargo.toml.

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use ldk_server_client::ldk_server_grpc::events::event_envelope::Event as EventVariant;
 use ldk_server_client::ldk_server_grpc::events::{ChannelState, EventEnvelope};
@@ -68,9 +68,8 @@ async fn dispatch(
                 mgr.handle_channel_closed(e.user_channel_id.clone());
             }
         },
-        Some(EventVariant::PaymentReceived(_)) => {
-            // Upstream PaymentReceived has no channel_id, so run_tick + reconcile_from_grpc catch up instead.
-            debug!("[event_loop] PaymentReceived (no channel_id available, deferred to tick)");
+        Some(EventVariant::PaymentReceived(e)) => {
+            mgr.handle_payment_received(e.custom_records, ldk, btc_price).await;
         },
         Some(EventVariant::PaymentForwarded(e)) => {
             if let Some(fp) = e.forwarded_payment {

--- a/server/stable-channels-lsp/src/handlers/register_push.rs
+++ b/server/stable-channels-lsp/src/handlers/register_push.rs
@@ -1,13 +1,46 @@
-//! RegisterPush handler: wallets POST an APNs/FCM device token and Lightning node id, stored in push_tokens.db.
+//! RegisterPush handler: wallets POST a signed APNs/FCM device token and Lightning node id, stored in push_tokens.db.
 
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::response::Response;
 
+use ldk_server_client::ldk_server_grpc::api::VerifySignatureRequest;
 use sc_protos::stable::{RegisterPushRequest, RegisterPushResponse};
 
 use crate::handlers::{decode_body, ok_response};
+use crate::stable_manager::LdkServerCalls;
 use crate::state::AppState;
+
+/// Freshness window for the signed timestamp, in seconds.
+const PUSH_SIG_WINDOW_SECS: u64 = 300;
+
+/// Verify a RegisterPush node-ownership proof: the signature over the canonical
+/// {type,node_id,token,ts} JSON must verify against node_id, and ts must be within the window.
+pub async fn verify_push_registration(
+    ldk: &dyn LdkServerCalls,
+    node_id: &str,
+    token: &str,
+    signature: &str,
+    timestamp: u64,
+    now: u64,
+    window_secs: u64,
+) -> bool {
+    if now.abs_diff(timestamp) > window_secs {
+        return false;
+    }
+    let message = crate::messages::register_push_signed_bytes(node_id, token, timestamp);
+    match ldk
+        .verify_signature(VerifySignatureRequest {
+            message: message.into(),
+            signature: signature.to_string(),
+            public_key: node_id.to_string(),
+        })
+        .await
+    {
+        Ok(r) => r.valid,
+        Err(_) => false,
+    }
+}
 
 pub async fn register_push(State(state): State<AppState>, body: Bytes) -> Response {
     let req: RegisterPushRequest = match decode_body(&body) {
@@ -15,10 +48,101 @@ pub async fn register_push(State(state): State<AppState>, body: Bytes) -> Respon
         Err(resp) => return resp,
     };
 
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let ldk = state.ldk_server.as_ref() as &dyn LdkServerCalls;
+    let ok = verify_push_registration(
+        ldk,
+        &req.node_id,
+        &req.token,
+        &req.signature,
+        req.timestamp,
+        now,
+        PUSH_SIG_WINDOW_SECS,
+    )
+    .await;
+    if !ok {
+        stable_channels::audit::audit_event(
+            "REGISTER_PUSH_SIGNATURE_INVALID",
+            serde_json::json!({ "node_id": req.node_id }),
+        );
+        return ok_response(RegisterPushResponse { ok: false });
+    }
+
     {
         let push = state.push.lock().await;
         push.register_token(&req.token, &req.platform, &req.node_id, &req.environment);
     }
-
+    stable_channels::audit::audit_event(
+        "REGISTER_PUSH_OK",
+        serde_json::json!({ "node_id": req.node_id }),
+    );
     ok_response(RegisterPushResponse { ok: true })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ldk_server_client::error::LdkServerError;
+    use ldk_server_client::ldk_server_grpc::api::{
+        ListChannelsRequest, ListChannelsResponse, SignMessageRequest, SignMessageResponse,
+        SpontaneousSendRequest, SpontaneousSendResponse, VerifySignatureRequest,
+        VerifySignatureResponse,
+    };
+
+    struct VerifyFake {
+        valid: bool,
+    }
+
+    #[async_trait]
+    impl LdkServerCalls for VerifyFake {
+        async fn list_channels(
+            &self,
+            _req: ListChannelsRequest,
+        ) -> Result<ListChannelsResponse, LdkServerError> {
+            Ok(ListChannelsResponse { channels: vec![] })
+        }
+        async fn spontaneous_send(
+            &self,
+            _req: SpontaneousSendRequest,
+        ) -> Result<SpontaneousSendResponse, LdkServerError> {
+            Ok(SpontaneousSendResponse { payment_id: String::new() })
+        }
+        async fn sign_message(
+            &self,
+            _req: SignMessageRequest,
+        ) -> Result<SignMessageResponse, LdkServerError> {
+            Ok(SignMessageResponse { signature: String::new() })
+        }
+        async fn verify_signature(
+            &self,
+            _req: VerifySignatureRequest,
+        ) -> Result<VerifySignatureResponse, LdkServerError> {
+            Ok(VerifySignatureResponse { valid: self.valid })
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_fresh_signature_accepted() {
+        let fake = VerifyFake { valid: true };
+        let ok = verify_push_registration(&fake, "node", "token", "sig", 1000, 1000, 300).await;
+        assert!(ok);
+    }
+
+    #[tokio::test]
+    async fn stale_timestamp_rejected() {
+        let fake = VerifyFake { valid: true };
+        let ok = verify_push_registration(&fake, "node", "token", "sig", 1000, 2000, 300).await;
+        assert!(!ok); // 1000s drift > 300s window
+    }
+
+    #[tokio::test]
+    async fn invalid_signature_rejected() {
+        let fake = VerifyFake { valid: false };
+        let ok = verify_push_registration(&fake, "node", "token", "sig", 1000, 1000, 300).await;
+        assert!(!ok);
+    }
 }

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod config;
 mod event_loop;
 mod handlers;
+pub mod messages;
 mod price_task;
 mod push;
 mod stability_tick;

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -1,0 +1,128 @@
+//! TRADE_V1 / SYNC_V1 / RegisterPush signed-message codec over custom TLV 13377331.
+
+use serde::{Deserialize, Serialize};
+
+/// Max bytes of a custom-TLV value we will attempt to parse (DoS guard).
+pub const MAX_TLV_VALUE_BYTES: usize = 8 * 1024;
+
+/// Outer signed envelope: a JSON-string payload plus a zbase32 signature over its bytes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedEnvelope {
+    pub payload: String,
+    pub signature: String,
+}
+
+/// Inbound TRADE_V1 payload (wallet to LSP). `expected_usd` is required (no default).
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradePayload {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub channel_id: Option<String>,
+    #[serde(default)]
+    pub user_channel_id: Option<String>,
+    pub expected_usd: f64,
+}
+
+/// RegisterPush signed body. Field declaration order IS the canonical serialization order;
+/// the wallet must serialize an identical struct so the daemon can reconstruct the signed bytes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterPushSigned {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub node_id: String,
+    pub token: String,
+    pub ts: u64,
+}
+
+/// Build the SYNC_V1 payload string (the exact bytes the daemon signs and ships).
+pub fn build_sync_payload(user_channel_id: u128, expected_usd: f64) -> String {
+    serde_json::json!({
+        "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
+        "user_channel_id": format!("{}", user_channel_id),
+        "expected_usd": expected_usd,
+    })
+    .to_string()
+}
+
+/// Wrap a signed payload string + signature into the envelope JSON string.
+pub fn build_envelope(payload: String, signature: String) -> String {
+    serde_json::to_string(&SignedEnvelope { payload, signature }).unwrap_or_default()
+}
+
+/// Parse the outer envelope from raw (already UTF-8) TLV bytes.
+pub fn parse_envelope(raw: &str) -> Option<SignedEnvelope> {
+    serde_json::from_str::<SignedEnvelope>(raw).ok()
+}
+
+/// Parse the inner TRADE payload from the envelope's payload string.
+pub fn parse_trade_payload(payload: &str) -> Option<TradePayload> {
+    serde_json::from_str::<TradePayload>(payload).ok()
+}
+
+/// Canonical RegisterPush signed bytes. Must match the wallet's serialization exactly.
+pub fn register_push_signed_bytes(node_id: &str, token: &str, ts: u64) -> Vec<u8> {
+    serde_json::to_vec(&RegisterPushSigned {
+        kind: "REGISTER_PUSH_V1".to_string(),
+        node_id: node_id.to_string(),
+        token: token.to_string(),
+        ts,
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_payload_has_expected_shape() {
+        let payload = build_sync_payload(7u128, 25.0);
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["type"], "SYNC_V1");
+        assert_eq!(v["user_channel_id"], "7");
+        assert_eq!(v["expected_usd"], 25.0);
+    }
+
+    #[test]
+    fn envelope_round_trips() {
+        let env = build_envelope("the-payload".to_string(), "the-sig".to_string());
+        let parsed = parse_envelope(&env).unwrap();
+        assert_eq!(parsed.payload, "the-payload");
+        assert_eq!(parsed.signature, "the-sig");
+    }
+
+    #[test]
+    fn trade_payload_parses_wallet_shape() {
+        let payload = r#"{"type":"TRADE_V1","channel_id":"abcd","user_channel_id":"189476124653200987495269098788434301048","expected_usd":12.5}"#;
+        let t = parse_trade_payload(payload).unwrap();
+        assert_eq!(t.kind, "TRADE_V1");
+        assert_eq!(t.channel_id.as_deref(), Some("abcd"));
+        assert_eq!(
+            t.user_channel_id.as_deref(),
+            Some("189476124653200987495269098788434301048")
+        );
+        assert_eq!(t.expected_usd, 12.5);
+    }
+
+    #[test]
+    fn bad_json_is_none() {
+        assert!(parse_envelope("not json").is_none());
+        assert!(parse_trade_payload("not json").is_none());
+    }
+
+    #[test]
+    fn trade_missing_expected_usd_is_none() {
+        let payload = r#"{"type":"TRADE_V1","channel_id":"abcd"}"#;
+        assert!(parse_trade_payload(payload).is_none());
+    }
+
+    #[test]
+    fn register_push_bytes_are_canonical_and_deterministic() {
+        let a = register_push_signed_bytes("nodehex", "tok:en", 1717000000);
+        let expected = r#"{"type":"REGISTER_PUSH_V1","node_id":"nodehex","token":"tok:en","ts":1717000000}"#;
+        assert_eq!(String::from_utf8(a.clone()).unwrap(), expected);
+        let b = register_push_signed_bytes("nodehex", "tok:en", 1717000000);
+        assert_eq!(a, b);
+    }
+}

--- a/server/stable-channels-lsp/src/push/fcm.rs
+++ b/server/stable-channels-lsp/src/push/fcm.rs
@@ -93,17 +93,11 @@ impl FcmService {
 }
 
 async fn generate_access_token(creds: &FcmCredentials) -> Option<String> {
-    use openssl::base64;
-    use openssl::hash::MessageDigest;
-    use openssl::pkey::PKey;
-    use openssl::sign::Signer;
-
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .ok()?
         .as_secs();
 
-    let header = serde_json::json!({"alg": "RS256", "typ": "JWT"});
     let claims = serde_json::json!({
         "iss": creds.client_email,
         "scope": "https://www.googleapis.com/auth/firebase.messaging",
@@ -112,24 +106,10 @@ async fn generate_access_token(creds: &FcmCredentials) -> Option<String> {
         "exp": now + 3600,
     });
 
-    let b64_encode = |data: &[u8]| -> String {
-        base64::encode_block(data)
-            .replace('+', "-")
-            .replace('/', "_")
-            .replace('=', "")
-    };
-
-    let header_b64 = b64_encode(header.to_string().as_bytes());
-    let claims_b64 = b64_encode(claims.to_string().as_bytes());
-    let signing_input = format!("{}.{}", header_b64, claims_b64);
-
-    let pkey = PKey::private_key_from_pem(creds.private_key.as_bytes()).ok()?;
-    let mut signer = Signer::new(MessageDigest::sha256(), &pkey).ok()?;
-    signer.update(signing_input.as_bytes()).ok()?;
-    let signature = signer.sign_to_vec().ok()?;
-    let sig_b64 = b64_encode(&signature);
-
-    let jwt = format!("{}.{}", signing_input, sig_b64);
+    // RS256-sign the OAuth2 assertion with the service account key.
+    let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(creds.private_key.as_bytes()).ok()?;
+    let jwt = jsonwebtoken::encode(&header, &claims, &key).ok()?;
 
     let client = reqwest::Client::new();
     let resp = client

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -7,10 +7,11 @@ use async_trait::async_trait;
 use ldk_server_client::client::LdkServerClient;
 use ldk_server_client::error::LdkServerError;
 use ldk_server_client::ldk_server_grpc::api::{
-    ListChannelsRequest, ListChannelsResponse, SpontaneousSendRequest,
-    SpontaneousSendResponse,
+    ListChannelsRequest, ListChannelsResponse, SignMessageRequest, SignMessageResponse,
+    SpontaneousSendRequest, SpontaneousSendResponse, VerifySignatureRequest,
+    VerifySignatureResponse,
 };
-use ldk_server_client::ldk_server_grpc::types::Channel;
+use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
 use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
@@ -26,6 +27,14 @@ pub trait LdkServerCalls: Send + Sync {
         &self,
         req: SpontaneousSendRequest,
     ) -> Result<SpontaneousSendResponse, LdkServerError>;
+    async fn sign_message(
+        &self,
+        req: SignMessageRequest,
+    ) -> Result<SignMessageResponse, LdkServerError>;
+    async fn verify_signature(
+        &self,
+        req: VerifySignatureRequest,
+    ) -> Result<VerifySignatureResponse, LdkServerError>;
 }
 
 #[async_trait]
@@ -41,6 +50,18 @@ impl LdkServerCalls for LdkServerClient {
         req: SpontaneousSendRequest,
     ) -> Result<SpontaneousSendResponse, LdkServerError> {
         LdkServerClient::spontaneous_send(self, req).await
+    }
+    async fn sign_message(
+        &self,
+        req: SignMessageRequest,
+    ) -> Result<SignMessageResponse, LdkServerError> {
+        LdkServerClient::sign_message(self, req).await
+    }
+    async fn verify_signature(
+        &self,
+        req: VerifySignatureRequest,
+    ) -> Result<VerifySignatureResponse, LdkServerError> {
+        LdkServerClient::verify_signature(self, req).await
     }
 }
 
@@ -337,6 +358,8 @@ impl StableChannelManager {
         let target_uid = parse_user_channel_id(&user_channel_id);
         if let Some(uid) = target_uid {
             if self.stable_channels.iter().any(|sc| sc.user_channel_id == uid) {
+                self.handle_channel_ready_splice(uid, ldk, btc_price)
+                    .await;
                 return;
             }
         }
@@ -418,72 +441,41 @@ impl StableChannelManager {
         );
     }
 
-    /// On PaymentReceived, refresh the channel's balances from a fresh ListChannels and recompute native/backing. Noop if untracked.
+    /// On PaymentReceived, route a STABLE_CHANNEL_TLV to the trade handler. A plain payment (no
+    /// such TLV) is left to run_tick + reconcile_from_grpc to catch up.
     pub async fn handle_payment_received(
         &mut self,
-        channel_id: String,
+        custom_records: Vec<CustomTlvRecord>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
-        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
-            Ok(r) => r.channels,
-            Err(e) => {
-                tracing::error!(
-                    "[stable] handle_payment_received: list_channels failed: {}",
-                    e
+        for rec in &custom_records {
+            if rec.type_num != stable_channels::constants::STABLE_CHANNEL_TLV_TYPE {
+                continue;
+            }
+            if rec.value.len() > crate::messages::MAX_TLV_VALUE_BYTES {
+                stable_channels::audit::audit_event(
+                    "TRADE_PARSE_SIGNED_FAILED",
+                    serde_json::json!({ "reason": "oversize", "len": rec.value.len() }),
                 );
                 return;
             }
-        };
-        let Some(c) = channels.into_iter().find(|c| c.channel_id == channel_id) else {
-            return;
-        };
-
-        let Some(target_uid) = parse_user_channel_id(&c.user_channel_id) else {
-            return;
-        };
-
-        let Some(sc) = self
-            .stable_channels
-            .iter_mut()
-            .find(|sc| sc.user_channel_id == target_uid)
-        else {
-            return;
-        };
-
-        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
-
-        sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
-        sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
-        sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
-        sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
-        sc.latest_price = btc_price;
-        stable_channels::stable::recompute_native(sc);
-
-        let expected_usd_f = sc.expected_usd.0;
-        let backing = sc.backing_sats;
-        let native = sc.native_sats;
-        let note = sc.note.clone();
-
-        if let Err(e) = self.db.save_channel(
-            &c.channel_id,
-            &c.user_channel_id,
-            expected_usd_f,
-            backing,
-            native,
-            note.as_deref(),
-        ) {
-            tracing::error!(
-                "[stable] handle_payment_received: db.save_channel failed: {}",
-                e
+            let Ok(raw) = std::str::from_utf8(rec.value.as_ref()) else {
+                stable_channels::audit::audit_event(
+                    "TRADE_PARSE_SIGNED_FAILED",
+                    serde_json::json!({ "reason": "utf8" }),
+                );
+                return;
+            };
+            stable_channels::audit::audit_event(
+                "MESSAGE_RECEIVED",
+                serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE }),
             );
+            let raw = raw.to_string();
+            self.handle_trade_message(&raw, ldk, btc_price).await;
+            return;
         }
-        stable_channels::audit::audit_event(
-            "PAYMENT_RECEIVED_RECONCILED",
-            serde_json::json!({ "channel_id": channel_id }),
-        );
+        // No stable TLV: plain payment, balance catch-up handled by run_tick + reconcile_from_grpc.
     }
 
     /// 60s tick: per stable channel, skip below threshold/cooldown/zero-target, then SpontaneousSend a connected peer or push an offline one.
@@ -568,6 +560,7 @@ impl StableChannelManager {
                         amount_msat,
                         node_id: sc.counterparty.to_string(),
                         route_parameters: None,
+                        custom_tlvs: vec![],
                     };
                     let channel_id_clone = c.channel_id.clone();
                     let user_channel_id_clone = c.user_channel_id.clone();
@@ -651,6 +644,64 @@ impl StableChannelManager {
         }
     }
 
+    /// Sign a SYNC_V1 payload and keysend it (1 msat) to the counterparty in custom TLV 13377331.
+    /// Best effort: a send failure is audited, never propagated. Mutates no state.
+    pub async fn send_sync_message(
+        &self,
+        ldk: &dyn LdkServerCalls,
+        user_channel_id: u128,
+        expected_usd: f64,
+        counterparty: &str,
+    ) {
+        let payload = crate::messages::build_sync_payload(user_channel_id, expected_usd);
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(r) => r.signature,
+            Err(e) => {
+                stable_channels::audit::audit_event(
+                    "SYNC_MESSAGE_FAILED",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", user_channel_id),
+                        "stage": "sign",
+                        "error": e.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let envelope = crate::messages::build_envelope(payload, signature);
+        let req = SpontaneousSendRequest {
+            amount_msat: 1,
+            node_id: counterparty.to_string(),
+            route_parameters: None,
+            custom_tlvs: vec![CustomTlvRecord {
+                type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                value: envelope.into_bytes().into(),
+            }],
+        };
+        match ldk.spontaneous_send(req).await {
+            Ok(_) => stable_channels::audit::audit_event(
+                "SYNC_MESSAGE_SENT",
+                serde_json::json!({
+                    "user_channel_id": format!("{}", user_channel_id),
+                    "expected_usd": expected_usd,
+                }),
+            ),
+            Err(e) => stable_channels::audit::audit_event(
+                "SYNC_MESSAGE_FAILED",
+                serde_json::json!({
+                    "user_channel_id": format!("{}", user_channel_id),
+                    "stage": "send",
+                    "error": e.to_string(),
+                }),
+            ),
+        }
+    }
+
     /// On a forward out of a stable channel, reconcile the spend: native BTC first, overflow reduces `expected_usd`.
     pub async fn handle_payment_forwarded(
         &mut self,
@@ -721,8 +772,9 @@ impl StableChannelManager {
             let native_before = sc.native_sats;
             let old_expected = sc.expected_usd.0;
             let user_sats_before = post_user_sats.saturating_add(total_sats);
+            let counterparty_hex = sc.counterparty.to_string();
 
-            if let Some(usd_deducted) = stable_channels::stable::reconcile_forwarded(
+            let deducted = if let Some(usd_deducted) = stable_channels::stable::reconcile_forwarded(
                 sc,
                 user_sats_before,
                 total_sats,
@@ -747,11 +799,13 @@ impl StableChannelManager {
                     sc.user_channel_id, total_sats, native_before, stable_sats_spent,
                     old_expected, sc.expected_usd.0
                 );
+                true
             } else {
                 // Fully covered by native BTC: reflect the spend in the buffer.
                 sc.native_sats = post_user_sats.saturating_sub(sc.backing_sats);
                 stable_channels::stable::recompute_native(sc);
-            }
+                false
+            };
 
             (
                 format!("{}", sc.user_channel_id),
@@ -759,10 +813,13 @@ impl StableChannelManager {
                 sc.backing_sats,
                 sc.native_sats,
                 sc.note.clone(),
+                counterparty_hex,
+                deducted,
             )
         };
 
-        let (ucid_str, expected_usd_f, backing_sats, native_sats, note) = persisted;
+        let (ucid_str, expected_usd_f, backing_sats, native_sats, note, counterparty_hex, deducted) =
+            persisted;
         if let Err(e) = self.db.save_channel(
             &channel_id_hex,
             &ucid_str,
@@ -773,6 +830,254 @@ impl StableChannelManager {
         ) {
             error!("[forwarded] db.save_channel failed: {}", e);
         }
+        if deducted {
+            self.send_sync_message(ldk, target_uid, expected_usd_f, &counterparty_hex)
+                .await;
+        }
+    }
+
+    /// Post-confirmation splice reconcile: refresh the new balance, infer any stable-spend overflow
+    /// via reconcile_outgoing, persist, and SYNC the wallet if stable value was deducted.
+    async fn handle_channel_ready_splice(
+        &mut self,
+        uid: u128,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                error!("[splice] list_channels gRPC failed: {}", e);
+                return;
+            }
+        };
+        let Some(c) = channels
+            .into_iter()
+            .find(|c| parse_user_channel_id(&c.user_channel_id) == Some(uid))
+        else {
+            return;
+        };
+        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
+        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
+        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+        let channel_id_hex = c.channel_id.clone();
+        let new_channel_id_bytes = parse_channel_id_hex(&c.channel_id);
+
+        let persisted = {
+            let Some(sc) = self
+                .stable_channels
+                .iter_mut()
+                .find(|sc| sc.user_channel_id == uid)
+            else {
+                return;
+            };
+            // Refresh receiver balance from the new snapshot but PRESERVE backing_sats so reconcile_outgoing can infer the overflow.
+            sc.channel_id =
+                ldk_node::lightning::ln::types::ChannelId::from_bytes(new_channel_id_bytes);
+            sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
+            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
+            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+            sc.latest_price = btc_price;
+            stable_channels::stable::recompute_native(sc);
+
+            let counterparty_hex = sc.counterparty.to_string();
+            let usd_deducted = stable_channels::stable::reconcile_outgoing(sc, btc_price);
+            if let Some(d) = usd_deducted {
+                stable_channels::audit::audit_event(
+                    "SPLICE_OUT_STABLE_DEDUCTED",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", uid),
+                        "usd_deducted": d,
+                        "new_expected_usd": sc.expected_usd.0,
+                    }),
+                );
+            }
+            (
+                format!("{}", sc.user_channel_id),
+                sc.expected_usd.0,
+                sc.backing_sats,
+                sc.native_sats,
+                sc.note.clone(),
+                counterparty_hex,
+                usd_deducted.is_some(),
+            )
+        };
+
+        let (ucid_str, expected_usd_f, backing, native, note, counterparty_hex, deducted) =
+            persisted;
+        if let Err(e) = self.db.save_channel(
+            &channel_id_hex,
+            &ucid_str,
+            expected_usd_f,
+            backing,
+            native,
+            note.as_deref(),
+        ) {
+            error!("[splice] db.save_channel failed: {}", e);
+        }
+        stable_channels::audit::audit_event(
+            "CHANNEL_READY_SPLICE",
+            serde_json::json!({ "user_channel_id": ucid_str, "deducted": deducted }),
+        );
+        if deducted {
+            self.send_sync_message(ldk, uid, expected_usd_f, &counterparty_hex)
+                .await;
+        }
+    }
+
+    /// Parse a TRADE_V1 envelope, verify it against the channel counterparty, validate against
+    /// balance, and apply the new USD target. Drops (with an audit line) on any failure.
+    pub async fn handle_trade_message(
+        &mut self,
+        raw: &str,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let Some(envelope) = crate::messages::parse_envelope(raw) else {
+            stable_channels::audit::audit_event("TRADE_PARSE_SIGNED_FAILED", serde_json::json!({}));
+            return;
+        };
+        let Some(payload) = crate::messages::parse_trade_payload(&envelope.payload) else {
+            stable_channels::audit::audit_event("TRADE_PARSE_PAYLOAD_FAILED", serde_json::json!({}));
+            return;
+        };
+        if payload.kind != stable_channels::constants::TRADE_MESSAGE_TYPE {
+            stable_channels::audit::audit_event(
+                "TRADE_UNHANDLED_TYPE",
+                serde_json::json!({ "type": payload.kind }),
+            );
+            return;
+        }
+        if payload.expected_usd < 0.0 {
+            stable_channels::audit::audit_event(
+                "TRADE_INVALID_AMOUNT",
+                serde_json::json!({ "expected_usd": payload.expected_usd }),
+            );
+            return;
+        }
+        stable_channels::audit::audit_event(
+            "TRADE_PARSED_PAYLOAD_OK",
+            serde_json::json!({ "expected_usd": payload.expected_usd }),
+        );
+
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(r) => r.channels,
+            Err(e) => {
+                error!("[trade] list_channels gRPC failed: {}", e);
+                return;
+            }
+        };
+        // channel_id is authoritative when present; user_channel_id is the fallback.
+        let chan = channels.into_iter().find(|c| {
+            if let Some(cid) = payload.channel_id.as_deref() {
+                if c.channel_id == cid {
+                    return true;
+                }
+            }
+            if let Some(ucid) = payload.user_channel_id.as_deref() {
+                let want = parse_user_channel_id(ucid);
+                if want.is_some() && want == parse_user_channel_id(&c.user_channel_id) {
+                    return true;
+                }
+            }
+            false
+        });
+        let Some(chan) = chan else {
+            stable_channels::audit::audit_event(
+                "TRADE_CHANNEL_NOT_FOUND",
+                serde_json::json!({
+                    "channel_id": payload.channel_id,
+                    "user_channel_id": payload.user_channel_id,
+                }),
+            );
+            return;
+        };
+
+        let verify = ldk
+            .verify_signature(VerifySignatureRequest {
+                message: envelope.payload.as_bytes().to_vec().into(),
+                signature: envelope.signature.clone(),
+                public_key: chan.counterparty_node_id.clone(),
+            })
+            .await;
+        let valid = matches!(verify, Ok(ref r) if r.valid);
+        if !valid {
+            stable_channels::audit::audit_event(
+                "TRADE_SIGNATURE_INVALID",
+                serde_json::json!({ "channel_id": chan.channel_id }),
+            );
+            return;
+        }
+        stable_channels::audit::audit_event(
+            "TRADE_SIGNATURE_VALID",
+            serde_json::json!({ "channel_id": chan.channel_id }),
+        );
+
+        let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
+            stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({}));
+            return;
+        };
+        let unspendable = chan.unspendable_punishment_reserve.unwrap_or(0);
+        let our_sats = (chan.outbound_capacity_msat / 1000) + unspendable;
+        let their_sats = chan.channel_value_sats.saturating_sub(our_sats);
+        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
+        let new_expected = payload.expected_usd;
+        // Cannot stabilize more than the user holds. Residual drift self-heals via the tick.
+        if new_expected > receiver_usd {
+            stable_channels::audit::audit_event(
+                "TRADE_EXCEEDS_BALANCE",
+                serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd }),
+            );
+            return;
+        }
+        let channel_id_hex = chan.channel_id.clone();
+
+        let persisted = {
+            let Some(sc) = self
+                .stable_channels
+                .iter_mut()
+                .find(|sc| sc.user_channel_id == target_uid)
+            else {
+                stable_channels::audit::audit_event(
+                    "TRADE_STABLE_ENTRY_NOT_FOUND",
+                    serde_json::json!({ "user_channel_id": format!("{}", target_uid) }),
+                );
+                return;
+            };
+            sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
+            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
+            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+            sc.latest_price = btc_price;
+            stable_channels::stable::apply_trade(sc, new_expected, btc_price);
+            (
+                format!("{}", sc.user_channel_id),
+                sc.expected_usd.0,
+                sc.backing_sats,
+                sc.native_sats,
+                sc.note.clone(),
+            )
+        };
+
+        let (ucid_str, expected_usd_f, backing, native, note) = persisted;
+        if let Err(e) = self.db.save_channel(
+            &channel_id_hex,
+            &ucid_str,
+            expected_usd_f,
+            backing,
+            native,
+            note.as_deref(),
+        ) {
+            error!("[trade] db.save_channel failed: {}", e);
+        }
+        stable_channels::audit::audit_event(
+            "TRADE_APPLIED",
+            serde_json::json!({
+                "user_channel_id": ucid_str,
+                "new_expected_usd": expected_usd_f,
+            }),
+        );
     }
 }
 
@@ -861,6 +1166,9 @@ mod tests {
         pub channels: StdMutex<Vec<GrpcChannel>>,
         pub sends: StdMutex<Vec<SpontaneousSendRequest>>,
         pub send_should_fail: bool,
+        pub verify_should_pass: bool,
+        pub signature: String,
+        pub sign_calls: StdMutex<Vec<Vec<u8>>>,
     }
 
     impl FakeLdkServer {
@@ -869,10 +1177,17 @@ mod tests {
                 channels: StdMutex::new(channels),
                 sends: StdMutex::new(Vec::new()),
                 send_should_fail: false,
+                verify_should_pass: true,
+                signature: "fake-sig".to_string(),
+                sign_calls: StdMutex::new(Vec::new()),
             }
         }
         pub fn with_send_failure(mut self) -> Self {
             self.send_should_fail = true;
+            self
+        }
+        pub fn with_verify_failure(mut self) -> Self {
+            self.verify_should_pass = false;
             self
         }
     }
@@ -900,6 +1215,23 @@ mod tests {
             self.sends.lock().unwrap().push(req);
             Ok(SpontaneousSendResponse {
                 payment_id: "fake-payment-id".to_string(),
+            })
+        }
+        async fn sign_message(
+            &self,
+            req: SignMessageRequest,
+        ) -> Result<SignMessageResponse, LdkServerError> {
+            self.sign_calls.lock().unwrap().push(req.message.to_vec());
+            Ok(SignMessageResponse {
+                signature: self.signature.clone(),
+            })
+        }
+        async fn verify_signature(
+            &self,
+            _req: VerifySignatureRequest,
+        ) -> Result<VerifySignatureResponse, LdkServerError> {
+            Ok(VerifySignatureResponse {
+                valid: self.verify_should_pass,
             })
         }
     }
@@ -1066,40 +1398,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_payment_received_refreshes_balances() {
+    async fn payment_received_trade_tlv_applies() {
         let mut mgr = make_manager();
-        let fake_initial = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
         )]);
-        mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), None,
-            &fake_initial as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        // After payment, outbound dropped from 50_000 sats to 30_000 sats.
-        let fake_after = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 30_000_000, true,
-        )]);
-        mgr.handle_payment_received(
-            CHANNEL_ID_HEX.to_string(),
-            &fake_after as &dyn LdkServerCalls,
-            100_000.0,
-        ).await;
-        assert_eq!(mgr.stable_channels[0].stable_receiver_btc.sats, 70_000);
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 8.0);
+        let records = vec![CustomTlvRecord {
+            type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+            value: env.into_bytes().into(),
+        }];
+        mgr.handle_payment_received(records, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
     }
 
     #[tokio::test]
-    async fn handle_payment_received_untracked_channel_is_noop() {
+    async fn payment_received_no_tlv_is_noop() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![]);
-        mgr.handle_payment_received(
-            CHANNEL_ID_HEX.to_string(),
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        ).await;
-        assert_eq!(mgr.stable_channels.len(), 0);
+        seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
+
+        mgr.handle_payment_received(vec![], &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // untouched
     }
 
     // Seed a stable channel: 100k value, 50k user side, $10 at $100k/BTC, giving backing 10k + native 40k.
@@ -1192,6 +1516,35 @@ mod tests {
             100_000.0,
         ).await;
         assert!(mgr.stable_channels.is_empty());
+    }
+
+    #[tokio::test]
+    async fn forwarded_deduction_sends_sync() {
+        let mut mgr = make_manager();
+        // Post-forward channel snapshot: their = 5,000 sats (our 95k via outbound 95M msat).
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+        )]);
+        // expected $10 -> backing 10,000; native 40,000; receiver 50,000 at $100k.
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+
+        // Forward 45,000 sats out: pre = 5,000 + 45,000 = 50,000, native 40,000, overflow 5,000 = $5.
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            45_000_000, // outbound_amount_forwarded_msat
+            0,          // fee_msat
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1, "a SYNC should be sent after a stable deduction");
+        assert_eq!(sends[0].amount_msat, 1);
+        assert_eq!(
+            sends[0].custom_tlvs[0].type_num,
+            stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
+        );
     }
 
     #[tokio::test]
@@ -1422,6 +1775,238 @@ mod tests {
                    Some(189476124653200987495269098788434301048u128));
         // hex fallback still works for 0x-prefixed values
         assert_eq!(parse_user_channel_id("0x01"), Some(1));
+    }
+
+    #[tokio::test]
+    async fn send_sync_message_keysends_signed_tlv() {
+        let mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![]);
+        mgr.send_sync_message(&fake as &dyn LdkServerCalls, 7u128, 25.0, COUNTERPARTY_HEX)
+            .await;
+
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert_eq!(sends[0].amount_msat, 1);
+        assert_eq!(sends[0].node_id, COUNTERPARTY_HEX);
+        assert_eq!(sends[0].custom_tlvs.len(), 1);
+        assert_eq!(
+            sends[0].custom_tlvs[0].type_num,
+            stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
+        );
+        assert_eq!(fake.sign_calls.lock().unwrap().len(), 1);
+
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let env = crate::messages::parse_envelope(raw).unwrap();
+        assert_eq!(env.signature, "fake-sig");
+        let v: serde_json::Value = serde_json::from_str(&env.payload).unwrap();
+        assert_eq!(v["type"], "SYNC_V1");
+        assert_eq!(v["user_channel_id"], "7");
+        assert_eq!(v["expected_usd"], 25.0);
+    }
+
+    #[tokio::test]
+    async fn fake_sign_and_verify_behaviour() {
+        let fake = FakeLdkServer::new(vec![]);
+        let sig = fake
+            .sign_message(SignMessageRequest { message: b"hello".to_vec().into() })
+            .await
+            .unwrap();
+        assert_eq!(sig.signature, "fake-sig");
+        assert_eq!(fake.sign_calls.lock().unwrap().len(), 1);
+
+        let ok = fake
+            .verify_signature(VerifySignatureRequest {
+                message: b"hello".to_vec().into(),
+                signature: "fake-sig".to_string(),
+                public_key: COUNTERPARTY_HEX.to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(ok.valid);
+
+        let bad = FakeLdkServer::new(vec![]).with_verify_failure();
+        let res = bad
+            .verify_signature(VerifySignatureRequest {
+                message: b"x".to_vec().into(),
+                signature: "s".to_string(),
+                public_key: COUNTERPARTY_HEX.to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(!res.valid);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn seed_channel(
+        mgr: &mut StableChannelManager,
+        user_channel_id: u128,
+        counterparty: &str,
+        channel_id: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        receiver_sats: u64,
+        price: f64,
+    ) {
+        mgr.stable_channels.push(StableChannel {
+            channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(
+                parse_channel_id_hex(channel_id),
+            ),
+            user_channel_id,
+            counterparty: parse_pubkey_hex(counterparty),
+            is_stable_receiver: false,
+            expected_usd: USD::from_f64(expected_usd),
+            expected_btc: Bitcoin::from_sats(0),
+            stable_receiver_btc: Bitcoin::from_sats(receiver_sats),
+            stable_receiver_usd: USD::from_bitcoin(Bitcoin::from_sats(receiver_sats), price),
+            stable_provider_btc: Bitcoin::from_sats(0),
+            stable_provider_usd: USD(0.0),
+            latest_price: price,
+            risk_level: 0,
+            payment_made: false,
+            timestamp: 0,
+            formatted_datetime: String::new(),
+            sc_dir: String::new(),
+            prices: String::new(),
+            onchain_btc: Bitcoin::from_sats(0),
+            onchain_usd: USD(0.0),
+            note: None,
+            native_channel_btc: Bitcoin::from_sats(0),
+            backing_sats,
+            native_sats,
+            last_stability_payment: 0,
+        });
+    }
+
+    fn trade_envelope(channel_id: &str, user_channel_id: &str, expected_usd: f64) -> String {
+        let payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "channel_id": channel_id,
+            "user_channel_id": user_channel_id,
+            "expected_usd": expected_usd,
+        })
+        .to_string();
+        serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
+    }
+
+    #[tokio::test]
+    async fn trade_applies_valid_target() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_invalid_signature() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]).with_verify_failure();
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 3.0, 3_000, 47_000, 50_000, 100_000.0);
+
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 3.0).abs() < 1e-6); // unchanged
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_over_balance() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 999.0);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6); // unchanged
+    }
+
+    #[tokio::test]
+    async fn trade_channel_not_found_is_noop() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
+
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // unchanged
+    }
+
+    #[tokio::test]
+    async fn splice_out_deducts_and_syncs() {
+        let mut mgr = make_manager();
+        // Post-splice snapshot: their = 5,000 (our 95k via outbound 95M msat).
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+        )]);
+        // expected $10 -> backing 10,000; receiver was 50,000.
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        // backing 10,000 vs new receiver 5,000 -> overflow 5,000 = $5 -> expected $5.
+        assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1, "splice-out should SYNC");
+    }
+
+    #[tokio::test]
+    async fn splice_in_does_not_sync() {
+        let mut mgr = make_manager();
+        // Post-splice snapshot: their grew to 80,000 (our 20k via outbound 20M msat).
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 20_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_string(),
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6); // unchanged
+        assert_eq!(fake.sends.lock().unwrap().len(), 0, "splice-in must not SYNC");
+    }
+
+    #[tokio::test]
+    async fn splice_replay_does_not_double_deduct() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+
+        for _ in 0..2 {
+            mgr.handle_channel_ready(
+                CHANNEL_ID_HEX.to_string(),
+                USER_CHANNEL_ID_DECIMAL.to_string(),
+                &fake as &dyn LdkServerCalls,
+                100_000.0,
+            )
+            .await;
+        }
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // deducted once, not twice
+        assert_eq!(fake.sends.lock().unwrap().len(), 1, "second pass deducts nothing, no second SYNC");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds interactive stability on the two-daemon split (vanilla LDK Server plus stable-channels-lsp). The wallet drives Buy/Sell and balance changes over a custom Lightning TLV, the daemon verifies and applies them. The core stability math is the shared stable_channels crate, unchanged.

What it adds:
  - TRADE_V1 / SYNC_V1: a node-signed JSON envelope in a custom TLV (type 13377331) over a 1 msat keysend. The daemon reads inbound TRADE_V1 from PaymentReceived custom records, verifies the node signature via LDK Server gRPC, validates the balance, applies the trade, and keysends a signed SYNC_V1 back.
  - Splice reconcile: a splice-out deducts the spliced amount from the stable backing and syncs the wallet.
  - Forwarded-payment reconcile: a forward out of a stable channel deducts the spent amount and syncs.
  - RegisterPush hardening: requires a node-signed REGISTER_PUSH_V1 envelope verified via gRPC inside a 300s window, closing an IDOR where node_id was trusted from the client.
  - Operator GUI: an LDK Server log viewer tab.
  - FCM push: sign the OAuth2 JWT with jsonwebtoken instead of openssl.
  
   Notable differences from server-redo:
 - Splice timing. server-redo deducts pre-confirmation in handle_splice_pending (it reads the new funding output via a bitcoind getrawtransaction RPC) and keeps a post-confirmation reconcile_outgoing backstop. This daemon reconciles post-confirmation only, on the ChannelReady re-fire at splice-lock. It stays event-driven (it consumes the LDK Server SubscribeEvents stream and reacts to the post-splice ChannelReady), it just reconciles at confirmation rather than at broadcast, because the gRPC event stream has no SplicePending event (only ChannelStateChanged PENDING/READY/OPEN_FAILED/CLOSED). It also removes the hardcoded-localhost bitcoind dependency. The only cost is display latency: the wallet shows the last settled expected_usd until the splice locks, then updates in one step. This is arguably safer, since it never deducts for a splice that could still fail. A follow-up could react earlier if upstream adds a SplicePending event over gRPC.
  - RegisterPush is a breaking wire change. The mobile wallet must sign the canonical REGISTER_PUSH_V1 bytes and populate the new signature and timestamp fields, or registration fails closed. Mobile-client signing is a pending follow-up.
  - Forwarded-payment reconcile feeds reconcile_forwarded the pre-forward balance (reconstructed as post_user_sats + total_sats) so native is spent before the overflow eats the peg. server-redo passes the live post-forward balance, which over-deducts when a forward exceeds native. Flagging this for a second look.