### PR TITLE
fix(android): UI refresh issues and chain URL fallback

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -149,10 +149,8 @@ class AppState(private val context: Context) : ViewModel() {
                 loadChannelFromDB()
                 priceService.startAutoRefresh()
 
-                // Resolve best esplora endpoint in parallel
-                launch {
-                    chainUrl = resolveChainUrl()
-                }
+                // Resolve best esplora endpoint before starting node
+                chainUrl = resolveChainUrl()
 
                 // Subscribe to LDK events
                 launch { nodeService.events.collect { handleEvent(it) } }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -254,10 +254,10 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     btcPrice = btcPrice,
                     modifier = Modifier.padding(horizontal = 24.dp),
                     onDragStarted = { appState.ensureLSPConnected() },
-                    onTradeRequest = { direction, amountUSD ->
+                    onTradeRequest = if (hasReadyChannel) { direction, amountUSD ->
                         prefillTradeAmount = amountUSD
                         if (direction == TradeDirection.BUY) showBuy = true else showSell = true
-                    }
+                    } else null
                 )
                 Spacer(Modifier.height(16.dp))
             }
@@ -386,8 +386,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("USD → BTC", Icons.Default.ArrowCircleUp, Color(0xFFF59E0B), Modifier.weight(1f), rotation = 45f) { showBuy = true }
-                ActionButton("BTC → USD", Icons.Default.ArrowCircleDown, Color(0xFF8B5CF6), Modifier.weight(1f), rotation = -45f) { showSell = true }
+                ActionButton("USD → BTC", Icons.Default.ArrowCircleUp, Color(0xFFF59E0B), Modifier.weight(1f), rotation = 45f, enabled = hasReadyChannel) { showBuy = true }
+                ActionButton("BTC → USD", Icons.Default.ArrowCircleDown, Color(0xFF8B5CF6), Modifier.weight(1f), rotation = -45f, enabled = hasReadyChannel) { showSell = true }
             }
 
             // Status capsule
@@ -444,15 +444,18 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modifier = Modifier, rotation: Float = 0f, pulse: Boolean = false, onClick: () -> Unit) {
+fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modifier = Modifier, rotation: Float = 0f, pulse: Boolean = false, enabled: Boolean = true, onClick: () -> Unit) {
     Box(modifier = modifier.height(56.dp).clip(RoundedCornerShape(12.dp))) {
         FilledTonalButton(
             onClick = onClick,
             modifier = Modifier.fillMaxSize(),
             shape = RoundedCornerShape(12.dp),
+            enabled = enabled,
             colors = ButtonDefaults.filledTonalButtonColors(
                 containerColor = color.copy(alpha = if (isSystemInDarkTheme()) 0.1f else 0.15f),
-                contentColor = color
+                contentColor = color,
+                disabledContainerColor = color.copy(alpha = 0.05f),
+                disabledContentColor = color.copy(alpha = 0.3f)
             )
         ) {
             Icon(icon, contentDescription = title, modifier = Modifier.size(20.dp).rotate(rotation))

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -144,10 +144,15 @@ fun ChannelView(appState: AppState) {
                 TextButton(onClick = {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
+                    appState.setStatus("Closing channel...")
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)
-                        } catch (_: Exception) {}
+                            appState.refreshBalances()
+                        } catch (e: Exception) {
+                            appState.setStatus("Close failed: ${e.message}")
+                            appState.isChannelClosing = false
+                        }
                     }
                 }) { Text("Close", color = MaterialTheme.colorScheme.error) }
             },

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -300,6 +300,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         btcPrice = if (price > 0) price else null,
                                         txid = txid, address = addr
                                     )
+                                    appState.refreshBalances()
                                     result = "Sent successfully."
                                     successTxid = txid
                                 }


### PR DESCRIPTION
## Issues Fixed

### 1. Balance not refreshed after on-chain send
- After sending on-chain, total balance still showed old amount
- Added `appState.refreshBalances()` after successful send in `OnChainScreen.kt`

### 2. Slider/orders allowed without channel
- Buy/Sell buttons and slider were always enabled, even without a channel
- Added `enabled = hasReadyChannel` to Buy/Sell ActionButtons
- Pass `null` for `onTradeRequest` when no channel (disables slider interaction)

### 3. No feedback on channel close
- After clicking "Close Channel", page was static with no feedback
- Added `setStatus("Closing channel...")` when close is initiated
- Added `refreshBalances()` after successful close
- Added error handling with `setStatus("Close failed: ...")` on failure

### 4. Chain URL fallback not working
- `resolveChainUrl()` was running in parallel, so node started with default URL before fallback was determined
- Changed to resolve chain URL before starting node
- If blockstream.info is unreachable, node now uses mempool.space from the start

## Files Changed
- `HomeScreen.kt` — disabled Buy/Sell buttons and slider when no channel
- `OnChainScreen.kt` — added balance refresh after send
- `ChannelView.kt` — added close feedback and error handling
- `AppState.kt` — resolve chain URL before starting node
