### PR TITLE
feat(iOS): On-chain txid resolution

### DIFF
--- a/ios/StableChannels/Package.resolved
+++ b/ios/StableChannels/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "pins" : [
+    {
+      "identity" : "codescanner",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/twostraws/CodeScanner.git",
+      "state" : {
+        "revision" : "5e886430238944c7200fc9e10dbf2d9550dba865",
+        "version" : "2.5.2"
+      }
+    },
+    {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
+      "identity" : "ldk-node",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/toneloc/ldk-node.git",
+      "state" : {
+        "revision" : "8201aac5bc91b0647a5c75bd6f80125ecca02cbe",
+        "version" : "0.7.5"
+      }
+    },
+    {
+      "identity" : "qrcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/QRCode.git",
+      "state" : {
+        "revision" : "49fec812bd70eb9417c9bbdfac8f2a4e0d7b9a06",
+        "version" : "28.0.2"
+      }
+    },
+    {
+      "identity" : "swift-qrcode-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/swift-qrcode-generator",
+      "state" : {
+        "revision" : "2b1980b825f08a81ccc762b0c4d17fcde9d5e953",
+        "version" : "2.0.2"
+      }
+    },
+    {
+      "identity" : "swiftimagereadwrite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/SwiftImageReadWrite",
+      "state" : {
+        "revision" : "42ace2412279f18bc264bc306e96b51c36e12a33",
+        "version" : "1.9.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		499DBE762FD2DADF003E89F9 /* OnchainTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */; };
 		499DBE772FD2DADF003E89F9 /* ResilientEsploraClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE742FD2DADF003E89F9 /* ResilientEsploraClientTests.swift */; };
 		499DBE782FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */; };
+		499DBE7B2FD2F06F003E89F9 /* TxidLinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */; };
+		499DBE7C2FD2F06F003E89F9 /* DepositRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */; };
 		49D4DB062FD02F400074ACD2 /* CloseTxidResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */; };
 		49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */; };
 		49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */; };
@@ -129,6 +131,8 @@
 		499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainTxidResolverTests.swift; sourceTree = "<group>"; };
 		499DBE742FD2DADF003E89F9 /* ResilientEsploraClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResilientEsploraClientTests.swift; sourceTree = "<group>"; };
 		499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredTaskLauncherTests.swift; sourceTree = "<group>"; };
+		499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositRecorder.swift; sourceTree = "<group>"; };
+		499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxidLinkStore.swift; sourceTree = "<group>"; };
 		49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolver.swift; sourceTree = "<group>"; };
 		49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolverTests.swift; sourceTree = "<group>"; };
 		49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseServiceTests.swift; sourceTree = "<group>"; };
@@ -250,6 +254,8 @@
 		7EE46C95963B6C9F86006346 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				499DBE792FD2F06F003E89F9 /* DepositRecorder.swift */,
+				499DBE7A2FD2F06F003E89F9 /* TxidLinkStore.swift */,
 				499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */,
 				499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */,
 				499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */,
@@ -545,6 +551,8 @@
 				49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */,
 				06C3B1697681F176DD44C146 /* StableChannelsApp.swift in Sources */,
 				49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */,
+				499DBE7B2FD2F06F003E89F9 /* TxidLinkStore.swift in Sources */,
+				499DBE7C2FD2F06F003E89F9 /* DepositRecorder.swift in Sources */,
 				49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */,
 				49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */,
 				49F0B0E12FC0EF3A003A3B89 /* NotificationsSettingsView.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -24,6 +24,12 @@
 		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
+		499DBE702FD2DACF003E89F9 /* OnchainTxidResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */; };
+		499DBE712FD2DACF003E89F9 /* ResilientEsploraClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */; };
+		499DBE722FD2DACF003E89F9 /* StaggeredTaskLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */; };
+		499DBE762FD2DADF003E89F9 /* OnchainTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */; };
+		499DBE772FD2DADF003E89F9 /* ResilientEsploraClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE742FD2DADF003E89F9 /* ResilientEsploraClientTests.swift */; };
+		499DBE782FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */; };
 		49D4DB062FD02F400074ACD2 /* CloseTxidResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */; };
 		49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */; };
 		49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */; };
@@ -117,6 +123,12 @@
 		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
+		499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainTxidResolver.swift; sourceTree = "<group>"; };
+		499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResilientEsploraClient.swift; sourceTree = "<group>"; };
+		499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredTaskLauncher.swift; sourceTree = "<group>"; };
+		499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainTxidResolverTests.swift; sourceTree = "<group>"; };
+		499DBE742FD2DADF003E89F9 /* ResilientEsploraClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResilientEsploraClientTests.swift; sourceTree = "<group>"; };
+		499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredTaskLauncherTests.swift; sourceTree = "<group>"; };
 		49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolver.swift; sourceTree = "<group>"; };
 		49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolverTests.swift; sourceTree = "<group>"; };
 		49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseServiceTests.swift; sourceTree = "<group>"; };
@@ -238,6 +250,9 @@
 		7EE46C95963B6C9F86006346 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */,
+				499DBE6E2FD2DACF003E89F9 /* ResilientEsploraClient.swift */,
+				499DBE6F2FD2DACF003E89F9 /* StaggeredTaskLauncher.swift */,
 				49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */,
 				49D9C2E12FB6E52E00133509 /* BiometricService.swift */,
 				CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */,
@@ -353,6 +368,9 @@
 		F11CF0F21D3319E86AF791B6 /* StableChannelsTests */ = {
 			isa = PBXGroup;
 			children = (
+				499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */,
+				499DBE742FD2DADF003E89F9 /* ResilientEsploraClientTests.swift */,
+				499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */,
 				49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */,
 				49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */,
 				499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */,
@@ -478,6 +496,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */,
+				499DBE762FD2DADF003E89F9 /* OnchainTxidResolverTests.swift in Sources */,
+				499DBE772FD2DADF003E89F9 /* ResilientEsploraClientTests.swift in Sources */,
+				499DBE782FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift in Sources */,
 				49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */,
 				499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */,
 				1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */,
@@ -494,6 +515,9 @@
 				8A8C427CEEC2C65DD31A6E88 /* BuyView.swift in Sources */,
 				7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */,
 				DC5FA35343D89CB75FD4E402 /* ContentView.swift in Sources */,
+				499DBE702FD2DACF003E89F9 /* OnchainTxidResolver.swift in Sources */,
+				499DBE712FD2DACF003E89F9 /* ResilientEsploraClient.swift in Sources */,
+				499DBE722FD2DACF003E89F9 /* StaggeredTaskLauncher.swift in Sources */,
 				496A44462FCD5845005AF12F /* InputSanitizer.swift in Sources */,
 				3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */,
 				4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */,

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		4983BC9B2FCCA2B800E3B378 /* ShareableQRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
+		49D4DB062FD02F400074ACD2 /* CloseTxidResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */; };
+		49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */; };
+		49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
 		49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */; };
 		49E4567E2FCA3E8B00B0CA85 /* QRCode in Frameworks */ = {isa = PBXBuildFile; productRef = 49E4567D2FCA3E8B00B0CA85 /* QRCode */; };
@@ -114,6 +117,9 @@
 		4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableQRGenerator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
+		49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolver.swift; sourceTree = "<group>"; };
+		49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolverTests.swift; sourceTree = "<group>"; };
+		49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseServiceTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccessSettingsView.swift; sourceTree = "<group>"; };
 		49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenQRZoomView.swift; sourceTree = "<group>"; };
@@ -232,6 +238,7 @@
 		7EE46C95963B6C9F86006346 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				49D4DB052FD02F400074ACD2 /* CloseTxidResolver.swift */,
 				49D9C2E12FB6E52E00133509 /* BiometricService.swift */,
 				CC3C25041B1DA315BD7CD2E7 /* AuditService.swift */,
 				3940DC5406ABC63AA090441A /* DatabaseService.swift */,
@@ -346,6 +353,8 @@
 		F11CF0F21D3319E86AF791B6 /* StableChannelsTests */ = {
 			isa = PBXGroup;
 			children = (
+				49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */,
+				49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */,
 				499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */,
 				8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */,
 			);
@@ -468,6 +477,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */,
+				49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */,
 				499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */,
 				1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */,
 			);
@@ -500,6 +511,7 @@
 				8A8A0B0C2BA8736EC140DD0E /* PriceChartView.swift in Sources */,
 				4980E2882FCD0EB5009B5A3E /* ShareSheetPresenter.swift in Sources */,
 				05856856E6E8EF9E688EFA20 /* PriceService.swift in Sources */,
+				49D4DB062FD02F400074ACD2 /* CloseTxidResolver.swift in Sources */,
 				37DA6E9D4F5D4BF36DD86BC8 /* ReceiveView.swift in Sources */,
 				B4C85619D6A5506E1BD9FC11 /* SellView.swift in Sources */,
 				E8C9430FF8920728747EF550 /* SendView.swift in Sources */,

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -194,17 +194,27 @@ class AppState {
                 },
                 urlSession: resolverSession
             )
-            // Restore lastReceiveTxid from UserDefaults, with 7-day expiry so
-            // a txid from a previous session doesn't linger forever.
+            // Restore lastReceiveTxid / lastCloseTxid from UserDefaults, with 7-day expiry
+            // so a txid from a previous session doesn't linger forever.
             let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
+            let now = Date().timeIntervalSince1970
             if let stored = defaults?.string(forKey: "last_receive_txid"),
                let storedAt = defaults?.object(forKey: "last_receive_txid_at") as? Int64,
-               Date().timeIntervalSince1970 - TimeInterval(storedAt) < 7 * 86400 {
+               now - TimeInterval(storedAt) < 7 * 86400 {
                 lastReceiveTxid = stored
             } else {
                 defaults?.removeObject(forKey: "last_receive_txid")
                 defaults?.removeObject(forKey: "last_receive_txid_at")
                 lastReceiveTxid = nil
+            }
+            if let stored = defaults?.string(forKey: "last_close_txid"),
+               let storedAt = defaults?.object(forKey: "last_close_txid_at") as? Int64,
+               now - TimeInterval(storedAt) < 7 * 86400 {
+                lastCloseTxid = stored
+            } else {
+                defaults?.removeObject(forKey: "last_close_txid")
+                defaults?.removeObject(forKey: "last_close_txid_at")
+                lastCloseTxid = nil
             }
         }
 
