### PR TITLE
fix(android): deduct from BTC first when sending payments

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -3,6 +3,7 @@ package com.stablechannels.app.ui.transfer
 import android.content.ContextWrapper
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
+import com.stablechannels.app.services.StabilityService
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -488,6 +489,9 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             actualMsat = manualAmountMsat
                                             paymentId = appState.nodeService.sendPaymentUsingAmount(invoice, actualMsat)
                                         }
+                                        // Deduct from native (BTC) first, then USD if needed
+                                        val actualSats = actualMsat / 1000
+                                        StabilityService.deductOutgoing(appState.stableChannel.value, actualSats, price)
                                         appState.databaseService?.recordPayment(
                                             paymentId = paymentId, paymentType = "lightning",
                                             direction = "sent", amountMsat = actualMsat,


### PR DESCRIPTION
## Problem

When sending a payment, the app was deducting from the USD (stable) side instead of the BTC (native) side first. This happened because `deductOutgoing` (which takes from BTC first) was never called. Instead, `reconcileOutgoing` ran AFTER the payment and deducted from USD.

## Fix

Added `StabilityService.deductOutgoing()` call BEFORE the payment is sent in `SendScreen.kt`. This ensures:
- Native (BTC) balance is used first
- Only the overflow (if payment > native balance) comes from USD
- `reconcileOutgoing` still runs after payment to reconcile any remaining differences

## Files Changed
- `SendScreen.kt` — added `deductOutgoing` call before payment
