### PR TITLE
fix(android): set phase to WALLET after nodeService.start() for existing wallets

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -167,6 +167,7 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                     waitForBackgroundService()
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
                     detectOnchainDeposit()


### PR DESCRIPTION
## Problem

After a channel close, the app gets stuck on the "Syncing wallet" loading screen forever. The user cannot see their on-chain balance, receive, or open a new channel.

## Root Cause

In `AppState.start()`, when an existing wallet has no cached channel ID (`hasCachedChannel == false`), the phase is set to `SYNCING` but never transitions to `WALLET` after `nodeService.start()` completes. The new-wallet code path correctly sets `Phase.WALLET`, but the existing-wallet path was missing it.

## Fix

Added `_phase.value = Phase.WALLET` after `nodeService.start()` returns in the existing-wallet path (line 170 of `AppState.kt`).

## Testing

1. Install the app with an existing wallet that has no open channel
2. App should transition from "Syncing wallet" to the wallet screen
3. On-chain balance should be visible
4. Existing wallets with channels should continue working as before