@@ -326,7 +336,7 @@ class AppState {
     private func replayPendingChannelCloses() {
         guard let db = databaseService else { return }
         let pending = db.fetchPendingOperations()
-        for (i, op) in pending.enumerated() where op.opType == "channel_close" && op.status == "pending" {
+        for (i, op) in pending.enumerated() where op.opType == "channel_close" {
             // Stagger across close ops so a backlog of N pending closes does
             // not hit Esplora with N concurrent requests. 1s per op = at
             // most 1 req/sec on the public endpoints.
@@ -1152,6 +1162,17 @@ class AppState {
         }
     }
 
+    private func setLastCloseTxid(_ txid: String?) {
+        lastCloseTxid = txid
+        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        defaults?.set(txid, forKey: "last_close_txid")
+        if txid != nil {
+            defaults?.set(Int64(Date().timeIntervalSince1970), forKey: "last_close_txid_at")
+        } else {
+            defaults?.removeObject(forKey: "last_close_txid_at")
+        }
+    }
+
     @MainActor
     func handleCloseTxidResolved(opId: String, closingTxid: String) {
         // Read snapshot from DB row, not AppState globals (stale on re-tap, wrong on multi-channel)
@@ -1162,7 +1183,7 @@ class AppState {
         let counterparty = op?.counterparty
 
         // UI state first: if recordPayment throws, resolver swallows; user still sees the link
-        lastCloseTxid = closingTxid
+        setLastCloseTxid(closingTxid)
 
         // recordPayment dedups on paymentId, so a re-run is a no-op
         do {

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -140,9 +140,12 @@ class AppState {
     // pending_operations row at request time (NodeService.requestChannelClose)
     // and read back at resolve time. No need for in-memory snapshot fields.
 
+    private(set) var lastReceiveTxid: String?
+
     private var closeTxidResolver: CloseTxidResolver?
-    private var resolverTasks: [String: Task<Void, Never>] = [:]
-    private var resolverTaskGenerations: [String: UUID] = [:]
+    private var onchainTxidResolver: OnchainTxidResolver?
+    private var closeLauncher = StaggeredTaskLauncher()
+    private var onchainLauncher = StaggeredTaskLauncher()
 
     // Pending trade payments — deferred until PaymentSuccessful/PaymentFailed
     var pendingTradePayments: [String: PendingTradePayment] = [:]
@@ -178,12 +181,31 @@ class AppState {
             resolverConfig.timeoutIntervalForResource = 10
             let resolverSession = URLSession(configuration: resolverConfig)
             closeTxidResolver = CloseTxidResolver(
-                chainURLs: [Constants.primaryChainURL, Constants.fallbackChainURL],
+                chainURLs: Constants.esploraChainURLs,
                 onResolved: { [weak self] opId, closingTxid in
                     await self?.handleCloseTxidResolved(opId: opId, closingTxid: closingTxid)
                 },
                 urlSession: resolverSession
             )
+            onchainTxidResolver = OnchainTxidResolver(
+                chainURLs: Constants.esploraChainURLs,
+                onResolved: { [weak self] resolutionId, txid in
+                    await self?.handleOnchainReceiveResolved(resolutionId: resolutionId, txid: txid)
+                },
+                urlSession: resolverSession
+            )
+            // Restore lastReceiveTxid from UserDefaults, with 7-day expiry so
+            // a txid from a previous session doesn't linger forever.
+            let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
+            if let stored = defaults?.string(forKey: "last_receive_txid"),
+               let storedAt = defaults?.object(forKey: "last_receive_txid_at") as? Int64,
+               Date().timeIntervalSince1970 - TimeInterval(storedAt) < 7 * 86400 {
+                lastReceiveTxid = stored
+            } else {
+                defaults?.removeObject(forKey: "last_receive_txid")
+                defaults?.removeObject(forKey: "last_receive_txid_at")
+                lastReceiveTxid = nil
+            }
         }
 
         tradeService = TradeService(nodeService: nodeService)
@@ -268,6 +290,7 @@ class AppState {
                 // Check if NSE flagged a pending payment while app was killed
                 await processPendingPushPayment()
                 replayPendingChannelCloses()
+                replayPendingOnchainReceives()
             } catch {
                 await MainActor.run { phase = .error("Node start failed: \(error.localizedDescription)") }
             }
@@ -293,6 +316,7 @@ class AppState {
                 startStabilityTimer()
                 reregisterPushTokenIfNeeded()
                 replayPendingChannelCloses()
+                replayPendingOnchainReceives()
             } catch {
                 await MainActor.run { phase = .error("Wallet creation failed: \(error.localizedDescription)") }
             }
@@ -306,25 +330,28 @@ class AppState {
             // Stagger across close ops so a backlog of N pending closes does
             // not hit Esplora with N concurrent requests. 1s per op = at
             // most 1 req/sec on the public endpoints.
-            let delayNs = UInt64(i) * 1_000_000_000
-            // Cancel prior task: replay may run twice in some lifecycle paths
-            if let existing = resolverTasks[op.opId] {
-                existing.cancel()
-            }
-            let generation = UUID()
-            let newTask = Task { @MainActor [weak self] in
-                if delayNs > 0 {
-                    try? await Task.sleep(nanoseconds: delayNs)
-                }
+            let delay = UInt64(i) // 1s per op
+            closeLauncher.launch(opId: op.opId, delaySeconds: delay) { [weak self] in
                 guard let self, let db = self.databaseService else { return }
                 await self.closeTxidResolver?.resolve(opId: op.opId, databaseService: db)
-                if self.resolverTaskGenerations[op.opId] == generation {
-                    self.resolverTasks[op.opId] = nil
-                    self.resolverTaskGenerations[op.opId] = nil
-                }
             }
-            resolverTasks[op.opId] = newTask
-            resolverTaskGenerations[op.opId] = generation
+        }
+    }
+
+    private func replayPendingOnchainReceives() {
+        guard let db = databaseService else { return }
+        let pending = db.fetchPendingOnchainReceives()
+        for (i, res) in pending.enumerated() {
+            let delay = UInt64(i) // 1s per resolution
+            let opId = "onchain-receive-\(res.id)"
+            onchainLauncher.launch(opId: opId, delaySeconds: delay) { [weak self] in
+                guard let self, let db = self.databaseService else { return }
+                await self.onchainTxidResolver?.resolve(
+                    resolutionId: res.id,
+                    address: res.address,
+                    databaseService: db
+                )
+            }
         }
     }
 
@@ -1108,20 +1135,21 @@ class AppState {
 
         // Cancel prior; new task only clears state if generation still matches
         let opId = "close-\(userChannelId)"
-        if let existing = resolverTasks[opId] {
-            existing.cancel()
-        }
-        let generation = UUID()
-        let newTask = Task { @MainActor [weak self] in
+        closeLauncher.launch(opId: opId) { [weak self] in
             guard let self, let db = self.databaseService else { return }
             await self.closeTxidResolver?.resolve(opId: opId, databaseService: db)
-            if self.resolverTaskGenerations[opId] == generation {
-                self.resolverTasks[opId] = nil
-                self.resolverTaskGenerations[opId] = nil
-            }
         }
-        resolverTasks[opId] = newTask
-        resolverTaskGenerations[opId] = generation
+    }
+
+    private func setLastReceiveTxid(_ txid: String?) {
+        lastReceiveTxid = txid
+        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        defaults?.set(txid, forKey: "last_receive_txid")
+        if txid != nil {
+            defaults?.set(Int64(Date().timeIntervalSince1970), forKey: "last_receive_txid_at")
+        } else {
+            defaults?.removeObject(forKey: "last_receive_txid_at")
+        }
     }
 
     @MainActor
@@ -1160,6 +1188,25 @@ class AppState {
         AuditService.log("CLOSE_TXID_RESOLVED", data: [
             "op_id": opId,
             "closing_txid": closingTxid
+        ])
+    }
+
+    @MainActor
+    func handleOnchainReceiveResolved(resolutionId: Int64, txid: String) {
+        if let db = databaseService,
+           let row = db.fetchPendingOnchainReceiveRow(resolutionId: resolutionId) {
+            db.updatePaymentTxid(paymentId: row.paymentId, txid: txid, status: "completed")
+        }
+        // Latest resolved wins if a more recent resolver beat us to it.
+        if let db = databaseService,
+           let latest = db.fetchLatestResolvedOnchainTxid() {
+            setLastReceiveTxid(latest)
+        } else {
+            setLastReceiveTxid(txid)
+        }
+        AuditService.log("ONCHAIN_RECEIVE_RESOLVED", data: [
+            "resolution_id": "\(resolutionId)",
+            "txid": txid
         ])
     }
 
@@ -1344,22 +1391,67 @@ class AppState {
             let price = stableChannel.latestPrice > 0 ? stableChannel.latestPrice : btcPrice
             let amountUSD: Double? = price > 0 ? Double(depositSats) / 100_000_000.0 * price : nil
 
-            let depositId = "\(Int64(Date().timeIntervalSince1970))_\(depositSats)"
-            _ = try? databaseService?.recordPayment(
-                paymentId: depositId,
-                paymentType: "onchain",
-                direction: "received",
-                amountMsat: depositSats * 1000,
-                amountUSD: amountUSD,
-                btcPrice: price > 0 ? price : nil,
-                counterparty: nil,
-                status: "completed"
-            )
+            // UUID -> unique depositId -> recordPayment dedup on retry.
+            let depositId = "onchain_deposit_\(UUID().uuidString)"
+
+            // Resolver row first, then payments row linked via resolution_id.
+            // Crash between the two leaves an orphan resolver row, harmless
+            // on replay. Reverse order could leak a payments row with a
+            // dangling resolution_id.
+            if let address = onchainReceiveAddress, !address.isEmpty {
+                guard let resolutionId = databaseService?.insertOnchainReceiveResolution(address: address) else {
+                    AuditService.log("ONCHAIN_RECEIVE_RES_INSERT_FAILED", data: ["address": address])
+                    prevOnchainSats = currentOnchain
+                    return
+                }
+                let ok = databaseService?.recordOnchainPaymentWithResolution(
+                    paymentId: depositId,
+                    amountMsat: Int64(depositSats * 1000),
+                    amountUSD: amountUSD,
+                    btcPrice: price > 0 ? price : nil,
+                    resolutionId: resolutionId
+                ) ?? false
+                if !ok {
+                    // Roll back the resolver row to keep the world consistent.
+                    _ = databaseService?.deleteOnchainReceiveResolution(id: resolutionId)
+                    prevOnchainSats = currentOnchain
+                    return
+                }
+                // Kick the resolver
+                let opId = "onchain-receive-\(resolutionId)"
+                onchainLauncher.launch(opId: opId, delaySeconds: 0) { [weak self] in
+                    guard let self, let db = self.databaseService else { return }
+                    await self.onchainTxidResolver?.resolve(
+                        resolutionId: resolutionId,
+                        address: address,
+                        databaseService: db
+                    )
+                }
+                // NOTE: do NOT clear lastReceiveTxid here. The view should
+                // show the most recent resolved txid, not be blanked during
+                // the re-detection window. The resolver will update
+                // lastReceiveTxid via handleOnchainReceiveResolved.
+            } else {
+                // No current address known: write completed row without txid
+                // (the explorer link won't be available; user can re-generate
+                // an address to see the on-chain link).
+                try? databaseService?.recordPayment(
+                    paymentId: depositId,
+                    paymentType: "onchain",
+                    direction: "received",
+                    amountMsat: depositSats * 1000,
+                    amountUSD: amountUSD,
+                    btcPrice: price > 0 ? price : nil,
+                    counterparty: nil,
+                    status: "completed"
+                )
+            }
 
             AuditService.log("ONCHAIN_DEPOSIT_DETECTED", data: [
                 "amount_sats": "\(depositSats)",
                 "prev_onchain": "\(prevOnchainSats)",
-                "new_onchain": "\(currentOnchain)"
+                "new_onchain": "\(currentOnchain)",
+                "address_known": "\(onchainReceiveAddress != nil)"
             ])
         }
         prevOnchainSats = currentOnchain

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -133,6 +133,17 @@ class AppState {
         }
     }
 
+    // MARK: - Close-txid resolver state
+
+    private(set) var lastCloseTxid: String?
+    // Close metadata (balance, price, counterparty) is persisted to the
+    // pending_operations row at request time (NodeService.requestChannelClose)
+    // and read back at resolve time. No need for in-memory snapshot fields.
+
+    private var closeTxidResolver: CloseTxidResolver?
+    private var resolverTasks: [String: Task<Void, Never>] = [:]
+    private var resolverTaskGenerations: [String: UUID] = [:]
+
     // Pending trade payments — deferred until PaymentSuccessful/PaymentFailed
     var pendingTradePayments: [String: PendingTradePayment] = [:]
 
@@ -157,6 +168,22 @@ class AppState {
         } catch {
             await MainActor.run { phase = .error("Database init failed: \(error.localizedDescription)") }
             return
+        }
+
+        nodeService.databaseService = databaseService
+
+        if databaseService != nil {
+            let resolverConfig = URLSessionConfiguration.default
+            resolverConfig.timeoutIntervalForRequest = 5
+            resolverConfig.timeoutIntervalForResource = 10
+            let resolverSession = URLSession(configuration: resolverConfig)
+            closeTxidResolver = CloseTxidResolver(
+                chainURLs: [Constants.primaryChainURL, Constants.fallbackChainURL],
+                onResolved: { [weak self] opId, closingTxid in
+                    await self?.handleCloseTxidResolved(opId: opId, closingTxid: closingTxid)
+                },
+                urlSession: resolverSession
+            )
         }
 
         tradeService = TradeService(nodeService: nodeService)
@@ -240,6 +267,7 @@ class AppState {
                 reregisterPushTokenIfNeeded()
                 // Check if NSE flagged a pending payment while app was killed
                 await processPendingPushPayment()
+                replayPendingChannelCloses()
             } catch {
                 await MainActor.run { phase = .error("Node start failed: \(error.localizedDescription)") }
             }
@@ -264,9 +292,39 @@ class AppState {
                 }
                 startStabilityTimer()
                 reregisterPushTokenIfNeeded()
+                replayPendingChannelCloses()
             } catch {
                 await MainActor.run { phase = .error("Wallet creation failed: \(error.localizedDescription)") }
             }
+        }
+    }
+
+    private func replayPendingChannelCloses() {
+        guard let db = databaseService else { return }
+        let pending = db.fetchPendingOperations()
+        for (i, op) in pending.enumerated() where op.opType == "channel_close" && op.status == "pending" {
+            // Stagger across close ops so a backlog of N pending closes does
+            // not hit Esplora with N concurrent requests. 1s per op = at
+            // most 1 req/sec on the public endpoints.
+            let delayNs = UInt64(i) * 1_000_000_000
+            // Cancel prior task: replay may run twice in some lifecycle paths
+            if let existing = resolverTasks[op.opId] {
+                existing.cancel()
+            }
+            let generation = UUID()
+            let newTask = Task { @MainActor [weak self] in
+                if delayNs > 0 {
+                    try? await Task.sleep(nanoseconds: delayNs)
+                }
+                guard let self, let db = self.databaseService else { return }
+                await self.closeTxidResolver?.resolve(opId: op.opId, databaseService: db)
+                if self.resolverTaskGenerations[op.opId] == generation {
+                    self.resolverTasks[op.opId] = nil
+                    self.resolverTaskGenerations[op.opId] = nil
+                }
+            }
+            resolverTasks[op.opId] = newTask
+            resolverTaskGenerations[op.opId] = generation
         }
     }
 
@@ -982,6 +1040,34 @@ class AppState {
 
     // MARK: - Channel Closed
 
+    func requestChannelClose(
+        userChannelId: UserChannelId,
+        counterpartyNodeId: PublicKey,
+        fundingOutpointTxid: String,
+        fundingOutpointVout: UInt32
+    ) async throws {
+        // Snapshot here: AppState globals could be wrong for rapid re-tap or multi-channel
+        let balanceSats = stableChannel.stableReceiverBTC.sats
+        let price = btcPrice > 0 ? btcPrice : stableChannel.latestPrice
+        let balanceUSD: Double? = price > 0
+            ? Double(balanceSats) / Double(Constants.satsInBTC) * price
+            : nil
+        let counterparty: String? = stableChannel.counterparty.isEmpty
+            ? nil
+            : stableChannel.counterparty
+
+        try await nodeService.requestChannelClose(
+            userChannelId: userChannelId,
+            counterpartyNodeId: counterpartyNodeId,
+            fundingOutpointTxid: fundingOutpointTxid,
+            fundingOutpointVout: fundingOutpointVout,
+            balanceSats: balanceSats,
+            balanceUsd: balanceUSD,
+            btcPrice: price > 0 ? price : nil,
+            counterparty: counterparty
+        )
+    }
+
     private func handleChannelClosed(
         channelId: ChannelId,
         userChannelId: UserChannelId,
@@ -989,10 +1075,6 @@ class AppState {
     ) {
         let reasonStr = reason.map { "\($0)" } ?? "unknown"
         let balanceSats = stableChannel.stableReceiverBTC.sats
-        let price = btcPrice > 0 ? btcPrice : stableChannel.latestPrice
-        let balanceUSD: Double? = price > 0
-            ? Double(balanceSats) / Double(Constants.satsInBTC) * price
-            : nil
 
         AuditService.log("CHANNEL_CLOSED", data: [
             "channel_id": "\(channelId)",
@@ -1001,19 +1083,7 @@ class AppState {
             "balance_sats": "\(balanceSats)"
         ])
 
-        // Record in payment history — use funding txid as the close tx reference
-        let closeTxid = fundingTxid
-        _ = try? databaseService?.recordPayment(
-            paymentId: closeTxid ?? channelId,
-            paymentType: "channel_close",
-            direction: "received",
-            amountMsat: balanceSats * 1000,
-            amountUSD: balanceUSD,
-            btcPrice: price > 0 ? price : nil,
-            counterparty: stableChannel.counterparty.isEmpty ? nil : stableChannel.counterparty,
-            status: "completed",
-            txid: closeTxid
-        )
+        // Funding txid is NOT close txid; defer payments row to handleCloseTxidResolved
 
         // Clear stable state if this is our channel or no channels remain
         if stableChannel.userChannelId == userChannelId || nodeService.channels.isEmpty {
@@ -1026,15 +1096,71 @@ class AppState {
             stableChannel.stableReceiverUSD = .zero
             stableChannel.channelId = ""
             stableChannel.userChannelId = ""
+            // Stale after close: would otherwise link to the old channel's funding tx.
+            fundingTxid = nil
+            UserDefaults(suiteName: Constants.appGroupIdentifier)?
+                .removeObject(forKey: "funding_txid")
         }
 
-        // Refresh balances — keep isChannelClosing true until lightning balance
-        // fully resolves to avoid double-counting with on-chain balance.
+        // refreshBalances() self-clears isChannelClosing when lightning balance hits 0
         refreshBalances()
-        if lightningBalanceSats == 0 {
-            isChannelClosing = false
-        }
         statusMessage = "Channel closed"
+
+        // Cancel prior; new task only clears state if generation still matches
+        let opId = "close-\(userChannelId)"
+        if let existing = resolverTasks[opId] {
+            existing.cancel()
+        }
+        let generation = UUID()
+        let newTask = Task { @MainActor [weak self] in
+            guard let self, let db = self.databaseService else { return }
+            await self.closeTxidResolver?.resolve(opId: opId, databaseService: db)
+            if self.resolverTaskGenerations[opId] == generation {
+                self.resolverTasks[opId] = nil
+                self.resolverTaskGenerations[opId] = nil
+            }
+        }
+        resolverTasks[opId] = newTask
+        resolverTaskGenerations[opId] = generation
+    }
+
+    @MainActor
+    func handleCloseTxidResolved(opId: String, closingTxid: String) {
+        // Read snapshot from DB row, not AppState globals (stale on re-tap, wrong on multi-channel)
+        let op = databaseService?.fetchPendingOperation(opId: opId)
+        let balanceSats = op?.balanceSats ?? 0
+        let balanceUSD = op?.balanceUsd
+        let price = op?.btcPrice ?? 0
+        let counterparty = op?.counterparty
+
+        // UI state first: if recordPayment throws, resolver swallows; user still sees the link
+        lastCloseTxid = closingTxid
+
+        // recordPayment dedups on paymentId, so a re-run is a no-op
+        do {
+            try databaseService?.recordPayment(
+                paymentId: opId,
+                paymentType: "channel_close",
+                direction: "received",
+                amountMsat: balanceSats * 1000,
+                amountUSD: balanceUSD,
+                btcPrice: price > 0 ? price : nil,
+                counterparty: counterparty,
+                status: "completed",
+                txid: closingTxid
+            )
+        } catch {
+            AuditService.log("CLOSE_TXID_PAYMENT_ROW_FAILED", data: [
+                "op_id": opId,
+                "closing_txid": closingTxid,
+                "error": "\(error)"
+            ])
+        }
+
+        AuditService.log("CLOSE_TXID_RESOLVED", data: [
+            "op_id": opId,
+            "closing_txid": closingTxid
+        ])
     }
 
     // MARK: - Splice Pending
@@ -1197,6 +1323,15 @@ class AppState {
     private func detectOnchainDeposit() {
         // Use already-updated onchainBalanceSats — refreshBalances() was just called before this
         let currentOnchain = onchainBalanceSats
+
+        // Skip detection while a channel close is in flight: LDK sweeps the
+        // channel balance to the on-chain wallet, which makes onchainBalanceSats
+        // jump and would otherwise be recorded as a phantom "Received on-chain"
+        // row. The real close row is written by handleCloseTxidResolved.
+        if isChannelClosing {
+            prevOnchainSats = currentOnchain
+            return
+        }
 
         if currentOnchain > prevOnchainSats && !isSweeping && pendingSplice == nil {
             let depositSats = currentOnchain - prevOnchainSats

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -135,12 +135,10 @@ class AppState {
 
     // MARK: - Close-txid resolver state
 
-    private(set) var lastCloseTxid: String?
+    let txidLinks = TxidLinkStore()
     // Close metadata (balance, price, counterparty) is persisted to the
     // pending_operations row at request time (NodeService.requestChannelClose)
     // and read back at resolve time. No need for in-memory snapshot fields.
-
-    private(set) var lastReceiveTxid: String?
 
     private var closeTxidResolver: CloseTxidResolver?
     private var onchainTxidResolver: OnchainTxidResolver?
@@ -189,33 +187,16 @@ class AppState {
             )
             onchainTxidResolver = OnchainTxidResolver(
                 chainURLs: Constants.esploraChainURLs,
-                onResolved: { [weak self] resolutionId, txid in
+                onResolved: { [weak self] workId, txid in
+                    // workId is "res-<resolutionId>"; recover the Int64.
+                    guard let idStr = workId.split(separator: "-", maxSplits: 1).last,
+                          let resolutionId = Int64(idStr) else { return }
                     await self?.handleOnchainReceiveResolved(resolutionId: resolutionId, txid: txid)
                 },
                 urlSession: resolverSession
             )
-            // Restore lastReceiveTxid / lastCloseTxid from UserDefaults, with 7-day expiry
-            // so a txid from a previous session doesn't linger forever.
-            let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-            let now = Date().timeIntervalSince1970
-            if let stored = defaults?.string(forKey: "last_receive_txid"),
-               let storedAt = defaults?.object(forKey: "last_receive_txid_at") as? Int64,
-               now - TimeInterval(storedAt) < 7 * 86400 {
-                lastReceiveTxid = stored
-            } else {
-                defaults?.removeObject(forKey: "last_receive_txid")
-                defaults?.removeObject(forKey: "last_receive_txid_at")
-                lastReceiveTxid = nil
-            }
-            if let stored = defaults?.string(forKey: "last_close_txid"),
-               let storedAt = defaults?.object(forKey: "last_close_txid_at") as? Int64,
-               now - TimeInterval(storedAt) < 7 * 86400 {
-                lastCloseTxid = stored
-            } else {
-                defaults?.removeObject(forKey: "last_close_txid")
-                defaults?.removeObject(forKey: "last_close_txid_at")
-                lastCloseTxid = nil
-            }
+            // txidLinks (TxidLinkStore) restores its own lastClose/lastReceive
+            // from UserDefaults on init, with 7-day expiry.
         }
 
         tradeService = TradeService(nodeService: nodeService)
@@ -1152,25 +1133,11 @@ class AppState {
     }
 
     private func setLastReceiveTxid(_ txid: String?) {
-        lastReceiveTxid = txid
-        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        defaults?.set(txid, forKey: "last_receive_txid")
-        if txid != nil {
-            defaults?.set(Int64(Date().timeIntervalSince1970), forKey: "last_receive_txid_at")
-        } else {
-            defaults?.removeObject(forKey: "last_receive_txid_at")
-        }
+        txidLinks.setReceive(txid)
     }
 
     private func setLastCloseTxid(_ txid: String?) {
-        lastCloseTxid = txid
-        let defaults = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        defaults?.set(txid, forKey: "last_close_txid")
-        if txid != nil {
-            defaults?.set(Int64(Date().timeIntervalSince1970), forKey: "last_close_txid_at")
-        } else {
-            defaults?.removeObject(forKey: "last_close_txid_at")
-        }
+        txidLinks.setClose(txid)
     }
 
     @MainActor
@@ -1415,58 +1382,42 @@ class AppState {
             // UUID -> unique depositId -> recordPayment dedup on retry.
             let depositId = "onchain_deposit_\(UUID().uuidString)"
 
-            // Resolver row first, then payments row linked via resolution_id.
-            // Crash between the two leaves an orphan resolver row, harmless
-            // on replay. Reverse order could leak a payments row with a
-            // dangling resolution_id.
-            if let address = onchainReceiveAddress, !address.isEmpty {
-                guard let resolutionId = databaseService?.insertOnchainReceiveResolution(address: address) else {
-                    AuditService.log("ONCHAIN_RECEIVE_RES_INSERT_FAILED", data: ["address": address])
-                    prevOnchainSats = currentOnchain
-                    return
-                }
-                let ok = databaseService?.recordOnchainPaymentWithResolution(
-                    paymentId: depositId,
-                    amountMsat: Int64(depositSats * 1000),
-                    amountUSD: amountUSD,
-                    btcPrice: price > 0 ? price : nil,
-                    resolutionId: resolutionId
-                ) ?? false
-                if !ok {
-                    // Roll back the resolver row to keep the world consistent.
-                    _ = databaseService?.deleteOnchainReceiveResolution(id: resolutionId)
-                    prevOnchainSats = currentOnchain
-                    return
-                }
-                // Kick the resolver
-                let opId = "onchain-receive-\(resolutionId)"
-                onchainLauncher.launch(opId: opId, delaySeconds: 0) { [weak self] in
-                    guard let self, let db = self.databaseService else { return }
-                    await self.onchainTxidResolver?.resolve(
-                        resolutionId: resolutionId,
-                        address: address,
-                        databaseService: db
-                    )
-                }
-                // NOTE: do NOT clear lastReceiveTxid here. The view should
-                // show the most recent resolved txid, not be blanked during
-                // the re-detection window. The resolver will update
-                // lastReceiveTxid via handleOnchainReceiveResolved.
-            } else {
-                // No current address known: write completed row without txid
-                // (the explorer link won't be available; user can re-generate
-                // an address to see the on-chain link).
-                try? databaseService?.recordPayment(
-                    paymentId: depositId,
-                    paymentType: "onchain",
-                    direction: "received",
-                    amountMsat: depositSats * 1000,
-                    amountUSD: amountUSD,
-                    btcPrice: price > 0 ? price : nil,
-                    counterparty: nil,
-                    status: "completed"
+            // Select recorder based on whether we know the current receive
+            // address. Each strategy handles its own crash-safe ordering and
+            // resolver launching. See DepositRecorder.swift for invariants.
+            let address = onchainReceiveAddress
+            let recorder: DepositRecorder = (address?.isEmpty == false)
+                ? KnownAddressDepositRecorder(
+                    databaseService: databaseService,
+                    onLaunchResolver: { [weak self] resolutionId, addr in
+                        let opId = "onchain-receive-\(resolutionId)"
+                        self?.onchainLauncher.launch(opId: opId, delaySeconds: 0) {
+                            guard let self, let db = self.databaseService else { return }
+                            await self.onchainTxidResolver?.resolve(
+                                resolutionId: resolutionId,
+                                address: addr,
+                                databaseService: db
+                            )
+                        }
+                    }
                 )
+                : UnknownAddressDepositRecorder(databaseService: databaseService)
+
+            let deposit = DepositRecordInput(
+                depositId: depositId,
+                depositSats: depositSats,
+                amountUSD: amountUSD,
+                btcPrice: price > 0 ? price : nil
+            )
+            let recorded = recorder.record(deposit: deposit, address: address)
+            if !recorded {
+                prevOnchainSats = currentOnchain
+                return
             }
+            // NOTE: do NOT clear lastReceiveTxid here. The view should
+            // show the most recent resolved txid, not be blanked during
+            // the re-detection window. The resolver will update
+            // lastReceiveTxid via handleOnchainReceiveResolved.
 
             AuditService.log("ONCHAIN_DEPOSIT_DETECTED", data: [
                 "amount_sats": "\(depositSats)",

--- a/ios/StableChannels/StableChannels/AppState.swift
+++ b/ios/StableChannels/StableChannels/AppState.swift
@@ -1405,7 +1405,7 @@ class AppState {
 
             let deposit = DepositRecordInput(
                 depositId: depositId,
-                depositSats: depositSats,
+                depositSats: Int64(depositSats),
                 amountUSD: amountUSD,
                 btcPrice: price > 0 ? price : nil
             )

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1093,6 +1093,17 @@
         }
       }
     },
+    "info_close_pending_confirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel closing - will appear on explorer after confirmation"
+          }
+        }
+      }
+    },
     "info_fee_approx" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1551,6 +1562,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Capacity"
+          }
+        }
+      }
+    },
+    "label_close_tx" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Tx"
           }
         }
       }
@@ -2737,6 +2759,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Channel Opening"
+          }
+        }
+      }
+    },
+    "status_onchain_receiving" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Receiving on-chain..."
+          }
+        }
+      }
+    },
+    "status_channel_closing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Channel closing..."
           }
         }
       }

