### PR TITLE
fix(android): close payment ID, txid resolution via Esplora polling

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -466,8 +466,9 @@ class AppState(private val context: Context) : ViewModel() {
             // Record in payment history before clearing state
             // If user initiated close, mark pending until on-chain confirms.
             // If force-closed by counterparty, mark completed immediately.
-            val closeTxid = fundingTxid
-            val paymentId = closeTxid ?: channelId
+            // Use channelId as paymentId to avoid collision with splice txids.
+            // Set txid to null — the close txid is not available from LDK event.
+            val paymentId = channelId
             val initialStatus = if (isChannelClosing) {
                 pendingClosePaymentId = paymentId
                 "pending"
@@ -483,7 +484,7 @@ class AppState(private val context: Context) : ViewModel() {
                 btcPrice = if (price > 0) price else null,
                 counterparty = sc.counterparty.ifEmpty { null },
                 status = initialStatus,
-                txid = closeTxid
+                txid = null
             )
 
             databaseService?.deleteChannel(sc.userChannelId)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.stablechannels.app.models.*
 import com.stablechannels.app.push.FCMService
 import com.stablechannels.app.push.StabilityProcessingService
+import com.stablechannels.app.services.CloseTxidResolver
 import com.stablechannels.app.services.*
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.usdFormatted
@@ -486,6 +487,25 @@ class AppState(private val context: Context) : ViewModel() {
                 status = initialStatus,
                 txid = null
             )
+
+            // Start background resolver to find the close TX
+            val closeFundingTxid = fundingTxid
+            if (closeFundingTxid != null && databaseService != null) {
+                val resolver = CloseTxidResolver(
+                    chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
+                    onResolved = { _, txid ->
+                        Log.d("AppState", "Close TX resolved: $txid")
+                    }
+                )
+                viewModelScope.launch(Dispatchers.IO) {
+                    resolver.resolve(
+                        paymentId = paymentId,
+                        fundingTxid = closeFundingTxid,
+                        vout = 0,
+                        databaseService = databaseService!!
+                    )
+                }
+            }
 
             databaseService?.deleteChannel(sc.userChannelId)
             _stableChannel.value = StableChannel.DEFAULT

--- a/android/app/src/main/java/com/stablechannels/app/services/CloseTxidResolver.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/CloseTxidResolver.kt
@@ -1,0 +1,103 @@
+package com.stablechannels.app.services
+
+import android.util.Log
+import kotlinx.coroutines.*
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * Polls Esplora /tx/{fundingTxid}/outspend/{vout} to resolve the close
+ * transaction ID for a force-closed channel. Runs in background until
+ * the close TX is found or budget expires.
+ */
+class CloseTxidResolver(
+    private val chainURLs: List<String>,
+    private val onResolved: (paymentId: String, closeTxid: String) -> Unit
+) {
+    companion object {
+        private const val TAG = "CloseTxidResolver"
+        private const val MAX_ATTEMPTS = 20
+        private val BACKOFF_SECONDS = listOf(5L, 10L, 15L, 30L, 60L, 60L, 60L, 60L, 60L, 60L)
+    }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build()
+
+    /**
+     * Start polling for the close TX. Call from a coroutine scope.
+     * @param paymentId The payment ID to update when resolved
+     * @param fundingTxid The funding transaction ID of the channel
+     * @param vout The output index of the funding transaction
+     * @param databaseService The database service to update the payment
+     */
+    suspend fun resolve(
+        paymentId: String,
+        fundingTxid: String,
+        vout: Int,
+        databaseService: DatabaseService
+    ) = withContext(Dispatchers.IO) {
+        Log.d(TAG, "Starting close TX resolution for paymentId=$paymentId, fundingTxid=$fundingTxid:$vout")
+
+        for (attempt in 0 until MAX_ATTEMPTS) {
+            try {
+                val closeTxid = pollForCloseTx(fundingTxid, vout)
+                if (closeTxid != null) {
+                    Log.d(TAG, "Close TX resolved: $closeTxid (attempt ${attempt + 1})")
+                    databaseService.updatePaymentTxid(paymentId, closeTxid)
+                    onResolved(paymentId, closeTxid)
+                    return@withContext
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Attempt ${attempt + 1} failed: ${e.message}")
+            }
+
+            // Backoff before retry
+            val delaySec = BACKOFF_SECONDS.getOrElse(attempt) { 60L }
+            Log.d(TAG, "Waiting ${delaySec}s before retry...")
+            delay(delaySec * 1000)
+        }
+
+        Log.w(TAG, "Close TX resolution failed after $MAX_ATTEMPTS attempts")
+    }
+
+    /**
+     * Poll a single Esplora endpoint for the close TX.
+     * @return The close TX if found, null otherwise
+     */
+    private fun pollForCloseTx(fundingTxid: String, vout: Int): String? {
+        for (baseURL in chainURLs) {
+            try {
+                val url = "${baseURL.trimEnd('/')}/tx/$fundingTxid/outspend/$vout"
+                val request = Request.Builder().url(url).build()
+                val response = client.newCall(request).execute()
+                val body = response.body?.string() ?: continue
+
+                if (!response.isSuccessful) continue
+
+                val json = JSONObject(body)
+                val spent = json.optBoolean("spent", false)
+
+                if (spent) {
+                    val txid = json.optString("txid", "")
+                    if (txid.isNotEmpty() && isValidTxid(txid)) {
+                        return txid
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to poll $baseURL: ${e.message}")
+            }
+        }
+        return null
+    }
+
+    /**
+     * Validate a transaction ID (64 hex characters).
+     */
+    private fun isValidTxid(txid: String): Boolean {
+        return txid.length == 64 && txid.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -263,6 +263,13 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
     }
 
+    fun updatePaymentTxid(paymentId: String, txid: String) {
+        val cv = ContentValues().apply {
+            put("txid", txid)
+        }
+        writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
+    }
+
     fun setPendingSpliceTxid(txid: String) {
         writableDatabase.execSQL(
             "UPDATE payments SET txid = ?, status = 'completed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status = 'pending' ORDER BY created_at DESC LIMIT 1)",


### PR DESCRIPTION
## Problem

1. Channel close payments had the same txid and payment_id as a previous splice out (confusing)
2. Close txid was not available from LDK's `ChannelClosed` event

## Solution

### Payment ID Fix
- Changed `paymentId` from `fundingTxid` to `channelId` — unique per channel, no collision with splice txids

### Close TX Resolution (inspired by iOS PR #118)
- Created `CloseTxidResolver` — polls Esplora `/tx/{fundingTxid}/outspend/{vout}` to find the close transaction
- When close TX is found, updates the payment with the real txid
- Runs in background with exponential backoff (5s → 10s → 15s → 30s → 60s...)
- Falls back to two chain URLs for reliability

### Database
- Added `updatePaymentTxid()` method to update payment txid after resolution

## How It Works

1. Channel closes → payment recorded with `txid = null`
2. `CloseTxidResolver` starts polling Esplora
3. When funding output is spent → extracts close txid
4. Updates payment with real close txid
5. User sees correct txid in payment history

## Files Changed
- `CloseTxidResolver.kt` — new file, Esplora polling logic
- `DatabaseService.kt` — added `updatePaymentTxid()`
- `AppState.kt` — integrated resolver into `handleChannelClosed()`
