### PR TITLE
UI, Terminology, Formatting & Payment Details Polish

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -39,6 +39,7 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
     var payments by remember { mutableStateOf<List<PaymentRecord>>(emptyList()) }
     var selectedTrade by remember { mutableStateOf<TradeRecord?>(null) }
     var selectedPayment by remember { mutableStateOf<PaymentRecord?>(null) }
+    val currentPrice by appState.priceService.currentPrice.collectAsState()
 
     fun loadHistory() {
         trades = appState.databaseService?.getRecentTrades() ?: emptyList()
@@ -160,7 +161,7 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
         OrderDetailBottomSheet(trade) { selectedTrade = null }
     }
     selectedPayment?.let { payment ->
-        PaymentDetailBottomSheet(payment) { selectedPayment = null }
+        PaymentDetailBottomSheet(payment, currentPrice) { selectedPayment = null }
     }
 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PaymentDetailBottomSheet(payment: PaymentRecord, onDismiss: () -> Unit) {
+fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0, onDismiss: () -> Unit) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -89,7 +89,20 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, onDismiss: () -> Unit) {
                     DetailRow("Type", typeLabel)
                     
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                    DetailRow("Amount", payment.amountUSD?.usdFormatted() ?: "${payment.amountSats.satsFormatted()} sats")
+                    val isLightning = payment.paymentType == "lightning" || payment.paymentType == "bolt12" || payment.paymentType == "bolt11" || typeLabel == "Lightning" || typeLabel == "Bolt12"
+                    val amountStr = if (isLightning) {
+                        val usdVal = payment.amountUSD ?: payment.btcPrice?.let { price ->
+                            if (price > 0.0) (payment.amountSats.toDouble() / 100_000_000.0) * price else null
+                        } ?: if (currentPrice > 0.0) {
+                            (payment.amountSats.toDouble() / 100_000_000.0) * currentPrice
+                        } else {
+                            null
+                        }
+                        usdVal?.usdFormatted() ?: "${payment.amountSats.satsFormatted()} sats"
+                    } else {
+                        payment.amountUSD?.usdFormatted() ?: "${payment.amountSats.satsFormatted()} sats"
+                    }
+                    DetailRow("Amount", amountStr)
                     
                     payment.btcPrice?.let {
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.unit.dp
 import com.stablechannels.app.models.TradeRecord
 import com.stablechannels.app.util.usdFormatted
 import com.stablechannels.app.util.shortString
+import com.stablechannels.app.util.btcSpacedFormatted
+import com.stablechannels.app.util.Constants
 import androidx.compose.foundation.isSystemInDarkTheme
 import java.util.Locale
 
@@ -84,7 +86,7 @@ fun OrderDetailBottomSheet(trade: TradeRecord, onDismiss: () -> Unit) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("Amount", trade.amountUSD.usdFormatted())
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                    DetailRow("BTC Amount", String.format(Locale.US, "%.8f", trade.amountBTC))
+                    DetailRow("BTC Amount", Math.round(trade.amountBTC * Constants.SATS_IN_BTC).btcSpacedFormatted() + " BTC")
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("BTC Price", trade.btcPrice.usdFormatted())
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/TradeDetailDialog.kt
@@ -86,7 +86,7 @@ fun OrderDetailBottomSheet(trade: TradeRecord, onDismiss: () -> Unit) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("Amount", trade.amountUSD.usdFormatted())
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                    DetailRow("BTC Amount", Math.round(trade.amountBTC * Constants.SATS_IN_BTC).btcSpacedFormatted() + " BTC")
+                    DetailRow("BTC Amount", Math.round(trade.amountBTC * Constants.SATS_IN_BTC).btcSpacedFormatted())
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("BTC Price", trade.btcPrice.usdFormatted())
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -207,7 +207,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 Spacer(Modifier.height(4.dp))
                 if (showBTC) {
                     Text(
-                        text = totalSats.btcSpacedFormatted(),
+                        text = totalSats.btcSpacedFormatted() + " BTC",
                         fontSize = 32.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
@@ -237,7 +237,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 Text(
                     text = if (showBTC) {
                         if (btcPrice > 0) totalUSD.usdFormatted() else "—"
-                    } else totalSats.btcSpacedFormatted(),
+                    } else totalSats.btcSpacedFormatted() + " BTC",
                     fontSize = 14.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -301,7 +301,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         ) {
                             Text("Onchain", style = MaterialTheme.typography.labelMedium)
                             Text(
-                                "${onchainSats.satsFormatted()} (${onchainUSD.usdFormatted()})",
+                                onchainUSD.usdFormatted(),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/OnChainSendSettingsView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/OnChainSendSettingsView.kt
@@ -9,6 +9,6 @@ import com.stablechannels.app.ui.transfer.OnChainSendScreen
  * The dismiss callback is a no-op since back navigation is handled by the scaffold.
  */
 @Composable
-fun OnChainSendSettingsView(appState: AppState) {
-    OnChainSendScreen(appState = appState, onDismiss = {})
+fun OnChainSendSettingsView(appState: AppState, onDismiss: () -> Unit) {
+    OnChainSendScreen(appState = appState, onDismiss = onDismiss)
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsHub.kt
@@ -64,7 +64,7 @@ fun SettingsHub(appState: AppState, navController: NavController) {
                 SettingsNavLink(
                     icon = Icons.Default.Send,
                     iconBackground = Color(0xFF10B981),
-                    label = "Send On-Chain",
+                    label = "Send Onchain",
                     onClick = { navController.navigate(SettingsRoute.OnChainSend.route) }
                 )
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
@@ -56,7 +56,7 @@ fun SettingsNavHost(appState: AppState, modifier: Modifier = Modifier) {
         }
         composable(SettingsRoute.OnChainSend.route) {
             SettingsSubViewScaffold(title = "Send On-Chain", navController = navController) {
-                OnChainSendSettingsView(appState = appState)
+                OnChainSendSettingsView(appState = appState, onDismiss = { navController.popBackStack() })
             }
         }
         composable(SettingsRoute.Appearance.route) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsNavigation.kt
@@ -55,7 +55,7 @@ fun SettingsNavHost(appState: AppState, modifier: Modifier = Modifier) {
             }
         }
         composable(SettingsRoute.OnChainSend.route) {
-            SettingsSubViewScaffold(title = "Send On-Chain", navController = navController) {
+            SettingsSubViewScaffold(title = "Send Onchain", navController = navController) {
                 OnChainSendSettingsView(appState = appState, onDismiss = { navController.popBackStack() })
             }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
 import com.stablechannels.app.models.PendingTradePayment
 import com.stablechannels.app.util.usdFormatted
+import com.stablechannels.app.util.btcSpacedFormatted
+import com.stablechannels.app.util.Constants
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.Locale
@@ -182,7 +184,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         ConfirmRow("BTC Price", btcPrice.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                        ConfirmRow("You receive", String.format(Locale.US, "%.8f", btcAmount))
+                        ConfirmRow("You receive", Math.round(btcAmount * Constants.SATS_IN_BTC).btcSpacedFormatted() + " BTC")
                     }
                 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -1,16 +1,20 @@
 package com.stablechannels.app.ui.trade
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -45,7 +49,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Toolbar header
+        // Top Toolbar (Cancel / Title)
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -54,7 +58,17 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             if (step != TradeStep.DONE) {
                 TextButton(
                     onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.CenterStart)
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        },
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
@@ -92,21 +106,35 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                 ) {
                     Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.width(2.dp))
-                    TextField(
+                    BasicTextField(
                         value = amountText,
                         onValueChange = { amountText = it.filter { c -> c.isDigit() || c == '.' } },
-                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
-                        singleLine = true,
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
-                            disabledContainerColor = Color.Transparent,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent
+                        textStyle = TextStyle(
+                            fontSize = 44.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Start
                         ),
-                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                        singleLine = true,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.width(IntrinsicSize.Min),
+                        decorationBox = { innerTextField ->
+                            Box(contentAlignment = Alignment.CenterStart) {
+                                if (amountText.isEmpty()) {
+                                    Text(
+                                        text = "0.00",
+                                        style = TextStyle(
+                                            fontSize = 44.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
                     )
                 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -1,5 +1,9 @@
 package com.stablechannels.app.ui.trade
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -57,7 +61,17 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
             if (step != TradeStep.DONE) {
                 TextButton(
                     onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.CenterStart)
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = if (isSystemInDarkTheme()) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            Color(0xFFE5E5EA)
+                        },
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     Text("Cancel", style = MaterialTheme.typography.bodyMedium)
                 }
@@ -95,21 +109,35 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                 ) {
                     Text("$", fontSize = 44.sp, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.width(2.dp))
-                    TextField(
+                    BasicTextField(
                         value = amountText,
                         onValueChange = { amountText = it.filter { c -> c.isDigit() || c == '.' } },
-                        placeholder = { Text("0.00", style = LocalTextStyle.current.copy(color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        textStyle = LocalTextStyle.current.copy(fontSize = 44.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center),
-                        singleLine = true,
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
-                            disabledContainerColor = Color.Transparent,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent
+                        textStyle = TextStyle(
+                            fontSize = 44.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Start
                         ),
-                        modifier = Modifier.width(IntrinsicSize.Min).defaultMinSize(minWidth = 120.dp)
+                        singleLine = true,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.width(IntrinsicSize.Min),
+                        decorationBox = { innerTextField ->
+                            Box(contentAlignment = Alignment.CenterStart) {
+                                if (amountText.isEmpty()) {
+                                    Text(
+                                        text = "0.00",
+                                        style = TextStyle(
+                                            fontSize = 44.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        }
                     )
                 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -22,6 +22,7 @@ import com.stablechannels.app.models.PendingSplice
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
+import com.stablechannels.app.util.btcSpacedFormatted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -41,7 +42,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
 
     Column(
         modifier = Modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -79,11 +80,17 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
         Spacer(Modifier.height(16.dp))
 
         if (result != null) {
+            Spacer(Modifier.height(40.dp))
             Text("Sent!", style = MaterialTheme.typography.headlineMedium, color = MaterialTheme.colorScheme.primary)
             Spacer(Modifier.height(8.dp))
-            Text(result!!, style = MaterialTheme.typography.bodySmall)
-            Spacer(Modifier.height(16.dp))
-            Button(onClick = onDismiss) { Text("Done") }
+            Text(result!!, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Done")
+            }
         } else {
             if (hasChannel && !sendAll) {
                 Card(
@@ -184,12 +191,25 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                     Text("~ ${satsFromUSD.satsFormatted()} sats", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             } else {
-                Text(
-                    text = "Send All (${onchainSats.satsFormatted()} sats)",
-                    fontSize = 22.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
-                )
+                val onchainUSD = (onchainSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = onchainUSD.usdFormatted(),
+                        fontSize = 44.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = onchainSats.btcSpacedFormatted() + " BTC",
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                    )
+                }
             }
 
             error?.let {
@@ -198,6 +218,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
             }
 
             Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.weight(1f))
             Button(
                 onClick = {
                     isSending = true

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -129,8 +129,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
             }
             Spacer(Modifier.weight(1f))
             Button(
-                onClick = onDismiss,
-                modifier = Modifier.fillMaxWidth()
+                onClick = onDismiss
             ) {
                 Text("Done")
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.runtime.*
@@ -33,6 +35,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
     var sendAll by remember { mutableStateOf(false) }
     var isSending by remember { mutableStateOf(false) }
     var result by remember { mutableStateOf<String?>(null) }
+    var successTxid by remember { mutableStateOf<String?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
@@ -81,9 +84,49 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
 
         if (result != null) {
             Spacer(Modifier.height(40.dp))
-            Text("Sent!", style = MaterialTheme.typography.headlineMedium, color = MaterialTheme.colorScheme.primary)
-            Spacer(Modifier.height(8.dp))
-            Text(result!!, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = "Success",
+                tint = Color(0xFF10B981),
+                modifier = Modifier.size(64.dp)
+            )
+            Spacer(Modifier.height(16.dp))
+            Text("Sent!", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(12.dp))
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    } else {
+                        Color(0xFFF2F2F7)
+                    }
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = result!!,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                    if (successTxid != null) {
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            text = "Transaction ID",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = successTxid!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
             Spacer(Modifier.weight(1f))
             Button(
                 onClick = onDismiss,
@@ -237,7 +280,8 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                     btcPrice = if (price > 0) price else null,
                                     txid = txid, address = addr
                                 )
-                                result = "All funds sent. TXID: $txid"
+                                result = "All funds sent successfully."
+                                successTxid = txid
                             } else {
                                 val usd = amountUSDStr.toDoubleOrNull() ?: throw Exception("Enter amount")
                                 val sats = if (price > 0) (usd / price * Constants.SATS_IN_BTC).toLong() else throw Exception("No price available")
@@ -246,7 +290,8 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                     val sc = appState.stableChannel.value
                                     appState.pendingSplice = PendingSplice("out", sats, addr)
                                     appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
-                                    result = "Splice-out initiated for $sats sats"
+                                    result = "Splice-out initiated for ${sats.satsFormatted()} sats."
+                                    successTxid = null
                                 } else {
                                     val txid = appState.nodeService.sendOnchain(addr, sats)
                                     appState.databaseService?.recordPayment(
@@ -256,7 +301,8 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         btcPrice = if (price > 0) price else null,
                                         txid = txid, address = addr
                                     )
-                                    result = "Sent. TXID: $txid"
+                                    result = "Sent successfully."
+                                    successTxid = txid
                                 }
                             }
                         } catch (e: Exception) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -328,7 +328,12 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                     Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     TextButton(
                         onClick = {
-                            val maxSats = if (inputType == InputType.ONCHAIN) spendableOnchainSats else lightningSats
+                            val hasChannel = appState.nodeService.channels.any { it.isChannelReady }
+                            val maxSats = if (inputType == InputType.ONCHAIN) {
+                                if (hasChannel) lightningSats else spendableOnchainSats
+                            } else {
+                                lightningSats
+                            }
                             val maxUSD = (maxSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
                             amountUSDStr = String.format(java.util.Locale.US, "%.2f", maxUSD)
                         },

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.QuestionMark
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.ui.graphics.SolidColor
@@ -170,7 +171,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
 
     Column(
         modifier = Modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -269,11 +270,42 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
         Spacer(Modifier.height(16.dp))
 
         if (result != null) {
-            Text("Sent!", style = MaterialTheme.typography.headlineMedium, color = MaterialTheme.colorScheme.primary)
-            Spacer(Modifier.height(8.dp))
-            Text(result!!, style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(40.dp))
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = "Success",
+                tint = Color(0xFF10B981),
+                modifier = Modifier.size(64.dp)
+            )
             Spacer(Modifier.height(16.dp))
-            Button(onClick = onDismiss) { Text("Done") }
+            Text("Sent!", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(12.dp))
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isSystemInDarkTheme()) {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    } else {
+                        Color(0xFFF2F2F7)
+                    }
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+            ) {
+                Text(
+                    text = result!!,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(16.dp),
+                    textAlign = TextAlign.Center
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Done")
+            }
         } else {
             // Loading indicator during photo QR extraction
             if (isExtractingQR) {
@@ -399,6 +431,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
             }
 
             Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.weight(1f))
             Button(
                 onClick = {
                     isSending = true

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -301,8 +301,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
             }
             Spacer(Modifier.weight(1f))
             Button(
-                onClick = onDismiss,
-                modifier = Modifier.fillMaxWidth()
+                onClick = onDismiss
             ) {
                 Text("Done")
             }
@@ -481,7 +480,9 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         }
                                         appState.databaseService?.recordPayment(
                                             paymentId = paymentId, paymentType = "lightning",
-                                            direction = "sent", amountMsat = actualMsat, btcPrice = price
+                                            direction = "sent", amountMsat = actualMsat,
+                                            amountUSD = if (price > 0) (actualMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price else null,
+                                            btcPrice = if (price > 0) price else null
                                         )
                                         result = "Payment sent"
                                     }
@@ -492,7 +493,9 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         val paymentId = appState.nodeService.sendBolt12UsingAmount(offer, sats * 1000)
                                         appState.databaseService?.recordPayment(
                                             paymentId = paymentId, paymentType = "bolt12",
-                                            direction = "sent", amountMsat = sats * 1000, btcPrice = price
+                                            direction = "sent", amountMsat = sats * 1000,
+                                            amountUSD = if (price > 0) (sats.toDouble() / Constants.SATS_IN_BTC) * price else null,
+                                            btcPrice = if (price > 0) price else null
                                         )
                                         result = "Bolt12 payment sent"
                                     }
@@ -511,7 +514,9 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             appState.databaseService?.recordPayment(
                                                 paymentId = null, paymentType = "onchain",
                                                 direction = "sent", amountMsat = sats * 1000,
-                                                btcPrice = price, txid = txid, address = trimmed
+                                                amountUSD = if (price > 0) (sats.toDouble() / Constants.SATS_IN_BTC) * price else null,
+                                                btcPrice = if (price > 0) price else null,
+                                                txid = txid, address = trimmed
                                             )
                                             result = "On-chain tx sent: $txid"
                                         }


### PR DESCRIPTION
## What
Implement refined formatting, layout alignment, and button actions on the Home screen, Onchain Send screen, Order Details, and Conversion screens:
- Appended `" BTC"` to the total balance display on the Home Screen.
- Simplified the Onchain card on the Home Screen to show only the USD balance (e.g., `$17.91`), removing the raw satoshi count and parentheses.
- Refined the Send All UI on the Onchain Send screen to display the USD equivalent in large digits, with the standard spaced BTC format (e.g., `0.00 028 193 BTC`) in small text underneath it.
- Replaced standard "Sent!" success header text with a large green `CheckCircle` icon on both the **Send** screen and the **Onchain Send** screen.
- Aligned the success screen "Done" buttons to the bottom of the layout, and set them to standard wrap-content width rather than full-screen stretched width.
- Aligned the "Send" button to the bottom of the form on the Onchain Send screen and the main Send screen.
- Formatted the transaction details (success messages and TXID) inside a styled `Card` container on both success screens.
- Formatted the "BTC Amount" field in the Order Details bottom sheet to use spaced formatting (e.g., `0.00 028 193`) without appending `" BTC"`.
- Recorded the USD value (`amountUSD`) on all outgoing Lightning payments (Bolt11 & Bolt12) and direct Onchain payments so the Transaction Details dialog displays the amount in USD (`$`) rather than raw satoshis.
- Centered the currency symbol (`$`) and amount input inline on the Buy and Sell screens to eliminate alignment gaps.
- Fixed the "Send Max" button on the main Send screen to reference `lightningSats` for onchain destinations if an active channel is present (splice-out).
- Aligned terminology by replacing remaining occurrences of "On-Chain" with "Onchain" in Settings titles and labels.
- Formatted the "You receive" field on the Buy confirmation screen to use spaced formatting and the `" BTC"` suffix (e.g., `0.00 028 193 BTC`).
- Updated the **Payment Details** dialog to preferentially display Lightning payments in USD (`$`) rather than raw satoshis, dynamically computing USD from the payment's `btcPrice` or current market price if `amountUSD` was null in the database.

## Files Modified
- `HomeScreen.kt` — appended `" BTC"` to total balance formatting, and simplified Onchain card value.
- `OnChainScreen.kt` — replaced "Sent!" with a CheckCircle icon, formatted success info inside a Card, center-aligned USD and spaced BTC on Send All, aligned Send and Done buttons to the bottom of the layout (Done button uses wrap-content width), and set root column to fill max size.
- `OnChainSendSettingsView.kt` — passed the `onDismiss` callback to allow navigation popping.
- `SettingsNavigation.kt` — passed the `navController.popBackStack()` callback to `OnChainSendSettingsView`, and renamed the route title to "Send Onchain".
- `SettingsHub.kt` — changed "Send On-Chain" label to "Send Onchain".
- `TradeDetailDialog.kt` — formatted `BTC Amount` using spaced formatting without suffix.
- `SendScreen.kt` — replaced "Sent!" with a CheckCircle icon, formatted success info inside a Card, aligned Send/Done buttons to the bottom (Done button uses wrap-content width), recorded `amountUSD` on database payments, and fixed "Send Max" button to use `lightningSats` for onchain payments when a channel is active.
- `BuyScreen.kt` — center-aligned and inline-grouped the currency symbol and amount input, and formatted the "You receive" row with spaced BTC and `" BTC"` suffix.
- `SellScreen.kt` — center-aligned and inline-grouped the currency symbol and amount input, and styled the Cancel button.
- `PaymentDetailDialog.kt` — updated `PaymentDetailBottomSheet` to format Lightning payments as USD, resolving USD value with price fallbacks.
- `HistoryScreen.kt` — collected and passed `currentPrice` from `AppState` to `PaymentDetailBottomSheet`.

## Testing
- [x] Verified total balance shows `" BTC"` suffix on device
- [x] Verified Onchain card displays only the USD amount on device
- [x] Verified Onchain Send All screen shows large USD and small spaced BTC on device
- [x] Verified success screen displays the CheckCircle icon and formatted details card on device
- [x] Verified Onchain Send Done button dismisses/pops the screen on success and is aligned to the bottom on device
- [x] Verified BTC Amount in Order Details shows spaced format (e.g., `0.00 028 193`) without suffix on device
- [x] Verified currency symbol and amount input are tightly centered inline on Buy and Sell screens on device
- [x] Verified Send Max button for Onchain destination uses channel balance when a channel is active on device
- [x] Verified Settings page uses the aligned "Send Onchain" label on device
- [x] Verified "You receive" field on Buy confirmation screen is formatted with spaced BTC and suffix on device
- [x] Verified that Lightning payment details dialog displays USD ($) instead of sats, falling back to computed USD when necessary

