### PR TITLE
fix(android): gossip stripping, TLV marker, and isRunning state

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -78,6 +78,10 @@ class StabilityProcessingService : Service() {
             return
         }
 
+        // Strip gossip from SQLite to avoid OOM in the foreground service.
+        // The NSE doesn't need gossip (it only routes to the LSP, a direct peer).
+        stripGossipFromDB(dataDir)
+
         // Build lightweight LDK node (no RGS, no LSPS2)
         val anchorConfig = AnchorChannelsConfig(
             trustedPeersNoReserve = listOf(Constants.DEFAULT_LSP_PUBKEY),
@@ -258,7 +262,7 @@ class StabilityProcessingService : Service() {
         Log.d(TAG, "Sending stability payment: $amountMsat msat ($$dollarsFromPar)")
 
         try {
-            val tlv = CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), emptyList())
+            val tlv = CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), listOf(1.toUByte()))
             node.spontaneousPayment().sendWithCustomTlvs(
                 amountMsat.toULong(),
                 Constants.DEFAULT_LSP_PUBKEY,
@@ -299,7 +303,7 @@ class StabilityProcessingService : Service() {
             val db = SQLiteDatabase.openDatabase(dbFile.absolutePath, null, SQLiteDatabase.OPEN_READONLY)
             val cursor = db.rawQuery(
                 // Deterministic fallback row when multiple channels exist.
-                "SELECT expected_usd, receiver_sats, latest_price, native_sats, stable_sats FROM channels ORDER BY updated_at DESC, channel_id DESC LIMIT 1",
+                "SELECT expected_usd, receiver_sats, latest_price, stable_sats FROM channels ORDER BY updated_at DESC, channel_id DESC LIMIT 1",
                 null
             )
             val result = cursor.use {
@@ -307,8 +311,8 @@ class StabilityProcessingService : Service() {
                     ChannelState(
                         expectedUsd = it.getDouble(0),
                         receiverSats = it.getLong(1),
-                        nativeSats = if (it.columnCount > 3) it.getLong(3) else 0,
-                        backingSats = if (it.columnCount > 4) it.getLong(4) else 0,
+                        nativeSats = 0,  // not in DB schema, computed at runtime
+                        backingSats = it.getLong(3),
                         latestPrice = it.getDouble(2)
                     )
                 } else null
@@ -438,6 +442,36 @@ class StabilityProcessingService : Service() {
             is String -> current.toDoubleOrNull()
             is JSONArray -> (current.opt(0) as? String)?.toDoubleOrNull()
             else -> null
+        }
+    }
+
+    /**
+     * Delete network_graph, scorer, and node_metrics from the LDK SQLite DB.
+     * The background service doesn't need gossip (it only routes to the LSP, a direct peer).
+     * This reduces the DB from ~10MB to ~30KB, preventing OOM on low-memory devices.
+     */
+    private fun stripGossipFromDB(dataDir: File) {
+        val ldkDbPath = File(dataDir, "ldk_node_data.sqlite")
+        if (!ldkDbPath.exists()) return
+
+        try {
+            val db = SQLiteDatabase.openDatabase(ldkDbPath.absolutePath, null, SQLiteDatabase.OPEN_READWRITE)
+
+            // Check if network_graph exists and is large enough to matter
+            val cursor = db.rawQuery("SELECT LENGTH(value) FROM ldk_node_data WHERE key = 'network_graph'", null)
+            val graphSize = cursor.use { if (it.moveToFirst()) it.getInt(0) else 0 }
+
+            if (graphSize > 100_000) {
+                db.execSQL("DELETE FROM ldk_node_data WHERE key = 'network_graph'")
+                db.execSQL("DELETE FROM ldk_node_data WHERE key = 'scorer'")
+                db.execSQL("DELETE FROM ldk_node_data WHERE key = 'node_metrics'")
+                Log.d(TAG, "Stripped gossip from LDK DB (saved ${graphSize / 1024}KB)")
+            } else {
+                Log.d(TAG, "Gossip data small ($graphSize bytes), skipping strip")
+            }
+            db.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to strip gossip from LDK DB: ${e.message}")
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
@@ -8,7 +8,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.*
 import java.io.File
@@ -17,8 +20,9 @@ class NodeService(private val context: Context) {
 
     var node: Node? = null
         private set
-    var isRunning: Boolean = false
-        private set
+    private val _isRunning = MutableStateFlow(false)
+    val isRunningFlow: StateFlow<Boolean> = _isRunning.asStateFlow()
+    val isRunning: Boolean get() = _isRunning.value
     var nodeId: String = ""
         private set
     var channels: List<ChannelDetails> = emptyList()
@@ -104,7 +108,7 @@ class NodeService(private val context: Context) {
         ldkNode.start()
 
         node = ldkNode
-        isRunning = true
+        _isRunning.value = true
         nodeId = ldkNode.nodeId()
 
         // Connect to gateway and LSP
@@ -128,7 +132,7 @@ class NodeService(private val context: Context) {
         eventJob = null
         node?.stop()
         node = null
-        isRunning = false
+        _isRunning.value = false
     }
 
     private fun startEventLoop() {

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/NodeView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/NodeView.kt
@@ -3,6 +3,7 @@ package com.stablechannels.app.ui.settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,6 +18,7 @@ import com.stablechannels.app.util.Constants
 @Composable
 fun NodeView(appState: AppState) {
     val clipboardManager = LocalClipboardManager.current
+    val isRunning by appState.nodeService.isRunningFlow.collectAsState()
     var showNodeId by remember { mutableStateOf(false) }
     var copiedNodeId by remember { mutableStateOf(false) }
 
@@ -41,14 +43,14 @@ fun NodeView(appState: AppState) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     Surface(
                         shape = MaterialTheme.shapes.small,
-                        color = if (appState.nodeService.isRunning) Color(0xFF10B981) else Color(0xFFEF4444),
+                        color = if (isRunning) Color(0xFF10B981) else Color(0xFFEF4444),
                         modifier = Modifier.size(8.dp)
                     ) {}
                     Text(
-                        text = if (appState.nodeService.isRunning) "Running" else "Stopped",
+                        text = if (isRunning) "Running" else "Stopped",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Medium,
-                        color = if (appState.nodeService.isRunning) Color(0xFF10B981) else Color(0xFFEF4444)
+                        color = if (isRunning) Color(0xFF10B981) else Color(0xFFEF4444)
                     )
                 }
             }


### PR DESCRIPTION
## Changes

### Gossip Stripping
- Before building LDK node in `StabilityProcessingService`, strips `network_graph`, `scorer`, `node_metrics` from SQLite
- Reduces DB from ~10MB to ~30KB, preventing OOM on low-memory devices
- Matches iOS NSE behavior

### TLV Marker Alignment
- Changed stability keysend TLV from `emptyList()` to `listOf(1.toUByte())`
- Sends `[1]` marker byte matching iOS NSE format
- Ensures LSP can validate Android background payments

### Node Status Fix
- `NodeService.isRunning` changed from plain Boolean to `StateFlow<Boolean>`
- NodeView now updates reactively when node starts/stops
- Was showing "Stopped" even when node was running

### DB Schema Fix
- `loadChannelStateFromDB()` referenced non-existent `native_sats` column
- Removed from query, set to 0 in ChannelState

## Files Changed
- `StabilityProcessingService.kt` — gossip stripping, TLV marker, DB fix
- `NodeService.kt` — isRunning StateFlow
- `NodeView.kt` — reactive status display