--- a/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
@@ -10,21 +10,17 @@ struct CloseTxidResolver {
         let backoffSeconds: [UInt64]
         let esploraTimeout: TimeInterval
         let chainURLs: [String]
-        let onResolved: @Sendable (String, String) async
-            -> Void // (opId, closingTxid); never throws, caller handles its own errors
 
         init(
             maxAttempts: Int = 5,
             backoffSeconds: [UInt64] = [1, 4, 16, 64, 256],
             esploraTimeout: TimeInterval = 5,
-            chainURLs: [String],
-            onResolved: @escaping @Sendable (String, String) async -> Void
+            chainURLs: [String]
         ) {
             self.maxAttempts = maxAttempts
             self.backoffSeconds = backoffSeconds
             self.esploraTimeout = esploraTimeout
             self.chainURLs = chainURLs
-            self.onResolved = onResolved
         }
     }
 
@@ -39,7 +35,7 @@ struct CloseTxidResolver {
     ) {
         precondition(!chainURLs.isEmpty, "CloseTxidResolver requires at least one chain URL")
         self.onResolved = onResolved
-        let cfg = config ?? Config(chainURLs: chainURLs, onResolved: onResolved)
+        let cfg = config ?? Config(chainURLs: chainURLs)
         self.client = ResilientEsploraClient(
             urlSession: urlSession,
             config: .init(

--- a/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
@@ -14,17 +14,20 @@ struct CloseTxidResolver {
         let maxAttempts: Int
         let backoffSeconds: [UInt64]
         let esploraTimeout: TimeInterval
+        let wallClockBudgetSeconds: TimeInterval
         let chainURLs: [String]
 
         init(
             maxAttempts: Int = 5,
             backoffSeconds: [UInt64] = [1, 4, 16, 64, 256],
             esploraTimeout: TimeInterval = 5,
+            wallClockBudgetSeconds: TimeInterval = 900,
             chainURLs: [String]
         ) {
             self.maxAttempts = maxAttempts
             self.backoffSeconds = backoffSeconds
             self.esploraTimeout = esploraTimeout
+            self.wallClockBudgetSeconds = wallClockBudgetSeconds
             self.chainURLs = chainURLs
         }
     }
@@ -47,7 +50,8 @@ struct CloseTxidResolver {
                 chainURLs: cfg.chainURLs,
                 maxAttempts: cfg.maxAttempts,
                 backoffSeconds: cfg.backoffSeconds,
-                timeout: cfg.esploraTimeout
+                timeout: cfg.esploraTimeout,
+                wallClockBudgetSeconds: cfg.wallClockBudgetSeconds
             )
         )
     }

--- a/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Resolves the real close txid for a cooperatively-closed channel by
+/// polling Esplora's `/outspend/{vout}` endpoint for the funding outpoint.
+/// `databaseService` is passed per-call so the struct stays Sendable.
+struct CloseTxidResolver {
+    struct Config {
+        let maxAttempts: Int
+        let backoffSeconds: [UInt64]
+        let esploraTimeout: TimeInterval
+        let chainURLs: [String]
+        let onResolved: @Sendable (String, String) async
+            -> Void // (opId, closingTxid); never throws, caller handles its own errors
+
+        init(
+            maxAttempts: Int = 5,
+            backoffSeconds: [UInt64] = [1, 4, 16, 64, 256],
+            esploraTimeout: TimeInterval = 5,
+            chainURLs: [String],
+            onResolved: @escaping @Sendable (String, String) async -> Void
+        ) {
+            self.maxAttempts = maxAttempts
+            self.backoffSeconds = backoffSeconds
+            self.esploraTimeout = esploraTimeout
+            self.chainURLs = chainURLs
+            self.onResolved = onResolved
+        }
+    }
+
+    private let urlSession: URLSession
+    private let config: Config
+
+    init(
+        chainURLs: [String],
+        onResolved: @escaping @Sendable (String, String) async -> Void,
+        urlSession: URLSession = .shared,
+        config: Config? = nil
+    ) {
+        precondition(!chainURLs.isEmpty, "CloseTxidResolver requires at least one chain URL")
+        self.urlSession = urlSession
+        self.config = config ?? Config(chainURLs: chainURLs, onResolved: onResolved)
+    }
+
+    static func isValidTxid(_ s: String) -> Bool {
+        guard s.count == 64 else { return false }
+        for c in s {
+            switch c {
+            case "0"..."9", "a"..."f": continue
+            default: return false
+            }
+        }
+        return true
+    }
+
+    func resolve(opId: String, databaseService: DatabaseService) async {
+        guard let op = databaseService.fetchPendingOperation(opId: opId),
+              op.status == "pending",
+              let fundingTxid = op.fundingOutpointTxid,
+              let vout = op.fundingOutpointVout
+        else { return }
+
+        for attempt in 0..<config.maxAttempts {
+            if attempt > 0 {
+                if Task.isCancelled { return }
+                let sleepSeconds = config.backoffSeconds[
+                    min(attempt - 1, config.backoffSeconds.count - 1)
+                ]
+                do {
+                    try await Task.sleep(nanoseconds: sleepSeconds * 1_000_000_000)
+                } catch {
+                    return
+                }
+            }
+            for chainURL in config.chainURLs {
+                if Task.isCancelled { return }
+                do {
+                    let trimmedBase = chainURL.hasSuffix("/")
+                        ? String(chainURL.dropLast())
+                        : chainURL
+                    guard !trimmedBase.isEmpty,
+                          let url = URL(string: "\(trimmedBase)/tx/\(fundingTxid)/outspend/\(vout)")
+                    else { continue }
+                    var req = URLRequest(url: url, timeoutInterval: config.esploraTimeout)
+                    req.httpMethod = "GET"
+                    let (data, response) = try await urlSession.data(for: req)
+                    guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                          let spent = json["spent"] as? Bool
+                    else { continue }
+
+                    if spent, let spendingTxid = json["txid"] as? String,
+                       Self.isValidTxid(spendingTxid) {
+                        databaseService.updatePendingOperation(
+                            opId: opId,
+                            closingTxid: spendingTxid,
+                            status: "resolved"
+                        )
+                        await config.onResolved(opId, spendingTxid)
+                        return
+                    }
+                } catch {
+                    continue
+                }
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
@@ -5,6 +5,11 @@ import Foundation
 /// `ResilientEsploraClient`. `databaseService` is per-call so the struct
 /// stays Sendable.
 struct CloseTxidResolver {
+    /// Shared callback for both `CloseTxidResolver` and `OnchainTxidResolver`.
+    /// `workId` is opId for close, `"res-\(resolutionId)"` for onchain-receive
+    /// (caller parses the prefix to recover the Int64).
+    typealias OnTxidResolved = @MainActor (_ workId: String, _ txid: String) async -> Void
+
     struct Config {
         let maxAttempts: Int
         let backoffSeconds: [UInt64]
@@ -25,11 +30,11 @@ struct CloseTxidResolver {
     }
 
     private let client: ResilientEsploraClient
-    private let onResolved: @Sendable (String, String) async -> Void
+    private let onResolved: OnTxidResolved
 
     init(
         chainURLs: [String],
-        onResolved: @escaping @Sendable (String, String) async -> Void,
+        onResolved: @escaping OnTxidResolved,
         urlSession: URLSession = .shared,
         config: Config? = nil
     ) {
@@ -52,11 +57,16 @@ struct CloseTxidResolver {
     }
 
     func resolve(opId: String, databaseService: DatabaseService) async {
-        guard let op = databaseService.fetchPendingOperation(opId: opId),
-              op.status == "pending",
-              let fundingTxid = op.fundingOutpointTxid,
-              let vout = op.fundingOutpointVout
-        else { return }
+        // Snapshot from DB on caller's actor; check happens before any Sendable hop.
+        let snapshot: (String, UInt32)? = await MainActor.run {
+            guard let op = databaseService.fetchPendingOperation(opId: opId),
+                  op.status == "pending",
+                  let fundingTxid = op.fundingOutpointTxid,
+                  let vout = op.fundingOutpointVout
+            else { return nil }
+            return (fundingTxid, vout)
+        }
+        guard let (fundingTxid, vout) = snapshot else { return }
 
         let onResolved = self.onResolved
         let parser: ResilientEsploraClient.ResultParser<String> = { data in
@@ -75,11 +85,14 @@ struct CloseTxidResolver {
             },
             resultParser: parser,
             onResolved: { txid in
-                databaseService.updatePendingOperation(
-                    opId: opId,
-                    closingTxid: txid,
-                    status: "resolved"
-                )
+                // databaseService is non-Sendable; hop to MainActor for the DB write.
+                await MainActor.run {
+                    databaseService.updatePendingOperation(
+                        opId: opId,
+                        closingTxid: txid,
+                        status: "resolved"
+                    )
+                }
                 await onResolved(opId, txid)
             }
         )

--- a/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/CloseTxidResolver.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// Resolves the real close txid for a cooperatively-closed channel by
-/// polling Esplora's `/outspend/{vout}` endpoint for the funding outpoint.
-/// `databaseService` is passed per-call so the struct stays Sendable.
+/// Polls `/tx/{fundingTxid}/outspend/{vout}` for a cooperatively-closed
+/// channel's closing txid. HTTP/retry plumbing lives in
+/// `ResilientEsploraClient`. `databaseService` is per-call so the struct
+/// stays Sendable.
 struct CloseTxidResolver {
     struct Config {
         let maxAttempts: Int
@@ -27,8 +28,8 @@ struct CloseTxidResolver {
         }
     }
 
-    private let urlSession: URLSession
-    private let config: Config
+    private let client: ResilientEsploraClient
+    private let onResolved: @Sendable (String, String) async -> Void
 
     init(
         chainURLs: [String],
@@ -37,19 +38,21 @@ struct CloseTxidResolver {
         config: Config? = nil
     ) {
         precondition(!chainURLs.isEmpty, "CloseTxidResolver requires at least one chain URL")
-        self.urlSession = urlSession
-        self.config = config ?? Config(chainURLs: chainURLs, onResolved: onResolved)
+        self.onResolved = onResolved
+        let cfg = config ?? Config(chainURLs: chainURLs, onResolved: onResolved)
+        self.client = ResilientEsploraClient(
+            urlSession: urlSession,
+            config: .init(
+                chainURLs: cfg.chainURLs,
+                maxAttempts: cfg.maxAttempts,
+                backoffSeconds: cfg.backoffSeconds,
+                timeout: cfg.esploraTimeout
+            )
+        )
     }
 
     static func isValidTxid(_ s: String) -> Bool {
-        guard s.count == 64 else { return false }
-        for c in s {
-            switch c {
-            case "0"..."9", "a"..."f": continue
-            default: return false
-            }
-        }
-        return true
+        ResilientEsploraClient.isValidTxid(s)
     }
 
     func resolve(opId: String, databaseService: DatabaseService) async {
@@ -59,49 +62,30 @@ struct CloseTxidResolver {
               let vout = op.fundingOutpointVout
         else { return }
 
-        for attempt in 0..<config.maxAttempts {
-            if attempt > 0 {
-                if Task.isCancelled { return }
-                let sleepSeconds = config.backoffSeconds[
-                    min(attempt - 1, config.backoffSeconds.count - 1)
-                ]
-                do {
-                    try await Task.sleep(nanoseconds: sleepSeconds * 1_000_000_000)
-                } catch {
-                    return
-                }
-            }
-            for chainURL in config.chainURLs {
-                if Task.isCancelled { return }
-                do {
-                    let trimmedBase = chainURL.hasSuffix("/")
-                        ? String(chainURL.dropLast())
-                        : chainURL
-                    guard !trimmedBase.isEmpty,
-                          let url = URL(string: "\(trimmedBase)/tx/\(fundingTxid)/outspend/\(vout)")
-                    else { continue }
-                    var req = URLRequest(url: url, timeoutInterval: config.esploraTimeout)
-                    req.httpMethod = "GET"
-                    let (data, response) = try await urlSession.data(for: req)
-                    guard let http = response as? HTTPURLResponse, http.statusCode == 200,
-                          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                          let spent = json["spent"] as? Bool
-                    else { continue }
-
-                    if spent, let spendingTxid = json["txid"] as? String,
-                       Self.isValidTxid(spendingTxid) {
-                        databaseService.updatePendingOperation(
-                            opId: opId,
-                            closingTxid: spendingTxid,
-                            status: "resolved"
-                        )
-                        await config.onResolved(opId, spendingTxid)
-                        return
-                    }
-                } catch {
-                    continue
-                }
-            }
+        let onResolved = self.onResolved
+        let parser: ResilientEsploraClient.ResultParser<String> = { data in
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let spent = json["spent"] as? Bool
+            else { return nil }
+            guard spent, let txid = json["txid"] as? String,
+                  ResilientEsploraClient.isValidTxid(txid)
+            else { return nil }
+            return txid
         }
+
+        await client.run(
+            endpointBuilder: { base in
+                ["\(ResilientEsploraClient.trimSlash(base))/tx/\(fundingTxid)/outspend/\(vout)"]
+            },
+            resultParser: parser,
+            onResolved: { txid in
+                databaseService.updatePendingOperation(
+                    opId: opId,
+                    closingTxid: txid,
+                    status: "resolved"
+                )
+                await onResolved(opId, txid)
+            }
+        )
     }
 }

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -70,6 +70,7 @@ class DatabaseService {
                 txid TEXT,
                 address TEXT,
                 confirmations INTEGER NOT NULL DEFAULT 0,
+                resolution_id INTEGER,
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )
             """,
@@ -122,11 +123,22 @@ class DatabaseService {
                 resolved_at INTEGER
             )
             """,
+            """
+            CREATE TABLE IF NOT EXISTS onchain_receive_txids (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                address TEXT NOT NULL,
+                txid TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                resolved_at INTEGER
+            )
+            """,
             "CREATE INDEX IF NOT EXISTS idx_price_history_timestamp ON price_history(timestamp DESC)",
             "CREATE INDEX IF NOT EXISTS idx_pending_operations_status ON pending_operations(status)",
             "CREATE INDEX IF NOT EXISTS idx_payments_created ON payments(created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_daily_prices_date ON daily_prices(date DESC)",
-            "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)"
+            "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_onchain_receive_txids_status ON onchain_receive_txids(status)"
         ]
 
         for sql in statements {
@@ -144,6 +156,13 @@ class DatabaseService {
         }
         if !colNames.contains("native_sats") {
             try execute("ALTER TABLE channels ADD COLUMN native_sats INTEGER NOT NULL DEFAULT 0")
+        }
+
+        // Migrate: add resolution_id to payments if missing (onchain deposit <-> resolver link)
+        let paymentsCols = try query("PRAGMA table_info(payments)")
+        let paymentsColNames = paymentsCols.compactMap { $0[1] as? String }
+        if !paymentsColNames.contains("resolution_id") {
+            try execute("ALTER TABLE payments ADD COLUMN resolution_id INTEGER")
         }
     }
 
@@ -502,6 +521,230 @@ class DatabaseService {
         }
     }
 
+    // MARK: - Onchain Receive Resolutions
+
+    @discardableResult
+    func insertOnchainReceiveResolution(address: String) -> Int64? {
+        do {
+            try execute(
+                """
+                INSERT INTO onchain_receive_txids (address, status)
+                VALUES (?, 'pending')
+                """,
+                params: [.text(address)]
+            )
+            return Int64(sqlite3_last_insert_rowid(db))
+        } catch {
+            AuditService.log("DB_INSERT_RECEIVE_RES_FAILED", data: ["error": "\(error)"])
+            return nil
+        }
+    }
+
+    func fetchPendingOnchainReceives() -> [OnchainReceiveResolution] {
+        do {
+            let rows = try query(
+                """
+                SELECT id, address, txid, status, created_at, resolved_at
+                FROM onchain_receive_txids
+                WHERE status = 'pending'
+                ORDER BY created_at ASC
+                """,
+                params: []
+            )
+            return rows.map { row in
+                OnchainReceiveResolution(
+                    id: row[0] as? Int64 ?? 0,
+                    address: row[1] as? String ?? "",
+                    txid: row[2] as? String,
+                    status: row[3] as? String ?? "pending",
+                    createdAt: row[4] as? Int64 ?? 0,
+                    resolvedAt: row[5] as? Int64
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
+    @discardableResult
+    func updateOnchainReceiveResolution(id: Int64, txid: String) -> Bool {
+        do {
+            try execute(
+                """
+                UPDATE onchain_receive_txids
+                SET txid = ?, status = 'resolved', resolved_at = strftime('%s', 'now')
+                WHERE id = ? AND status = 'pending'
+                """,
+                params: [.text(txid), .integer(id)]
+            )
+            return sqlite3_changes(db) > 0
+        } catch {
+            return false
+        }
+    }
+
+    /// Read pending onchain received payments (no txid yet). Used by the
+    /// AppState to find the row to back-fill once the resolver returns a
+    /// real txid. FIFO order (oldest first).
+    func fetchPendingOnchainReceiveRows() -> [PendingOnchainPayment] {
+        do {
+            let rows = try query(
+                """
+                SELECT payment_id, amount_msat, created_at
+                FROM payments
+                WHERE payment_type = 'onchain'
+                  AND direction = 'received'
+                  AND status = 'pending'
+                ORDER BY created_at ASC
+                """,
+                params: []
+            )
+            return rows.map { row in
+                PendingOnchainPayment(
+                    paymentId: row[0] as? String ?? "",
+                    amountMsat: row[1] as? Int64 ?? 0,
+                    createdAt: row[2] as? Int64 ?? 0
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
+    /// Update a payments row with a real txid and status. Used by the
+    /// AppState once the onchain resolver hits Esplora and we know the
+    /// real receiving txid.
+    @discardableResult
+    func updatePaymentTxid(paymentId: String, txid: String, status: String) -> Bool {
+        do {
+            try execute(
+                """
+                UPDATE payments
+                SET txid = ?, status = ?
+                WHERE payment_id = ?
+                """,
+                params: [.text(txid), .text(status), .text(paymentId)]
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Set the `resolution_id` link on a payments row. Used to wire a
+    /// `payments` row to its corresponding `onchain_receive_txids` resolver row.
+    @discardableResult
+    func updatePaymentResolution(paymentId: String, resolutionId: Int64) -> Bool {
+        do {
+            try execute(
+                "UPDATE payments SET resolution_id = ? WHERE payment_id = ?",
+                params: [.integer(resolutionId), .text(paymentId)]
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Insert a pending onchain-received `payments` row that is pre-linked
+    /// to a freshly-created `onchain_receive_txids` resolution. Use this
+    /// (instead of `recordPayment` + `updatePaymentResolution`) so a crash
+    /// between the two writes cannot leave an orphan row.
+    @discardableResult
+    func recordOnchainPaymentWithResolution(
+        paymentId: String,
+        amountMsat: Int64,
+        amountUSD: Double?,
+        btcPrice: Double?,
+        resolutionId: Int64
+    ) -> Bool {
+        do {
+            try execute(
+                """
+                INSERT INTO payments (
+                    payment_id, payment_type, direction, amount_msat,
+                    amount_usd, btc_price, status, created_at, resolution_id
+                )
+                VALUES (?, 'onchain', 'received', ?, ?, ?, 'pending', strftime('%s', 'now'), ?)
+                """,
+                params: [
+                    .text(paymentId),
+                    .integer(amountMsat),
+                    amountUSD.map { .real($0) } ?? .null,
+                    btcPrice.map { .real($0) } ?? .null,
+                    .integer(resolutionId)
+                ]
+            )
+            return true
+        } catch {
+            AuditService.log("DB_INSERT_ONCHAIN_PAYMENT_FAILED", data: ["error": "\(error)"])
+            return false
+        }
+    }
+
+    /// Fetch the single pending onchain-received payments row that was
+    /// created with the given `resolutionId`. Used to back-fill the row
+    /// with the real txid once the resolver succeeds.
+    func fetchPendingOnchainReceiveRow(resolutionId: Int64) -> PendingOnchainPayment? {
+        do {
+            let rows = try query(
+                """
+                SELECT payment_id, amount_msat, created_at
+                FROM payments
+                WHERE payment_type = 'onchain'
+                  AND direction = 'received'
+                  AND status = 'pending'
+                  AND resolution_id = ?
+                ORDER BY created_at ASC
+                LIMIT 1
+                """,
+                params: [.integer(resolutionId)]
+            )
+            guard let row = rows.first else { return nil }
+            return PendingOnchainPayment(
+                paymentId: row[0] as? String ?? "",
+                amountMsat: row[1] as? Int64 ?? 0,
+                createdAt: row[2] as? Int64 ?? 0
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    /// Fetch the most recent *resolved* onchain receive txid. Used by
+    /// `AppState.handleOnchainReceiveResolved` so the UI shows the latest
+    /// resolved txid (not just the one that fired the callback).
+    func fetchLatestResolvedOnchainTxid() -> String? {
+        do {
+            let rows = try query(
+                """
+                SELECT txid FROM onchain_receive_txids
+                WHERE status = 'resolved' AND txid IS NOT NULL
+                ORDER BY resolved_at DESC LIMIT 1
+                """,
+                params: []
+            )
+            return rows.first?.first as? String
+        } catch {
+            return nil
+        }
+    }
+
+    /// Delete a pending `onchain_receive_txids` row. Used to roll back the
+    /// resolver-side row if the linked `payments` row insert fails.
+    @discardableResult
+    func deleteOnchainReceiveResolution(id: Int64) -> Bool {
+        do {
+            try execute(
+                "DELETE FROM onchain_receive_txids WHERE id = ?",
+                params: [.integer(id)]
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
     private static func parsePendingOperation(_ row: [Any?]) -> PendingOperation {
         PendingOperation(
             opId: row[0] as? String ?? "",
@@ -711,6 +954,21 @@ enum DatabaseError: LocalizedError {
         case .executeFailed(let msg): return "SQL execute failed: \(msg)"
         }
     }
+}
+
+struct OnchainReceiveResolution: Hashable {
+    let id: Int64
+    let address: String
+    let txid: String?
+    let status: String
+    let createdAt: Int64
+    let resolvedAt: Int64?
+}
+
+struct PendingOnchainPayment: Hashable {
+    let paymentId: String
+    let amountMsat: Int64
+    let createdAt: Int64
 }
 
 struct PendingOperation: Equatable {

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -492,6 +492,7 @@ class DatabaseService {
                        closing_txid, balance_sats, balance_usd, btc_price, counterparty,
                        status, created_at, resolved_at
                 FROM pending_operations
+                WHERE status = 'pending'
                 """
             )
             return rows.map { Self.parsePendingOperation($0) }

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -714,14 +714,15 @@ class DatabaseService {
 
     /// Fetch the most recent *resolved* onchain receive txid. Used by
     /// `AppState.handleOnchainReceiveResolved` so the UI shows the latest
-    /// resolved txid (not just the one that fired the callback).
+    /// resolved txid (not just the one that fired the callback). Tiebreak
+    /// by `id DESC` so two resolutions in the same second are deterministic.
     func fetchLatestResolvedOnchainTxid() -> String? {
         do {
             let rows = try query(
                 """
                 SELECT txid FROM onchain_receive_txids
                 WHERE status = 'resolved' AND txid IS NOT NULL
-                ORDER BY resolved_at DESC LIMIT 1
+                ORDER BY resolved_at DESC, id DESC LIMIT 1
                 """,
                 params: []
             )

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -106,7 +106,24 @@ class DatabaseService {
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )
             """,
+            """
+            CREATE TABLE IF NOT EXISTS pending_operations (
+                op_id TEXT PRIMARY KEY NOT NULL,
+                op_type TEXT NOT NULL,
+                funding_outpoint_txid TEXT,
+                funding_outpoint_vout INTEGER,
+                closing_txid TEXT,
+                balance_sats INTEGER,
+                balance_usd REAL,
+                btc_price REAL,
+                counterparty TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                resolved_at INTEGER
+            )
+            """,
             "CREATE INDEX IF NOT EXISTS idx_price_history_timestamp ON price_history(timestamp DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_pending_operations_status ON pending_operations(status)",
             "CREATE INDEX IF NOT EXISTS idx_payments_created ON payments(created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_daily_prices_date ON daily_prices(date DESC)",
             "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)"
@@ -381,6 +398,127 @@ class DatabaseService {
         }
     }
 
+    // MARK: - Pending Operations
+
+    @discardableResult
+    func insertPendingOperation(
+        opId: String,
+        opType: String,
+        fundingOutpointTxid: String?,
+        fundingOutpointVout: UInt32?,
+        balanceSats: UInt64? = nil,
+        balanceUsd: Double? = nil,
+        btcPrice: Double? = nil,
+        counterparty: String? = nil
+    ) -> Bool {
+        do {
+            try execute(
+                """
+                INSERT INTO pending_operations
+                    (op_id, op_type, funding_outpoint_txid, funding_outpoint_vout,
+                     balance_sats, balance_usd, btc_price, counterparty, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+                ON CONFLICT(op_id) DO UPDATE SET
+                    op_type = excluded.op_type,
+                    funding_outpoint_txid = excluded.funding_outpoint_txid,
+                    funding_outpoint_vout = excluded.funding_outpoint_vout,
+                    balance_sats = excluded.balance_sats,
+                    balance_usd = excluded.balance_usd,
+                    btc_price = excluded.btc_price,
+                    counterparty = excluded.counterparty,
+                    status = 'pending'
+                """,
+                params: [
+                    .text(opId),
+                    .text(opType),
+                    fundingOutpointTxid.map { .text($0) } ?? .null,
+                    fundingOutpointVout.map { .integer(Int64($0)) } ?? .null,
+                    balanceSats.map { .integer(Int64($0)) } ?? .null,
+                    balanceUsd.map { .real($0) } ?? .null,
+                    btcPrice.map { .real($0) } ?? .null,
+                    counterparty.map { .text($0) } ?? .null
+                ]
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Update a pending_operations row, only if it is still in 'pending' state.
+    /// Used by the resolver so a stale update can't clobber a row that's
+    /// already been marked resolved/failed by a parallel attempt.
+    @discardableResult
+    func updatePendingOperation(opId: String, closingTxid: String, status: String) -> Bool {
+        do {
+            try execute(
+                """
+                UPDATE pending_operations
+                SET closing_txid = ?, status = ?, resolved_at = strftime('%s', 'now')
+                WHERE op_id = ? AND status = 'pending'
+                """,
+                params: [.text(closingTxid), .text(status), .text(opId)]
+            )
+            return sqlite3_changes(db) > 0
+        } catch {
+            return false
+        }
+    }
+
+    func fetchPendingOperations() -> [PendingOperation] {
+        do {
+            let rows = try query(
+                """
+                SELECT op_id, op_type, funding_outpoint_txid, funding_outpoint_vout,
+                       closing_txid, balance_sats, balance_usd, btc_price, counterparty,
+                       status, created_at, resolved_at
+                FROM pending_operations
+                """
+            )
+            return rows.map { Self.parsePendingOperation($0) }
+        } catch {
+            return []
+        }
+    }
+
+    /// Fetch a single pending_operations row by opId. Uses the primary key
+    /// index for an O(1) lookup instead of a full table scan.
+    func fetchPendingOperation(opId: String) -> PendingOperation? {
+        do {
+            let rows = try query(
+                """
+                SELECT op_id, op_type, funding_outpoint_txid, funding_outpoint_vout,
+                       closing_txid, balance_sats, balance_usd, btc_price, counterparty,
+                       status, created_at, resolved_at
+                FROM pending_operations
+                WHERE op_id = ?
+                LIMIT 1
+                """,
+                params: [.text(opId)]
+            )
+            return rows.first.map { Self.parsePendingOperation($0) }
+        } catch {
+            return nil
+        }
+    }
+
+    private static func parsePendingOperation(_ row: [Any?]) -> PendingOperation {
+        PendingOperation(
+            opId: row[0] as? String ?? "",
+            opType: row[1] as? String ?? "",
+            fundingOutpointTxid: row[2] as? String,
+            fundingOutpointVout: row[3].flatMap { ($0 as? Int64).map { UInt32($0) } },
+            closingTxid: row[4] as? String,
+            balanceSats: row[5].flatMap { ($0 as? Int64).map { UInt64($0) } },
+            balanceUsd: row[6] as? Double,
+            btcPrice: row[7] as? Double,
+            counterparty: row[8] as? String,
+            status: row[9] as? String ?? "pending",
+            createdAt: row[10] as? Int64 ?? 0,
+            resolvedAt: row[11] as? Int64
+        )
+    }
+
     // MARK: - Price History
 
     func recordPrice(_ price: Double, source: String? = nil) throws {
@@ -573,4 +711,19 @@ enum DatabaseError: LocalizedError {
         case .executeFailed(let msg): return "SQL execute failed: \(msg)"
         }
     }
+}
+
+struct PendingOperation: Equatable {
+    let opId: String
+    let opType: String
+    let fundingOutpointTxid: String?
+    let fundingOutpointVout: UInt32?
+    let closingTxid: String?
+    let balanceSats: UInt64?
+    let balanceUsd: Double?
+    let btcPrice: Double?
+    let counterparty: String?
+    let status: String
+    let createdAt: Int64
+    let resolvedAt: Int64?
 }

--- a/ios/StableChannels/StableChannels/Services/DepositRecorder.swift
+++ b/ios/StableChannels/StableChannels/Services/DepositRecorder.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Records a detected on-chain deposit. Two strategies:
+///
+/// - `KnownAddress`: insert a resolution row, write a payment row linked
+///   via `resolutionId`, and kick the Esplora resolver.
+/// - `UnknownAddress`: write a completed payment row with no resolver
+///   (the explorer link is unavailable until the user re-generates an
+///   address).
+///
+/// Each strategy handles its own crash-safety ordering. The protocol
+/// keeps AppState's `detectOnchainDeposit` branch as a single dispatch
+/// instead of a hard-coded `if let address` ladder.
+@MainActor
+protocol DepositRecorder {
+    /// Returns true if the deposit was recorded (and resolver launched if
+    /// applicable). False means a precondition failed and the caller should
+    /// leave `prevOnchainSats` untouched.
+    @discardableResult
+    func record(deposit: DepositRecordInput, address: String?) -> Bool
+}
+
+struct DepositRecordInput {
+    let depositId: String
+    let depositSats: Int64
+    let amountUSD: Double?
+    let btcPrice: Double?
+}
+
+/// Records when the current receive address is known. Crash-safe ordering:
+/// resolver row first, payment row linked via `resolution_id`. Crash
+/// between the two leaves an orphan resolver row (harmless on replay).
+@MainActor
+final class KnownAddressDepositRecorder: DepositRecorder {
+    private let databaseService: DatabaseService?
+    private let onLaunchResolver: (Int64, String) -> Void
+
+    init(databaseService: DatabaseService?, onLaunchResolver: @escaping (Int64, String) -> Void) {
+        self.databaseService = databaseService
+        self.onLaunchResolver = onLaunchResolver
+    }
+
+    func record(deposit: DepositRecordInput, address: String?) -> Bool {
+        guard let address, !address.isEmpty else { return false }
+        guard let resolutionId = databaseService?.insertOnchainReceiveResolution(address: address) else {
+            AuditService.log("ONCHAIN_RECEIVE_RES_INSERT_FAILED", data: ["address": address])
+            return false
+        }
+        let ok = databaseService?.recordOnchainPaymentWithResolution(
+            paymentId: deposit.depositId,
+            amountMsat: deposit.depositSats * 1000,
+            amountUSD: deposit.amountUSD,
+            btcPrice: deposit.btcPrice,
+            resolutionId: resolutionId
+        ) ?? false
+        if !ok {
+            _ = databaseService?.deleteOnchainReceiveResolution(id: resolutionId)
+            return false
+        }
+        onLaunchResolver(resolutionId, address)
+        return true
+    }
+}
+
+/// Records when no current receive address is known. Writes a completed
+/// payment row with no resolver; user can re-generate an address to see
+/// the on-chain link.
+@MainActor
+final class UnknownAddressDepositRecorder: DepositRecorder {
+    private let databaseService: DatabaseService?
+
+    init(databaseService: DatabaseService?) {
+        self.databaseService = databaseService
+    }
+
+    func record(deposit: DepositRecordInput, address _: String?) -> Bool {
+        try? databaseService?.recordPayment(
+            paymentId: deposit.depositId,
+            paymentType: "onchain",
+            direction: "received",
+            amountMsat: deposit.depositSats * 1000,
+            amountUSD: deposit.amountUSD,
+            btcPrice: deposit.btcPrice,
+            counterparty: nil,
+            status: "completed"
+        )
+        return true
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/DepositRecorder.swift
+++ b/ios/StableChannels/StableChannels/Services/DepositRecorder.swift
@@ -48,7 +48,7 @@ final class KnownAddressDepositRecorder: DepositRecorder {
         }
         let ok = databaseService?.recordOnchainPaymentWithResolution(
             paymentId: deposit.depositId,
-            amountMsat: deposit.depositSats * 1000,
+            amountMsat: Int64(deposit.depositSats) * 1000,
             amountUSD: deposit.amountUSD,
             btcPrice: deposit.btcPrice,
             resolutionId: resolutionId
@@ -64,7 +64,9 @@ final class KnownAddressDepositRecorder: DepositRecorder {
 
 /// Records when no current receive address is known. Writes a completed
 /// payment row with no resolver; user can re-generate an address to see
-/// the on-chain link.
+/// the on-chain link. Returns `false` if the write fails so the caller
+/// can leave `prevOnchainSats` unchanged and retry on the next balance
+/// poll (matches `KnownAddressDepositRecorder` semantics).
 @MainActor
 final class UnknownAddressDepositRecorder: DepositRecorder {
     private let databaseService: DatabaseService?
@@ -74,16 +76,21 @@ final class UnknownAddressDepositRecorder: DepositRecorder {
     }
 
     func record(deposit: DepositRecordInput, address _: String?) -> Bool {
-        try? databaseService?.recordPayment(
-            paymentId: deposit.depositId,
-            paymentType: "onchain",
-            direction: "received",
-            amountMsat: deposit.depositSats * 1000,
-            amountUSD: deposit.amountUSD,
-            btcPrice: deposit.btcPrice,
-            counterparty: nil,
-            status: "completed"
-        )
-        return true
+        guard let databaseService else { return false }
+        do {
+            try databaseService.recordPayment(
+                paymentId: deposit.depositId,
+                paymentType: "onchain",
+                direction: "received",
+                amountMsat: UInt64(Int64(deposit.depositSats) * 1000),
+                amountUSD: deposit.amountUSD,
+                btcPrice: deposit.btcPrice,
+                counterparty: nil,
+                status: "completed"
+            )
+            return true
+        } catch {
+            return false
+        }
     }
 }

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -10,6 +10,8 @@ class NodeService {
     private(set) var savedMnemonic: String?
     private var eventTask: Task<Void, Never>?
 
+    weak var databaseService: DatabaseService?
+
     init() {
         // Pre-load saved mnemonic from disk so it's available immediately,
         // even before start() completes (avoids race with early UI display)
@@ -193,6 +195,55 @@ class NodeService {
     func closeChannel(userChannelId: UserChannelId, counterpartyNodeId: PublicKey) throws {
         guard let node else { throw NodeServiceError.notRunning }
         try node.closeChannel(userChannelId: userChannelId, counterpartyNodeId: counterpartyNodeId)
+    }
+
+    func requestChannelClose(
+        userChannelId: UserChannelId,
+        counterpartyNodeId: PublicKey,
+        fundingOutpointTxid: String,
+        fundingOutpointVout: UInt32,
+        balanceSats: UInt64,
+        balanceUsd: Double?,
+        btcPrice: Double?,
+        counterparty: String?
+    ) async throws {
+        guard let node else { throw NodeServiceError.notRunning }
+
+        // Persist intent + snapshot first: resolver reads from this row at resolve time
+        let opId = "close-\(userChannelId)"
+        databaseService?.insertPendingOperation(
+            opId: opId,
+            opType: "channel_close",
+            fundingOutpointTxid: fundingOutpointTxid,
+            fundingOutpointVout: fundingOutpointVout,
+            balanceSats: balanceSats,
+            balanceUsd: balanceUsd,
+            btcPrice: btcPrice,
+            counterparty: counterparty
+        )
+
+        AuditService.log("CHANNEL_CLOSE_REQUESTED", data: [
+            "user_channel_id": "\(userChannelId)",
+            "funding_outpoint": "\(fundingOutpointTxid):\(fundingOutpointVout)"
+        ])
+
+        do {
+            try node.closeChannel(
+                userChannelId: userChannelId,
+                counterpartyNodeId: counterpartyNodeId
+            )
+        } catch {
+            databaseService?.updatePendingOperation(
+                opId: opId,
+                closingTxid: "",
+                status: "failed"
+            )
+            AuditService.log("CHANNEL_CLOSE_REQUEST_FAILED", data: [
+                "user_channel_id": "\(userChannelId)",
+                "error": "\(error)"
+            ])
+            throw error
+        }
     }
 
     // MARK: - Splice Operations

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -9,7 +9,7 @@ struct OnchainTxidResolver {
 
     init(
         chainURLs: [String],
-        onResolved: @escaping OnTxidResolved,
+        onResolved: @escaping CloseTxidResolver.OnTxidResolved,
         urlSession: URLSession = .shared,
         maxAttempts: Int = 8,
         backoffSeconds: [UInt64] = [2, 8, 30, 60, 120, 300, 600, 900],

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Polls Esplora for the first txid hitting a receive address. On hit,
+/// updates the DB row (`resolutionId`) and fires `onResolved`. Thin
+/// policy wrapper over `ResilientEsploraClient`: paths + parser only.
+struct OnchainTxidResolver {
+    typealias OnResolved = @MainActor (Int64, String) async
+        -> Void // (resolutionId, txid); never throws
+
+    private let client: ResilientEsploraClient
+    private let onResolved: OnResolved
+
+    init(
+        chainURLs: [String],
+        onResolved: @escaping OnResolved,
+        urlSession: URLSession = .shared,
+        maxAttempts: Int = 8,
+        backoffSeconds: [UInt64] = [2, 8, 30, 60, 120, 300, 600, 900],
+        esploraTimeout: TimeInterval = 8,
+        wallClockBudgetSeconds: TimeInterval = 420
+    ) {
+        precondition(!chainURLs.isEmpty, "OnchainTxidResolver requires at least one chain URL")
+        self.onResolved = onResolved
+        self.client = ResilientEsploraClient(
+            urlSession: urlSession,
+            config: .init(
+                chainURLs: chainURLs,
+                maxAttempts: maxAttempts,
+                backoffSeconds: backoffSeconds,
+                timeout: esploraTimeout,
+                wallClockBudgetSeconds: wallClockBudgetSeconds
+            )
+        )
+    }
+
+    /// Poll for any tx hitting `address`. On first hit, update the DB
+    /// row at `resolutionId` and fire `onResolved`. Returns silently
+    /// on exhaustion, budget overrun, or cancellation.
+    func resolve(resolutionId: Int64, address: String, databaseService: DatabaseService) async {
+        let onResolved = self.onResolved
+        let parser: ResilientEsploraClient.ResultParser<String> = { data in
+            guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+            else { return nil }
+            if let first = arr.first,
+               let txid = first["txid"] as? String,
+               ResilientEsploraClient.isValidTxid(txid) {
+                return txid
+            }
+            return nil
+        }
+
+        await client.run(
+            endpointBuilder: { base in
+                let b = ResilientEsploraClient.trimSlash(base)
+                return [
+                    "\(b)/address/\(address)/txs/chain",
+                    "\(b)/address/\(address)/txs/mempool"
+                ]
+            },
+            resultParser: parser,
+            onResolved: { txid in
+                if databaseService.updateOnchainReceiveResolution(id: resolutionId, txid: txid) {
+                    await onResolved(resolutionId, txid)
+                }
+            }
+        )
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -61,6 +61,14 @@ struct OnchainTxidResolver {
             onResolved: { txid in
                 if databaseService.updateOnchainReceiveResolution(id: resolutionId, txid: txid) {
                     await onResolved(resolutionId, txid)
+                } else {
+                    // Update refused: row already resolved by an earlier resolver run,
+                    // or the row was deleted. Skip onResolved to avoid clobbering the
+                    // existing state. Log so a stuck UI is debuggable from audit trail.
+                    AuditService.log("ONCHAIN_RECEIVE_RES_UPDATE_SKIPPED", data: [
+                        "resolution_id": "\(resolutionId)",
+                        "txid": "\(txid)"
+                    ])
                 }
             }
         )

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -4,15 +4,12 @@ import Foundation
 /// updates the DB row (`resolutionId`) and fires `onResolved`. Thin
 /// policy wrapper over `ResilientEsploraClient`: paths + parser only.
 struct OnchainTxidResolver {
-    typealias OnResolved = @MainActor (Int64, String) async
-        -> Void // (resolutionId, txid); never throws
-
     private let client: ResilientEsploraClient
-    private let onResolved: OnResolved
+    private let onResolved: CloseTxidResolver.OnTxidResolved
 
     init(
         chainURLs: [String],
-        onResolved: @escaping OnResolved,
+        onResolved: @escaping OnTxidResolved,
         urlSession: URLSession = .shared,
         maxAttempts: Int = 8,
         backoffSeconds: [UInt64] = [2, 8, 30, 60, 120, 300, 600, 900],
@@ -38,6 +35,7 @@ struct OnchainTxidResolver {
     /// on exhaustion, budget overrun, or cancellation.
     func resolve(resolutionId: Int64, address: String, databaseService: DatabaseService) async {
         let onResolved = self.onResolved
+        let workId = "res-\(resolutionId)"
         let parser: ResilientEsploraClient.ResultParser<String> = { data in
             guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
             else { return nil }
@@ -59,16 +57,23 @@ struct OnchainTxidResolver {
             },
             resultParser: parser,
             onResolved: { txid in
-                if databaseService.updateOnchainReceiveResolution(id: resolutionId, txid: txid) {
-                    await onResolved(resolutionId, txid)
+                // databaseService is non-Sendable; hop to MainActor for the DB
+                // call so the closure stays Sendable-safe.
+                let updated = await MainActor.run {
+                    databaseService.updateOnchainReceiveResolution(id: resolutionId, txid: txid)
+                }
+                if updated {
+                    await onResolved(workId, txid)
                 } else {
                     // Update refused: row already resolved by an earlier resolver run,
                     // or the row was deleted. Skip onResolved to avoid clobbering the
                     // existing state. Log so a stuck UI is debuggable from audit trail.
-                    AuditService.log("ONCHAIN_RECEIVE_RES_UPDATE_SKIPPED", data: [
-                        "resolution_id": "\(resolutionId)",
-                        "txid": "\(txid)"
-                    ])
+                    await MainActor.run {
+                        AuditService.log("ONCHAIN_RECEIVE_RES_UPDATE_SKIPPED", data: [
+                            "resolution_id": "\(resolutionId)",
+                            "txid": "\(txid)"
+                        ])
+                    }
                 }
             }
         )

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -14,7 +14,7 @@ struct OnchainTxidResolver {
         maxAttempts: Int = 8,
         backoffSeconds: [UInt64] = [2, 8, 30, 60, 120, 300, 600, 900],
         esploraTimeout: TimeInterval = 8,
-        wallClockBudgetSeconds: TimeInterval = 420
+        wallClockBudgetSeconds: TimeInterval = 900
     ) {
         precondition(!chainURLs.isEmpty, "OnchainTxidResolver requires at least one chain URL")
         self.onResolved = onResolved

--- a/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
+++ b/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
@@ -61,6 +61,17 @@ struct ResilientEsploraClient {
     /// (and fires `onExhausted`) after `maxAttempts` or the wall-clock
     /// budget is exhausted. Honors `Task.isCancelled` between attempts
     /// and chain URLs.
+    ///
+    /// Exit semantics:
+    /// - `onResolved` fired: clean success, function returns.
+    /// - `Task.isCancelled`: silent return. `onExhausted` is NOT fired — the
+    ///   caller (e.g. `StaggeredTaskLauncher` replacing a stale task) is
+    ///   responsible for any cleanup, and treating cancellation as
+    ///   "exhaustion" would double-fire side effects.
+    /// - Budget or attempts exhausted: falls through to `onExhausted`.
+    ///   The exhaustion path is the only branch that fires the callback,
+    ///   so callers can use `onExhausted` as a definitive "we tried and
+    ///   gave up" signal.
     func run<T: Sendable>(
         endpointBuilder: @escaping EndpointBuilder,
         resultParser: @escaping ResultParser<T>,
@@ -107,7 +118,8 @@ struct ResilientEsploraClient {
                 }
             }
         }
-        // Fell through without a hit: exhaustion.
+        // Fell through without a hit AND without cancellation: true exhaustion.
+        // Cancellation paths above already returned without reaching this point.
         Self.log("ESPLORA_EXHAUSTED", [
             "chainURLs": "\(config.chainURLs)",
             "attempts": "\(config.maxAttempts)"

--- a/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
+++ b/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Esplora poller. Wraps the `/tx/.../outspend/...`, `/address/.../txs/...`
+/// calls shared by `CloseTxidResolver` and `OnchainTxidResolver`.
+/// Owns: chain-URL fallback, backoff with jitter, wall-clock budget, body
+/// cap, cancellation, and the txid format check. Caller supplies:
+///   - `endpointBuilder`: paths to try on a chain, in order. `[]` skips.
+///   - `resultParser`: 200/JSON body -> resolved value, or `nil` to retry.
+///   - `onResolved`: fires once on success.
+struct ResilientEsploraClient {
+    struct Config {
+        let chainURLs: [String]
+        let maxAttempts: Int
+        let backoffSeconds: [UInt64]
+        let timeout: TimeInterval
+        /// Total wall-clock cap across all attempts. `run` returns and
+        /// fires `onExhausted` if the budget is exceeded.
+        let wallClockBudgetSeconds: TimeInterval
+        /// Fires once after the attempt loop falls through without a hit.
+        let onExhausted: (@Sendable () async -> Void)?
+
+        init(
+            chainURLs: [String],
+            maxAttempts: Int = 5,
+            backoffSeconds: [UInt64] = [1, 4, 16, 64, 256],
+            timeout: TimeInterval = 5,
+            wallClockBudgetSeconds: TimeInterval = 420,
+            onExhausted: (@Sendable () async -> Void)? = nil
+        ) {
+            precondition(!chainURLs.isEmpty, "ResilientEsploraClient needs at least one chain URL")
+            self.chainURLs = chainURLs
+            self.maxAttempts = maxAttempts
+            self.backoffSeconds = backoffSeconds
+            self.timeout = timeout
+            self.wallClockBudgetSeconds = wallClockBudgetSeconds
+            self.onExhausted = onExhausted
+        }
+    }
+
+    /// Per-chain path list. Tried in order on one chain before falling
+    /// back to the next chain in `chainURLs`. `[]` skips the chain.
+    typealias EndpointBuilder = @Sendable (String) -> [String]
+
+    /// 200/JSON body -> resolved value, or `nil` to try the next path.
+    typealias ResultParser<T> = @Sendable (Data) throws -> T?
+
+    let urlSession: URLSession
+    let config: Config
+
+    init(urlSession: URLSession = .shared, config: Config) {
+        self.urlSession = urlSession
+        self.config = config
+    }
+
+    /// 1 MB cap on response body. Long-history `/address/.../txs/chain`
+    /// can blow past this; a hostile or buggy mempool could push hundreds
+    /// of MB into memory otherwise.
+    private static let maxBodyBytes = 1_048_576
+
+    /// Run the poll loop. Calls `onResolved` once on success, or returns
+    /// (and fires `onExhausted`) after `maxAttempts` or the wall-clock
+    /// budget is exhausted. Honors `Task.isCancelled` between attempts
+    /// and chain URLs.
+    func run<T: Sendable>(
+        endpointBuilder: @escaping EndpointBuilder,
+        resultParser: @escaping ResultParser<T>,
+        onResolved: @escaping @Sendable (T) async -> Void
+    ) async {
+        let start = Date()
+        for attempt in 0..<config.maxAttempts {
+            if Task.isCancelled { return }
+            if Date().timeIntervalSince(start) >= config.wallClockBudgetSeconds { break }
+            if attempt > 0 {
+                let base = config.backoffSeconds[
+                    min(attempt - 1, config.backoffSeconds.count - 1)
+                ]
+                let sleepNs = Self.jitteredBackoff(base: base) * 1_000_000_000
+                // Skip the sleep if it would blow the wall-clock budget.
+                if Date().timeIntervalSince(start) + (Double(sleepNs) / 1_000_000_000)
+                    >= config.wallClockBudgetSeconds { break }
+                do {
+                    try await Task.sleep(nanoseconds: sleepNs)
+                } catch {
+                    return
+                }
+                if Task.isCancelled { return }
+                if Date().timeIntervalSince(start) >= config.wallClockBudgetSeconds { break }
+            }
+            for base in config.chainURLs {
+                if Task.isCancelled { return }
+                let paths = endpointBuilder(base)
+                for path in paths {
+                    if Task.isCancelled { return }
+                    guard let data = await fetchJSON(path: path) else { continue }
+                    do {
+                        if let hit = try resultParser(data) {
+                            Self.log("ESPLORA_RESOLVED", [
+                                "path": path,
+                                "attempt": "\(attempt)"
+                            ])
+                            await onResolved(hit)
+                            return
+                        }
+                    } catch {
+                        continue
+                    }
+                }
+            }
+        }
+        // Fell through without a hit: exhaustion.
+        Self.log("ESPLORA_EXHAUSTED", [
+            "chainURLs": "\(config.chainURLs)",
+            "attempts": "\(config.maxAttempts)"
+        ])
+        await config.onExhausted?()
+    }
+
+    /// GET `path`. Returns the body on 200, nil on non-200, network
+    /// error, body too large, or invalid URL.
+    func fetchJSON(path: String) async -> Data? {
+        guard let url = URL(string: path) else { return nil }
+        var req = URLRequest(url: url, timeoutInterval: config.timeout)
+        req.httpMethod = "GET"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            let (data, response) = try await urlSession.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200
+            else { return nil }
+            guard data.count <= Self.maxBodyBytes else {
+                Self.log("ESPLORA_BODY_TOO_LARGE", [
+                    "path": path,
+                    "size": "\(data.count)"
+                ])
+                return nil
+            }
+            return data
+        } catch {
+            return nil
+        }
+    }
+
+    /// +/-25% multiplicative jitter on a base backoff. Prevents N wallet
+    /// instances from hammering the public mempool in lockstep.
+    /// Rounded so a 1s base doesn't truncate to 0 at the lower bound.
+    static func jitteredBackoff(base: UInt64) -> UInt64 {
+        let jitter = Double.random(in: 0.75...1.25)
+        return UInt64((Double(base) * jitter).rounded())
+    }
+
+    /// Terse AuditService wrapper.
+    private static func log(_ event: String, _ data: [String: String]) {
+        AuditService.log(event, data: data)
+    }
+
+    /// 64 lowercase hex chars.
+    static func isValidTxid(_ s: String) -> Bool {
+        guard s.count == 64 else { return false }
+        for c in s {
+            switch c {
+            case "0"..."9", "a"..."f": continue
+            default: return false
+            }
+        }
+        return true
+    }
+
+    /// Strip a trailing slash from a chain base URL.
+    static func trimSlash(_ base: String) -> String {
+        base.hasSuffix("/") ? String(base.dropLast()) : base
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
+++ b/ios/StableChannels/StableChannels/Services/ResilientEsploraClient.swift
@@ -24,7 +24,7 @@ struct ResilientEsploraClient {
             maxAttempts: Int = 5,
             backoffSeconds: [UInt64] = [1, 4, 16, 64, 256],
             timeout: TimeInterval = 5,
-            wallClockBudgetSeconds: TimeInterval = 420,
+            wallClockBudgetSeconds: TimeInterval = 900,
             onExhausted: (@Sendable () async -> Void)? = nil
         ) {
             precondition(!chainURLs.isEmpty, "ResilientEsploraClient needs at least one chain URL")

--- a/ios/StableChannels/StableChannels/Services/StaggeredTaskLauncher.swift
+++ b/ios/StableChannels/StableChannels/Services/StaggeredTaskLauncher.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Manages one cancellable `Task` per `opId` on the MainActor, with an
+/// optional staggered start delay (used to spread burst replays across
+/// time to avoid hammering the public Esplora endpoints).
+@MainActor
+final class StaggeredTaskLauncher {
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var generations: [String: UUID] = [:]
+
+    /// Launch `task` after `delaySeconds`. If a task is already running
+    /// for `opId`, it is cancelled and replaced. The closure may exit
+    /// early by checking `Task.isCancelled`.
+    func launch(opId: String, delaySeconds: UInt64 = 0, _ task: @escaping @MainActor () async -> Void) {
+        tasks[opId]?.cancel()
+        let generation = UUID()
+        generations[opId] = generation
+        let newTask = Task { @MainActor [weak self] in
+            if delaySeconds > 0 {
+                try? await Task.sleep(nanoseconds: delaySeconds * 1_000_000_000)
+                if Task.isCancelled { return }
+            }
+            await task()
+            if self?.generations[opId] == generation {
+                self?.tasks[opId] = nil
+                self?.generations[opId] = nil
+            }
+        }
+        tasks[opId] = newTask
+    }
+
+    /// Cancel any running task for `opId`.
+    func cancel(opId: String) {
+        tasks[opId]?.cancel()
+        tasks[opId] = nil
+        generations[opId] = nil
+    }
+
+    /// Cancel all running tasks.
+    func cancelAll() {
+        for task in tasks.values {
+            task.cancel()
+        }
+        tasks.removeAll()
+        generations.removeAll()
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/StaggeredTaskLauncher.swift
+++ b/ios/StableChannels/StableChannels/Services/StaggeredTaskLauncher.swift
@@ -8,8 +8,9 @@ final class StaggeredTaskLauncher {
     private var tasks: [String: Task<Void, Never>] = [:]
     private var generations: [String: UUID] = [:]
 
-    /// Launch `task` after `delaySeconds`. If a task is already running
-    /// for `opId`, it is cancelled and replaced. The closure may exit
+    /// Launch `task` after `delaySeconds` (SECONDS, not milliseconds — multiplied
+    /// by 1e9 below to get nanoseconds for `Task.sleep`). If a task is already
+    /// running for `opId`, it is cancelled and replaced. The closure may exit
     /// early by checking `Task.isCancelled`.
     func launch(opId: String, delaySeconds: UInt64 = 0, _ task: @escaping @MainActor () async -> Void) {
         tasks[opId]?.cancel()
@@ -17,6 +18,8 @@ final class StaggeredTaskLauncher {
         generations[opId] = generation
         let newTask = Task { @MainActor [weak self] in
             if delaySeconds > 0 {
+                // Unit: seconds. Caller passes e.g. UInt64(i) where i is a per-op index
+                // in a burst-replay loop, e.g. 0s, 2s, 4s, 6s for 4 ops.
                 try? await Task.sleep(nanoseconds: delaySeconds * 1_000_000_000)
                 if Task.isCancelled { return }
             }

--- a/ios/StableChannels/StableChannels/Services/TxidLinkStore.swift
+++ b/ios/StableChannels/StableChannels/Services/TxidLinkStore.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Persists the most recent close and onchain-receive txids across app
+/// launches, with a 7-day expiry so a txid from a long-finished session
+/// does not linger on the UI forever.
+///
+/// One value type holds both slots and the shared UserDefaults read/write
+/// logic. Callers observe via the `lastCloseTxid` / `lastReceiveTxid`
+/// computed properties and call `setClose(_:)` / `setReceive(_:)` to
+/// update. All access is MainActor-isolated because the values drive UI.
+@MainActor
+@Observable
+final class TxidLinkStore {
+    private(set) var lastCloseTxid: String?
+    private(set) var lastReceiveTxid: String?
+
+    private let defaults: UserDefaults?
+    private static let expirySeconds: TimeInterval = 7 * 86400
+
+    private enum Key {
+        static let close = "last_close_txid"
+        static let closeAt = "last_close_txid_at"
+        static let receive = "last_receive_txid"
+        static let receiveAt = "last_receive_txid_at"
+    }
+
+    init(defaults: UserDefaults? = UserDefaults(suiteName: Constants.appGroupIdentifier)) {
+        self.defaults = defaults
+        let now = Date().timeIntervalSince1970
+        self.lastCloseTxid = Self.restore(key: Key.close, atKey: Key.closeAt, now: now, defaults: defaults)
+        self.lastReceiveTxid = Self.restore(key: Key.receive, atKey: Key.receiveAt, now: now, defaults: defaults)
+    }
+
+    func setClose(_ txid: String?) {
+        lastCloseTxid = txid
+        Self.persist(txid: txid, valueKey: Key.close, atKey: Key.closeAt, defaults: defaults)
+    }
+
+    func setReceive(_ txid: String?) {
+        lastReceiveTxid = txid
+        Self.persist(txid: txid, valueKey: Key.receive, atKey: Key.receiveAt, defaults: defaults)
+    }
+
+    private static func restore(key: String, atKey: String, now: TimeInterval, defaults: UserDefaults?) -> String? {
+        guard let stored = defaults?.string(forKey: key),
+              let storedAt = defaults?.object(forKey: atKey) as? Int64,
+              now - TimeInterval(storedAt) < expirySeconds
+        else {
+            defaults?.removeObject(forKey: key)
+            defaults?.removeObject(forKey: atKey)
+            return nil
+        }
+        return stored
+    }
+
+    private static func persist(txid: String?, valueKey: String, atKey: String, defaults: UserDefaults?) {
+        defaults?.set(txid, forKey: valueKey)
+        if txid != nil {
+            defaults?.set(Int64(Date().timeIntervalSince1970), forKey: atKey)
+        } else {
+            defaults?.removeObject(forKey: atKey)
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -18,6 +18,7 @@ enum Constants {
 
     static let primaryChainURL = "https://blockstream.info/api"
     static let fallbackChainURL = "https://mempool.space/api"
+    static let esploraChainURLs: [String] = [primaryChainURL, fallbackChainURL]
     static let txExplorerURL = "https://mempool.space/tx"
 
     static func txExplorerLink(for txid: String) -> URL? {

--- a/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
@@ -13,7 +13,10 @@ struct PaymentDetailView: View {
                             ? String(localized: "payment_received", defaultValue: "Received")
                             : String(localized: "payment_sent", defaultValue: "Sent"))
                     row(String(localized: "label_type", defaultValue: "Type"), paymentTypeLabel)
-                    row(String(localized: "label_amount", defaultValue: "Amount"), "\(payment.amountSats.btcSpacedFormatted) BTC")
+                    row(
+                        String(localized: "label_amount", defaultValue: "Amount"),
+                        "\(payment.amountSats.btcSpacedFormatted) BTC"
+                    )
                     if let usd = payment.amountUSD {
                         row(String(localized: "label_usd_value", defaultValue: "USD Value"), usd.usdFormatted)
                     }

--- a/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Views/History/PaymentDetailView.swift
@@ -33,7 +33,7 @@ struct PaymentDetailView: View {
                     }
                     if let txid = payment.txid {
                         row(String(localized: "label_txid", defaultValue: "TXID"), txid)
-                        if let url = URL(string: "https://mempool.space/tx/\(txid)") {
+                        if let url = Constants.txExplorerLink(for: txid) {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
                                     Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -339,7 +339,7 @@ struct HomeView: View {
                 // 1. Splice-in in progress
                 pendingRow(kind: .sweep(txid: appState.spliceTxid))
             } else if appState.isChannelClosing {
-                if let closeTxid = appState.lastCloseTxid, !closeTxid.isEmpty {
+                if let closeTxid = appState.txidLinks.lastCloseTxid, !closeTxid.isEmpty {
                     pendingRow(kind: .close(txid: closeTxid))
                 } else {
                     pendingRow(kind: .closeNoLink)
@@ -367,7 +367,7 @@ struct HomeView: View {
                 if appState.isOpeningChannel, let fundingTx = appState.fundingTxid {
                     pendingRow(kind: .deposit(txid: fundingTx))
                 } else {
-                    pendingRow(kind: .onchainReceive(txid: appState.lastReceiveTxid))
+                    pendingRow(kind: .onchainReceive(txid: appState.txidLinks.lastReceiveTxid))
                 }
                 if !hasReadyChannel {
                     Text(String(

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -337,10 +337,13 @@ struct HomeView: View {
 
             if appState.isSweeping {
                 // 1. Splice-in in progress
-                pendingRow(
-                    text: String(localized: "status_sweeping", defaultValue: "Swap pending..."),
-                    txid: appState.spliceTxid
-                )
+                pendingRow(kind: .sweep(txid: appState.spliceTxid))
+            } else if appState.isChannelClosing {
+                if let closeTxid = appState.lastCloseTxid, !closeTxid.isEmpty {
+                    pendingRow(kind: .close(txid: closeTxid))
+                } else {
+                    pendingRow(kind: .closeNoLink)
+                }
             } else if hasReadyChannel && appState.spendableOnchainSats > 0 {
                 // 2. Channel + confirmed funds — offer to sweep
                 HStack {
@@ -361,11 +364,11 @@ struct HomeView: View {
                     }
                 }
             } else if appState.spendableOnchainSats == 0 {
-                // 3. Unconfirmed deposit (with or without channel)
-                pendingRow(
-                    text: String(localized: "status_channel_opening", defaultValue: "Deposit confirming..."),
-                    txid: appState.fundingTxid
-                )
+                if appState.isOpeningChannel, let fundingTx = appState.fundingTxid {
+                    pendingRow(kind: .deposit(txid: fundingTx))
+                } else {
+                    pendingRow(kind: .onchainReceive)
+                }
                 if !hasReadyChannel {
                     Text(String(
                         localized: "hint_create_account",
@@ -388,7 +391,62 @@ struct HomeView: View {
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
     }
 
-    private func pendingRow(text: String, txid: String?) -> some View {
+    private enum PendingRowKind {
+        case deposit(txid: String?)
+        case sweep(txid: String?)
+        case close(txid: String?)
+        case closeNoLink
+        case onchainReceive
+    }
+
+    @ViewBuilder
+    private func pendingRow(kind: PendingRowKind) -> some View {
+        switch kind {
+        case .deposit(let txid):
+            pendingRowImpl(
+                text: String(localized: "status_channel_opening", defaultValue: "Deposit confirming..."),
+                txid: txid
+            )
+        case .sweep(let txid):
+            pendingRowImpl(
+                text: String(localized: "status_sweeping", defaultValue: "Swap pending..."),
+                txid: txid
+            )
+        case .close(let txid):
+            pendingRowImpl(
+                text: String(localized: "status_channel_closing", defaultValue: "Channel closing…"),
+                txid: txid
+            )
+        case .closeNoLink:
+            HStack(spacing: 6) {
+                Image(systemName: "hourglass")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                Text(String(
+                    localized: "info_close_pending_confirmation",
+                    defaultValue: "Channel closing - pending confirmation"
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                Spacer()
+            }
+        case .onchainReceive:
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.down.circle")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                Text(String(
+                    localized: "status_onchain_receiving",
+                    defaultValue: "Receiving on-chain..."
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                Spacer()
+            }
+        }
+    }
+
+    private func pendingRowImpl(text: String, txid: String?) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "hourglass")
                 .font(.caption)

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -349,7 +349,7 @@ struct HomeView: View {
                 HStack {
                     Text(String(localized: "move_to_trading", defaultValue: "Move to Lightning Account"))
                         .font(.caption2)
-                    .foregroundStyle(.secondary)
+                        .foregroundStyle(.secondary)
                     Spacer()
                     Button {
                         appState.sweepToChannel()

--- a/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Views/Home/HomeView.swift
@@ -367,7 +367,7 @@ struct HomeView: View {
                 if appState.isOpeningChannel, let fundingTx = appState.fundingTxid {
                     pendingRow(kind: .deposit(txid: fundingTx))
                 } else {
-                    pendingRow(kind: .onchainReceive)
+                    pendingRow(kind: .onchainReceive(txid: appState.lastReceiveTxid))
                 }
                 if !hasReadyChannel {
                     Text(String(
@@ -396,7 +396,7 @@ struct HomeView: View {
         case sweep(txid: String?)
         case close(txid: String?)
         case closeNoLink
-        case onchainReceive
+        case onchainReceive(txid: String?)
     }
 
     @ViewBuilder
@@ -430,19 +430,11 @@ struct HomeView: View {
                 .foregroundStyle(.secondary)
                 Spacer()
             }
-        case .onchainReceive:
-            HStack(spacing: 6) {
-                Image(systemName: "arrow.down.circle")
-                    .font(.caption)
-                    .foregroundStyle(.green)
-                Text(String(
-                    localized: "status_onchain_receiving",
-                    defaultValue: "Receiving on-chain..."
-                ))
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                Spacer()
-            }
+        case .onchainReceive(let txid):
+            pendingRowImpl(
+                text: String(localized: "status_onchain_receiving", defaultValue: "Receiving on-chain..."),
+                txid: txid
+            )
         }
     }
 

--- a/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
@@ -37,7 +37,33 @@ struct ChannelSettingsView: View {
                         Text(((channel.inboundCapacityMsat) / 1000).satsFormatted)
                     }
 
-                    if let txid = appState.fundingTxid, !txid.isEmpty {
+                    if let closeTxid = appState.lastCloseTxid, !closeTxid.isEmpty {
+                        HStack {
+                            Text(String(localized: "label_close_tx", defaultValue: "Close Tx"))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(String(closeTxid.prefix(8)) + "..." + String(closeTxid.suffix(8)))
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                        if let url = URL(string: "https://mempool.space/tx/\(closeTxid)") {
+                            Link(destination: url) {
+                                HStack(spacing: 4) {
+                                    Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))
+                                    Image(systemName: "arrow.up.right.square")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.blue)
+                            }
+                        }
+                    } else if appState.isChannelClosing {
+                        Text(String(
+                            localized: "info_close_pending_confirmation",
+                            defaultValue: "Channel closing — will appear on explorer after confirmation"
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    } else if let txid = appState.fundingTxid, !txid.isEmpty {
                         HStack {
                             Text(String(localized: "label_funding_tx", defaultValue: "Funding Tx"))
                                 .foregroundStyle(.secondary)
@@ -95,12 +121,30 @@ struct ChannelSettingsView: View {
         }
     }
 
+    @MainActor
     private func closeChannel() {
-        guard let channel = appState.nodeService.channels.first else { return }
+        guard let channel = appState.nodeService.channels.first,
+              let outpoint = channel.fundingTxo else {
+            // Edge case: channel exists but no funding outpoint. Log and abort.
+            // AuditService.log is synchronous — call directly.
+            AuditService.log("CHANNEL_CLOSE_NO_OUTPOINT", data: [
+                "user_channel_id": appState.stableChannel.userChannelId
+            ])
+            return
+        }
         appState.isChannelClosing = true
-        try? appState.nodeService.closeChannel(
-            userChannelId: channel.userChannelId,
-            counterpartyNodeId: channel.counterpartyNodeId
-        )
+        Task { @MainActor in
+            do {
+                try await appState.requestChannelClose(
+                    userChannelId: channel.userChannelId,
+                    counterpartyNodeId: channel.counterpartyNodeId,
+                    fundingOutpointTxid: "\(outpoint.txid)",
+                    fundingOutpointVout: outpoint.vout
+                )
+            } catch {
+                appState.statusMessage = "Close channel failed: \(error.localizedDescription)"
+                appState.isChannelClosing = false
+            }
+        }
     }
 }

--- a/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
@@ -46,7 +46,7 @@ struct ChannelSettingsView: View {
                                 .font(.system(.caption, design: .monospaced))
                                 .foregroundStyle(.secondary)
                         }
-                        if let url = URL(string: "https://mempool.space/tx/\(closeTxid)") {
+                        if let url = Constants.txExplorerLink(for: closeTxid) {
                             Link(destination: url) {
                                 HStack(spacing: 4) {
                                     Text(String(localized: "view_on_explorer", defaultValue: "View on explorer"))

--- a/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Views/Settings/ChannelSettingsView.swift
@@ -37,7 +37,7 @@ struct ChannelSettingsView: View {
                         Text(((channel.inboundCapacityMsat) / 1000).satsFormatted)
                     }
 
-                    if let closeTxid = appState.lastCloseTxid, !closeTxid.isEmpty {
+                    if let closeTxid = appState.txidLinks.lastCloseTxid, !closeTxid.isEmpty {
                         HStack {
                             Text(String(localized: "label_close_tx", defaultValue: "Close Tx"))
                                 .foregroundStyle(.secondary)

--- a/ios/StableChannels/StableChannelsTests/CloseTxidResolverTests.swift
+++ b/ios/StableChannels/StableChannelsTests/CloseTxidResolverTests.swift
@@ -134,10 +134,13 @@ final class CloseTxidResolverTests: XCTestCase {
         let resolver = makeResolver()
         await resolver.resolve(opId: "close-test", databaseService: service)
 
-        let ops = service.fetchPendingOperations()
-        XCTAssertEqual(ops.count, 1)
-        XCTAssertEqual(ops[0].status, "resolved")
-        XCTAssertEqual(ops[0].closingTxid, validTxid)
+        // PK lookup: fetchPendingOperations() filters by status='pending',
+        // so a resolved row is excluded.
+        let op = service.fetchPendingOperation(opId: "close-test")
+        XCTAssertNotNil(op)
+        guard let op else { return }
+        XCTAssertEqual(op.status, "resolved")
+        XCTAssertEqual(op.closingTxid, validTxid)
     }
 
     func testResolveExhaustsAttempts() async {
@@ -177,9 +180,11 @@ final class CloseTxidResolverTests: XCTestCase {
         let resolver = makeResolver(maxAttempts: 5, backoffSeconds: [0, 0, 0, 0])
         await resolver.resolve(opId: "close-test", databaseService: service)
 
-        let ops = service.fetchPendingOperations()
-        XCTAssertEqual(ops[0].status, "resolved")
-        XCTAssertEqual(ops[0].closingTxid, validTxid)
+        let op = service.fetchPendingOperation(opId: "close-test")
+        XCTAssertNotNil(op)
+        guard let op else { return }
+        XCTAssertEqual(op.status, "resolved")
+        XCTAssertEqual(op.closingTxid, validTxid)
     }
 
     func testResolveValidatesTxidShape() async {
@@ -215,9 +220,11 @@ final class CloseTxidResolverTests: XCTestCase {
         let resolver = makeResolver(maxAttempts: 3, backoffSeconds: [0, 0])
         await resolver.resolve(opId: "close-test", databaseService: service)
 
-        let ops = service.fetchPendingOperations()
-        XCTAssertEqual(ops[0].status, "resolved",
+        let op = service.fetchPendingOperation(opId: "close-test")
+        XCTAssertNotNil(op)
+        guard let op else { return }
+        XCTAssertEqual(op.status, "resolved",
                        "Resolver should fall back to the second chain URL")
-        XCTAssertEqual(ops[0].closingTxid, validTxid)
+        XCTAssertEqual(op.closingTxid, validTxid)
     }
 }

--- a/ios/StableChannels/StableChannelsTests/CloseTxidResolverTests.swift
+++ b/ios/StableChannels/StableChannelsTests/CloseTxidResolverTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+@testable import StableChannels
+
+final class MockURLProtocol: URLProtocol {
+    typealias Handler = (URLRequest) -> (HTTPURLResponse, Data)
+
+    static var requestHandler: Handler?
+    static var callCount: Int = 0
+    static var seenURLs: [URL] = []
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        Self.callCount += 1
+        if let url = request.url { Self.seenURLs.append(url) }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+final class CloseTxidResolverTests: XCTestCase {
+    private var dataDir: URL!
+    private var service: DatabaseService!
+    private var session: URLSession!
+    private let validTxid = String(repeating: "0", count: 64)
+
+    override func setUp() {
+        super.setUp()
+        dataDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("CloseTxidResolverTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        service = try? DatabaseService(dataDir: dataDir)
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+
+        MockURLProtocol.requestHandler = nil
+        MockURLProtocol.callCount = 0
+        MockURLProtocol.seenURLs = []
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: dataDir)
+        service = nil
+        session = nil
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    private func seedPending(opId: String = "close-test") {
+        _ = service.insertPendingOperation(
+            opId: opId,
+            opType: "channel_close",
+            fundingOutpointTxid: String(repeating: "a", count: 64),
+            fundingOutpointVout: 0
+        )
+    }
+
+    private func jsonResponse(body: [String: Any], status: Int = 200) -> (HTTPURLResponse, Data) {
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        let resp = HTTPURLResponse(
+            url: URL(string: "https://mock.local")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        return (resp, data)
+    }
+
+    private func makeResolver(
+        chainURLs: [String] = ["https://primary.local/api", "https://fallback.local/api"],
+        maxAttempts: Int = 3,
+        backoffSeconds: [UInt64] = [0, 0, 0],
+        onResolved: @escaping @Sendable (String, String) async -> Void = { _, _ in }
+    ) -> CloseTxidResolver {
+        let config = CloseTxidResolver.Config(
+            maxAttempts: maxAttempts,
+            backoffSeconds: backoffSeconds,
+            esploraTimeout: 5,
+            chainURLs: chainURLs,
+            onResolved: onResolved
+        )
+        return CloseTxidResolver(
+            chainURLs: chainURLs,
+            onResolved: onResolved,
+            urlSession: session,
+            config: config
+        )
+    }
+
+    // MARK: - isValidTxid
+
+    func testIsValidTxidAccepts64LowercaseHex() {
+        XCTAssertTrue(CloseTxidResolver.isValidTxid(validTxid))
+    }
+
+    func testIsValidTxidRejectsWrongLength() {
+        XCTAssertFalse(CloseTxidResolver.isValidTxid("abc"))
+    }
+
+    func testIsValidTxidRejectsUppercase() {
+        let upper = "ABCDEF" + String(repeating: "0", count: 58)
+        XCTAssertFalse(CloseTxidResolver.isValidTxid(upper))
+    }
+
+    // MARK: - resolve()
+
+    func testResolveFindsTxidOnSecondAttempt() async {
+        seedPending()
+
+        var attempts = 0
+        MockURLProtocol.requestHandler = { _ in
+            attempts += 1
+            if attempts == 1 {
+                return self.jsonResponse(body: ["spent": false])
+            }
+            return self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let resolver = makeResolver()
+        await resolver.resolve(opId: "close-test", databaseService: service)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops.count, 1)
+        XCTAssertEqual(ops[0].status, "resolved")
+        XCTAssertEqual(ops[0].closingTxid, validTxid)
+    }
+
+    func testResolveExhaustsAttempts() async {
+        seedPending()
+
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let resolver = makeResolver(maxAttempts: 3, backoffSeconds: [0, 0])
+        await resolver.resolve(opId: "close-test", databaseService: service)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops.count, 1)
+        XCTAssertEqual(ops[0].status, "pending",
+                       "Row must remain pending when resolver exhausts attempts")
+        XCTAssertNil(ops[0].closingTxid)
+    }
+
+    func testResolveRetriesOnNetworkError() async {
+        seedPending()
+
+        var attempts = 0
+        MockURLProtocol.requestHandler = { _ in
+            attempts += 1
+            if attempts <= 2 {
+                // Throw a network error on first two attempts.
+                // Note: our handler can't actually `throw` (URLProtocol must
+                // return a response or call didFailWithError), so we simulate
+                // a 5xx; the resolver treats that as a non-200 and
+                // continues to the next attempt.
+                return self.jsonResponse(body: [:], status: 503)
+            }
+            return self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let resolver = makeResolver(maxAttempts: 5, backoffSeconds: [0, 0, 0, 0])
+        await resolver.resolve(opId: "close-test", databaseService: service)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops[0].status, "resolved")
+        XCTAssertEqual(ops[0].closingTxid, validTxid)
+    }
+
+    func testResolveValidatesTxidShape() async {
+        seedPending()
+
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": "not-hex"])
+        }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(opId: "close-test", databaseService: service)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops[0].status, "pending",
+                       "Row must stay pending when Esplora returns garbage")
+        XCTAssertNil(ops[0].closingTxid)
+    }
+
+    func testResolveUsesBothChainURLs() async {
+        seedPending()
+
+        var attempts = 0
+        MockURLProtocol.requestHandler = { req in
+            attempts += 1
+            // First 3 calls go to the primary (5xx every time).
+            if let host = req.url?.host, host == "primary.local" {
+                return self.jsonResponse(body: [:], status: 500)
+            }
+            // Fallback succeeds.
+            return self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let resolver = makeResolver(maxAttempts: 3, backoffSeconds: [0, 0])
+        await resolver.resolve(opId: "close-test", databaseService: service)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops[0].status, "resolved",
+                       "Resolver should fall back to the second chain URL")
+        XCTAssertEqual(ops[0].closingTxid, validTxid)
+    }
+}

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -96,4 +96,263 @@ final class DatabaseServiceTests: XCTestCase {
         let ops = service.fetchPendingOperations()
         XCTAssertEqual(ops.first?.closingTxid, "first")
     }
+
+    // MARK: - onchain_receive_txids
+
+    func testInsertOnchainReceiveResolution_returnsNonZeroId() {
+        let id = service.insertOnchainReceiveResolution(address: "bc1qexampleaddress")
+        XCTAssertNotNil(id)
+        let unwrapped = try? XCTUnwrap(id)
+        XCTAssertGreaterThan(unwrapped ?? 0, 0)
+    }
+
+    func testFetchPendingOnchainReceives_returnsInsertedRow() {
+        _ = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qfirst"))
+        _ = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qsecond"))
+
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(pending.count, 2)
+        XCTAssertEqual(pending[0].address, "bc1qfirst")
+        XCTAssertEqual(pending[1].address, "bc1qsecond")
+        XCTAssertEqual(pending[0].status, "pending")
+        XCTAssertNil(pending[0].txid)
+        XCTAssertNil(pending[0].resolvedAt)
+    }
+
+    func testUpdateOnchainReceiveResolution_setsTxidAndMarksResolved() {
+        let id = try? XCTUnwrap(
+            service.insertOnchainReceiveResolution(address: "bc1qtoupdate")
+        )
+        let txid = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        let ok = service.updateOnchainReceiveResolution(
+            id: id ?? 0,
+            txid: txid
+        )
+        XCTAssertTrue(ok)
+
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertTrue(pending.isEmpty, "Resolved rows must not appear in pending fetch")
+
+        // Re-insert another pending row so we can confirm via absence the resolved
+        // row is no longer in the pending list.
+        _ = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qother"))
+        let stillPending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(stillPending.count, 1)
+        XCTAssertEqual(stillPending[0].address, "bc1qother")
+    }
+
+    func testFetchPendingOnchainReceives_excludesResolvedRows() {
+        let id = try? XCTUnwrap(
+            service.insertOnchainReceiveResolution(address: "bc1qresolve")
+        )
+        XCTAssertTrue(
+            service.updateOnchainReceiveResolution(
+                id: id ?? 0,
+                txid: String(repeating: "f", count: 64)
+            )
+        )
+
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertTrue(pending.isEmpty)
+    }
+
+    func testUpdateOnchainReceiveResolution_onlyAffectsTargetRow() {
+        let idA = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qA"))
+        let idB = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qB"))
+        let txidA = String(repeating: "a", count: 64)
+        let txidB = String(repeating: "b", count: 64)
+
+        XCTAssertTrue(
+            service.updateOnchainReceiveResolution(id: idA ?? 0, txid: txidA)
+        )
+
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending[0].id, idB)
+        XCTAssertEqual(pending[0].address, "bc1qB")
+        XCTAssertNil(pending[0].txid)
+
+        XCTAssertTrue(
+            service.updateOnchainReceiveResolution(id: idB ?? 0, txid: txidB)
+        )
+        let finalPending = service.fetchPendingOnchainReceives()
+        XCTAssertTrue(finalPending.isEmpty)
+    }
+
+    // MARK: - Onchain receive integration flow
+
+    /// Full on-chain receive lifecycle: insert resolution -> verify pending ->
+    /// update with real txid -> verify resolved (no longer in pending list) ->
+    /// verify latest resolved txid is queryable.
+    func testOnchainReceiveFlow_pendingRowGetsTxidOnUpdate() {
+        let address = "tb1qfakeaddressforintegrationtest1234567890abcdef"
+
+        // 1) Insert resolution row
+        guard let resolutionId = service.insertOnchainReceiveResolution(address: address) else {
+            XCTFail("insertOnchainReceiveResolution returned nil")
+            return
+        }
+        XCTAssertGreaterThan(resolutionId, 0)
+
+        // 2) Verify the row is in pending state
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending[0].address, address)
+        XCTAssertEqual(pending[0].id, resolutionId)
+        XCTAssertNil(pending[0].txid)
+        XCTAssertEqual(pending[0].status, "pending")
+
+        // 3) Update with a real txid
+        let txid = String(repeating: "a", count: 64)
+        let updated = service.updateOnchainReceiveResolution(id: resolutionId, txid: txid)
+        XCTAssertTrue(updated)
+
+        // 4) Verify the row is no longer in the pending fetch
+        let stillPending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(stillPending.count, 0, "Resolved row should not appear in pending fetch")
+
+        // 5) Latest resolved txid
+        XCTAssertEqual(service.fetchLatestResolvedOnchainTxid(), txid)
+    }
+
+    /// Dedup invariant: a second `updateOnchainReceiveResolution` on the same
+    /// row must return false (the SQL is gated by `status = 'pending'`, so a
+    /// resolved row is no longer updatable via this method).
+    func testUpdateOnchainReceiveResolution_returnsFalseOnSecondCall() {
+        guard let id = service.insertOnchainReceiveResolution(address: "tb1qtest") else {
+            XCTFail("insertOnchainReceiveResolution returned nil")
+            return
+        }
+        let txidA = String(repeating: "a", count: 64)
+        let txidB = String(repeating: "b", count: 64)
+
+        XCTAssertTrue(service.updateOnchainReceiveResolution(id: id, txid: txidA))
+        XCTAssertFalse(
+            service.updateOnchainReceiveResolution(id: id, txid: txidB),
+            "Second update must be a no-op (row is no longer pending)"
+        )
+
+        // The original txid must be preserved.
+        XCTAssertEqual(service.fetchLatestResolvedOnchainTxid(), txidA)
+    }
+
+    /// `fetchPendingOnchainReceiveRow` returns the row tied to a given
+    /// `resolution_id`; a non-matching id returns nil.
+    func testFetchPendingOnchainReceiveRow_returnsMatchingRow() {
+        guard let resId = service.insertOnchainReceiveResolution(address: "tb1qtest") else {
+            XCTFail("insertOnchainReceiveResolution returned nil")
+            return
+        }
+
+        let ok = service.recordOnchainPaymentWithResolution(
+            paymentId: "p1",
+            amountMsat: 50_000_000,
+            amountUSD: 100.0,
+            btcPrice: 50_000.0,
+            resolutionId: resId
+        )
+        XCTAssertTrue(ok)
+
+        let row = service.fetchPendingOnchainReceiveRow(resolutionId: resId)
+        XCTAssertNotNil(row)
+        XCTAssertEqual(row?.paymentId, "p1")
+        XCTAssertEqual(row?.amountMsat, 50_000_000)
+
+        // Different resolutionId returns nil (no row linked to it).
+        XCTAssertNil(service.fetchPendingOnchainReceiveRow(resolutionId: resId + 1))
+    }
+
+    /// `recordOnchainPaymentWithResolution` writes a row that is
+    /// (a) visible in `fetchPendingOnchainReceives` for the same resolution,
+    /// (b) survives rollback of the resolution row by the cleanup path
+    /// (we just verify the write itself succeeds and is findable).
+    func testRecordOnchainPaymentWithResolution_writesResolutionId() {
+        guard let resId = service.insertOnchainReceiveResolution(address: "tb1qtest") else {
+            XCTFail("insertOnchainReceiveResolution returned nil")
+            return
+        }
+
+        XCTAssertTrue(
+            service.recordOnchainPaymentWithResolution(
+                paymentId: "p1",
+                amountMsat: 1_000_000,
+                amountUSD: nil,
+                btcPrice: nil,
+                resolutionId: resId
+            )
+        )
+
+        // The payments row exists, linked to the resolution.
+        let row = service.fetchPendingOnchainReceiveRow(resolutionId: resId)
+        XCTAssertNotNil(row, "Inserted payment must be findable via resolutionId")
+        XCTAssertEqual(row?.paymentId, "p1")
+        XCTAssertEqual(row?.amountMsat, 1_000_000)
+
+        // And the resolution row itself is still in pending state.
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending[0].id, resId)
+    }
+
+    /// `deleteOnchainReceiveResolution` removes the resolution row; the
+    /// payments row linked to it survives (resolution cleanup must not
+    /// cascade — the resolution is a separate concern from the payment).
+    func testDeleteOnchainReceiveResolution_removesResolutionRow() {
+        guard let resId = service.insertOnchainReceiveResolution(address: "tb1qtest") else {
+            XCTFail("insertOnchainReceiveResolution returned nil")
+            return
+        }
+        XCTAssertTrue(
+            service.recordOnchainPaymentWithResolution(
+                paymentId: "p1",
+                amountMsat: 1_000_000,
+                amountUSD: nil,
+                btcPrice: nil,
+                resolutionId: resId
+            )
+        )
+
+        // Delete the resolution row.
+        XCTAssertTrue(service.deleteOnchainReceiveResolution(id: resId))
+
+        // The resolution is gone.
+        let pending = service.fetchPendingOnchainReceives()
+        XCTAssertTrue(pending.isEmpty, "Resolution row must be deleted")
+
+        // The payments row survives — it's the user-facing record.
+        let row = service.fetchPendingOnchainReceiveRow(resolutionId: resId)
+        XCTAssertNotNil(row, "Payments row must survive resolution deletion")
+    }
+
+    /// `fetchLatestResolvedOnchainTxid` returns a resolved txid (the
+    /// schema uses whole-second `strftime('%s','now')` for `resolved_at`,
+    /// so we cannot reliably distinguish "most recent" within a single
+    /// second — both txids are correct answers in that case. We assert
+    /// the basic contract: a resolved txid is queryable, and after two
+    /// distinct resolutions the call still returns one of them).
+    func testFetchLatestResolvedOnchainTxid_returnsResolvedTxid() {
+        let idA = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qA"))
+        let idB = try? XCTUnwrap(service.insertOnchainReceiveResolution(address: "bc1qB"))
+        let txidA = String(repeating: "a", count: 64)
+        let txidB = String(repeating: "b", count: 64)
+
+        XCTAssertTrue(service.updateOnchainReceiveResolution(id: idA ?? 0, txid: txidA))
+        let first = service.fetchLatestResolvedOnchainTxid()
+        XCTAssertTrue(
+            first == txidA || first == txidB,
+            "Expected a resolved txid, got \(first ?? "nil")"
+        )
+
+        XCTAssertTrue(service.updateOnchainReceiveResolution(id: idB ?? 0, txid: txidB))
+        let second = service.fetchLatestResolvedOnchainTxid()
+        XCTAssertTrue(
+            second == txidA || second == txidB,
+            "Expected a resolved txid, got \(second ?? "nil")"
+        )
+
+        // Sanity: with both resolved, fetchLatestResolvedOnchainTxid
+        // must not return nil.
+        XCTAssertNotNil(second)
+    }
 }

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import StableChannels
+
+final class DatabaseServiceTests: XCTestCase {
+    private var service: DatabaseService!
+    private var dataDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        dataDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("DatabaseServiceTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        service = try? DatabaseService(dataDir: dataDir)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: dataDir)
+        service = nil
+        super.tearDown()
+    }
+
+    // MARK: - pending_operations
+
+    func testPendingOperationsInsertFetch() {
+        let ok = service.insertPendingOperation(
+            opId: "close-abc",
+            opType: "channel_close",
+            fundingOutpointTxid: "deadbeef",
+            fundingOutpointVout: 1
+        )
+        XCTAssertTrue(ok)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops.count, 1)
+        let op = ops[0]
+        XCTAssertEqual(op.opId, "close-abc")
+        XCTAssertEqual(op.opType, "channel_close")
+        XCTAssertEqual(op.fundingOutpointTxid, "deadbeef")
+        XCTAssertEqual(op.fundingOutpointVout, 1)
+        XCTAssertEqual(op.status, "pending")
+        XCTAssertNil(op.closingTxid)
+        XCTAssertNil(op.resolvedAt)
+    }
+
+    func testPendingOperationsUpdatePreservesRow() {
+        _ = service.insertPendingOperation(
+            opId: "close-xyz",
+            opType: "channel_close",
+            fundingOutpointTxid: "cafebabe",
+            fundingOutpointVout: 0
+        )
+        let ok = service.updatePendingOperation(
+            opId: "close-xyz",
+            closingTxid: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            status: "resolved"
+        )
+        XCTAssertTrue(ok)
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops.count, 1)
+        let op = ops[0]
+        XCTAssertEqual(op.opId, "close-xyz")
+        XCTAssertEqual(op.opType, "channel_close")
+        XCTAssertEqual(op.fundingOutpointTxid, "cafebabe")
+        XCTAssertEqual(op.fundingOutpointVout, 0)
+        XCTAssertEqual(op.closingTxid,
+                       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+        XCTAssertEqual(op.status, "resolved")
+        XCTAssertNotNil(op.resolvedAt)
+    }
+
+    func testUpdatePendingOperationOnlyUpdatesPending() {
+        _ = service.insertPendingOperation(
+            opId: "close-q",
+            opType: "channel_close",
+            fundingOutpointTxid: nil,
+            fundingOutpointVout: nil
+        )
+        // First update succeeds and flips status to resolved.
+        let first = service.updatePendingOperation(
+            opId: "close-q",
+            closingTxid: "first",
+            status: "resolved"
+        )
+        XCTAssertTrue(first)
+
+        // Second update must be a no-op because the row is no longer pending.
+        let second = service.updatePendingOperation(
+            opId: "close-q",
+            closingTxid: "second",
+            status: "resolved"
+        )
+        XCTAssertFalse(second, "Second update must not clobber a resolved row")
+
+        let ops = service.fetchPendingOperations()
+        XCTAssertEqual(ops.first?.closingTxid, "first")
+    }
+}

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -57,9 +57,11 @@ final class DatabaseServiceTests: XCTestCase {
         )
         XCTAssertTrue(ok)
 
-        let ops = service.fetchPendingOperations()
-        XCTAssertEqual(ops.count, 1)
-        let op = ops[0]
+        // fetchPendingOperations() filters by status='pending', so the
+        // resolved row is excluded. Use the PK lookup instead.
+        let op = service.fetchPendingOperation(opId: "close-xyz")
+        XCTAssertNotNil(op)
+        guard let op else { return }
         XCTAssertEqual(op.opId, "close-xyz")
         XCTAssertEqual(op.opType, "channel_close")
         XCTAssertEqual(op.fundingOutpointTxid, "cafebabe")

--- a/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
@@ -183,7 +183,7 @@ final class OnchainTxidResolverTests: XCTestCase {
         XCTAssertNotNil(pending)
     }
 
-    func testResolve_cancelsBeforeAnyFire_strict() async throws {
+    func testResolve_allFailingResponses_neverFiresOnResolved() async throws {
         // Force a 503 on every response so onResolved can never fire
         // regardless of cancellation timing.
         MockURLProtocol.requestHandler = { _ in

--- a/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+@testable import StableChannels
+
+final class OnchainTxidResolverTests: XCTestCase {
+    private let validTxid = String(repeating: "a", count: 64)
+    private let testAddress = "bc1qtest0000000000000000000000000000000000"
+    private var dataDir: URL!
+    private var service: DatabaseService!
+    private var session: URLSession!
+    private var resolutionId: Int64!
+    private var box: ResolvedOnchainBox!
+
+    override func setUp() {
+        super.setUp()
+        dataDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("OnchainTxidResolverTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        service = try? DatabaseService(dataDir: dataDir)
+        resolutionId = service?.insertOnchainReceiveResolution(address: testAddress)
+        XCTAssertNotNil(resolutionId, "Failed to insert seed row for test")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+
+        MockURLProtocol.requestHandler = nil
+        MockURLProtocol.callCount = 0
+        MockURLProtocol.seenURLs = []
+
+        box = ResolvedOnchainBox()
+    }
+
+    override func tearDown() {
+        session = nil
+        service = nil
+        box = nil
+        MockURLProtocol.requestHandler = nil
+        try? FileManager.default.removeItem(at: dataDir)
+        super.tearDown()
+    }
+
+    private func jsonArrayResponse(body: [[String: Any]], status: Int = 200) -> (HTTPURLResponse, Data) {
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        let resp = HTTPURLResponse(
+            url: URL(string: "https://mock.local")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        return (resp, data)
+    }
+
+    private func emptyArrayResponse() -> (HTTPURLResponse, Data) {
+        jsonArrayResponse(body: [])
+    }
+
+    private func makeResolver(
+        chainURLs: [String] = ["https://primary.local/api", "https://fallback.local/api"],
+        maxAttempts: Int = 2,
+        backoffSeconds: [UInt64] = [0]
+    ) -> OnchainTxidResolver {
+        // setUp guarantees box != nil; force-unwrap is safe.
+        let captureBox = self.box!
+        return OnchainTxidResolver(
+            chainURLs: chainURLs,
+            onResolved: { id, txid in
+                await captureBox.set(id: id, txid: txid)
+            },
+            urlSession: session,
+            maxAttempts: maxAttempts,
+            backoffSeconds: backoffSeconds,
+            esploraTimeout: 5
+        )
+    }
+
+    // MARK: - isValidTxid delegates
+
+    func testIsValidTxid_validatesThroughClient() {
+        XCTAssertTrue(ResilientEsploraClient.isValidTxid(validTxid))
+        XCTAssertFalse(ResilientEsploraClient.isValidTxid("short"))
+    }
+
+    // MARK: - resolve()
+
+    func testResolve_findsTxidOnChainEndpoint() async {
+        MockURLProtocol.requestHandler = { req in
+            if let path = req.url?.path, path.hasSuffix("/txs/chain") {
+                return self.jsonArrayResponse(body: [["txid": self.validTxid]])
+            }
+            return self.emptyArrayResponse()
+        }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        try? await Task.sleep(nanoseconds: 100_000_000) // yield to MainActor
+
+        let captured = await box.value
+        XCTAssertEqual(captured?.id, resolutionId)
+        XCTAssertEqual(captured?.txid, validTxid)
+
+        // DB should be updated to resolved; row no longer pending
+        let pending = service.fetchPendingOnchainReceives().first { $0.id == resolutionId }
+        XCTAssertNil(pending, "Row should no longer be pending after resolve")
+    }
+
+    func testResolve_findsTxidOnMempoolEndpoint() async {
+        MockURLProtocol.requestHandler = { req in
+            if let path = req.url?.path, path.hasSuffix("/txs/chain") {
+                return self.emptyArrayResponse()
+            }
+            if let path = req.url?.path, path.hasSuffix("/txs/mempool") {
+                return self.jsonArrayResponse(body: [["txid": self.validTxid]])
+            }
+            return self.emptyArrayResponse()
+        }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let captured = await box.value
+        XCTAssertEqual(captured?.txid, validTxid)
+    }
+
+    func testResolve_fallsBackToSecondaryChain() async {
+        MockURLProtocol.requestHandler = { req in
+            guard let host = req.url?.host else {
+                return self.emptyArrayResponse()
+            }
+            if host == "primary.local" {
+                return self.emptyArrayResponse()
+            }
+            // fallback chain returns the hit on its chain endpoint
+            if let path = req.url?.path, path.hasSuffix("/txs/chain") {
+                return self.jsonArrayResponse(body: [["txid": self.validTxid]])
+            }
+            return self.emptyArrayResponse()
+        }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let captured = await box.value
+        XCTAssertEqual(captured?.txid, validTxid)
+        XCTAssertTrue(MockURLProtocol.seenURLs.contains { $0.host == "fallback.local" })
+    }
+
+    func testResolve_doesNotFireOnEmptyResponse() async {
+        MockURLProtocol.requestHandler = { _ in self.emptyArrayResponse() }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let captured = await box.value
+        XCTAssertNil(captured, "onResolved must not fire when all responses are empty")
+
+        // Row must remain pending
+        let pending = service.fetchPendingOnchainReceives().first { $0.id == resolutionId }
+        XCTAssertNotNil(pending, "Row should still be pending")
+    }
+
+    func testResolve_rejectsInvalidTxid() async {
+        MockURLProtocol.requestHandler = { req in
+            // Always return a non-64-hex "txid"
+            if let path = req.url?.path, path.hasSuffix("/txs/chain") {
+                return self.jsonArrayResponse(body: [["txid": "short"]])
+            }
+            return self.emptyArrayResponse()
+        }
+
+        let resolver = makeResolver(maxAttempts: 2, backoffSeconds: [0])
+        await resolver.resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let captured = await box.value
+        XCTAssertNil(captured, "Invalid txid must not fire onResolved")
+
+        // Row must remain pending
+        let pending = service.fetchPendingOnchainReceives().first { $0.id == resolutionId }
+        XCTAssertNotNil(pending)
+    }
+
+    func testResolve_cancelsBeforeAnyFire_strict() async throws {
+        // Force a 503 on every response so onResolved can never fire
+        // regardless of cancellation timing.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonArrayResponse(body: [], status: 503)
+        }
+
+        let captureBox = try XCTUnwrap(self.box)
+        let resolver = OnchainTxidResolver(
+            chainURLs: ["https://primary.local/api", "https://fallback.local/api"],
+            onResolved: { id, txid in
+                await captureBox.set(id: id, txid: txid)
+            },
+            urlSession: session,
+            maxAttempts: 5,
+            backoffSeconds: [1, 1, 1, 1],
+            esploraTimeout: 5
+        )
+
+        let task = Task {
+            await resolver.resolve(
+                resolutionId: self.resolutionId,
+                address: self.testAddress,
+                databaseService: self.service
+            )
+        }
+        task.cancel()
+        await task.value
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let captured = await box.value
+        XCTAssertNil(captured, "Cancelled task with all-failing responses must never fire onResolved")
+    }
+}
+
+/// Captures (id, txid) hits from the resolver's `@MainActor` callback.
+actor ResolvedOnchainBox {
+    struct Captured: Equatable {
+        let id: Int64
+        let txid: String
+    }
+
+    var value: Captured?
+
+    func set(id: Int64, txid: String) {
+        value = Captured(id: id, txid: txid)
+    }
+}

--- a/ios/StableChannels/StableChannelsTests/PendingPushPaymentTests.swift
+++ b/ios/StableChannels/StableChannelsTests/PendingPushPaymentTests.swift
@@ -1,6 +1,7 @@
 @testable import StableChannels
 import XCTest
 
+@MainActor
 final class PendingPushPaymentTests: XCTestCase {
     private let key = "pending_push_payment"
 

--- a/ios/StableChannels/StableChannelsTests/ResilientEsploraClientTests.swift
+++ b/ios/StableChannels/StableChannelsTests/ResilientEsploraClientTests.swift
@@ -1,0 +1,716 @@
+import XCTest
+@testable import StableChannels
+
+final class ResilientEsploraClientTests: XCTestCase {
+    private let validTxid = String(repeating: "a", count: 64)
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+
+        MockURLProtocol.requestHandler = nil
+        MockURLProtocol.callCount = 0
+        MockURLProtocol.seenURLs = []
+
+        // Reset the audit log path so audit log tests can capture clean output.
+        // We don't snapshot the prior path because no other test in this class
+        // sets it; teardown clears it again.
+        AuditService.setLogPath("")
+    }
+
+    override func tearDown() {
+        // Clear the audit log path so subsequent tests start clean.
+        AuditService.setLogPath("")
+        session = nil
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    private func jsonResponse(body: [String: Any], status: Int = 200) -> (HTTPURLResponse, Data) {
+        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        let resp = HTTPURLResponse(
+            url: URL(string: "https://mock.local")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        return (resp, data)
+    }
+
+    private func makeClient(
+        chainURLs: [String] = ["https://primary.local/api", "https://fallback.local/api"],
+        maxAttempts: Int = 2,
+        backoffSeconds: [UInt64] = [0],
+        wallClockBudgetSeconds: TimeInterval = 420,
+        onExhausted: (@Sendable () async -> Void)? = nil
+    ) -> ResilientEsploraClient {
+        let cfg = ResilientEsploraClient.Config(
+            chainURLs: chainURLs,
+            maxAttempts: maxAttempts,
+            backoffSeconds: backoffSeconds,
+            timeout: 5,
+            wallClockBudgetSeconds: wallClockBudgetSeconds,
+            onExhausted: onExhausted
+        )
+        return ResilientEsploraClient(urlSession: session, config: cfg)
+    }
+
+    // Default parser used by most tests: extracts a valid txid from the
+    // "spent" JSON shape, returns nil otherwise.
+    private func spentTxidParser(data: Data) throws -> String? {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let spent = json["spent"] as? Bool,
+              spent,
+              let txid = json["txid"] as? String,
+              ResilientEsploraClient.isValidTxid(txid)
+        else { return nil }
+        return txid
+    }
+
+    // MARK: - isValidTxid
+
+    func testIsValidTxid_accepts64Hex() {
+        // 48 zeros + 16 hex digits = 64 chars, with a non-zero hex range
+        let s = String(repeating: "0", count: 48) + "abcdef0123456789"
+        XCTAssertEqual(s.count, 64)
+        XCTAssertTrue(ResilientEsploraClient.isValidTxid(s))
+        XCTAssertTrue(ResilientEsploraClient.isValidTxid(validTxid))
+    }
+
+    func testIsValidTxid_rejectsShort() {
+        XCTAssertFalse(ResilientEsploraClient.isValidTxid(String(repeating: "a", count: 63)))
+    }
+
+    func testIsValidTxid_rejectsUppercase() {
+        let upper = "ABCDEF" + String(repeating: "0", count: 58)
+        XCTAssertFalse(ResilientEsploraClient.isValidTxid(upper))
+    }
+
+    func testIsValidTxid_rejectsNonHex() {
+        let bad = "g" + String(repeating: "0", count: 63)
+        XCTAssertFalse(ResilientEsploraClient.isValidTxid(bad))
+        let mixed = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdez"
+        XCTAssertEqual(mixed.count, 64)
+        XCTAssertFalse(ResilientEsploraClient.isValidTxid(mixed))
+    }
+
+    // MARK: - trimSlash
+
+    func testTrimSlash_stripsTrailingSlash() {
+        XCTAssertEqual(
+            ResilientEsploraClient.trimSlash("https://x.com/"),
+            "https://x.com"
+        )
+    }
+
+    func testTrimSlash_keepsNonTrailingSlash() {
+        XCTAssertEqual(
+            ResilientEsploraClient.trimSlash("https://x.com"),
+            "https://x.com"
+        )
+    }
+
+    // MARK: - run()
+
+    func testRun_resolvesOnFirstAttempt_primarySuccess() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient()
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/somefunding/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+    }
+
+    func testRun_fallsBackToSecondaryChain() async {
+        MockURLProtocol.requestHandler = { req in
+            if let host = req.url?.host, host == "primary.local" {
+                return self.jsonResponse(body: [:], status: 500)
+            }
+            return self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient(maxAttempts: 2, backoffSeconds: [0])
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+        XCTAssertTrue(MockURLProtocol.seenURLs.contains { $0.host == "fallback.local" })
+    }
+
+    func testRun_retriesOnParseFailure() async {
+        var attempts = 0
+        MockURLProtocol.requestHandler = { _ in
+            attempts += 1
+            if attempts == 1 {
+                // 200 but with a "not spent" shape — parser returns nil → retry
+                return self.jsonResponse(body: ["spent": false])
+            }
+            return self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient(maxAttempts: 3, backoffSeconds: [0, 0])
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+        XCTAssertGreaterThanOrEqual(attempts, 2)
+    }
+
+    func testRun_doesNotResolveAfterMaxAttempts() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let client = makeClient(maxAttempts: 2, backoffSeconds: [0])
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertNil(v, "onResolved must not fire when all attempts fail")
+    }
+
+    func testRun_cancelsMidAttempt() async {
+        // Cancel the task before the poll loop runs. The handler is
+        // synchronous so we cannot introduce real network latency in
+        // MockURLProtocol; instead we just ensure that a task cancelled
+        // before any attempt completes does not fire onResolved.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient(maxAttempts: 5, backoffSeconds: [1, 1, 1, 1])
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        let task = Task {
+            await client.run(
+                endpointBuilder: builder,
+                resultParser: parser,
+                onResolved: { hit in await resolved.set(hit) }
+            )
+        }
+        // Cancel immediately. The poll loop checks Task.isCancelled at the
+        // top of each attempt, so the first attempt's URL request may or
+        // may not complete — but with a nil parser, even a 200 hit will
+        // not fire onResolved. The assertion below covers both cases.
+        task.cancel()
+        await task.value
+
+        let v = await resolved.value
+        // Parser always returns nil, so onResolved must never fire
+        // regardless of cancellation timing.
+        XCTAssertNil(v)
+    }
+
+    func testRun_respectsBackoffSchedule() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let client = makeClient(
+            maxAttempts: 3,
+            backoffSeconds: [0, 1] // second attempt waits 1s
+        )
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        let start = Date()
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertGreaterThanOrEqual(
+            elapsed, 1.0,
+            "Backoff of 1s before attempt 2 must elapse before completion"
+        )
+    }
+
+    func testRun_skipsChainWhenEndpointBuilderReturnsEmpty() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient(
+            chainURLs: ["https://primary.local", "https://fallback.local"],
+            maxAttempts: 1,
+            backoffSeconds: []
+        )
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { data in
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let txid = json["txid"] as? String
+            else { return nil }
+            return txid
+        }
+        // Skip primary, build for fallback.
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            if base.contains("primary") { return [] }
+            return ["\(ResilientEsploraClient.trimSlash(base))/tx/abc"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+        XCTAssertFalse(MockURLProtocol.seenURLs.contains { $0.host == "primary.local" })
+    }
+
+    func testRun_returnsSilentlyOn400() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["error": "bad"], status: 400)
+        }
+
+        let client = makeClient(maxAttempts: 2, backoffSeconds: [0])
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertNil(v)
+    }
+
+    func testRun_handlesNetworkError() async {
+        MockURLProtocol.requestHandler = { _ in
+            // Return a 5xx so the URLProtocol hands the resolver a non-200
+            // response — same effect as a network error for our purposes.
+            // The resolver treats anything that isn't 200 as a continue.
+            return self.jsonResponse(body: [:], status: 503)
+        }
+
+        let client = makeClient(maxAttempts: 2, backoffSeconds: [0])
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertNil(v)
+    }
+
+    // MARK: - Production hardening: jitter, budget, body cap, onExhausted, telemetry
+
+    func testRun_appliesBackoffJitter() async {
+        // With base backoff [1] and 2 attempts, attempt 2 sleeps ~1s ±25%.
+        // We allow 0.75..1.5s to be CI-tolerant. If the test is flaky on a
+        // particular runner, set backoff to [0] and skip the assertion.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let client = makeClient(
+            maxAttempts: 2,
+            backoffSeconds: [1]
+        )
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        let start = Date()
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertGreaterThanOrEqual(
+            elapsed, 0.75,
+            "Jittered backoff of base 1s must elapse at least 0.75s (jitter lower bound 0.75x)"
+        )
+        XCTAssertLessThanOrEqual(
+            elapsed, 1.5,
+            "Jittered backoff of base 1s must elapse at most 1.5s (jitter upper bound 1.25x + slack)"
+        )
+    }
+
+    func testRun_jitteredBackoff_helperStaysInBand() {
+        // Direct unit test of the helper: 1000 samples, all in [0.75x, 1.25x].
+        for _ in 0..<1000 {
+            let j = ResilientEsploraClient.jitteredBackoff(base: 1000)
+            XCTAssertGreaterThanOrEqual(j, 750)
+            XCTAssertLessThanOrEqual(j, 1250)
+        }
+    }
+
+    func testRun_respectsWallClockBudget() async {
+        // Budget of 0.1s with a 10s backoff must short-circuit before
+        // the long sleep, and onResolved must not fire.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let client = makeClient(
+            maxAttempts: 5,
+            backoffSeconds: [10],
+            wallClockBudgetSeconds: 0.1
+        )
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        let start = Date()
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(
+            elapsed, 1.0,
+            "Wall-clock budget of 0.1s must short-circuit the 10s backoff"
+        )
+        let v = await resolved.value
+        XCTAssertNil(v, "onResolved must not fire when wall-clock budget is exceeded")
+    }
+
+    func testRun_capsBodyAt1MB() async {
+        // Return a 2MB body. The 1MB cap must reject it and onResolved
+        // must not fire.
+        let bigBody = Data(repeating: 0x20, count: 2 * 1_048_576) // 2 MB of spaces
+        MockURLProtocol.requestHandler = { _ in
+            let resp = HTTPURLResponse(
+                url: URL(string: "https://mock.local")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (resp, bigBody)
+        }
+
+        let client = makeClient(maxAttempts: 1, backoffSeconds: [])
+        let resolved = ResolvedBox<String>()
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertNil(v, "onResolved must not fire when the body is over the 1MB cap")
+    }
+
+    func testRun_acceptsBodyAt1MB() async {
+        // Edge: a body exactly at the cap (1MB) must pass through.
+        let exactlyOneMB = Data(repeating: 0x20, count: 1_048_576)
+        MockURLProtocol.requestHandler = { _ in
+            let resp = HTTPURLResponse(
+                url: URL(string: "https://mock.local")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (resp, exactlyOneMB)
+        }
+
+        // Parser intentionally returns nil for this body so we can verify
+        // the cap is enforced as "<= 1MB" (inclusive). The body should
+        // reach the parser; with a nil parser, onResolved does not fire.
+        let client = makeClient(maxAttempts: 1, backoffSeconds: [])
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+        // No assertion on resolved.value; the important thing is that
+        // run() returns cleanly without crashing on the 1MB edge.
+    }
+
+    func testRun_invokesOnExhausted() async {
+        // All attempts fail; onExhausted must fire exactly once.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let exhaustedFlag = ExhaustedFlag()
+        let client = makeClient(
+            maxAttempts: 2,
+            backoffSeconds: [0],
+            onExhausted: { await exhaustedFlag.set() }
+        )
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+
+        let fired = await exhaustedFlag.value
+        XCTAssertTrue(fired, "onExhausted must fire after the attempt loop falls through")
+    }
+
+    func testRun_doesNotInvokeOnExhaustedOnSuccess() async {
+        // When a hit is found, onExhausted must NOT fire.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let exhaustedFlag = ExhaustedFlag()
+        let client = makeClient(
+            maxAttempts: 3,
+            backoffSeconds: [0, 0],
+            onExhausted: { await exhaustedFlag.set() }
+        )
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+        let fired = await exhaustedFlag.value
+        XCTAssertFalse(fired, "onExhausted must not fire when a hit is found")
+    }
+
+    func testRun_logsEsploraResolvedOnHit() async {
+        // AuditService.log writes to a private file. We can't intercept
+        // the log destination from tests, so the best we can do is
+        // verify the call path does not crash and the run completes.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+
+        let client = makeClient(maxAttempts: 1, backoffSeconds: [])
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid, "Resolved path must not crash on AuditService.log call")
+    }
+
+    func testRun_logsEsploraExhaustedOnNoHit() async {
+        // Best-effort: confirm the exhaustion log call path completes.
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+
+        let client = makeClient(maxAttempts: 1, backoffSeconds: [])
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+        // No assertion; we just verify the exhaustion log call path runs
+        // without crashing.
+    }
+
+    // MARK: - Audit log assertions
+
+    //
+    // AuditService writes to a file path; we point it at a temp file via
+    // setLogPath and then read the file back. AuditService is a global
+    // singleton, so these tests are not parallel-safe with other tests
+    // that touch the log file. Each test uses its own temp path; setUp
+    // and tearDown clear the path between tests.
+
+    func testRun_writesESPLORA_RESOLVED_event_to_audit_log() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("audit_test_\(UUID().uuidString).log")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        AuditService.setLogPath(tmp.path)
+
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+        let client = makeClient(maxAttempts: 1, backoffSeconds: [])
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        // Flush: AuditService writes synchronously, so by the time run()
+        // returns, the file should be readable.
+        let log = try String(contentsOf: tmp, encoding: .utf8)
+        XCTAssertTrue(
+            log.contains("ESPLORA_RESOLVED"),
+            "expected ESPLORA_RESOLVED in audit log, got: \(log)"
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+    }
+
+    func testRun_writesESPLORA_EXHAUSTED_event_to_audit_log() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("audit_test_\(UUID().uuidString).log")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        AuditService.setLogPath(tmp.path)
+
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": false])
+        }
+        let client = makeClient(maxAttempts: 2, backoffSeconds: [0])
+        let parser: ResilientEsploraClient.ResultParser<String> = { _ in nil }
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: parser,
+            onResolved: { _ in }
+        )
+
+        let log = try String(contentsOf: tmp, encoding: .utf8)
+        XCTAssertTrue(
+            log.contains("ESPLORA_EXHAUSTED"),
+            "expected ESPLORA_EXHAUSTED in audit log, got: \(log)"
+        )
+    }
+
+    func testRun_doesNotWriteESPLORA_EXHAUSTED_onSuccess() async throws {
+        // The exhaustion event must only fire on the fall-through path.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("audit_test_\(UUID().uuidString).log")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        AuditService.setLogPath(tmp.path)
+
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonResponse(body: ["spent": true, "txid": self.validTxid])
+        }
+        let client = makeClient(maxAttempts: 3, backoffSeconds: [0, 0])
+        let resolved = ResolvedBox<String>()
+        let builder: ResilientEsploraClient.EndpointBuilder = { base in
+            ["\(ResilientEsploraClient.trimSlash(base))/tx/abc/outspend/0"]
+        }
+
+        await client.run(
+            endpointBuilder: builder,
+            resultParser: spentTxidParser,
+            onResolved: { hit in await resolved.set(hit) }
+        )
+
+        let v = await resolved.value
+        XCTAssertEqual(v, self.validTxid)
+
+        let log = try String(contentsOf: tmp, encoding: .utf8)
+        XCTAssertTrue(log.contains("ESPLORA_RESOLVED"))
+        XCTAssertFalse(
+            log.contains("ESPLORA_EXHAUSTED"),
+            "ESPLORA_EXHAUSTED must not fire when a hit is found; got: \(log)"
+        )
+    }
+}
+
+/// Minimal actor-isolated box for capturing `onResolved` hits in tests.
+actor ResolvedBox<T: Sendable> {
+    var value: T?
+    func set(_ v: T) { value = v }
+}
+
+/// Actor-isolated flag for capturing `onExhausted` invocations in tests.
+actor ExhaustedFlag {
+    var value: Bool = false
+    func set() { value = true }
+}

--- a/ios/StableChannels/StableChannelsTests/StaggeredTaskLauncherTests.swift
+++ b/ios/StableChannels/StableChannelsTests/StaggeredTaskLauncherTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import StableChannels
+
+@MainActor
+final class StaggeredTaskLauncherTests: XCTestCase {
+    func testLaunch_runsTask() async {
+        let sut = StaggeredTaskLauncher()
+        var didRun = false
+        let exp = expectation(description: "body ran")
+        sut.launch(opId: "a", delaySeconds: 0) {
+            didRun = true
+            exp.fulfill()
+        }
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(didRun)
+    }
+
+    func testLaunch_withDelay_delaysStart() async {
+        let sut = StaggeredTaskLauncher()
+        let start = Date()
+        var didRun = false
+        let exp = expectation(description: "body ran")
+        sut.launch(opId: "a", delaySeconds: 1) {
+            didRun = true
+            exp.fulfill()
+        }
+        await fulfillment(of: [exp], timeout: 5)
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertTrue(didRun)
+        XCTAssertGreaterThanOrEqual(elapsed, 0.9, "Expected delay >= 0.9s, got \(elapsed)")
+    }
+
+    func testLaunch_replacesExistingTask_cancelsOld() async {
+        let sut = StaggeredTaskLauncher()
+        let aStarted = expectation(description: "A started")
+        let aCancelled = expectation(description: "A saw cancel")
+        let bRan = expectation(description: "B ran")
+
+        sut.launch(opId: "x", delaySeconds: 0) {
+            aStarted.fulfill()
+            // Sleep long enough that B's launch() definitely calls cancel()
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            if Task.isCancelled { aCancelled.fulfill() }
+        }
+        await fulfillment(of: [aStarted], timeout: 1)
+
+        sut.launch(opId: "x", delaySeconds: 0) {
+            bRan.fulfill()
+        }
+        await fulfillment(of: [bRan], timeout: 2)
+        await fulfillment(of: [aCancelled], timeout: 3)
+    }
+
+    func testCancel_stopsTask() async {
+        let sut = StaggeredTaskLauncher()
+        let started = expectation(description: "started")
+        let finishedEarly = expectation(description: "saw cancel before sleep done")
+        var finishedEarlyFlag = false
+
+        sut.launch(opId: "k", delaySeconds: 0) {
+            started.fulfill()
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            if Task.isCancelled {
+                finishedEarlyFlag = true
+                finishedEarly.fulfill()
+            }
+        }
+        await fulfillment(of: [started], timeout: 1)
+        sut.cancel(opId: "k")
+        await fulfillment(of: [finishedEarly], timeout: 2)
+        XCTAssertTrue(finishedEarlyFlag)
+    }
+
+    func testCancelAll_clearsAll() async {
+        let sut = StaggeredTaskLauncher()
+        let s1 = expectation(description: "s1")
+        let s2 = expectation(description: "s2")
+        let s3 = expectation(description: "s3")
+        let c1 = expectation(description: "c1")
+        let c2 = expectation(description: "c2")
+        let c3 = expectation(description: "c3")
+        var saw1 = false, saw2 = false, saw3 = false
+
+        sut.launch(opId: "1", delaySeconds: 0) {
+            s1.fulfill()
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            if Task.isCancelled { saw1 = true; c1.fulfill() }
+        }
+        sut.launch(opId: "2", delaySeconds: 0) {
+            s2.fulfill()
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            if Task.isCancelled { saw2 = true; c2.fulfill() }
+        }
+        sut.launch(opId: "3", delaySeconds: 0) {
+            s3.fulfill()
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            if Task.isCancelled { saw3 = true; c3.fulfill() }
+        }
+        await fulfillment(of: [s1, s2, s3], timeout: 1)
+        sut.cancelAll()
+        await fulfillment(of: [c1, c2, c3], timeout: 2)
+        XCTAssertTrue(saw1 && saw2 && saw3)
+    }
+
+    func testGenerationMismatch_doesNotClearNewest() async {
+        let sut = StaggeredTaskLauncher()
+        let aStarted = expectation(description: "A started")
+        let bStarted = expectation(description: "B started")
+        let aCancelled = expectation(description: "A saw cancel")
+
+        // A is launched with a long sleep; B replaces it before A finishes.
+        // When B's body completes, B's generation still matches -> clears.
+        // When A's body resumes and finds Task.isCancelled, A's generation
+        // check fails, so A does NOT clear the launcher state.
+        sut.launch(opId: "g", delaySeconds: 0) {
+            aStarted.fulfill()
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            if Task.isCancelled { aCancelled.fulfill() }
+        }
+        await fulfillment(of: [aStarted], timeout: 1)
+
+        sut.launch(opId: "g", delaySeconds: 0) {
+            bStarted.fulfill()
+        }
+        await fulfillment(of: [bStarted], timeout: 2)
+        // Give A a chance to wake from sleep and observe its own cancel.
+        await fulfillment(of: [aCancelled], timeout: 4)
+    }
+}


### PR DESCRIPTION
## Summary

On-chain deposit resolution via Esplora polling. Close tx resolution via instant LDK API. Shared infrastructure: `ResilientEsploraClient`, `StaggeredTaskLauncher`, `TxidLinkStore`, and `DepositRecorder`. Crash-safe replay.

---

## Problem

- On-chain deposits had no explorer links
- Crash mid-resolution lost pending operations

## Solution

Esplora polling for deposit resolution. Crash-safe replay with shared infrastructure. Extracted testable components: `ResilientEsploraClient`, `StaggeredTaskLauncher`, `TxidLinkStore`, `DepositRecorder`.

---
## Video

https://github.com/user-attachments/assets/28df2ad5-c007-4f69-91e0-546707bbfaec

---

## Architecture Diagram
<img width="8192" height="2215" alt="image" src="https://github.com/user-attachments/assets/941b94cc-8113-4585-89a5-3ce732b4514b" />


### Architecture Notes

- **ResilientEsploraClient** handles HTTP + jittered backoff + 1MB cap + 15-min budget
- **OnchainTxidResolver** handles receive-address polling for deposits
- **StaggeredTaskLauncher** ensures one task per opId with generation UUIDs
- **Crash-safe**: deposit resolver row written before payment row
- **Replay**: pending ops replayed on app launch

---

1. **On-chain Receive Resolution**
   - Send BTC to receive address
   - Watch `onchain_receive_resolutions` insert and resolve
   - Verify HomeView shows explorer link
   - Check payment row links via `resolution_id`

5. **Unknown Address Flow**
   - Send when no address known
   - Verify bare payment row created (no resolver)
   - HomeView shows pending row without link

6. **Receive Recovery**
   - Force-kill app during receive resolution
   - Relaunch and verify `replayPendingOnchainReceives()` resumes

7. **Expiration Test**
   - Wait 8+ days after resolution
   - Verify `TxidLinkStore` doesn't restore stale txid

### Key Points to Verify

- **Deterministic ordering**: `fetchLatestResolvedOnchainTxid` returns same txid on repeated calls
- **Error handling**: Invalid responses logged but don't crash
- **Memory safety**: No leaks during repeated resolution cycles
- **UI consistency**: All pending rows show appropriate states

## Related
- Closes #105 
- Closes #119