### PR TITLE
fix(android): channel close UI feedback and prevent duplicate payment entries

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -587,14 +587,25 @@ class AppState(private val context: Context) : ViewModel() {
                 return
             }
             val price = priceService.currentPrice.value
-            val dedupId = "${System.currentTimeMillis() / 1000}_$depositSats"
-            databaseService?.recordPayment(
-                paymentId = dedupId, paymentType = "onchain", direction = "received",
-                amountMsat = depositSats * 1000,
-                amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                btcPrice = price
-            )
-            AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf("sats" to depositSats))
+
+            // Check for pending channel close (in-memory or DB) to avoid duplicate entries
+            val closeId = pendingClosePaymentId
+                ?: databaseService?.getPendingChannelClosePaymentId()
+            if (closeId != null) {
+                databaseService?.updatePaymentStatus(closeId, "completed")
+                pendingClosePaymentId = null
+                AuditService.log("CHANNEL_CLOSE_CONFIRMED", mapOf("sats" to depositSats))
+            } else {
+                // No pending close — record as new on-chain deposit
+                val dedupId = "${System.currentTimeMillis() / 1000}_$depositSats"
+                databaseService?.recordPayment(
+                    paymentId = dedupId, paymentType = "onchain", direction = "received",
+                    amountMsat = depositSats * 1000,
+                    amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
+                    btcPrice = price
+                )
+                AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf("sats" to depositSats))
+            }
             // Start faster polling until deposit confirms
             startPendingDepositPolling()
         }
@@ -721,12 +732,10 @@ class AppState(private val context: Context) : ViewModel() {
         _spendableOnchainSats.value = balances.spendableOnchainBalanceSats.toLong()
 
         // Clear closing flag once lightning balance fully resolves
+        // Don't clear pendingClosePaymentId here — let detectOnchainDeposit()
+        // handle it when the on-chain funds arrive
         if (isChannelClosing && lightning == 0L) {
             isChannelClosing = false
-            pendingClosePaymentId?.let {
-                databaseService?.updatePaymentStatus(it, "completed")
-                pendingClosePaymentId = null
-            }
         }
 
         _totalBalanceSats.value = when {

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -270,6 +270,14 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
     }
 
+    fun getPendingChannelClosePaymentId(): String? {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT payment_id FROM payments WHERE payment_type = 'channel_close' AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
+            null
+        )
+        return cursor.use { if (it.moveToFirst()) it.getString(0) else null }
+    }
+
     fun setPendingSpliceTxid(txid: String) {
         writableDatabase.execSQL(
             "UPDATE payments SET txid = ?, status = 'completed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status = 'pending' ORDER BY created_at DESC LIMIT 1)",

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -33,7 +33,7 @@ fun ChannelView(appState: AppState) {
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        if (channels.isNotEmpty()) {
+        if (channels.isNotEmpty() && !appState.isChannelClosing) {
             val ch = channels.first()
 
             // Status with colored dot
@@ -119,6 +119,30 @@ fun ChannelView(appState: AppState) {
                 ) {
                     Text("Close Channel")
                 }
+            }
+        } else if (appState.isChannelClosing) {
+            // Channel is closing — show status
+            Spacer(Modifier.height(32.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp),
+                    color = Color(0xFFF59E0B)
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "Closing channel...",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Funds will be swept to your on-chain wallet",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         } else {
             Text(


### PR DESCRIPTION
## Issues Fixed

### 1. No UI feedback on channel close
- After clicking "Close Channel", dialog closed with no feedback
- Added "Closing channel..." screen with spinner and explanatory text
- Shows while close is in progress, hides when done

### 2. Duplicate payment entries after channel close
- Channel close created "pending" payment
- On-chain deposit detection created separate "completed" payment
- User saw two entries for same funds
- **Fix:** If pending close exists, update it to "completed" instead of creating new entry

## Files Changed
- `ChannelView.kt` — added closing state UI with spinner
- `AppState.kt` — check for pending close before creating new deposit entry
