### PR TITLE
feat(android): implement send and receive flows with borderless centered amount input and send max button

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -10,6 +10,7 @@ import com.stablechannels.app.push.FCMService
 import com.stablechannels.app.push.StabilityProcessingService
 import com.stablechannels.app.services.*
 import com.stablechannels.app.util.Constants
+import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -338,7 +339,8 @@ class AppState(private val context: Context) : ViewModel() {
         val sc = StabilityService.reconcileIncoming(_stableChannel.value)
         _stableChannel.value = sc
         saveChannelToDB()
-        _statusMessage.value = "Payment received: ${amountMsat / 1000} sats"
+        val usdVal = (amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price
+        _statusMessage.value = "Payment received: ${usdVal.usdFormatted()}"
         triggerPaymentFlash()
     }
 
@@ -401,11 +403,26 @@ class AppState(private val context: Context) : ViewModel() {
                 reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
             }
             _stableChannel.value = reconciled
+            var displayVal: String? = null
             if (paymentId != null) {
                 databaseService?.updatePaymentStatus(paymentId, "completed", feePaidMsat ?: 0)
+                try {
+                    val db = databaseService?.readableDatabase
+                    val cursor = db?.rawQuery("SELECT amount_msat, amount_usd FROM payments WHERE payment_id = ?", arrayOf(paymentId))
+                    cursor?.use {
+                        if (it.moveToFirst()) {
+                            val amountMsat = it.getLong(0)
+                            val amountUsd = if (!it.isNull(1)) it.getDouble(1) else 0.0
+                            val usdVal = if (amountUsd > 0.0) amountUsd else ((amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price)
+                            displayVal = usdVal.usdFormatted()
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
+                }
             }
             saveChannelToDB()
-            _statusMessage.value = "Payment confirmed"
+            _statusMessage.value = if (displayVal != null) "Payment sent: $displayVal" else "Payment confirmed"
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -167,6 +167,7 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                     waitForBackgroundService()
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
                     detectOnchainDeposit()

--- a/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
@@ -1,8 +1,9 @@
 package com.stablechannels.app.ui
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
@@ -16,7 +17,7 @@ import com.stablechannels.app.ui.settings.SettingsNavHost
 
 enum class Tab(val label: String, val icon: ImageVector) {
     HOME("Home", Icons.Default.Home),
-    HISTORY("History", Icons.Default.History),
+    HISTORY("History", Icons.Default.AccessTime),
     SETTINGS("Settings", Icons.Default.Settings)
 }
 
@@ -26,14 +27,30 @@ fun MainTabView(appState: AppState) {
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                Tab.entries.forEach { tab ->
-                    NavigationBarItem(
-                        icon = { Icon(tab.icon, contentDescription = tab.label) },
-                        label = { Text(tab.label) },
-                        selected = selectedTab == tab,
-                        onClick = { selectedTab = tab }
-                    )
+            Column {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    thickness = 0.5.dp
+                )
+                NavigationBar(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    tonalElevation = 0.dp
+                ) {
+                    Tab.entries.forEach { tab ->
+                        NavigationBarItem(
+                            icon = { Icon(tab.icon, contentDescription = tab.label) },
+                            label = { Text(tab.label) },
+                            selected = selectedTab == tab,
+                            onClick = { selectedTab = tab },
+                            colors = NavigationBarItemDefaults.colors(
+                                selectedIconColor = MaterialTheme.colorScheme.primary,
+                                selectedTextColor = MaterialTheme.colorScheme.primary,
+                                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                indicatorColor = androidx.compose.ui.graphics.Color.Transparent
+                            )
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -124,12 +124,12 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
             }
         }
 
-    // Detail dialogs
+    // Detail bottom sheets
     selectedTrade?.let { trade ->
-        TradeDetailDialog(trade) { selectedTrade = null }
+        OrderDetailBottomSheet(trade) { selectedTrade = null }
     }
     selectedPayment?.let { payment ->
-        PaymentDetailDialog(payment) { selectedPayment = null }
+        PaymentDetailBottomSheet(payment) { selectedPayment = null }
     }
 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -75,7 +75,7 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
                     inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             ) {
-                Text("Trades")
+                Text("Orders")
             }
             SegmentedButton(
                 selected = selectedSegment == 1,
@@ -98,8 +98,8 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
             if (selectedSegment == 0 && trades.isEmpty()) {
                 EmptyStateView(
                     icon = Icons.Default.SwapHoriz,
-                    title = "No Trades",
-                    description = "Buy or sell BTC to see trades here."
+                    title = "No Orders",
+                    description = "Convert BTC to see orders here."
                 )
             } else if (selectedSegment == 1 && payments.isEmpty()) {
                 EmptyStateView(
@@ -165,7 +165,7 @@ private fun TradeRow(trade: TradeRecord, onClick: () -> Unit) {
             // Title + time
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = if (isBuy) "Buy BTC" else "Sell BTC",
+                    text = if (isBuy) "USD → BTC" else "BTC → USD",
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium
                 )
@@ -199,7 +199,7 @@ private fun PaymentRow(payment: PaymentRecord, onClick: () -> Unit) {
         "lightning" -> "Lightning"
         "splice_in" -> "Splice In"
         "splice_out" -> "Splice Out"
-        "onchain" -> "On-chain"
+        "onchain" -> "Onchain"
         "channel_close" -> "Channel Close"
         "bolt12" -> "Bolt12"
         else -> payment.paymentType

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -1,9 +1,11 @@
 package com.stablechannels.app.ui.history
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowCircleDown
@@ -55,41 +57,58 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
             text = "History",
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(12.dp))
 
         // Segmented control (like iOS Picker .segmented)
-        SingleChoiceSegmentedButtonRow(
-            modifier = Modifier.fillMaxWidth()
+        val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val activeBg = if (isDark) Color(0xFF3A3A3C) else Color.White
+        val inactiveBg = if (isDark) Color(0xFF1C1C1E) else Color(0xFFE5E5EA)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(36.dp)
+                .background(inactiveBg, shape = RoundedCornerShape(8.dp))
+                .padding(2.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            SegmentedButton(
-                selected = selectedSegment == 0,
-                onClick = { selectedSegment = 0 },
-                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                icon = {},
-                colors = SegmentedButtonDefaults.colors(
-                    activeContainerColor = Color(0xFF10B981).copy(alpha = 0.15f),
-                    activeContentColor = Color(0xFF10B981),
-                    inactiveContainerColor = Color.Transparent,
-                    inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(
+                        color = if (selectedSegment == 0) activeBg else Color.Transparent,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+                    .clickable { selectedSegment = 0 },
+                contentAlignment = Alignment.Center
             ) {
-                Text("Orders")
+                Text(
+                    text = "Orders",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = if (selectedSegment == 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-            SegmentedButton(
-                selected = selectedSegment == 1,
-                onClick = { selectedSegment = 1 },
-                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                icon = {},
-                colors = SegmentedButtonDefaults.colors(
-                    activeContainerColor = Color(0xFF10B981).copy(alpha = 0.15f),
-                    activeContentColor = Color(0xFF10B981),
-                    inactiveContainerColor = Color.Transparent,
-                    inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .background(
+                        color = if (selectedSegment == 1) activeBg else Color.Transparent,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+                    .clickable { selectedSegment = 1 },
+                contentAlignment = Alignment.Center
             ) {
-                Text("Payments")
+                Text(
+                    text = "Payments",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = if (selectedSegment == 1) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
 
@@ -108,16 +127,28 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
                     description = "Send or receive payments to see history here."
                 )
             } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
+                LazyColumn {
                     if (selectedSegment == 0) {
-                        items(trades) { trade ->
+                        itemsIndexed(trades) { index, trade ->
                             TradeRow(trade) { selectedTrade = trade }
+                            if (index < trades.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(start = 68.dp),
+                                    color = MaterialTheme.colorScheme.outlineVariant,
+                                    thickness = 0.5.dp
+                                )
+                            }
                         }
                     } else {
-                        items(payments) { payment ->
+                        itemsIndexed(payments) { index, payment ->
                             PaymentRow(payment) { selectedPayment = payment }
+                            if (index < payments.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(start = 68.dp),
+                                    color = MaterialTheme.colorScheme.outlineVariant,
+                                    thickness = 0.5.dp
+                                )
+                            }
                         }
                     }
                 }
@@ -139,52 +170,48 @@ private fun TradeRow(trade: TradeRecord, onClick: () -> Unit) {
     val icon = if (isBuy) Icons.Default.TrendingUp else Icons.Default.TrendingDown
     val iconColor = if (isBuy) Color(0xFFF59E0B) else Color(0xFF8B5CF6)
 
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = 1.dp,
-        modifier = Modifier.fillMaxWidth()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically
+        // Icon with colored background
+        Surface(
+            shape = RoundedCornerShape(10.dp),
+            color = iconColor.copy(alpha = 0.12f),
+            modifier = Modifier.size(40.dp)
         ) {
-            // Icon with colored background
-            Surface(
-                shape = RoundedCornerShape(10.dp),
-                color = iconColor.copy(alpha = 0.12f),
-                modifier = Modifier.size(40.dp)
-            ) {
-                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                    Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
-                }
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
             }
+        }
 
-            Spacer(Modifier.width(12.dp))
+        Spacer(Modifier.width(12.dp))
 
-            // Title + time
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = if (isBuy) "USD → BTC" else "BTC → USD",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                Text(
-                    text = trade.date.relativeString(),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+        // Title + time
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = if (isBuy) "USD → BTC" else "BTC → USD",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = trade.date.relativeString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
 
-            // Amount + status
-            Column(horizontalAlignment = Alignment.End) {
-                Text(
-                    text = trade.amountUSD.usdFormatted(),
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                StatusBadge(trade.status)
-            }
+        // Amount + status
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = trade.amountUSD.usdFormatted(),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            StatusBadge(trade.status)
         }
     }
 }
@@ -205,52 +232,50 @@ private fun PaymentRow(payment: PaymentRecord, onClick: () -> Unit) {
         else -> payment.paymentType
     }
 
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = 1.dp,
-        modifier = Modifier.fillMaxWidth()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.padding(14.dp),
-            verticalAlignment = Alignment.CenterVertically
+        // Icon with colored background
+        Surface(
+            shape = RoundedCornerShape(10.dp),
+            color = iconColor.copy(alpha = 0.12f),
+            modifier = Modifier.size(40.dp)
         ) {
-            // Icon with colored background
-            Surface(
-                shape = RoundedCornerShape(10.dp),
-                color = iconColor.copy(alpha = 0.12f),
-                modifier = Modifier.size(40.dp)
-            ) {
-                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-                    Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
-                }
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(22.dp))
             }
+        }
 
-            Spacer(Modifier.width(12.dp))
+        Spacer(Modifier.width(12.dp))
 
-            // Title + type + time
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = if (isIncoming) "Received" else "Sent",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                Text(
-                    text = "$typeLabel · ${payment.date.relativeString()}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+        // Title + type + time
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = if (isIncoming) "Received" else "Sent",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = "$typeLabel · ${payment.date.relativeString()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
 
-            // Amount + status
-            Column(horizontalAlignment = Alignment.End) {
-                Text(
-                    text = payment.amountUSD?.usdFormatted() ?: payment.amountSats.satsFormatted(),
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                StatusBadge(payment.status)
-            }
+        // Amount + status
+        Column(horizontalAlignment = Alignment.End) {
+            val usdVal = payment.amountUSD ?: ((payment.amountSats.toDouble() / 100_000_000.0) * (payment.btcPrice ?: 0.0))
+            Text(
+                text = (if (isIncoming) "+" else "-") + usdVal.usdFormatted(),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = if (isIncoming) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurface
+            )
+            StatusBadge(payment.status)
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -21,7 +21,8 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, onDismiss: () -> Unit) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White
     ) {
         Column(
             modifier = Modifier

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -23,7 +23,7 @@ fun PaymentDetailDialog(payment: PaymentRecord, onDismiss: () -> Unit) {
                     "stability" -> "Stability"
                     "splice_in" -> "Splice In"
                     "splice_out" -> "Splice Out"
-                    "onchain" -> "On-chain"
+                    "onchain" -> "Onchain"
                     "channel_close" -> "Channel Close"
                     else -> "Lightning"
                 }
@@ -31,7 +31,7 @@ fun PaymentDetailDialog(payment: PaymentRecord, onDismiss: () -> Unit) {
                 DetailRow("Amount", payment.amountUSD?.usdFormatted() ?: payment.amountSats.satsFormatted())
                 payment.btcPrice?.let { DetailRow("BTC Price", it.usdFormatted()) }
                 if (payment.feeMsat > 0) DetailRow("Fee", (payment.feeMsat / 1000).satsFormatted())
-                DetailRow("Status", payment.status)
+                DetailRow("Status", payment.status.replaceFirstChar { it.uppercase() })
                 DetailRow("Date", payment.date.toString())
                 payment.paymentId?.let { DetailRow("Payment ID", it) }
                 payment.txid?.let { DetailRow("TXID", it) }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -1,47 +1,146 @@
 package com.stablechannels.app.ui.history
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stablechannels.app.models.PaymentRecord
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
+import com.stablechannels.app.util.shortString
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.isSystemInDarkTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PaymentDetailDialog(payment: PaymentRecord, onDismiss: () -> Unit) {
-    AlertDialog(
+fun PaymentDetailBottomSheet(payment: PaymentRecord, onDismiss: () -> Unit) {
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        title = { Text("Payment Details") },
-        text = {
-            SelectionContainer {
-            Column {
-                DetailRow("Direction", if (payment.isIncoming) "Received" else "Sent")
-                val typeLabel = when (payment.paymentType) {
-                    "stability" -> "Stability"
-                    "splice_in" -> "Splice In"
-                    "splice_out" -> "Splice Out"
-                    "onchain" -> "Onchain"
-                    "channel_close" -> "Channel Close"
-                    else -> "Lightning"
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(bottom = 24.dp, start = 24.dp, end = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Header Row (Item 32: cancel button in bottomsheet, Item 12: title at center)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        }
+                    ),
+                    shape = RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
-                DetailRow("Type", typeLabel)
-                DetailRow("Amount", payment.amountUSD?.usdFormatted() ?: payment.amountSats.satsFormatted())
-                payment.btcPrice?.let { DetailRow("BTC Price", it.usdFormatted()) }
-                if (payment.feeMsat > 0) DetailRow("Fee", (payment.feeMsat / 1000).satsFormatted())
-                DetailRow("Status", payment.status.replaceFirstChar { it.uppercase() })
-                DetailRow("Date", payment.date.toString())
-                payment.paymentId?.let { DetailRow("Payment ID", it) }
-                payment.txid?.let { DetailRow("TXID", it) }
-                payment.address?.let { DetailRow("Address", it) }
-                if (payment.confirmations > 0) DetailRow("Confirmations", payment.confirmations.toString())
+                Text(
+                    text = "Payment Details",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center)
+                )
             }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Details rows in a nice rounded block matching iOS list look
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    } else {
+                        Color(0xFFF2F2F7)
+                    }
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    DetailRow("Direction", if (payment.isIncoming) "Received" else "Sent")
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    
+                    val typeLabel = when (payment.paymentType) {
+                        "stability" -> "Stability"
+                        "splice_in" -> "Splice In"
+                        "splice_out" -> "Splice Out"
+                        "onchain" -> "Onchain"
+                        "channel_close" -> "Channel Close"
+                        else -> "Lightning"
+                    }
+                    DetailRow("Type", typeLabel)
+                    
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Amount", payment.amountUSD?.usdFormatted() ?: "${payment.amountSats.satsFormatted()} sats")
+                    
+                    payment.btcPrice?.let {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        DetailRow("BTC Price", it.usdFormatted())
+                    }
+                    
+                    if (payment.feeMsat > 0) {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        DetailRow("Fee", "${payment.feeMsat / 1000} sats")
+                    }
+                    
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Status", payment.status.replaceFirstChar { it.uppercase() })
+                    
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Date", payment.date.shortString())
+                    
+                    payment.paymentId?.let { pid ->
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        val displayPid = if (pid.length > 16) pid.take(8) + "..." + pid.takeLast(8) else pid
+                        CopyableDetailRow("Payment ID", displayPid, pid)
+                    }
+                    
+                    payment.txid?.let { txid ->
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        val displayTxid = if (txid.length > 16) txid.take(8) + "..." + txid.takeLast(8) else txid
+                        CopyableDetailRow("TXID", displayTxid, txid)
+                    }
+                    
+                    payment.address?.let { addr ->
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        val displayAddr = if (addr.length > 16) addr.take(8) + "..." + addr.takeLast(8) else addr
+                        CopyableDetailRow("Address", displayAddr, addr)
+                    }
+                    
+                    if (payment.confirmations > 0) {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        DetailRow("Confirmations", payment.confirmations.toString())
+                    }
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Action Button (Item 33: button should be below and center where thumb is)
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(0.6f),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text("Done", fontWeight = FontWeight.Bold)
+            }
         }
-    )
+    }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -1,49 +1,174 @@
 package com.stablechannels.app.ui.history
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stablechannels.app.models.TradeRecord
 import com.stablechannels.app.util.usdFormatted
+import com.stablechannels.app.util.shortString
+import androidx.compose.foundation.isSystemInDarkTheme
 import java.util.Locale
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TradeDetailDialog(trade: TradeRecord, onDismiss: () -> Unit) {
-    AlertDialog(
+fun OrderDetailBottomSheet(trade: TradeRecord, onDismiss: () -> Unit) {
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        title = { Text("Order Details") },
-        text = {
-            SelectionContainer {
-            Column {
-                DetailRow("Action", if (trade.action == "buy") "USD → BTC" else "BTC → USD")
-                DetailRow("Amount", trade.amountUSD.usdFormatted())
-                DetailRow("BTC Amount", String.format(Locale.US, "%.8f", trade.amountBTC))
-                DetailRow("BTC Price", trade.btcPrice.usdFormatted())
-                DetailRow("Fee", trade.feeUSD.usdFormatted())
-                DetailRow("Status", trade.status.replaceFirstChar { it.uppercase() })
-                DetailRow("Date", trade.date.toString())
-                trade.paymentId?.let { DetailRow("Payment ID", it) }
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(bottom = 24.dp, start = 24.dp, end = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Header Row (Item 32: cancel button in bottomsheet, Item 12: title at center)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        }
+                    ),
+                    shape = RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
+                }
+                Text(
+                    text = "Order Details",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Center)
+                )
             }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Details rows in a nice rounded block matching iOS list look
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    } else {
+                        Color(0xFFF2F2F7)
+                    }
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    DetailRow("Action", if (trade.action == "buy") "USD → BTC" else "BTC → USD")
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Amount", trade.amountUSD.usdFormatted())
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("BTC Amount", String.format(Locale.US, "%.8f", trade.amountBTC))
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("BTC Price", trade.btcPrice.usdFormatted())
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Fee", trade.feeUSD.usdFormatted())
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Status", trade.status.replaceFirstChar { it.uppercase() })
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                    DetailRow("Date", trade.date.shortString())
+                    trade.paymentId?.let { pid ->
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        val displayPid = if (pid.length > 16) pid.take(8) + "..." + pid.takeLast(8) else pid
+                        CopyableDetailRow("Payment ID", displayPid, pid)
+                    }
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Action Button (Item 33: button should be below and center where thumb is)
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(0.6f),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text("Done", fontWeight = FontWeight.Bold)
+            }
         }
-    )
+    }
 }
 
 @Composable
 fun DetailRow(label: String, value: String) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.bodySmall)
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+fun CopyableDetailRow(label: String, value: String, fullValue: String) {
+    val clipboardManager = LocalClipboardManager.current
+    var copied by remember { mutableStateOf(false) }
+
+    LaunchedEffect(copied) {
+        if (copied) {
+            kotlinx.coroutines.delay(2000)
+            copied = false
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
+        ) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1
+            )
+            Spacer(Modifier.width(6.dp))
+            IconButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(fullValue))
+                    copied = true
+                },
+                modifier = Modifier.size(24.dp)
+            ) {
+                Icon(
+                    imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                    contentDescription = "Copy",
+                    modifier = Modifier.size(14.dp),
+                    tint = if (copied) Color(0xFF10B981) else MaterialTheme.colorScheme.primary
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -26,7 +26,8 @@ fun OrderDetailBottomSheet(trade: TradeRecord, onDismiss: () -> Unit) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White
     ) {
         Column(
             modifier = Modifier

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -14,16 +14,16 @@ import java.util.Locale
 fun TradeDetailDialog(trade: TradeRecord, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Trade Details") },
+        title = { Text("Order Details") },
         text = {
             SelectionContainer {
             Column {
-                DetailRow("Action", if (trade.action == "buy") "Buy BTC" else "Sell BTC")
+                DetailRow("Action", if (trade.action == "buy") "USD → BTC" else "BTC → USD")
                 DetailRow("Amount", trade.amountUSD.usdFormatted())
-                DetailRow("BTC Amount", String.format(Locale.US, "%.8f BTC", trade.amountBTC))
+                DetailRow("BTC Amount", String.format(Locale.US, "%.8f", trade.amountBTC))
                 DetailRow("BTC Price", trade.btcPrice.usdFormatted())
                 DetailRow("Fee", trade.feeUSD.usdFormatted())
-                DetailRow("Status", trade.status)
+                DetailRow("Status", trade.status.replaceFirstChar { it.uppercase() })
                 DetailRow("Date", trade.date.toString())
                 trade.paymentId?.let { DetailRow("Payment ID", it) }
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
@@ -4,10 +4,14 @@ import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
@@ -19,7 +23,7 @@ import com.google.zxing.qrcode.QRCodeWriter
 import com.stablechannels.app.AppState
 
 @Composable
-fun FundWalletScreen(appState: AppState) {
+fun FundWalletScreen(appState: AppState, onBack: () -> Unit) {
     var address by remember { mutableStateOf<String?>(null) }
     var isCopied by remember { mutableStateOf(false) }
     val clipboardManager = LocalClipboardManager.current
@@ -30,13 +34,39 @@ fun FundWalletScreen(appState: AppState) {
         } catch (_: Exception) {}
     }
 
+    LaunchedEffect(isCopied) {
+        if (isCopied) {
+            kotlinx.coroutines.delay(2000)
+            isCopied = false
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("On-chain Receive", style = MaterialTheme.typography.headlineSmall)
+        // Toolbar (Back button, centered title)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            TextButton(
+                onClick = onBack,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Text("Back", style = MaterialTheme.typography.bodyMedium)
+            }
+            Text(
+                text = "Onchain Receive",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+
         Spacer(Modifier.height(16.dp))
 
         val addr = address
@@ -49,24 +79,52 @@ fun FundWalletScreen(appState: AppState) {
                     modifier = Modifier.size(200.dp)
                 )
             }
-            Spacer(Modifier.height(16.dp))
-            SelectionContainer {
-                Text(
-                    text = addr,
-                    fontFamily = FontFamily.Monospace,
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center
-                )
+            Spacer(Modifier.height(24.dp))
+
+            // Address container with background
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SelectionContainer(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = addr,
+                            fontFamily = FontFamily.Monospace,
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Start,
+                            maxLines = 2
+                        )
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(
+                        onClick = {
+                            clipboardManager.setText(AnnotatedString(addr))
+                            isCopied = true
+                        }
+                    ) {
+                        Icon(
+                            imageVector = if (isCopied) Icons.Default.Check else Icons.Default.ContentCopy,
+                            contentDescription = "Copy Address",
+                            tint = if (isCopied) Color(0xFF10B981) else MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
             }
             Spacer(Modifier.height(12.dp))
-            Button(onClick = {
-                clipboardManager.setText(AnnotatedString(addr))
-                isCopied = true
-            }) {
-                Text(if (isCopied) "Copied!" else "Copy Address")
-            }
+            Text(
+                text = if (isCopied) "Address Copied!" else "Tap copy icon to copy address",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (isCopied) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurfaceVariant
+            )
         } else {
-            CircularProgressIndicator()
+            Box(Modifier.height(300.dp), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
@@ -3,6 +3,8 @@ package com.stablechannels.app.ui.home
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -55,7 +57,17 @@ fun FundWalletScreen(appState: AppState, onBack: () -> Unit) {
         ) {
             TextButton(
                 onClick = onBack,
-                modifier = Modifier.align(Alignment.CenterStart)
+                modifier = Modifier.align(Alignment.CenterStart),
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    } else {
+                        Color(0xFFE5E5EA)
+                    },
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                shape = RoundedCornerShape(20.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text("Back", style = MaterialTheme.typography.bodyMedium)
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -27,8 +27,10 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -141,6 +143,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 text = "Stable Channels",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
@@ -383,8 +386,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("USD → BTC", Icons.Default.TrendingUp, Color(0xFFF59E0B), Modifier.weight(1f)) { showBuy = true }
-                ActionButton("BTC → USD", Icons.Default.TrendingDown, Color(0xFF8B5CF6), Modifier.weight(1f)) { showSell = true }
+                ActionButton("USD → BTC", Icons.Default.ArrowCircleUp, Color(0xFFF59E0B), Modifier.weight(1f), rotation = 45f) { showBuy = true }
+                ActionButton("BTC → USD", Icons.Default.ArrowCircleDown, Color(0xFF8B5CF6), Modifier.weight(1f), rotation = -45f) { showSell = true }
             }
 
             // Status capsule
@@ -402,6 +405,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
         ModalBottomSheet(
             onDismissRequest = { showSend = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
             modifier = Modifier.fillMaxHeight(0.9f)
         ) {
             SendScreen(appState) { showSend = false }
@@ -411,6 +415,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
         ModalBottomSheet(
             onDismissRequest = { showReceive = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
             modifier = Modifier.fillMaxHeight(0.9f)
         ) {
             ReceiveScreen(appState) { showReceive = false }
@@ -420,6 +425,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
         ModalBottomSheet(
             onDismissRequest = { showBuy = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
             modifier = Modifier.fillMaxHeight(0.9f)
         ) {
             BuyScreen(appState, prefillAmountUSD = prefillTradeAmount) { showBuy = false; prefillTradeAmount = 0.0 }
@@ -429,6 +435,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
         ModalBottomSheet(
             onDismissRequest = { showSell = false },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
             modifier = Modifier.fillMaxHeight(0.9f)
         ) {
             SellScreen(appState, prefillAmountUSD = prefillTradeAmount) { showSell = false; prefillTradeAmount = 0.0 }
@@ -437,17 +444,18 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modifier = Modifier, pulse: Boolean = false, onClick: () -> Unit) {
+fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modifier = Modifier, rotation: Float = 0f, pulse: Boolean = false, onClick: () -> Unit) {
     Box(modifier = modifier.height(56.dp).clip(RoundedCornerShape(12.dp))) {
         FilledTonalButton(
             onClick = onClick,
             modifier = Modifier.fillMaxSize(),
+            shape = RoundedCornerShape(12.dp),
             colors = ButtonDefaults.filledTonalButtonColors(
-                containerColor = color.copy(alpha = 0.1f),
+                containerColor = color.copy(alpha = if (isSystemInDarkTheme()) 0.1f else 0.15f),
                 contentColor = color
             )
         ) {
-            Icon(icon, contentDescription = title, modifier = Modifier.size(20.dp))
+            Icon(icon, contentDescription = title, modifier = Modifier.size(20.dp).rotate(rotation))
             Spacer(Modifier.width(6.dp))
             Text(title)
         }
@@ -463,7 +471,7 @@ fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modif
                 Box(
                     Modifier
                         .matchParentSize()
-                        .clip(ButtonDefaults.shape)
+                        .clip(RoundedCornerShape(12.dp))
                         .background(color.copy(alpha = alpha))
                 )
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -296,7 +296,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text("On-chain", style = MaterialTheme.typography.labelMedium)
+                            Text("Onchain", style = MaterialTheme.typography.labelMedium)
                             Text(
                                 "${onchainSats.satsFormatted()} (${onchainUSD.usdFormatted()})",
                                 style = MaterialTheme.typography.labelSmall,
@@ -383,8 +383,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("Buy BTC", Icons.Default.TrendingUp, Color(0xFFF59E0B), Modifier.weight(1f)) { showBuy = true }
-                ActionButton("Sell BTC", Icons.Default.TrendingDown, Color(0xFF8B5CF6), Modifier.weight(1f)) { showSell = true }
+                ActionButton("USD → BTC", Icons.Default.TrendingUp, Color(0xFFF59E0B), Modifier.weight(1f)) { showBuy = true }
+                ActionButton("BTC → USD", Icons.Default.TrendingDown, Color(0xFF8B5CF6), Modifier.weight(1f)) { showSell = true }
             }
 
             // Status capsule

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -196,8 +197,8 @@ fun PriceChart(
                     val selected = chartPeriod == period
                     Surface(
                         onClick = { chartPeriod = period },
-                        shape = CircleShape,
-                        color = if (selected) Color(0xFF3B82F6) else Color.Transparent,
+                        shape = RoundedCornerShape(20.dp),
+                        color = if (selected) Color(0xFF3B82F6) else MaterialTheme.colorScheme.surfaceVariant,
                     ) {
                         Text(
                             period.label,

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
@@ -38,7 +38,7 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 .fillMaxWidth()
                 .padding(top = 16.dp)
         )
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(8.dp))
 
         // Wallet section
         SettingsSectionHeader(title = "Wallet", color = Color(0xFF10B981))
@@ -69,8 +69,6 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
-
             // Preferences section
             SettingsSectionHeader(title = "Preferences", color = Color(0xFF8B5CF6))
             SettingsNavLink(
@@ -85,8 +83,6 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 label = "Notifications",
                 onClick = { navController.navigate(SettingsRoute.Notifications.route) }
             )
-
-            Spacer(Modifier.height(16.dp))
 
             // Node & Network section
             SettingsSectionHeader(title = "Node & Network", color = Color(0xFF3B82F6))
@@ -103,8 +99,6 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 onClick = { navController.navigate(SettingsRoute.PushConnectivity.route) }
             )
 
-            Spacer(Modifier.height(16.dp))
-
             // Privacy & Security section
             SettingsSectionHeader(title = "Privacy & Security", color = Color(0xFF6366F1))
             SettingsNavLink(
@@ -113,8 +107,6 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 label = "App Access",
                 onClick = { navController.navigate(SettingsRoute.AppAccess.route) }
             )
-
-            Spacer(Modifier.height(16.dp))
 
             // About section
             SettingsSectionHeader(title = "About", color = Color(0xFF6B7280))
@@ -133,10 +125,10 @@ fun SettingsHub(appState: AppState, navController: NavController) {
 private fun SettingsSectionHeader(title: String, color: Color) {
     Text(
         text = title,
-        style = MaterialTheme.typography.titleMedium,
+        style = MaterialTheme.typography.titleSmall,
         fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
         color = color,
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp)
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 2.dp)
     )
 }
 
@@ -148,14 +140,14 @@ private fun SettingsNavLink(
     onClick: () -> Unit
 ) {
     ListItem(
-        headlineContent = { Text(label) },
+        headlineContent = { Text(label, style = MaterialTheme.typography.bodyMedium) },
         leadingContent = {
             Box(
                 modifier = Modifier
-                    .size(32.dp)
+                    .size(28.dp)
                     .background(
                         color = iconBackground.copy(alpha = 0.15f),
-                        shape = RoundedCornerShape(8.dp)
+                        shape = RoundedCornerShape(6.dp)
                     ),
                 contentAlignment = Alignment.Center
             ) {
@@ -163,7 +155,7 @@ private fun SettingsNavLink(
                     imageVector = icon,
                     contentDescription = label,
                     tint = iconBackground,
-                    modifier = Modifier.size(18.dp)
+                    modifier = Modifier.size(16.dp)
                 )
             }
         },
@@ -174,6 +166,6 @@ private fun SettingsNavLink(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         },
-        modifier = Modifier.clickable(onClick = onClick)
+        modifier = Modifier.height(44.dp).clickable(onClick = onClick)
     )
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
@@ -20,24 +20,28 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.stablechannels.app.AppState
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsHub(appState: AppState, navController: NavController) {
     val onchainSats by appState.onchainBalanceSats.collectAsState()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text("Settings") })
-        }
-    ) { padding ->
-        Column(
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
             modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState())
-        ) {
-            // Wallet section
-            SettingsSectionHeader(title = "Wallet", color = Color(0xFF10B981))
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+        )
+        Spacer(Modifier.height(12.dp))
+
+        // Wallet section
+        SettingsSectionHeader(title = "Wallet", color = Color(0xFF10B981))
             SettingsNavLink(
                 icon = Icons.Default.AccountBalance,
                 iconBackground = Color(0xFF10B981),
@@ -123,7 +127,6 @@ fun SettingsHub(appState: AppState, navController: NavController) {
 
             Spacer(Modifier.height(32.dp))
         }
-    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
@@ -101,7 +101,7 @@ fun SettingsSubViewScaffold(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
+            CenterAlignedTopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -173,11 +173,11 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
         Spacer(Modifier.height(16.dp))
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(Modifier.padding(16.dp)) {
-                Text("On-Chain", style = MaterialTheme.typography.titleMedium)
+                Text("Onchain", style = MaterialTheme.typography.titleMedium)
                 Spacer(Modifier.height(8.dp))
                 DetailRow("Balance", onchainSats.satsFormatted())
 
-                TextButton(onClick = { showOnchainSend = true }) { Text("Send On-Chain") }
+                TextButton(onClick = { showOnchainSend = true }) { Text("Send Onchain") }
             }
         }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
@@ -61,7 +62,13 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
-        Text("Settings", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
         Spacer(Modifier.height(16.dp))
 
         // Node section
@@ -410,11 +417,11 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
         )
     }
 
-    // On-chain send sheet
     if (showOnchainSend) {
         ModalBottomSheet(
             onDismissRequest = { showOnchainSend = false },
-            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = if (isSystemInDarkTheme()) Color.Black else Color.White
         ) {
             OnChainSendScreen(appState) { showOnchainSend = false }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
@@ -21,16 +21,16 @@ import androidx.compose.ui.platform.LocalContext
 
 // ─── Branded Color Palette ───────────────────────────────────────────────────
 
-// Primary: Green (stability/USD)
-private val PrimaryLight = Color(0xFF10B981)
+// Primary: Blue (active tint)
+private val PrimaryLight = Color(0xFF007AFF)
 private val OnPrimaryLight = Color(0xFFFFFFFF)
-private val PrimaryContainerLight = Color(0xFFD1FAE5)
-private val OnPrimaryContainerLight = Color(0xFF064E3B)
+private val PrimaryContainerLight = Color(0xFFE5F1FF)
+private val OnPrimaryContainerLight = Color(0xFF003366)
 
-private val PrimaryDark = Color(0xFF34D399)
-private val OnPrimaryDark = Color(0xFF064E3B)
-private val PrimaryContainerDark = Color(0xFF065F46)
-private val OnPrimaryContainerDark = Color(0xFFD1FAE5)
+private val PrimaryDark = Color(0xFF0A84FF)
+private val OnPrimaryDark = Color(0xFFFFFFFF)
+private val PrimaryContainerDark = Color(0xFF004488)
+private val OnPrimaryContainerDark = Color(0xFFE5F1FF)
 
 // Secondary: Orange (BTC/native)
 private val SecondaryLight = Color(0xFFF59E0B)
@@ -66,24 +66,24 @@ private val ErrorContainerDark = Color(0xFF991B1B)
 private val OnErrorContainerDark = Color(0xFFFEE2E2)
 
 // Surfaces - Light
-private val BackgroundLight = Color(0xFFFAFAFA)
-private val OnBackgroundLight = Color(0xFF1A1A1A)
+private val BackgroundLight = Color(0xFFFFFFFF)
+private val OnBackgroundLight = Color(0xFF000000)
 private val SurfaceLight = Color(0xFFFFFFFF)
-private val OnSurfaceLight = Color(0xFF1A1A1A)
-private val SurfaceVariantLight = Color(0xFFF3F4F6)
-private val OnSurfaceVariantLight = Color(0xFF4B5563)
-private val OutlineLight = Color(0xFFD1D5DB)
-private val OutlineVariantLight = Color(0xFFE5E7EB)
+private val OnSurfaceLight = Color(0xFF000000)
+private val SurfaceVariantLight = Color(0xFFF2F2F7) // systemGray6
+private val OnSurfaceVariantLight = Color(0xFF3C3C43)
+private val OutlineLight = Color(0xFFC7C7CC)
+private val OutlineVariantLight = Color(0xFFE5E5EA)
 
 // Surfaces - Dark
-private val BackgroundDark = Color(0xFF111111)
-private val OnBackgroundDark = Color(0xFFF3F4F6)
-private val SurfaceDark = Color(0xFF1A1A1A)
-private val OnSurfaceDark = Color(0xFFF3F4F6)
-private val SurfaceVariantDark = Color(0xFF2D2D2D)
-private val OnSurfaceVariantDark = Color(0xFFD1D5DB)
-private val OutlineDark = Color(0xFF4B5563)
-private val OutlineVariantDark = Color(0xFF374151)
+private val BackgroundDark = Color(0xFF000000)
+private val OnBackgroundDark = Color(0xFFFFFFFF)
+private val SurfaceDark = Color(0xFF000000)
+private val OnSurfaceDark = Color(0xFFFFFFFF)
+private val SurfaceVariantDark = Color(0xFF1C1C1E) // systemGray6
+private val OnSurfaceVariantDark = Color(0xFFEBEBF5)
+private val OutlineDark = Color(0xFF38383A)
+private val OutlineVariantDark = Color(0xFF2C2C2E)
 
 // ─── Color Schemes ───────────────────────────────────────────────────────────
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -46,7 +46,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
     ) {
         when (step) {
             TradeStep.AMOUNT -> {
-                Text("Buy BTC", style = MaterialTheme.typography.headlineSmall)
+                Text("USD → BTC", style = MaterialTheme.typography.headlineSmall)
                 Spacer(Modifier.height(4.dp))
                 Text("Max: ${maxBuyUSD.usdFormatted()}", style = MaterialTheme.typography.labelMedium)
                 Spacer(Modifier.height(16.dp))
@@ -88,7 +88,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             }
 
             TradeStep.CONFIRM -> {
-                Text("Confirm Buy", style = MaterialTheme.typography.headlineSmall)
+                Text("Confirm Order", style = MaterialTheme.typography.headlineSmall)
                 Spacer(Modifier.height(16.dp))
 
                 ConfirmRow("Amount", amountUSD.usdFormatted())
@@ -124,7 +124,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                                     action = "buy"
                                 ))
                                 pendingPaymentId = result.paymentId
-                                appState.setStatus(String.format(Locale.US, "Buy pending (fee: $%.2f)", feeUSD))
+                                appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
                                 step = TradeStep.DONE
                             } catch (e: Exception) {
                                 error = e.message ?: "Trade failed"
@@ -136,7 +136,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Buy")
+                    else Text("Confirm Order")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -154,19 +154,19 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your buy order has been confirmed.",
+                        "Your order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your buy order is being processed. Balance will update when the payment confirms.",
+                        "Your order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
@@ -25,7 +26,7 @@ enum class TradeStep { AMOUNT, CONFIRM, DONE }
 @Composable
 fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () -> Unit) {
     var step by remember { mutableStateOf(TradeStep.AMOUNT) }
-    var amountText by remember { mutableStateOf(if (prefillAmountUSD > 0) String.format(java.util.Locale.US, "%.2f", prefillAmountUSD) else "") }
+    var amountText by remember { mutableStateOf(if (prefillAmountUSD > 0) String.format(Locale.US, "%.2f", prefillAmountUSD) else "") }
     var error by remember { mutableStateOf<String?>(null) }
     var isExecuting by remember { mutableStateOf(false) }
     var pendingPaymentId by remember { mutableStateOf<String?>(null) }
@@ -44,33 +45,86 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Toolbar header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            if (step != TradeStep.DONE) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            Text(
+                text = if (step == TradeStep.CONFIRM) "Confirm Order" else if (step == TradeStep.DONE) "Order Confirmed" else "USD → BTC",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+
         when (step) {
             TradeStep.AMOUNT -> {
-                Text("USD → BTC", style = MaterialTheme.typography.headlineSmall)
-                Spacer(Modifier.height(4.dp))
-                Text("Max: ${maxBuyUSD.usdFormatted()}", style = MaterialTheme.typography.labelMedium)
-                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    TextButton(
+                        onClick = { amountText = String.format(Locale.US, "%.2f", maxBuyUSD) },
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Text("Max", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
 
-                OutlinedTextField(
-                    value = amountText,
-                    onValueChange = { amountText = it },
-                    label = { Text("Amount (USD)") },
-                    prefix = if (amountText.isNotEmpty()) {{ Text("$", fontSize = 16.sp, fontWeight = FontWeight.Medium) }} else null,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
-                )
+                ) {
+                    Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
+                    Spacer(Modifier.width(2.dp))
+                    TextField(
+                        value = amountText,
+                        onValueChange = { amountText = it.filter { c -> c.isDigit() || c == '.' } },
+                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
+                        singleLine = true,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                    )
+                }
 
                 if (amountUSD > 0 && btcPrice > 0) {
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "~ ${String.format(Locale.US, "%.8f", btcAmount)} BTC",
-                        style = MaterialTheme.typography.labelSmall
+                        "~ ${String.format(Locale.US, "%.8f", btcAmount)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
+                Spacer(Modifier.height(8.dp))
+                Text("Max: ${maxBuyUSD.usdFormatted()}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
                 error?.let {
                     Spacer(Modifier.height(8.dp))
-                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
 
                 Spacer(Modifier.height(16.dp))
@@ -88,20 +142,28 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             }
 
             TradeStep.CONFIRM -> {
-                Text("Confirm Order", style = MaterialTheme.typography.headlineSmall)
-                Spacer(Modifier.height(16.dp))
-
-                ConfirmRow("Amount", amountUSD.usdFormatted())
-                ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
-                ConfirmRow("BTC Price", btcPrice.usdFormatted())
-                ConfirmRow("You receive", String.format(Locale.US, "%.8f BTC", btcAmount))
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        ConfirmRow("Amount", amountUSD.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("BTC Price", btcPrice.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("You receive", String.format(Locale.US, "%.8f", btcAmount))
+                    }
+                }
 
                 error?.let {
                     Spacer(Modifier.height(8.dp))
-                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
 
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(24.dp))
                 Button(
                     onClick = {
                         isExecuting = true
@@ -150,23 +212,23 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     Icon(
                         Icons.Filled.CheckCircle,
                         contentDescription = "Confirmed",
-                        tint = Color(0xFF4CAF50),
+                        tint = Color(0xFF10B981),
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your order has been confirmed.",
+                        "Your buy order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your order is being processed. Balance will update when the payment confirms.",
+                        "Your buy order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
@@ -186,6 +248,6 @@ fun ConfirmRow(label: String, value: String) {
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
@@ -47,33 +48,86 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Toolbar header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            if (step != TradeStep.DONE) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            Text(
+                text = if (step == TradeStep.CONFIRM) "Confirm Order" else if (step == TradeStep.DONE) "Order Confirmed" else "BTC → USD",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+
         when (step) {
             TradeStep.AMOUNT -> {
-                Text("BTC → USD", style = MaterialTheme.typography.headlineSmall)
-                Spacer(Modifier.height(4.dp))
-                Text("Max: ${maxSellUSD.usdFormatted()}", style = MaterialTheme.typography.labelMedium)
-                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    TextButton(
+                        onClick = { amountText = String.format(Locale.US, "%.2f", maxSellUSD) },
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Text("Max", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
 
-                OutlinedTextField(
-                    value = amountText,
-                    onValueChange = { amountText = it },
-                    label = { Text("Amount (USD)") },
-                    prefix = if (amountText.isNotEmpty()) {{ Text("$", fontSize = 16.sp, fontWeight = FontWeight.Medium) }} else null,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
-                )
+                ) {
+                    Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
+                    Spacer(Modifier.width(2.dp))
+                    TextField(
+                        value = amountText,
+                        onValueChange = { amountText = it.filter { c -> c.isDigit() || c == '.' } },
+                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
+                        singleLine = true,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                    )
+                }
 
                 if (amountUSD > 0 && btcPrice > 0) {
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "~ ${String.format(Locale.US, "%.8f", btcAmount)} BTC",
-                        style = MaterialTheme.typography.labelSmall
+                        "~ ${String.format(Locale.US, "%.8f", btcAmount)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
+                Spacer(Modifier.height(8.dp))
+                Text("Max: ${maxSellUSD.usdFormatted()}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
                 error?.let {
                     Spacer(Modifier.height(8.dp))
-                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
 
                 Spacer(Modifier.height(16.dp))
@@ -91,20 +145,28 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
             }
 
             TradeStep.CONFIRM -> {
-                Text("Confirm Order", style = MaterialTheme.typography.headlineSmall)
-                Spacer(Modifier.height(16.dp))
-
-                ConfirmRow("Amount", amountUSD.usdFormatted())
-                ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
-                ConfirmRow("BTC Price", btcPrice.usdFormatted())
-                ConfirmRow("You receive", (amountUSD - feeUSD).usdFormatted())
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        ConfirmRow("Amount", amountUSD.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("BTC Price", btcPrice.usdFormatted())
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
+                        ConfirmRow("You receive", (amountUSD - feeUSD).usdFormatted())
+                    }
+                }
 
                 error?.let {
                     Spacer(Modifier.height(8.dp))
-                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
 
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(24.dp))
                 Button(
                     onClick = {
                         isExecuting = true
@@ -154,23 +216,23 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     Icon(
                         Icons.Filled.CheckCircle,
                         contentDescription = "Confirmed",
-                        tint = Color(0xFF4CAF50),
+                        tint = Color(0xFF10B981),
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your order has been confirmed.",
+                        "Your sell order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your order is being processed. Balance will update when the payment confirms.",
+                        "Your sell order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -49,7 +49,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
     ) {
         when (step) {
             TradeStep.AMOUNT -> {
-                Text("Sell BTC", style = MaterialTheme.typography.headlineSmall)
+                Text("BTC → USD", style = MaterialTheme.typography.headlineSmall)
                 Spacer(Modifier.height(4.dp))
                 Text("Max: ${maxSellUSD.usdFormatted()}", style = MaterialTheme.typography.labelMedium)
                 Spacer(Modifier.height(16.dp))
@@ -91,7 +91,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
             }
 
             TradeStep.CONFIRM -> {
-                Text("Confirm Sell", style = MaterialTheme.typography.headlineSmall)
+                Text("Confirm Order", style = MaterialTheme.typography.headlineSmall)
                 Spacer(Modifier.height(16.dp))
 
                 ConfirmRow("Amount", amountUSD.usdFormatted())
@@ -128,7 +128,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                                     action = "sell"
                                 ))
                                 pendingPaymentId = result.paymentId
-                                appState.setStatus(String.format(Locale.US, "Sell pending (fee: $%.2f)", feeUSD))
+                                appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
                                 step = TradeStep.DONE
                             } catch (e: Exception) {
                                 error = e.message ?: "Trade failed"
@@ -140,7 +140,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Sell")
+                    else Text("Confirm Order")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -158,19 +158,19 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your sell order has been confirmed.",
+                        "Your order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your sell order is being processed. Balance will update when the payment confirms.",
+                        "Your order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -1,7 +1,12 @@
 package com.stablechannels.app.ui.transfer
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.*
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,7 +54,17 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
             if (result == null) {
                 TextButton(
                     onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.CenterStart)
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        },
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
@@ -130,21 +145,35 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                 ) {
                     Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.width(2.dp))
-                    TextField(
+                    BasicTextField(
                         value = amountUSDStr,
                         onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
-                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
-                        singleLine = true,
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
-                            disabledContainerColor = Color.Transparent,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent
+                        textStyle = TextStyle(
+                            fontSize = 44.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Start
                         ),
-                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                        singleLine = true,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.width(IntrinsicSize.Min),
+                        decorationBox = { innerTextField ->
+                            Box(contentAlignment = Alignment.CenterStart) {
+                                if (amountUSDStr.isEmpty()) {
+                                    Text(
+                                        text = "0.00",
+                                        style = TextStyle(
+                                            fontSize = 44.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
                     )
                 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -7,7 +7,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
 import com.stablechannels.app.models.PendingSplice
 import com.stablechannels.app.util.Constants
@@ -36,7 +40,27 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("On-Chain Send", style = MaterialTheme.typography.headlineSmall)
+        // Toolbar (Cancel button, centered title)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            if (result == null) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            Text(
+                text = "Onchain Send",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
         Spacer(Modifier.height(16.dp))
 
         if (result != null) {
@@ -60,33 +84,83 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                 Spacer(Modifier.height(12.dp))
             }
 
+            if (appState.isChannelClosing) {
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                ) {
+                    Text(
+                        "Channel is closing — you should sweep your remaining onchain funds.",
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+
             OutlinedTextField(
                 value = address,
                 onValueChange = { address = it },
                 label = { Text("Bitcoin Address") },
                 modifier = Modifier.fillMaxWidth()
             )
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                TextButton(
+                    onClick = { sendAll = !sendAll },
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(if (sendAll) "Enter Amount" else "Send Max", style = MaterialTheme.typography.labelMedium)
+                }
+            }
             Spacer(Modifier.height(12.dp))
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(checked = sendAll, onCheckedChange = { sendAll = it })
-                Text("Send all (${onchainSats.satsFormatted()})")
-            }
-
             if (!sendAll) {
-                OutlinedTextField(
-                    value = amountUSDStr,
-                    onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
-                    label = { Text("Amount (USD)") },
-                    prefix = { Text("$") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
-                )
+                ) {
+                    Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
+                    Spacer(Modifier.width(2.dp))
+                    TextField(
+                        value = amountUSDStr,
+                        onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
+                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
+                        singleLine = true,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                    )
+                }
+
                 val usd = amountUSDStr.toDoubleOrNull() ?: 0.0
                 val satsFromUSD = if (btcPrice > 0 && usd > 0) (usd / btcPrice * Constants.SATS_IN_BTC).toLong() else 0L
                 if (satsFromUSD > 0) {
-                    Text("~ ${satsFromUSD.satsFormatted()}", style = MaterialTheme.typography.labelSmall)
+                    Spacer(Modifier.height(4.dp))
+                    Text("~ ${satsFromUSD.satsFormatted()} sats", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
+            } else {
+                Text(
+                    text = "Send All (${onchainSats.satsFormatted()} sats)",
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
             }
 
             error?.let {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
@@ -2,8 +2,12 @@ package com.stablechannels.app.ui.transfer
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -13,6 +17,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -66,7 +71,17 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
         ) {
             TextButton(
                 onClick = onDismiss,
-                modifier = Modifier.align(Alignment.CenterStart)
+                modifier = Modifier.align(Alignment.CenterStart),
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    } else {
+                        Color(0xFFE5E5EA)
+                    },
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                shape = RoundedCornerShape(20.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text("Cancel", style = MaterialTheme.typography.bodyMedium)
             }
@@ -78,7 +93,17 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
             )
             TextButton(
                 onClick = { showOnChain = true },
-                modifier = Modifier.align(Alignment.CenterEnd)
+                modifier = Modifier.align(Alignment.CenterEnd),
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    } else {
+                        Color(0xFFE5E5EA)
+                    },
+                    contentColor = MaterialTheme.colorScheme.primary
+                ),
+                shape = RoundedCornerShape(20.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 Text("Onchain", style = MaterialTheme.typography.bodyMedium)
             }
@@ -159,21 +184,35 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
             ) {
                 Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
                 Spacer(Modifier.width(2.dp))
-                TextField(
+                BasicTextField(
                     value = amountUSD,
                     onValueChange = { amountUSD = it.filter { c -> c.isDigit() || c == '.' } },
-                    placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                    textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
-                    singleLine = true,
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = Color.Transparent,
-                        unfocusedContainerColor = Color.Transparent,
-                        disabledContainerColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent
+                    textStyle = TextStyle(
+                        fontSize = 44.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Start
                     ),
-                    modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                    singleLine = true,
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    modifier = Modifier.width(IntrinsicSize.Min),
+                    decorationBox = { innerTextField ->
+                        Box(contentAlignment = Alignment.CenterStart) {
+                            if (amountUSD.isEmpty()) {
+                                Text(
+                                    text = "0.00",
+                                    style = TextStyle(
+                                        fontSize = 44.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        textAlign = TextAlign.Start
+                                    )
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
                 )
             }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -46,7 +48,7 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
     } else 0L
 
     if (showOnChain) {
-        FundWalletScreen(appState)
+        FundWalletScreen(appState, onBack = { showOnChain = false })
         return
     }
 
@@ -56,30 +58,30 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("Receive", style = MaterialTheme.typography.headlineSmall)
-        Spacer(Modifier.height(16.dp))
-
-        // Lightning vs On-Chain toggle
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        // Toolbar (Cancel button, centered title, top-right Onchain button)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
         ) {
-            FilledTonalButton(
-                onClick = { showOnChain = false },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = if (!showOnChain) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = if (!showOnChain) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            ) { Text("Lightning") }
-            FilledTonalButton(
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Text("Cancel", style = MaterialTheme.typography.bodyMedium)
+            }
+            Text(
+                text = "Receive",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+            TextButton(
                 onClick = { showOnChain = true },
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = if (showOnChain) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = if (showOnChain) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            ) { Text("On-Chain") }
+                modifier = Modifier.align(Alignment.CenterEnd)
+            ) {
+                Text("Onchain", style = MaterialTheme.typography.bodyMedium)
+            }
         }
         Spacer(Modifier.height(16.dp))
 
@@ -147,17 +149,33 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
                 Spacer(Modifier.height(12.dp))
             }
 
-            Text("Amount (USD)", style = MaterialTheme.typography.titleSmall)
-            Spacer(Modifier.height(8.dp))
-
-            OutlinedTextField(
-                value = amountUSD,
-                onValueChange = { amountUSD = it.filter { c -> c.isDigit() || c == '.' } },
-                placeholder = { Text("0.00") },
-                prefix = { Text("$") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+            Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(12.dp))
+ 
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
-            )
+            ) {
+                Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
+                Spacer(Modifier.width(2.dp))
+                TextField(
+                    value = amountUSD,
+                    onValueChange = { amountUSD = it.filter { c -> c.isDigit() || c == '.' } },
+                    placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
+                    singleLine = true,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent
+                    ),
+                    modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                )
+            }
 
             if (enteredSats > 0) {
                 Spacer(Modifier.height(4.dp))

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.fragment.app.FragmentActivity
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
@@ -54,6 +57,8 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     val context = LocalContext.current
     val activity = context.findActivity()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
+    val lightningSats by appState.lightningBalanceSats.collectAsState()
+    val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
 
     val inputType = remember(input) {
         val lower = input.trim().lowercase()
@@ -163,35 +168,49 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Header row with title and action buttons
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+        // Header row
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
         ) {
-            Text("Send", style = MaterialTheme.typography.headlineSmall)
-
-            Row {
-                // Photo library button (Task 7.4)
-                IconButton(onClick = {
-                    photoPickerLauncher.launch(
-                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                    )
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.PhotoLibrary,
-                        contentDescription = "Import from photo library",
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+            if (result == null) {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
+            }
+            Text(
+                text = "Send",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+            if (result == null) {
+                Row(modifier = Modifier.align(Alignment.CenterEnd)) {
+                    // Photo library button
+                    IconButton(onClick = {
+                        photoPickerLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.PhotoLibrary,
+                            contentDescription = "Import from photo library",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
 
-                // QR Scanner button (Task 7.5)
-                IconButton(onClick = { showScanner = true }) {
-                    Icon(
-                        imageVector = Icons.Default.QrCodeScanner,
-                        contentDescription = "Scan QR code",
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    // QR Scanner button
+                    IconButton(onClick = { showScanner = true }) {
+                        Icon(
+                            imageVector = Icons.Default.QrCodeScanner,
+                            contentDescription = "Scan QR code",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 }
             }
         }
@@ -249,15 +268,51 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
 
             // Amount input (USD) — for amountless bolt11, bolt12, onchain
             if (isAmountlessBolt11 || inputType == InputType.BOLT12 || inputType == InputType.ONCHAIN) {
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    TextButton(
+                        onClick = {
+                            val maxSats = if (inputType == InputType.ONCHAIN) spendableOnchainSats else lightningSats
+                            val maxUSD = (maxSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
+                            amountUSDStr = String.format(java.util.Locale.US, "%.2f", maxUSD)
+                        },
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Text("Send Max", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
                 Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value = amountUSDStr,
-                    onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
-                    label = { Text("Amount (USD)") },
-                    prefix = { Text("$") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
-                )
+                ) {
+                    Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
+                    Spacer(Modifier.width(2.dp))
+                    TextField(
+                        value = amountUSDStr,
+                        onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
+                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
+                        singleLine = true,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                    )
+                }
+
                 if (manualAmountSats > 0) {
                     Spacer(Modifier.height(4.dp))
                     Text(

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -5,7 +5,10 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Link
@@ -13,6 +16,9 @@ import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -177,7 +183,17 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
             if (result == null) {
                 TextButton(
                     onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.CenterStart)
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        },
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
@@ -189,26 +205,61 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                 modifier = Modifier.align(Alignment.Center)
             )
             if (result == null) {
-                Row(modifier = Modifier.align(Alignment.CenterEnd)) {
-                    // Photo library button
-                    IconButton(onClick = {
-                        photoPickerLauncher.launch(
-                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .background(
+                            color = if (isSystemInDarkTheme()) {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            } else {
+                                Color(0xFFE5E5EA)
+                            },
+                            shape = RoundedCornerShape(20.dp)
                         )
-                    }) {
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Photo library button
+                    IconButton(
+                        onClick = {
+                            photoPickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        },
+                        modifier = Modifier.size(36.dp)
+                    ) {
                         Icon(
                             imageVector = Icons.Default.PhotoLibrary,
                             contentDescription = "Import from photo library",
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
                         )
                     }
 
+                    // Divider
+                    Box(
+                        modifier = Modifier
+                            .width(0.5.dp)
+                            .height(20.dp)
+                            .background(
+                                color = if (isSystemInDarkTheme()) {
+                                    Color(0xFF38383A)
+                                } else {
+                                    Color(0xFFC7C7CC)
+                                }
+                            )
+                    )
+
                     // QR Scanner button
-                    IconButton(onClick = { showScanner = true }) {
+                    IconButton(
+                        onClick = { showScanner = true },
+                        modifier = Modifier.size(36.dp)
+                    ) {
                         Icon(
                             imageVector = Icons.Default.QrCodeScanner,
                             contentDescription = "Scan QR code",
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
                         )
                     }
                 }
@@ -242,7 +293,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
             OutlinedTextField(
                 value = input,
                 onValueChange = { input = it },
-                label = { Text("Invoice, Offer, or Address") },
+                label = { Text("Lightning invoice or Onchain address") },
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 2
             )
@@ -295,21 +346,35 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                 ) {
                     Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.width(2.dp))
-                    TextField(
+                    BasicTextField(
                         value = amountUSDStr,
                         onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
-                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
-                        singleLine = true,
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
-                            disabledContainerColor = Color.Transparent,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent
+                        textStyle = TextStyle(
+                            fontSize = 44.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Start
                         ),
-                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                        singleLine = true,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.width(IntrinsicSize.Min),
+                        decorationBox = { innerTextField ->
+                            Box(contentAlignment = Alignment.CenterStart) {
+                                if (amountUSDStr.isEmpty()) {
+                                    Text(
+                                        text = "0.00",
+                                        style = TextStyle(
+                                            fontSize = 44.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
                     )
                 }
 

--- a/android/app/src/main/java/com/stablechannels/app/util/Extensions.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Extensions.kt
@@ -16,18 +16,18 @@ fun Long.btcFormatted(): String {
     return String.format(Locale.US, "%.8f BTC", btc)
 }
 
-/** Format as BTC with spaced digit groups: "0.00 190 079 BTC" (matches iOS) */
+/** Format as BTC with spaced digit groups: "0.00 190 079" (matches iOS) */
 fun Long.btcSpacedFormatted(): String {
     val btc = this.toDouble() / Constants.SATS_IN_BTC
     val raw = String.format(Locale.US, "%.8f", btc)
     val dotIndex = raw.indexOf('.')
-    if (dotIndex < 0) return "$raw BTC"
+    if (dotIndex < 0) return raw
     val whole = raw.substring(0, dotIndex)
     val decimals = raw.substring(dotIndex + 1)
     val grouped = decimals.substring(0, 2) +
             "\u2009" + decimals.substring(2, 5) +
             "\u2009" + decimals.substring(5, 8)
-    return "$whole.$grouped BTC"
+    return "$whole.$grouped"
 }
 
 fun Double.usdFormatted(): String {


### PR DESCRIPTION
## What
Implement refined send & receive flows with borderless centered inputs, combined scan/photo header options, capsule-styled back/cancel actions, and correct cursor heights:
- Replaced currency text fields with a borderless, auto-resizing `BasicTextField` so that the currency symbol (`$`) and the amount digits are tightly grouped and perfectly centered inline.
- Resolved the cursor height scaling issue by using a clean `TextStyle` instead of inheriting smaller line-height constraints from `LocalTextStyle.current.copy()`.
- Grouped the Photo Library and QR Scanner header buttons in the Send screen into a single unified pill-shaped container with a thin vertical divider, matching standard grouped header item designs.
- Added rounded gray capsule backgrounds to modal navigation/header buttons (**Cancel**, **Onchain**, **Back**).
- Added a **Send Max** button on the Send and Onchain Send screens to instantly fill the full spendable balance.
- Formatted app-wide status message updates to display payment values in USD using the current exchange rate.
- Omitted " BTC" suffix from spaced bitcoin formatting.
- Updated the label hint text on the Send screen input field to `"Lightning invoice or Onchain address"`.

## Files Modified
- `ReceiveScreen.kt` — redesigned layout, added rounded capsule backgrounds to header buttons, centered USD amount field inline, and fixed cursor scaling.
- `SendScreen.kt` — added rounded backgrounds, grouped top-right scanner/photo buttons in a unified capsule, centered USD amount field inline, fixed cursor scaling, and added Send Max button and updated hint label.
- `OnChainScreen.kt` — centered USD amount field inline, fixed cursor scaling, added capsule Cancel button, and added Send Max action.
- `FundWalletScreen.kt` — styled Back button with a rounded capsule background.
- `BuyScreen.kt` — center-aligned USD amount input field and confirmation layout.
- `SellScreen.kt` — center-aligned USD amount input field and confirmation layout.
- `AppState.kt` — formatted status updates to print values in USD using btcPrice.
- `Extensions.kt` — omitted the trailing " BTC" suffix in spaced formatting.

## Testing
- [x] Verified that the currency symbol and input amount are perfectly centered inline with no visual gaps on device
- [x] Verified that the blinking input cursor matches the text font size (no longer cut in half) on device
- [x] Verified that the Send screen top-right scanner and photo options are combined inside a single pill container on device
- [x] Verified that Cancel, Onchain, and Back header buttons display the rounded capsule backgrounds on device
- [x] Verified that Send Max button populates the exact maximum balance on device
- [x] Verified that the input label text on Send screen shows "Lightning invoice or Onchain address" on device
