### PR TITLE
Stable-book sync fix + LSP operator GUI revamp

### DIFF
--- a/server/lsp-server-gui/Cargo.toml
+++ b/server/lsp-server-gui/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.4.0"
 
 # Native-only dependencies
 tokio = { version = "1.38.0", features = ["rt-multi-thread", "sync"], optional = true }
-rfd = { version = "0.15", optional = true }
+rfd = { version = "0.15", optional = true, default-features = false, features = ["gtk3"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
@@ -35,4 +35,4 @@ log = { version = "0.4", optional = true }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow", "persistence"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
+eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow", "persistence"] }

--- a/server/lsp-server-gui/src/app.rs
+++ b/server/lsp-server-gui/src/app.rs
@@ -17,9 +17,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	SpliceInRequest, SpliceOutRequest, SpontaneousSendRequest, UpdateChannelConfigRequest,
 	VerifySignatureRequest,
 };
-use sc_rest_client::sc_protos::stable::{
-	EditStableChannelRequest, GetPriceRequest, ListStableChannelsRequest, LogRequest,
-};
+use sc_rest_client::sc_protos::stable::{GetPriceRequest, ListStableChannelsRequest, LogRequest};
 use sc_rest_client::ldk_server_grpc::types::{
 	bolt11_invoice_description, Bolt11InvoiceDescription, ChannelConfig,
 };
@@ -32,6 +30,30 @@ use crate::state::{ActiveTab, AppState, ConnectionStatus, StatusMessage};
 use crate::task;
 use crate::ui;
 
+fn install_theme(ctx: &egui::Context) {
+    const AMBER: egui::Color32 = egui::Color32::from_rgb(0xF7, 0x93, 0x1A); // bitcoin orange
+    let mut visuals = egui::Visuals::dark();
+    visuals.selection.bg_fill = egui::Color32::from_rgb(0x4A, 0x39, 0x14);
+    visuals.selection.stroke = egui::Stroke::new(1.0, AMBER);
+    visuals.hyperlink_color = AMBER;
+    visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0, AMBER);
+    visuals.widgets.hovered.expansion = 0.0;
+    visuals.widgets.active.expansion = 0.0;
+    let rounding = egui::Rounding::same(6.0);
+    visuals.widgets.noninteractive.rounding = rounding;
+    visuals.widgets.inactive.rounding = rounding;
+    visuals.widgets.hovered.rounding = rounding;
+    visuals.widgets.active.rounding = rounding;
+    visuals.window_rounding = egui::Rounding::same(8.0);
+    ctx.set_visuals(visuals);
+
+    let mut style = (*ctx.style()).clone();
+    style.spacing.item_spacing = egui::vec2(8.0, 8.0);
+    style.spacing.button_padding = egui::vec2(8.0, 4.0);
+    ctx.set_style(style);
+    ctx.set_pixels_per_point(1.1);
+}
+
 pub struct LspServerApp {
 	pub state: AppState,
 	#[cfg(not(target_arch = "wasm32"))]
@@ -39,9 +61,10 @@ pub struct LspServerApp {
 }
 
 impl LspServerApp {
-	pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+	pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+		install_theme(&cc.egui_ctx);
 		#[cfg(not(target_arch = "wasm32"))]
-		let state = {
+		let mut state = {
 			let mut state = AppState::default();
 			// Try to load config from file and populate connection settings
 			if let Some(gui_config) = config::find_and_load_config() {
@@ -57,7 +80,18 @@ impl LspServerApp {
 		};
 
 		#[cfg(target_arch = "wasm32")]
-		let state = AppState::default();
+		let mut state = AppState::default();
+
+		if let Some(storage) = cc.storage {
+			if let Some(u) = eframe::get_value::<crate::state::DisplayUnit>(storage, "display_unit") {
+				state.display_unit = u;
+			}
+		}
+
+		// First launch with no connection to auto-attempt: land on Settings so connecting is obvious.
+		if !state.auto_connect_pending {
+			state.active_tab = ActiveTab::Settings;
+		}
 
 		Self {
 			state,
@@ -98,6 +132,7 @@ impl LspServerApp {
 					self.fetch_node_info();
 					self.fetch_balances();
 					self.fetch_channels();
+					self.fetch_price();
 				},
 				Err(e) => {
 					self.state.connection_status = ConnectionStatus::Error(e.clone());
@@ -123,6 +158,7 @@ impl LspServerApp {
 					self.fetch_node_info();
 					self.fetch_balances();
 					self.fetch_channels();
+					self.fetch_price();
 				},
 				Err(e) => {
 					self.state.connection_status = ConnectionStatus::Error(e.clone());
@@ -139,7 +175,7 @@ impl LspServerApp {
 		self.state.balances = None;
 		self.state.channels = None;
 		self.state.payments = None;
-		self.state.status_message = Some(StatusMessage::success("Disconnected"));
+		self.state.status_message = Some(StatusMessage::error("Disconnected"));
 	}
 
 	/// Spawns an async task using the appropriate runtime for the platform
@@ -288,7 +324,7 @@ impl LspServerApp {
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.onchain_send;
 			let address = form.address.trim().to_string();
-			let amount_sats = form.amount_sats.trim().parse::<u64>().ok();
+			let amount_sats = self.parse_amount_sats(&form.amount_sats);
 			let send_all = if form.send_all { Some(true) } else { None };
 			let fee_rate = form.fee_rate_sat_per_vb.trim().parse::<u64>().ok();
 
@@ -318,7 +354,7 @@ impl LspServerApp {
 		}
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.bolt11_receive;
-			let amount_msat = form.amount_msat.trim().parse::<u64>().ok();
+			let amount_msat = self.parse_amount_msat(&form.amount_msat);
 			let description = form.description.trim().to_string();
 			let expiry_secs = form.expiry_secs.trim().parse::<u32>().unwrap_or(86400);
 
@@ -351,7 +387,7 @@ impl LspServerApp {
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.bolt11_send;
 			let invoice = form.invoice.trim().to_string();
-			let amount_msat = form.amount_msat.trim().parse::<u64>().ok();
+			let amount_msat = self.parse_amount_msat(&form.amount_msat);
 
 			if invoice.is_empty() {
 				self.state.status_message = Some(StatusMessage::error("Invoice is required"));
@@ -375,7 +411,7 @@ impl LspServerApp {
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.bolt12_receive;
 			let description = form.description.trim().to_string();
-			let amount_msat = form.amount_msat.trim().parse::<u64>().ok();
+			let amount_msat = self.parse_amount_msat(&form.amount_msat);
 			let expiry_secs = form.expiry_secs.trim().parse::<u32>().ok();
 			let quantity = form.quantity.trim().parse::<u64>().ok();
 
@@ -406,7 +442,7 @@ impl LspServerApp {
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.bolt12_send;
 			let offer = form.offer.trim().to_string();
-			let amount_msat = form.amount_msat.trim().parse::<u64>().ok();
+			let amount_msat = self.parse_amount_msat(&form.amount_msat);
 			let quantity = form.quantity.trim().parse::<u64>().ok();
 			let payer_note = if form.payer_note.trim().is_empty() {
 				None
@@ -443,16 +479,16 @@ impl LspServerApp {
 			let form = &self.state.forms.open_channel;
 			let node_pubkey = form.node_pubkey.trim().to_string();
 			let address = form.address.trim().to_string();
-			let channel_amount_sats = match form.channel_amount_sats.trim().parse::<u64>() {
-				Ok(v) => v,
-				Err(_) => {
+			let channel_amount_sats = match self.parse_amount_sats(&form.channel_amount_sats) {
+				Some(v) => v,
+				None => {
 					self.state.status_message =
 						Some(StatusMessage::error("Invalid channel amount"));
 					return;
 				},
 			};
 			let push_to_counterparty_msat =
-				form.push_to_counterparty_msat.trim().parse::<u64>().ok();
+				self.parse_amount_msat(&form.push_to_counterparty_msat);
 			let announce_channel = form.announce_channel;
 
 			let channel_config = build_channel_config(
@@ -552,9 +588,9 @@ impl LspServerApp {
 			let form = &self.state.forms.splice_in;
 			let user_channel_id = form.user_channel_id.trim().to_string();
 			let counterparty_node_id = form.counterparty_node_id.trim().to_string();
-			let splice_amount_sats = match form.splice_amount_sats.trim().parse::<u64>() {
-				Ok(v) => v,
-				Err(_) => {
+			let splice_amount_sats = match self.parse_amount_sats(&form.splice_amount_sats) {
+				Some(v) => v,
+				None => {
 					self.state.status_message = Some(StatusMessage::error("Invalid splice amount"));
 					return;
 				},
@@ -588,9 +624,9 @@ impl LspServerApp {
 			let form = &self.state.forms.splice_out;
 			let user_channel_id = form.user_channel_id.trim().to_string();
 			let counterparty_node_id = form.counterparty_node_id.trim().to_string();
-			let splice_amount_sats = match form.splice_amount_sats.trim().parse::<u64>() {
-				Ok(v) => v,
-				Err(_) => {
+			let splice_amount_sats = match self.parse_amount_sats(&form.splice_amount_sats) {
+				Some(v) => v,
+				None => {
 					self.state.status_message = Some(StatusMessage::error("Invalid splice amount"));
 					return;
 				},
@@ -717,36 +753,6 @@ impl LspServerApp {
 		}
 	}
 
-	pub fn edit_stable_channel(&mut self) {
-		if self.state.tasks.edit_stable_channel.is_some() {
-			return;
-		}
-		if let Some(client) = &self.state.client {
-			let form = &self.state.forms.edit_stable_channel;
-			let channel_id = form.channel_id.trim().to_string();
-			let expected_usd = form.expected_usd.trim().parse::<f64>().ok();
-			let note =
-				if form.note.trim().is_empty() { None } else { Some(form.note.trim().to_string()) };
-
-			if channel_id.is_empty() {
-				self.state.status_message = Some(StatusMessage::error("Channel ID is required"));
-				return;
-			}
-
-			let client = client.clone();
-			self.state.tasks.edit_stable_channel = Some(self.spawn_task(async move {
-				client
-					.edit_stable_channel(EditStableChannelRequest {
-						channel_id,
-						expected_usd,
-						note,
-					})
-					.await
-					.map_err(|e| e.to_string())
-			}));
-		}
-	}
-
 	pub fn disconnect_peer(&mut self, node_pubkey: String) {
 		if self.state.tasks.disconnect_peer.is_some() {
 			return;
@@ -768,9 +774,9 @@ impl LspServerApp {
 		}
 		if let Some(client) = &self.state.client {
 			let form = &self.state.forms.spontaneous_send;
-			let amount_msat = match form.amount_msat.trim().parse::<u64>() {
-				Ok(v) => v,
-				Err(_) => {
+			let amount_msat = match self.parse_amount_msat(&form.amount_msat) {
+				Some(v) => v,
+				None => {
 					self.state.status_message = Some(StatusMessage::error("Invalid amount"));
 					return;
 				},
@@ -930,6 +936,53 @@ impl LspServerApp {
 		}
 	}
 
+	/// Shared connection gate: when not connected, render the "not connected" state (Open
+	/// Settings / Retry) and return true so the caller short-circuits. Returns false when connected.
+	pub fn render_disconnected_gate(&mut self, ui: &mut egui::Ui) -> bool {
+		if matches!(self.state.connection_status, ConnectionStatus::Connected) {
+			return false;
+		}
+		match ui::widgets::not_connected(ui, &self.state.connection_status, &self.state.server_url) {
+			ui::widgets::NotConnectedAction::OpenSettings => self.state.active_tab = ActiveTab::Settings,
+			ui::widgets::NotConnectedAction::Retry => self.connect(),
+			ui::widgets::NotConnectedAction::None => {},
+		}
+		true
+	}
+
+	pub fn fmt_sats(&self, sats: u64) -> String {
+		ui::format_amount_sats(sats, self.state.display_unit, self.state.price.as_ref().map(|p| p.price))
+	}
+	pub fn fmt_msat(&self, msat: u64) -> String {
+		ui::format_amount_msat(msat, self.state.display_unit, self.state.price.as_ref().map(|p| p.price))
+	}
+
+	fn price_value(&self) -> Option<f64> {
+		self.state.price.as_ref().map(|p| p.price)
+	}
+	/// Parse an amount the user typed in the active display unit into sats.
+	pub fn parse_amount_sats(&self, input: &str) -> Option<u64> {
+		ui::parse_amount_to_sats(input, self.state.display_unit, self.price_value())
+	}
+	/// Same, scaled to msats for the Lightning APIs.
+	pub fn parse_amount_msat(&self, input: &str) -> Option<u64> {
+		ui::parse_amount_to_msat(input, self.state.display_unit, self.price_value())
+	}
+	/// Preview line under an amount field: the sats that will actually be sent
+	/// (USD/BTC modes), or the ≈USD value (sats mode); None if unparseable.
+	pub fn amount_entry_preview(&self, input: &str) -> Option<String> {
+		let sats = self.parse_amount_sats(input)?;
+		match self.state.display_unit {
+			crate::state::DisplayUnit::Sats => match self.price_value() {
+				Some(p) if p > 0.0 => {
+					Some(format!("≈ {}", ui::format_amount_sats(sats, crate::state::DisplayUnit::Usd, self.price_value())))
+				},
+				_ => None,
+			},
+			_ => Some(format!("= {} sats", ui::format_sats(sats))),
+		}
+	}
+
 	fn poll_tasks(&mut self, _ctx: &egui::Context) {
 		macro_rules! poll_task {
 			($task:expr => |$val:ident| $handler:expr) => {
@@ -962,7 +1015,18 @@ impl LspServerApp {
 
 		poll_task!(self.state.tasks.payments => |v| {
 			self.state.payments_page_token = v.next_page_token.clone();
-			self.state.payments = Some(v);
+			if self.state.payments_appending {
+				// "Load More": append this page to the existing list (an empty page is a no-op).
+				if let Some(existing) = self.state.payments.as_mut() {
+					existing.payments.extend(v.payments);
+					existing.next_page_token = v.next_page_token;
+				} else {
+					self.state.payments = Some(v);
+				}
+			} else {
+				self.state.payments = Some(v);
+			}
+			self.state.payments_appending = false;
 		});
 
 		poll_task!(self.state.tasks.peers => |v| {
@@ -1064,22 +1128,27 @@ impl LspServerApp {
 			self.state.show_connect_peer_dialog = false;
 		});
 
-		poll_task!(self.state.tasks.get_price => |v| {
-			self.state.price = Some(v);
-		});
+		// The 5s price poll doubles as a connectivity heartbeat: a successful GetPrice means the
+		// LSP is reachable, an error means it is not — so the status badge reflects reality, not
+		// just whether the client object was built. Recovers automatically when the LSP returns.
+		if let Some(t) = &mut self.state.tasks.get_price {
+			if let Some(res) = t.try_take() {
+				self.state.tasks.get_price = None;
+				match res {
+					Ok(v) => {
+						self.state.price = Some(v);
+						self.state.connection_status = ConnectionStatus::Connected;
+					},
+					Err(e) => {
+						self.state.connection_status =
+							ConnectionStatus::Error(format!("LSP unreachable: {}", e));
+					},
+				}
+			}
+		}
 
 		poll_task!(self.state.tasks.list_stable_channels => |v| {
 			self.state.stable_channels = Some(v);
-		});
-
-		poll_task!(self.state.tasks.edit_stable_channel => |v| {
-			if v.ok {
-				self.state.status_message = Some(StatusMessage::success(v.status));
-			} else {
-				self.state.status_message = Some(StatusMessage::error(v.status));
-			}
-			self.state.forms.edit_stable_channel = Default::default();
-			self.fetch_stable_channels();
 		});
 
 		poll_task!(self.state.tasks.disconnect_peer => |_v| {
@@ -1152,6 +1221,10 @@ fn build_channel_config(fee_prop: &str, fee_base: &str, cltv: &str) -> Option<Ch
 }
 
 impl App for LspServerApp {
+	fn save(&mut self, storage: &mut dyn eframe::Storage) {
+		eframe::set_value(storage, "display_unit", &self.state.display_unit);
+	}
+
 	fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
 		self.poll_tasks(ctx);
 
@@ -1161,41 +1234,59 @@ impl App for LspServerApp {
 			self.connect();
 		}
 
-		if self.state.tasks.any_pending() {
-			ctx.request_repaint_after(Duration::from_millis(100));
+		if self.state.client.is_some() && self.state.tasks.get_price.is_none() {
+			let now = ctx.input(|i| i.time);
+			if now - self.state.last_price_fetch > 5.0 {
+				self.state.last_price_fetch = now;
+				self.fetch_price();
+			}
+		}
+
+		// Keep repainting while connected so the periodic price refresh fires even when idle.
+		if self.state.client.is_some() {
+			ctx.request_repaint_after(Duration::from_secs(1));
 		}
 
 		egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
 			ui.horizontal(|ui| {
-				ui.heading("LSP Server GUI");
+				ui.heading("LSP Server");
 				ui.separator();
 				ui::connection::render_status(ui, &self.state);
+				ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+					let mut unit = self.state.display_unit;
+					ui.selectable_value(&mut unit, crate::state::DisplayUnit::Sats, "Sats");
+					ui.selectable_value(&mut unit, crate::state::DisplayUnit::Btc, "BTC");
+					ui.selectable_value(&mut unit, crate::state::DisplayUnit::Usd, "USD");
+					self.state.display_unit = unit;
+					ui.separator();
+					match &self.state.price {
+						Some(p) if p.price > 0.0 => { ui.weak(format!("${:.0}/BTC", p.price)); }
+						_ => { ui.weak("price --"); }
+					}
+				});
 			});
 		});
 
-		egui::SidePanel::left("nav_panel").resizable(false).default_width(140.0).show(ctx, |ui| {
+		egui::SidePanel::left("nav_panel").resizable(true).default_width(160.0).show(ctx, |ui| {
+			egui::ScrollArea::vertical().show(ui, |ui| {
 			ui.add_space(10.0);
 			ui.heading("Navigation");
 			ui.separator();
 
-			let tabs = [
-				(ActiveTab::NodeInfo, "Node Info"),
-				(ActiveTab::Balances, "Balances"),
-				(ActiveTab::Channels, "Channels"),
-				(ActiveTab::Peers, "Peers"),
-				(ActiveTab::Payments, "Payments"),
-				(ActiveTab::ForwardedPayments, "Forwarded"),
-				(ActiveTab::Lightning, "Lightning"),
-				(ActiveTab::Onchain, "On-chain"),
-				(ActiveTab::StableChannels, "Stable"),
-				(ActiveTab::Tools, "Tools"),
-				(ActiveTab::NetworkGraph, "Graph"),
-				(ActiveTab::Logs, "Logs"),
+			let groups: [(&str, &[(ActiveTab, &str)]); 5] = [
+				("Overview", &[(ActiveTab::NodeInfo, "🏠 Node Info"), (ActiveTab::Balances, "💰 Balances")]),
+				("Lightning", &[(ActiveTab::Channels, "🔗 Channels"), (ActiveTab::StableChannels, "📈 Stable"), (ActiveTab::Peers, "👥 Peers"), (ActiveTab::Lightning, "⚡ Lightning"), (ActiveTab::Payments, "🧾 Payments"), (ActiveTab::ForwardedPayments, "↪ Forwarded")]),
+				("On-chain", &[(ActiveTab::Onchain, "⛓ On-chain")]),
+				("Network", &[(ActiveTab::NetworkGraph, "🌐 Graph")]),
+				("System", &[(ActiveTab::Tools, "🛠 Tools"), (ActiveTab::Logs, "📜 Logs"), (ActiveTab::Settings, "⚙ Settings")]),
 			];
-
-			for (tab, label) in tabs {
-				if ui.selectable_label(self.state.active_tab == tab, label).clicked() {
-					self.state.active_tab = tab;
+			for (section, items) in groups {
+				ui.add_space(6.0);
+				ui.label(egui::RichText::new(section).small().weak());
+				for (tab, label) in items {
+					if ui.selectable_label(self.state.active_tab == *tab, *label).clicked() {
+						self.state.active_tab = *tab;
+					}
 				}
 			}
 
@@ -1208,6 +1299,7 @@ impl App for LspServerApp {
 			ui.hyperlink_to("LDK Node", "https://docs.rs/ldk-node/latest/ldk_node/");
 			ui.hyperlink_to("Rust Lightning", "https://docs.rs/lightning/latest/lightning/");
 			ui.hyperlink_to("BDK", "https://docs.rs/bdk_wallet/latest/bdk_wallet/");
+			});
 		});
 
 		egui::TopBottomPanel::bottom("status_bar").show(ctx, |ui| {
@@ -1224,23 +1316,32 @@ impl App for LspServerApp {
 			});
 		});
 
-		egui::CentralPanel::default().show(ctx, |ui| match self.state.active_tab {
-			ActiveTab::NodeInfo => ui::node_info::render(ui, self),
-			ActiveTab::Balances => ui::balances::render(ui, self),
-			ActiveTab::Channels => ui::channels::render(ui, self),
-			ActiveTab::Peers => ui::peers::render(ui, self),
-			ActiveTab::Payments => ui::payments::render(ui, self),
-			ActiveTab::ForwardedPayments => ui::forwarded_payments::render(ui, self),
-			ActiveTab::Lightning => ui::lightning::render(ui, self),
-			ActiveTab::Onchain => ui::onchain::render(ui, self),
-			ActiveTab::StableChannels => ui::stable_channels::render(ui, self),
-			ActiveTab::Tools => ui::tools::render(ui, self),
-			ActiveTab::NetworkGraph => ui::network_graph::render(ui, self),
-			ActiveTab::Logs => ui::ldk_log::render(ui, self),
+		egui::CentralPanel::default().show(ctx, |ui| {
+			egui::ScrollArea::vertical().show(ui, |ui| match self.state.active_tab {
+				ActiveTab::NodeInfo => ui::node_info::render(ui, self),
+				ActiveTab::Balances => ui::balances::render(ui, self),
+				ActiveTab::Channels => ui::channels::render(ui, self),
+				ActiveTab::Peers => ui::peers::render(ui, self),
+				ActiveTab::Payments => ui::payments::render(ui, self),
+				ActiveTab::ForwardedPayments => ui::forwarded_payments::render(ui, self),
+				ActiveTab::Lightning => ui::lightning::render(ui, self),
+				ActiveTab::Onchain => ui::onchain::render(ui, self),
+				ActiveTab::StableChannels => ui::stable_channels::render(ui, self),
+				ActiveTab::Tools => ui::tools::render(ui, self),
+				ActiveTab::NetworkGraph => ui::network_graph::render(ui, self),
+				ActiveTab::Logs => ui::ldk_log::render(ui, self),
+				ActiveTab::Settings => ui::settings::render(ui, self),
+			});
 		});
 
 		ui::channels::render_dialogs(ctx, self);
 		ui::connection::render_load_config_dialog(ctx, self);
 		ui::payments::render_dialogs(ctx, self);
+
+		// A fetch spawned during this frame's render must schedule a near-term
+		// repaint, else its background result isn't polled until the next event.
+		if self.state.tasks.any_pending() {
+			ctx.request_repaint_after(Duration::from_millis(50));
+		}
 	}
 }

--- a/server/lsp-server-gui/src/state.rs
+++ b/server/lsp-server-gui/src/state.rs
@@ -17,9 +17,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	SpliceOutResponse, SpontaneousSendResponse, UpdateChannelConfigResponse,
 	VerifySignatureResponse,
 };
-use sc_rest_client::sc_protos::stable::{
-	EditStableChannelResponse, GetPriceResponse, ListStableChannelsResponse, LogResponse,
-};
+use sc_rest_client::sc_protos::stable::{GetPriceResponse, ListStableChannelsResponse, LogResponse};
 use sc_rest_client::ldk_server_grpc::types::PageToken;
 
 #[derive(Clone, PartialEq, Default)]
@@ -45,6 +43,15 @@ pub enum ActiveTab {
 	Tools,
 	NetworkGraph,
 	Logs,
+	Settings,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum DisplayUnit {
+	#[default]
+	Usd,
+	Btc,
+	Sats,
 }
 
 #[derive(Default, Clone)]
@@ -125,13 +132,6 @@ pub struct ConnectPeerForm {
 	pub node_pubkey: String,
 	pub address: String,
 	pub persist: bool,
-}
-
-#[derive(Default, Clone)]
-pub struct EditStableChannelForm {
-	pub channel_id: String,
-	pub expected_usd: String,
-	pub note: String,
 }
 
 #[derive(Default, Clone)]
@@ -242,7 +242,6 @@ pub struct Forms {
 	pub update_channel_config: UpdateChannelConfigForm,
 	pub close_channel: CloseChannelForm,
 	pub connect_peer: ConnectPeerForm,
-	pub edit_stable_channel: EditStableChannelForm,
 	pub spontaneous_send: SpontaneousSendForm,
 	pub sign_message: SignMessageForm,
 	pub verify_signature: VerifySignatureForm,
@@ -320,7 +319,6 @@ pub struct AsyncTasks {
 	pub export_pathfinding_scores: Option<ChannelTaskHandle<ExportPathfindingScoresResponse>>,
 	pub get_price: Option<ChannelTaskHandle<GetPriceResponse>>,
 	pub list_stable_channels: Option<ChannelTaskHandle<ListStableChannelsResponse>>,
-	pub edit_stable_channel: Option<ChannelTaskHandle<EditStableChannelResponse>>,
 	pub ldk_log: Option<ChannelTaskHandle<LogResponse>>,
 }
 
@@ -358,7 +356,6 @@ impl Default for AsyncTasks {
 			export_pathfinding_scores: None,
 			get_price: None,
 			list_stable_channels: None,
-			edit_stable_channel: None,
 			ldk_log: None,
 		}
 	}
@@ -397,7 +394,6 @@ impl AsyncTasks {
 			|| self.export_pathfinding_scores.is_some()
 			|| self.get_price.is_some()
 			|| self.list_stable_channels.is_some()
-			|| self.edit_stable_channel.is_some()
 			|| self.ldk_log.is_some()
 	}
 }
@@ -426,6 +422,8 @@ pub struct AppState {
 	pub channels: Option<ListChannelsResponse>,
 	pub payments: Option<ListPaymentsResponse>,
 	pub payments_page_token: Option<PageToken>,
+	// True while a "Load More" fetch is in flight, so its result appends instead of replacing.
+	pub payments_appending: bool,
 	pub peers: Option<ListPeersResponse>,
 	pub forwarded_payments: Option<ListForwardedPaymentsResponse>,
 	pub forwarded_payments_page_token: Option<PageToken>,
@@ -449,6 +447,8 @@ pub struct AppState {
 	pub forms: Forms,
 
 	// UI state
+	pub display_unit: DisplayUnit,
+	pub last_price_fetch: f64,
 	pub auto_connect_pending: bool,
 	pub status_message: Option<StatusMessage>,
 	pub show_open_channel_dialog: bool,
@@ -513,6 +513,7 @@ impl Default for AppState {
 			channels: None,
 			payments: None,
 			payments_page_token: None,
+			payments_appending: false,
 			peers: None,
 			forwarded_payments: None,
 			forwarded_payments_page_token: None,
@@ -532,6 +533,8 @@ impl Default for AppState {
 
 			forms: Forms::default(),
 
+			display_unit: DisplayUnit::default(),
+			last_price_fetch: 0.0,
 			auto_connect_pending: false,
 			status_message: None,
 			show_open_channel_dialog: false,

--- a/server/lsp-server-gui/src/ui/balances.rs
+++ b/server/lsp-server-gui/src/ui/balances.rs
@@ -1,22 +1,20 @@
 use egui::Ui;
 
 use crate::app::LspServerApp;
-use crate::state::ConnectionStatus;
 use crate::ui::format_sats;
+use crate::ui::widgets;
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("Balances");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to view balances.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
 	ui.horizontal(|ui| {
 		if app.state.tasks.balances.is_some() {
-			ui.spinner();
-			ui.label("Loading...");
+			widgets::loading_row(ui, "Loading balances...");
 		} else if ui.button("Refresh").clicked() {
 			app.fetch_balances();
 		}
@@ -24,31 +22,52 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 
 	ui.add_space(10.0);
 
+	if app.state.balances.is_none() {
+		widgets::empty_state(ui, "💰", "No balance data", "Click Refresh to load");
+		return;
+	}
+
+	// Extract headline totals into locals before borrowing state for iteration.
+	let total_onchain = app.state.balances.as_ref().map(|b| b.total_onchain_balance_sats).unwrap_or(0);
+	let spendable = app.state.balances.as_ref().map(|b| b.spendable_onchain_balance_sats).unwrap_or(0);
+	let reserve = app.state.balances.as_ref().map(|b| b.total_anchor_channels_reserve_sats).unwrap_or(0);
+	let total_lightning = app.state.balances.as_ref().map(|b| b.total_lightning_balance_sats).unwrap_or(0);
+
+	// Headline stat cards.
+	ui.horizontal(|ui| {
+		let onchain_val = app.fmt_sats(spendable);
+		let onchain_sec = format!("reserve {} | total {}", app.fmt_sats(reserve), app.fmt_sats(total_onchain));
+		widgets::stat_card(ui, "On-chain Spendable", &onchain_val, &onchain_sec);
+
+		let ln_val = app.fmt_sats(total_lightning);
+		widgets::stat_card(ui, "Lightning Total", &ln_val, "");
+	});
+
+	ui.add_space(10.0);
+
+	// Build a per-amount formatter once, before we borrow state.
+	let fmt = |sats: u64| app.fmt_sats(sats);
+
 	if let Some(balances) = &app.state.balances {
+		// On-chain detail rows.
 		ui.group(|ui| {
 			ui.heading("On-chain Balance");
 			egui::Grid::new("onchain_balance_grid").num_columns(2).spacing([10.0, 5.0]).show(
 				ui,
 				|ui| {
 					ui.label("Total:");
-					ui.monospace(format!(
-						"{} sats",
-						format_sats(balances.total_onchain_balance_sats)
-					));
+					ui.monospace(fmt(balances.total_onchain_balance_sats))
+						.on_hover_text(format!("{} sats", format_sats(balances.total_onchain_balance_sats)));
 					ui.end_row();
 
 					ui.label("Spendable:");
-					ui.monospace(format!(
-						"{} sats",
-						format_sats(balances.spendable_onchain_balance_sats)
-					));
+					ui.monospace(fmt(balances.spendable_onchain_balance_sats))
+						.on_hover_text(format!("{} sats", format_sats(balances.spendable_onchain_balance_sats)));
 					ui.end_row();
 
 					ui.label("Anchor Reserve:");
-					ui.monospace(format!(
-						"{} sats",
-						format_sats(balances.total_anchor_channels_reserve_sats)
-					));
+					ui.monospace(fmt(balances.total_anchor_channels_reserve_sats))
+						.on_hover_text(format!("{} sats", format_sats(balances.total_anchor_channels_reserve_sats)));
 					ui.end_row();
 				},
 			);
@@ -56,12 +75,10 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 
 		ui.add_space(10.0);
 
+		// Lightning detail rows.
 		ui.group(|ui| {
 			ui.heading("Lightning Balance");
-			ui.monospace(format!(
-				"Total: {} sats",
-				format_sats(balances.total_lightning_balance_sats)
-			));
+			ui.monospace(format!("Total: {}", fmt(balances.total_lightning_balance_sats)));
 
 			if !balances.lightning_balances.is_empty() {
 				ui.add_space(5.0);
@@ -74,7 +91,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 						ui.group(|ui| {
 							ui.label(format!("Balance #{}", i + 1));
 							if let Some(balance_type) = &balance.balance_type {
-								render_lightning_balance(ui, balance_type);
+								render_lightning_balance(ui, balance_type, &fmt);
 							}
 						});
 					}
@@ -98,21 +115,20 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 						ui.group(|ui| {
 							ui.label(format!("Sweep #{}", i + 1));
 							if let Some(balance_type) = &sweep.balance_type {
-								render_pending_sweep(ui, balance_type);
+								render_pending_sweep(ui, balance_type, &fmt);
 							}
 						});
 					}
 				});
 			});
 		}
-	} else {
-		ui.label("No balance data available. Click Refresh to fetch.");
 	}
 }
 
 fn render_lightning_balance(
 	ui: &mut Ui,
 	balance: &sc_rest_client::ldk_server_grpc::types::lightning_balance::BalanceType,
+	fmt: &dyn Fn(u64) -> String,
 ) {
 	use sc_rest_client::ldk_server_grpc::types::lightning_balance::BalanceType;
 
@@ -120,36 +136,36 @@ fn render_lightning_balance(
 		BalanceType::ClaimableOnChannelClose(b) => {
 			ui.label("Type: Claimable on Channel Close");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 		},
 		BalanceType::ClaimableAwaitingConfirmations(b) => {
 			ui.label("Type: Awaiting Confirmations");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("Confirmation Height: {}", b.confirmation_height));
 		},
 		BalanceType::ContentiousClaimable(b) => {
 			ui.label("Type: Contentious Claimable");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("Timeout Height: {}", b.timeout_height));
 		},
 		BalanceType::MaybeTimeoutClaimableHtlc(b) => {
 			ui.label("Type: Maybe Timeout Claimable HTLC");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("Claimable Height: {}", b.claimable_height));
 		},
 		BalanceType::MaybePreimageClaimableHtlc(b) => {
 			ui.label("Type: Maybe Preimage Claimable HTLC");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("Expiry Height: {}", b.expiry_height));
 		},
 		BalanceType::CounterpartyRevokedOutputClaimable(b) => {
 			ui.label("Type: Counterparty Revoked Output");
 			ui.label(format!("Channel: {}", crate::ui::truncate_id(&b.channel_id, 8, 8)));
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 		},
 	}
 }
@@ -157,6 +173,7 @@ fn render_lightning_balance(
 fn render_pending_sweep(
 	ui: &mut Ui,
 	balance: &sc_rest_client::ldk_server_grpc::types::pending_sweep_balance::BalanceType,
+	fmt: &dyn Fn(u64) -> String,
 ) {
 	use sc_rest_client::ldk_server_grpc::types::pending_sweep_balance::BalanceType;
 
@@ -166,14 +183,14 @@ fn render_pending_sweep(
 			if let Some(ch) = &b.channel_id {
 				ui.label(format!("Channel: {}", crate::ui::truncate_id(ch, 8, 8)));
 			}
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 		},
 		BalanceType::BroadcastAwaitingConfirmation(b) => {
 			ui.label("Type: Broadcast Awaiting Confirmation");
 			if let Some(ch) = &b.channel_id {
 				ui.label(format!("Channel: {}", crate::ui::truncate_id(ch, 8, 8)));
 			}
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("TXID: {}", crate::ui::truncate_id(&b.latest_spending_txid, 8, 8)));
 		},
 		BalanceType::AwaitingThresholdConfirmations(b) => {
@@ -181,7 +198,7 @@ fn render_pending_sweep(
 			if let Some(ch) = &b.channel_id {
 				ui.label(format!("Channel: {}", crate::ui::truncate_id(ch, 8, 8)));
 			}
-			ui.label(format!("Amount: {} sats", format_sats(b.amount_satoshis)));
+			ui.label(format!("Amount: {}", fmt(b.amount_satoshis)));
 			ui.label(format!("Confirmed at height: {}", b.confirmation_height));
 		},
 	}

--- a/server/lsp-server-gui/src/ui/channels.rs
+++ b/server/lsp-server-gui/src/ui/channels.rs
@@ -1,15 +1,17 @@
-use egui::{Context, ScrollArea, Ui};
+use egui::{Color32, Context, ScrollArea, Ui};
 
 use crate::app::LspServerApp;
-use crate::state::ConnectionStatus;
-use crate::ui::{format_msat, format_sats, truncate_id};
+use crate::ui::widgets;
+
+// Liquidity bar colors: amber = outbound (local funds), blue = inbound (remote funds).
+const OUTBOUND_COLOR: Color32 = Color32::from_rgb(0xF7, 0x93, 0x1A);
+const INBOUND_COLOR: Color32 = Color32::from_rgb(0x3D, 0x84, 0xC7);
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("Channels");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to view channels.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -34,105 +36,209 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 
 	ui.add_space(10.0);
 
-	if let Some(channels_response) = &app.state.channels {
-		let channels = &channels_response.channels;
-		if channels.is_empty() {
+	// Pre-extract per-row data into locals so the &app.state.channels borrow is
+	// released before we call app.fmt_* / borrow &mut app.state.status_message below.
+	let rows: Option<Vec<ChannelRow>> = app.state.channels.as_ref().map(|resp| {
+		resp.channels
+			.iter()
+			.map(|ch| ChannelRow {
+				channel_id: ch.channel_id.clone(),
+				counterparty_node_id: ch.counterparty_node_id.clone(),
+				user_channel_id: ch.user_channel_id.clone(),
+				funding_txid: ch.funding_txo.as_ref().map(|f| f.txid.clone()),
+				channel_value_sats: ch.channel_value_sats,
+				outbound_capacity_msat: ch.outbound_capacity_msat,
+				inbound_capacity_msat: ch.inbound_capacity_msat,
+				is_channel_ready: ch.is_channel_ready,
+				is_usable: ch.is_usable,
+			})
+			.collect()
+	});
+
+	if let Some(rows) = rows {
+		if rows.is_empty() {
 			ui.label("No channels found.");
 		} else {
-			ui.label(format!("{} channel(s)", channels.len()));
+			// Filter controls live in egui temp memory (not persisted).
+			let filter_id = ui.id().with("chan_filter");
+			let status_id = ui.id().with("chan_status");
+			let sort_id = ui.id().with("chan_sort");
+			let mut filter =
+				ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+			// status filter: -1 = all, 0 = ready, 1 = usable, 2 = pending
+			let mut status_filter =
+				ui.memory_mut(|m| m.data.get_temp::<i32>(status_id).unwrap_or(-1));
+			// sort key: (column, descending) where 0 = Capacity, 1 = Outbound, 2 = Inbound
+			let mut sort =
+				ui.memory_mut(|m| m.data.get_temp::<(u8, bool)>(sort_id).unwrap_or((0, true)));
+
+			ui.horizontal(|ui| {
+				ui.label("Filter:");
+				ui.add(
+					egui::TextEdit::singleline(&mut filter)
+						.hint_text("channel id or counterparty"),
+				);
+				egui::ComboBox::from_id_salt(status_id)
+					.selected_text(channel_status_label(status_filter))
+					.show_ui(ui, |ui| {
+						ui.selectable_value(&mut status_filter, -1, "All");
+						ui.selectable_value(&mut status_filter, 0, "Ready");
+						ui.selectable_value(&mut status_filter, 1, "Usable");
+						ui.selectable_value(&mut status_filter, 2, "Pending");
+					});
+			});
+
+			let needle = filter.trim().to_lowercase();
+			let mut view: Vec<usize> = (0..rows.len())
+				.filter(|&i| {
+					let r = &rows[i];
+					let matches_text = needle.is_empty()
+						|| r.channel_id.to_lowercase().contains(&needle)
+						|| r.counterparty_node_id.to_lowercase().contains(&needle);
+					let matches_status = match status_filter {
+						0 => r.is_channel_ready,
+						1 => r.is_usable,
+						2 => !r.is_channel_ready,
+						_ => true,
+					};
+					matches_text && matches_status
+				})
+				.collect();
+
+			// Sort the view (display ordering only; the underlying list is untouched).
+			view.sort_by(|&a, &b| {
+				let (ra, rb) = (&rows[a], &rows[b]);
+				let ord = match sort.0 {
+					1 => ra.outbound_capacity_msat.cmp(&rb.outbound_capacity_msat),
+					2 => ra.inbound_capacity_msat.cmp(&rb.inbound_capacity_msat),
+					_ => ra.channel_value_sats.cmp(&rb.channel_value_sats),
+				};
+				if sort.1 {
+					ord.reverse()
+				} else {
+					ord
+				}
+			});
+
+			ui.label(format!("{} of {} channel(s)", view.len(), rows.len()));
 			ui.add_space(5.0);
 
 			ScrollArea::both().max_height(400.0).show(ui, |ui| {
 				egui::Grid::new("channels_grid").striped(true).spacing([12.0, 6.0]).show(
 					ui,
 					|ui| {
-						// Header
+						// Header (values now carry their own unit).
 						ui.strong("Channel ID");
 						ui.strong("Counterparty");
 						ui.strong("Funding Tx");
-						ui.strong("Capacity");
-						ui.strong("Outbound");
-						ui.strong("Inbound");
+						if ui.button(sort_header("Capacity", &sort, 0)).clicked() {
+							sort = (0, if sort.0 == 0 { !sort.1 } else { true });
+						}
+						if ui.button(sort_header("Outbound", &sort, 1)).clicked() {
+							sort = (1, if sort.0 == 1 { !sort.1 } else { true });
+						}
+						if ui.button(sort_header("Inbound", &sort, 2)).clicked() {
+							sort = (2, if sort.0 == 2 { !sort.1 } else { true });
+						}
+						ui.strong("Liquidity");
 						ui.strong("Ready");
 						ui.strong("Use");
 						ui.strong("Actions");
 						ui.end_row();
 
-						for ch in channels {
+						for &i in &view {
+							let ch = &rows[i];
 							// Channel ID
-							ui.horizontal(|ui| {
-								ui.monospace(truncate_id(&ch.channel_id, 5, 4));
-								if ui.small_button("Copy").clicked() {
-									ui.output_mut(|o| o.copied_text = ch.channel_id.clone());
-								}
-							});
+							widgets::id_with_copy(
+								ui,
+								&ch.channel_id,
+								&mut app.state.status_message,
+							);
 
 							// Counterparty
-							ui.horizontal(|ui| {
-								ui.monospace(truncate_id(&ch.counterparty_node_id, 5, 4));
-								if ui.small_button("Copy").clicked() {
-									ui.output_mut(|o| {
-										o.copied_text = ch.counterparty_node_id.clone()
-									});
-								}
-							});
+							widgets::id_with_copy(
+								ui,
+								&ch.counterparty_node_id,
+								&mut app.state.status_message,
+							);
 
 							// Funding Txid
-							ui.horizontal(|ui| {
-								if let Some(ref funding_txo) = ch.funding_txo {
-									ui.monospace(truncate_id(&funding_txo.txid, 5, 4));
-									if ui.small_button("Copy").clicked() {
-										ui.output_mut(|o| o.copied_text = funding_txo.txid.clone());
-									}
-								} else {
-									ui.label("-");
-								}
-							});
+							if let Some(txid) = &ch.funding_txid {
+								widgets::id_with_copy(ui, txid, &mut app.state.status_message);
+							} else {
+								ui.label("-");
+							}
 
-							// Capacity
-							ui.label(format!("{} sats", format_sats(ch.channel_value_sats)));
+							// Capacity (unit-aware)
+							ui.label(app.fmt_sats(ch.channel_value_sats));
 
-							// Outbound capacity
-							ui.label(format_msat(ch.outbound_capacity_msat));
+							// Outbound capacity (unit-aware)
+							ui.label(app.fmt_msat(ch.outbound_capacity_msat));
 
-							// Inbound capacity
-							ui.label(format_msat(ch.inbound_capacity_msat));
+							// Inbound capacity (unit-aware)
+							ui.label(app.fmt_msat(ch.inbound_capacity_msat));
+
+							// Liquidity split bar (outbound vs inbound)
+							let total = ch.outbound_capacity_msat + ch.inbound_capacity_msat;
+							let frac = if total == 0 {
+								0.0
+							} else {
+								ch.outbound_capacity_msat as f32 / total as f32
+							};
+							let hover = format!(
+								"out {} / in {}",
+								app.fmt_msat(ch.outbound_capacity_msat),
+								app.fmt_msat(ch.inbound_capacity_msat)
+							);
+							liquidity_bar(ui, frac).on_hover_text(hover);
 
 							// Ready
-							ui.label(if ch.is_channel_ready { "Yes" } else { "No" });
+							if ch.is_channel_ready {
+								widgets::status_pill(ui, "Ready", Color32::GREEN);
+							} else {
+								widgets::status_pill(ui, "No", Color32::GRAY);
+							}
 
 							// Usable
-							ui.label(if ch.is_usable { "Yes" } else { "No" });
+							if ch.is_usable {
+								widgets::status_pill(ui, "Yes", Color32::GREEN);
+							} else {
+								widgets::status_pill(ui, "No", Color32::GRAY);
+							}
 
-							// Actions
-							ui.horizontal(|ui| {
-								if ui.small_button("Close").clicked() {
+							// Actions (collapsed into a single menu)
+							ui.menu_button("⋮", |ui| {
+								if ui.button("Close").clicked() {
 									app.state.forms.close_channel.user_channel_id =
 										ch.user_channel_id.clone();
 									app.state.forms.close_channel.counterparty_node_id =
 										ch.counterparty_node_id.clone();
 									app.state.show_close_channel_dialog = true;
+									ui.close_menu();
 								}
-								if ui.small_button("Splice+").clicked() {
+								if ui.button("Splice+").clicked() {
 									app.state.forms.splice_in.user_channel_id =
 										ch.user_channel_id.clone();
 									app.state.forms.splice_in.counterparty_node_id =
 										ch.counterparty_node_id.clone();
 									app.state.show_splice_in_dialog = true;
+									ui.close_menu();
 								}
-								if ui.small_button("Splice-").clicked() {
+								if ui.button("Splice-").clicked() {
 									app.state.forms.splice_out.user_channel_id =
 										ch.user_channel_id.clone();
 									app.state.forms.splice_out.counterparty_node_id =
 										ch.counterparty_node_id.clone();
 									app.state.show_splice_out_dialog = true;
+									ui.close_menu();
 								}
-								if ui.small_button("Config").clicked() {
+								if ui.button("Config").clicked() {
 									app.state.forms.update_channel_config.user_channel_id =
 										ch.user_channel_id.clone();
 									app.state.forms.update_channel_config.counterparty_node_id =
 										ch.counterparty_node_id.clone();
 									app.state.show_update_config_dialog = true;
+									ui.close_menu();
 								}
 							});
 
@@ -141,10 +247,70 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 					},
 				);
 			});
+
+			ui.memory_mut(|m| {
+				m.data.insert_temp(filter_id, filter);
+				m.data.insert_temp(status_id, status_filter);
+				m.data.insert_temp(sort_id, sort);
+			});
 		}
 	} else {
 		ui.label("No channel data available. Click Refresh to fetch.");
 	}
+}
+
+// Two-color liquidity bar: amber outbound (left) over a blue inbound track.
+fn liquidity_bar(ui: &mut Ui, frac: f32) -> egui::Response {
+	let frac = frac.clamp(0.0, 1.0);
+	let (rect, response) = ui.allocate_exact_size(egui::vec2(80.0, 14.0), egui::Sense::hover());
+	if ui.is_rect_visible(rect) {
+		let painter = ui.painter();
+		let full = egui::Rounding::same(3.0);
+		painter.rect_filled(rect, full, INBOUND_COLOR);
+		let out_w = rect.width() * frac;
+		if out_w > 0.0 {
+			let out_rect = egui::Rect::from_min_size(rect.min, egui::vec2(out_w, rect.height()));
+			let rounding = if frac >= 0.999 {
+				full
+			} else {
+				egui::Rounding { nw: 3.0, sw: 3.0, ne: 0.0, se: 0.0 }
+			};
+			painter.rect_filled(out_rect, rounding, OUTBOUND_COLOR);
+		}
+	}
+	response
+}
+
+fn channel_status_label(s: i32) -> &'static str {
+	match s {
+		0 => "Ready",
+		1 => "Usable",
+		2 => "Pending",
+		_ => "All",
+	}
+}
+
+// Header label with a sort-direction arrow when this column is the active sort key.
+fn sort_header(label: &str, sort: &(u8, bool), col: u8) -> String {
+	if sort.0 == col {
+		format!("{} {}", label, if sort.1 { "⬇" } else { "⬆" })
+	} else {
+		label.to_string()
+	}
+}
+
+// Per-row snapshot extracted from state.channels so the state borrow is released
+// before formatting/status-bar writes in the grid body.
+struct ChannelRow {
+	channel_id: String,
+	counterparty_node_id: String,
+	user_channel_id: String,
+	funding_txid: Option<String>,
+	channel_value_sats: u64,
+	outbound_capacity_msat: u64,
+	inbound_capacity_msat: u64,
+	is_channel_ready: bool,
+	is_usable: bool,
 }
 
 pub fn render_dialogs(ctx: &Context, app: &mut LspServerApp) {
@@ -204,6 +370,7 @@ fn render_open_channel_dialog(ctx: &Context, app: &mut LspServerApp) {
 	}
 
 	egui::Window::new("Open Channel").collapsible(false).resizable(false).show(ctx, |ui| {
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.open_channel;
 
 		egui::Grid::new("open_channel_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
@@ -215,11 +382,11 @@ fn render_open_channel_dialog(ctx: &Context, app: &mut LspServerApp) {
 			ui.text_edit_singleline(&mut form.address);
 			ui.end_row();
 
-			ui.label("Channel Amount (sats):");
+			ui.label(format!("Channel Amount ({}):", unit_label));
 			ui.text_edit_singleline(&mut form.channel_amount_sats);
 			ui.end_row();
 
-			ui.label("Push Amount (msat):");
+			ui.label(format!("Push Amount ({}):", unit_label));
 			ui.text_edit_singleline(&mut form.push_to_counterparty_msat);
 			ui.end_row();
 
@@ -290,25 +457,42 @@ fn render_close_channel_dialog(ctx: &Context, app: &mut LspServerApp) {
 
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_close_pending = app.state.tasks.close_channel.is_some();
-			let is_force_close_pending = app.state.tasks.force_close_channel.is_some();
+		let is_close_pending = app.state.tasks.close_channel.is_some();
+		let is_force_close_pending = app.state.tasks.force_close_channel.is_some();
 
+		// Cooperative close: a normal, non-gated button.
+		ui.horizontal(|ui| {
 			if is_close_pending || is_force_close_pending {
 				ui.spinner();
-			} else {
-				if ui.button("Close (Cooperative)").clicked() {
-					app.close_channel();
-				}
-				if ui.button("Force Close").clicked() {
-					app.force_close_channel();
-				}
+			} else if ui.button("Close (Cooperative)").clicked() {
+				app.close_channel();
 			}
 			if ui.button("Cancel").clicked() {
 				app.state.show_close_channel_dialog = false;
 				app.state.forms.close_channel = Default::default();
 			}
 		});
+
+		ui.separator();
+
+		// Destructive force close: gated behind an irreversibility checkbox.
+		ui.label(egui::RichText::new("Force Close").strong());
+		let id = ui.id().with("force_close_confirm");
+		let mut confirmed = ui.memory_mut(|m| m.data.get_temp::<bool>(id).unwrap_or(false));
+		ui.checkbox(&mut confirmed, "I understand this is irreversible");
+		ui.memory_mut(|m| m.data.insert_temp(id, confirmed));
+
+		if is_force_close_pending {
+			ui.spinner();
+		} else {
+			let btn = egui::Button::new(
+				egui::RichText::new("Force Close").color(egui::Color32::WHITE),
+			)
+			.fill(egui::Color32::DARK_RED);
+			if ui.add_enabled(confirmed, btn).clicked() {
+				app.force_close_channel();
+			}
+		}
 	});
 }
 
@@ -318,6 +502,7 @@ fn render_splice_in_dialog(ctx: &Context, app: &mut LspServerApp) {
 	}
 
 	egui::Window::new("Splice In").collapsible(false).resizable(false).show(ctx, |ui| {
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.splice_in;
 
 		ui.label("Add funds to an existing channel");
@@ -332,7 +517,7 @@ fn render_splice_in_dialog(ctx: &Context, app: &mut LspServerApp) {
 			ui.text_edit_singleline(&mut form.counterparty_node_id);
 			ui.end_row();
 
-			ui.label("Amount (sats):");
+			ui.label(format!("Amount ({}):", unit_label));
 			ui.text_edit_singleline(&mut form.splice_amount_sats);
 			ui.end_row();
 		});
@@ -360,6 +545,7 @@ fn render_splice_out_dialog(ctx: &Context, app: &mut LspServerApp) {
 	}
 
 	egui::Window::new("Splice Out").collapsible(false).resizable(false).show(ctx, |ui| {
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.splice_out;
 
 		ui.label("Remove funds from an existing channel");
@@ -374,7 +560,7 @@ fn render_splice_out_dialog(ctx: &Context, app: &mut LspServerApp) {
 			ui.text_edit_singleline(&mut form.counterparty_node_id);
 			ui.end_row();
 
-			ui.label("Amount (sats):");
+			ui.label(format!("Amount ({}):", unit_label));
 			ui.text_edit_singleline(&mut form.splice_amount_sats);
 			ui.end_row();
 
@@ -385,12 +571,24 @@ fn render_splice_out_dialog(ctx: &Context, app: &mut LspServerApp) {
 
 		ui.add_space(10.0);
 
+		// Destructive splice out: gated behind an irreversibility checkbox.
+		let id = ui.id().with("splice_out_confirm");
+		let mut confirmed = ui.memory_mut(|m| m.data.get_temp::<bool>(id).unwrap_or(false));
+		ui.checkbox(&mut confirmed, "I understand this is irreversible");
+		ui.memory_mut(|m| m.data.insert_temp(id, confirmed));
+
 		ui.horizontal(|ui| {
 			let is_pending = app.state.tasks.splice_out.is_some();
 			if is_pending {
 				ui.spinner();
-			} else if ui.button("Splice Out").clicked() {
-				app.splice_out();
+			} else {
+				let btn = egui::Button::new(
+					egui::RichText::new("Splice Out").color(egui::Color32::WHITE),
+				)
+				.fill(egui::Color32::DARK_RED);
+				if ui.add_enabled(confirmed, btn).clicked() {
+					app.splice_out();
+				}
 			}
 			if ui.button("Cancel").clicked() {
 				app.state.show_splice_out_dialog = false;

--- a/server/lsp-server-gui/src/ui/connection.rs
+++ b/server/lsp-server-gui/src/ui/connection.rs
@@ -9,16 +9,18 @@ use crate::state::ChainSourceForm;
 use crate::state::{AppState, ConnectionStatus, StatusMessage};
 
 pub fn render_status(ui: &mut Ui, state: &AppState) {
-	match &state.connection_status {
-		ConnectionStatus::Disconnected => {
-			ui.colored_label(egui::Color32::GRAY, "Disconnected");
-		},
-		ConnectionStatus::Connected => {
-			ui.colored_label(egui::Color32::GREEN, "Connected");
-		},
-		ConnectionStatus::Error(e) => {
-			ui.colored_label(egui::Color32::RED, format!("Error: {}", e));
-		},
+	let (color, text) = match &state.connection_status {
+		ConnectionStatus::Disconnected => (egui::Color32::GRAY, "Disconnected".to_string()),
+		ConnectionStatus::Connected => (egui::Color32::GREEN, "Connected".to_string()),
+		ConnectionStatus::Error(_) => (egui::Color32::RED, "Error".to_string()),
+	};
+	ui.colored_label(color, "●");
+	ui.label(&text);
+	if matches!(state.connection_status, ConnectionStatus::Connected) {
+		ui.weak(format!("· {}", state.server_url));
+	}
+	if let ConnectionStatus::Error(e) = &state.connection_status {
+		ui.label("·").on_hover_text(e.clone());
 	}
 }
 

--- a/server/lsp-server-gui/src/ui/forwarded_payments.rs
+++ b/server/lsp-server-gui/src/ui/forwarded_payments.rs
@@ -1,23 +1,83 @@
 use eframe::egui;
 
 use crate::app::LspServerApp;
-use crate::ui::format_msat;
+use crate::ui::widgets;
+
+// Per-row snapshot extracted from state.forwarded_payments so the state borrow
+// is released before app.fmt_msat runs in the grid body.
+struct ForwardRow {
+	fee_msat: u64,
+	amount_msat: u64,
+}
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("Forwarded Payments");
 	ui.add_space(5.0);
 
 	if ui.button("Refresh").clicked() {
+		app.state.forwarded_payments_page_token = None;
 		app.fetch_forwarded_payments();
+	}
+
+	let loading = app.state.tasks.forwarded_payments.is_some();
+	if loading {
+		ui.horizontal(|ui| {
+			ui.spinner();
+			ui.label("Loading...");
+		});
 	}
 
 	ui.add_space(10.0);
 
-	match &app.state.forwarded_payments {
-		Some(resp) => {
-			if resp.forwarded_payments.is_empty() {
-				ui.label("No forwarded payments.");
+	// Pre-extract rows and compute sums so the &app.state.forwarded_payments borrow
+	// ends before app.fmt_msat (borrows &app.state via &self) is called below.
+	let data: Option<(Vec<ForwardRow>, u64, u64)> =
+		app.state.forwarded_payments.as_ref().map(|resp| {
+			let mut total_fee: u64 = 0;
+			let mut total_forwarded: u64 = 0;
+			let rows: Vec<ForwardRow> = resp
+				.forwarded_payments
+				.iter()
+				.map(|fp| {
+					let fee = fp.total_fee_earned_msat.unwrap_or(0);
+					let amt = fp.outbound_amount_forwarded_msat.unwrap_or(0);
+					total_fee += fee;
+					total_forwarded += amt;
+					ForwardRow { fee_msat: fee, amount_msat: amt }
+				})
+				.collect();
+			(rows, total_fee, total_forwarded)
+		});
+
+	match data {
+		Some((rows, total_fee, total_forwarded)) => {
+			if rows.is_empty() {
+				if !loading {
+					widgets::empty_state(
+						ui,
+						"↪",
+						"No forwarded payments yet",
+						"Click Refresh to load",
+					);
+				}
 			} else {
+				// Summary header: count + operator revenue (fee) + total forwarded
+				ui.horizontal(|ui| {
+					ui.label(format!("{} forwards", rows.len()));
+					ui.separator();
+					ui.label(
+						egui::RichText::new(format!(
+							"Revenue: {}",
+							app.fmt_msat(total_fee)
+						))
+						.strong()
+						.color(egui::Color32::from_rgb(0xF7, 0x93, 0x1A)),
+					);
+					ui.separator();
+					ui.label(format!("Forwarded: {}", app.fmt_msat(total_forwarded)));
+				});
+				ui.add_space(5.0);
+
 				egui::ScrollArea::both().max_height(400.0).show(ui, |ui| {
 					egui::Grid::new("forwarded_payments_table")
 						.striped(true)
@@ -27,11 +87,20 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 							ui.label(egui::RichText::new("Amount Forwarded").strong());
 							ui.end_row();
 
-							for fp in &resp.forwarded_payments {
-								ui.label(format_msat(fp.total_fee_earned_msat.unwrap_or(0)));
-								ui.label(format_msat(
-									fp.outbound_amount_forwarded_msat.unwrap_or(0),
-								));
+							for row in &rows {
+								// Right-align both msat columns
+								ui.with_layout(
+									egui::Layout::right_to_left(egui::Align::Center),
+									|ui| {
+										ui.monospace(app.fmt_msat(row.fee_msat));
+									},
+								);
+								ui.with_layout(
+									egui::Layout::right_to_left(egui::Align::Center),
+									|ui| {
+										ui.monospace(app.fmt_msat(row.amount_msat));
+									},
+								);
 								ui.end_row();
 							}
 						});
@@ -39,7 +108,9 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			}
 		},
 		None => {
-			ui.label("Not loaded yet. Click Refresh.");
+			if !loading {
+				widgets::empty_state(ui, "↪", "No forwarded payments yet", "Click Refresh to load");
+			}
 		},
 	}
 }

--- a/server/lsp-server-gui/src/ui/ldk_log.rs
+++ b/server/lsp-server-gui/src/ui/ldk_log.rs
@@ -1,6 +1,7 @@
 use eframe::egui;
 
 use crate::app::LspServerApp;
+use crate::ui::widgets;
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("LDK Server Logs");
@@ -21,6 +22,34 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 		}
 	});
 
+	// Log controls — all stored in egui temp memory, no AppState fields
+	let filter_id = ui.id().with("log_filter");
+	let wrap_id = ui.id().with("log_wrap");
+	let follow_id = ui.id().with("log_follow");
+
+	let mut filter = ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+	let mut wrap = ui.memory_mut(|m| m.data.get_temp::<bool>(wrap_id).unwrap_or(false));
+	let mut follow = ui.memory_mut(|m| m.data.get_temp::<bool>(follow_id).unwrap_or(true));
+
+	ui.horizontal(|ui| {
+		ui.label("Filter:");
+		ui.text_edit_singleline(&mut filter);
+
+		if ui.button("Copy all").clicked() {
+			if let Some(resp) = &app.state.ldk_log {
+				let content = resp.content.clone();
+				ui.output_mut(|o| o.copied_text = content);
+			}
+		}
+
+		ui.checkbox(&mut wrap, "Wrap");
+		ui.checkbox(&mut follow, "Follow tail");
+	});
+
+	ui.memory_mut(|m| m.data.insert_temp(filter_id, filter.clone()));
+	ui.memory_mut(|m| m.data.insert_temp(wrap_id, wrap));
+	ui.memory_mut(|m| m.data.insert_temp(follow_id, follow));
+
 	ui.add_space(10.0);
 
 	match &app.state.ldk_log {
@@ -36,20 +65,35 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			);
 		},
 		Some(resp) => {
-			egui::ScrollArea::both().auto_shrink([false, false]).stick_to_bottom(true).show(
-				ui,
-				|ui| {
-					ui.add(
-						egui::TextEdit::multiline(&mut resp.content.as_str())
-							.font(egui::TextStyle::Monospace)
-							.desired_width(f32::INFINITY)
-							.desired_rows(30),
-					);
-				},
-			);
+			// Build filtered display string from already-fetched content
+			let display: String = if filter.is_empty() {
+				resp.content.clone()
+			} else {
+				resp.content
+					.lines()
+					.filter(|line| line.contains(&filter))
+					.collect::<Vec<_>>()
+					.join("\n")
+			};
+
+			// Wrap=false → ScrollArea::both (horizontal scroll); wrap=true → vertical only
+			let scroll = egui::ScrollArea::both()
+				.auto_shrink([false, false])
+				.stick_to_bottom(follow);
+			scroll.show(ui, |ui| {
+				let mut binding = display.as_str();
+				// When wrap is on, constrain width to force line-wrapping
+				let desired_w = if wrap { ui.available_width() } else { f32::INFINITY };
+				ui.add(
+					egui::TextEdit::multiline(&mut binding)
+						.font(egui::TextStyle::Monospace)
+						.desired_width(desired_w)
+						.desired_rows(30),
+				);
+			});
 		},
 		None => {
-			ui.label("Click Refresh to load.");
+			widgets::empty_state(ui, "📜", "No log loaded", "Click Refresh to load");
 		},
 	}
 }

--- a/server/lsp-server-gui/src/ui/lightning.rs
+++ b/server/lsp-server-gui/src/ui/lightning.rs
@@ -1,14 +1,13 @@
 use egui::Ui;
 
 use crate::app::LspServerApp;
-use crate::state::{ConnectionStatus, LightningTab};
+use crate::state::{LightningTab, StatusMessage};
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("Lightning Payments");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to use lightning payments.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -68,6 +67,7 @@ fn render_bolt11_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Pay BOLT11 Invoice");
 		ui.add_space(5.0);
 
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.bolt11_send;
 
 		ui.label("Invoice:");
@@ -80,22 +80,25 @@ fn render_bolt11_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.add_space(5.0);
 
 		egui::Grid::new("bolt11_send_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
-			ui.label("Amount (msat, for zero-amount invoices):");
+			ui.label(format!("Amount ({}, for zero-amount invoices):", unit_label));
 			ui.text_edit_singleline(&mut form.amount_msat);
 			ui.end_row();
 		});
 
+		// preview: read field text locally to avoid borrow conflict with the &self method
+		let amt = app.state.forms.bolt11_send.amount_msat.clone();
+		if let Some(preview) = app.amount_entry_preview(&amt) {
+			ui.weak(preview);
+		}
+
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_pending = app.state.tasks.bolt11_send.is_some();
-			if is_pending {
-				ui.spinner();
-				ui.label("Sending...");
-			} else if ui.button("Pay Invoice").clicked() {
-				app.send_bolt11();
-			}
-		});
+		let is_pending = app.state.tasks.bolt11_send.is_some();
+		if is_pending {
+			crate::ui::widgets::loading_row(ui, "Sending...");
+		} else if ui.button("Pay Invoice").clicked() {
+			app.send_bolt11();
+		}
 
 		if let Some(payment_id) = &app.state.last_payment_id {
 			ui.add_space(5.0);
@@ -115,10 +118,11 @@ fn render_bolt11_receive(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Generate BOLT11 Invoice");
 		ui.add_space(5.0);
 
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.bolt11_receive;
 
 		egui::Grid::new("bolt11_receive_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
-			ui.label("Amount (msat, optional):");
+			ui.label(format!("Amount ({}, optional):", unit_label));
 			ui.text_edit_singleline(&mut form.amount_msat);
 			ui.end_row();
 
@@ -131,19 +135,22 @@ fn render_bolt11_receive(ui: &mut Ui, app: &mut LspServerApp) {
 			ui.end_row();
 		});
 
+		// preview: read field text locally to avoid borrow conflict with fmt_msat
+		let amt = app.state.forms.bolt11_receive.amount_msat.clone();
+		if let Some(preview) = app.amount_entry_preview(&amt) {
+			ui.weak(preview);
+		}
+
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_pending = app.state.tasks.bolt11_receive.is_some();
-			if is_pending {
-				ui.spinner();
-				ui.label("Generating...");
-			} else if ui.button("Generate Invoice").clicked() {
-				app.generate_bolt11_invoice();
-			}
-		});
+		let is_pending = app.state.tasks.bolt11_receive.is_some();
+		if is_pending {
+			crate::ui::widgets::loading_row(ui, "Generating...");
+		} else if ui.button("Generate Invoice").clicked() {
+			app.generate_bolt11_invoice();
+		}
 
-		if let Some(invoice) = &app.state.generated_invoice {
+		if let Some(invoice) = &app.state.generated_invoice.clone() {
 			ui.add_space(10.0);
 			ui.separator();
 			ui.label("Generated Invoice:");
@@ -155,6 +162,7 @@ fn render_bolt11_receive(ui: &mut Ui, app: &mut LspServerApp) {
 			);
 			if ui.button("Copy Invoice").clicked() {
 				ui.output_mut(|o| o.copied_text = invoice.clone());
+				app.state.status_message = Some(StatusMessage::success("Copied"));
 			}
 		}
 	});
@@ -165,6 +173,7 @@ fn render_bolt12_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Pay BOLT12 Offer");
 		ui.add_space(5.0);
 
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.bolt12_send;
 
 		ui.label("Offer:");
@@ -175,7 +184,7 @@ fn render_bolt12_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.add_space(5.0);
 
 		egui::Grid::new("bolt12_send_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
-			ui.label("Amount (msat, optional):");
+			ui.label(format!("Amount ({}, optional):", unit_label));
 			ui.text_edit_singleline(&mut form.amount_msat);
 			ui.end_row();
 
@@ -188,17 +197,20 @@ fn render_bolt12_send(ui: &mut Ui, app: &mut LspServerApp) {
 			ui.end_row();
 		});
 
+		// preview: read field text locally to avoid borrow conflict with fmt_msat
+		let amt = app.state.forms.bolt12_send.amount_msat.clone();
+		if let Some(preview) = app.amount_entry_preview(&amt) {
+			ui.weak(preview);
+		}
+
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_pending = app.state.tasks.bolt12_send.is_some();
-			if is_pending {
-				ui.spinner();
-				ui.label("Sending...");
-			} else if ui.button("Pay Offer").clicked() {
-				app.send_bolt12();
-			}
-		});
+		let is_pending = app.state.tasks.bolt12_send.is_some();
+		if is_pending {
+			crate::ui::widgets::loading_row(ui, "Sending...");
+		} else if ui.button("Pay Offer").clicked() {
+			app.send_bolt12();
+		}
 
 		if let Some(payment_id) = &app.state.last_payment_id {
 			ui.add_space(5.0);
@@ -218,6 +230,7 @@ fn render_bolt12_receive(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Generate BOLT12 Offer");
 		ui.add_space(5.0);
 
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.bolt12_receive;
 
 		egui::Grid::new("bolt12_receive_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
@@ -225,7 +238,7 @@ fn render_bolt12_receive(ui: &mut Ui, app: &mut LspServerApp) {
 			ui.text_edit_singleline(&mut form.description);
 			ui.end_row();
 
-			ui.label("Amount (msat, optional):");
+			ui.label(format!("Amount ({}, optional):", unit_label));
 			ui.text_edit_singleline(&mut form.amount_msat);
 			ui.end_row();
 
@@ -238,19 +251,22 @@ fn render_bolt12_receive(ui: &mut Ui, app: &mut LspServerApp) {
 			ui.end_row();
 		});
 
+		// preview: read field text locally to avoid borrow conflict with fmt_msat
+		let amt = app.state.forms.bolt12_receive.amount_msat.clone();
+		if let Some(preview) = app.amount_entry_preview(&amt) {
+			ui.weak(preview);
+		}
+
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_pending = app.state.tasks.bolt12_receive.is_some();
-			if is_pending {
-				ui.spinner();
-				ui.label("Generating...");
-			} else if ui.button("Generate Offer").clicked() {
-				app.generate_bolt12_offer();
-			}
-		});
+		let is_pending = app.state.tasks.bolt12_receive.is_some();
+		if is_pending {
+			crate::ui::widgets::loading_row(ui, "Generating...");
+		} else if ui.button("Generate Offer").clicked() {
+			app.generate_bolt12_offer();
+		}
 
-		if let Some(offer) = &app.state.generated_offer {
+		if let Some(offer) = &app.state.generated_offer.clone() {
 			ui.add_space(10.0);
 			ui.separator();
 			ui.label("Generated Offer:");
@@ -262,6 +278,7 @@ fn render_bolt12_receive(ui: &mut Ui, app: &mut LspServerApp) {
 			);
 			if ui.button("Copy Offer").clicked() {
 				ui.output_mut(|o| o.copied_text = offer.clone());
+				app.state.status_message = Some(StatusMessage::success("Copied"));
 			}
 		}
 	});
@@ -272,6 +289,7 @@ fn render_spontaneous_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Spontaneous Payment (Keysend)");
 		ui.add_space(5.0);
 
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
 		let form = &mut app.state.forms.spontaneous_send;
 
 		egui::Grid::new("spontaneous_send_grid").num_columns(2).spacing([10.0, 5.0]).show(
@@ -281,23 +299,26 @@ fn render_spontaneous_send(ui: &mut Ui, app: &mut LspServerApp) {
 				ui.text_edit_singleline(&mut form.node_id);
 				ui.end_row();
 
-				ui.label("Amount (msat):");
+				ui.label(format!("Amount ({}):", unit_label));
 				ui.text_edit_singleline(&mut form.amount_msat);
 				ui.end_row();
 			},
 		);
 
+		// preview: read field text locally to avoid borrow conflict with fmt_msat
+		let amt = app.state.forms.spontaneous_send.amount_msat.clone();
+		if let Some(preview) = app.amount_entry_preview(&amt) {
+			ui.weak(preview);
+		}
+
 		ui.add_space(10.0);
 
-		ui.horizontal(|ui| {
-			let is_pending = app.state.tasks.spontaneous_send.is_some();
-			if is_pending {
-				ui.spinner();
-				ui.label("Sending...");
-			} else if ui.button("Send Keysend").clicked() {
-				app.spontaneous_send();
-			}
-		});
+		let is_pending = app.state.tasks.spontaneous_send.is_some();
+		if is_pending {
+			crate::ui::widgets::loading_row(ui, "Sending...");
+		} else if ui.button("Send Keysend").clicked() {
+			app.spontaneous_send();
+		}
 
 		if let Some(payment_id) = &app.state.last_payment_id {
 			ui.add_space(5.0);

--- a/server/lsp-server-gui/src/ui/mod.rs
+++ b/server/lsp-server-gui/src/ui/mod.rs
@@ -10,7 +10,11 @@ pub mod onchain;
 pub mod payments;
 pub mod peers;
 pub mod stable_channels;
+pub mod settings;
 pub mod tools;
+pub mod widgets;
+
+use crate::state::DisplayUnit;
 
 pub fn truncate_id(s: &str, start: usize, end: usize) -> String {
 	if s.len() <= start + end + 2 {
@@ -40,4 +44,138 @@ pub fn format_msat(msat: u64) -> String {
 	} else {
 		format!("{}.{:03} sats", format_sats(sats), remainder)
 	}
+}
+
+fn format_usd(amount: f64) -> String {
+	let s = format!("{:.2}", amount);
+	let (int_part, frac) = s.split_once('.').unwrap_or((s.as_str(), "00"));
+	let dollars: u64 = int_part.parse().unwrap_or(0);
+	format!("${}.{}", format_sats(dollars), frac)
+}
+
+pub fn format_amount_sats(sats: u64, unit: DisplayUnit, price: Option<f64>) -> String {
+	match unit {
+		DisplayUnit::Sats => format!("{} sats", format_sats(sats)),
+		DisplayUnit::Btc => format!("{:.8} BTC", sats as f64 / 100_000_000.0),
+		DisplayUnit::Usd => match price {
+			Some(p) if p > 0.0 => format_usd((sats as f64 / 100_000_000.0) * p),
+			_ => format!("{} sats", format_sats(sats)),
+		},
+	}
+}
+
+pub fn format_amount_msat(msat: u64, unit: DisplayUnit, price: Option<f64>) -> String {
+	match unit {
+		DisplayUnit::Sats => format_msat(msat),
+		DisplayUnit::Btc => format!("{:.8} BTC", msat as f64 / 100_000_000_000.0),
+		DisplayUnit::Usd => match price {
+			Some(p) if p > 0.0 => format_usd((msat as f64 / 100_000_000_000.0) * p),
+			_ => format_msat(msat),
+		},
+	}
+}
+
+/// Short label for the current entry unit, e.g. "USD" / "BTC" / "sats".
+pub fn unit_label(unit: DisplayUnit) -> &'static str {
+	match unit {
+		DisplayUnit::Usd => "USD",
+		DisplayUnit::Btc => "BTC",
+		DisplayUnit::Sats => "sats",
+	}
+}
+
+/// Parse a user-entered amount, interpreting it in `unit`, into whole sats.
+/// Sats must be a whole number; BTC/USD accept decimals; USD needs a positive
+/// price. Returns None for empty/invalid/negative input (or USD without price).
+pub fn parse_amount_to_sats(input: &str, unit: DisplayUnit, price: Option<f64>) -> Option<u64> {
+	let t = input.trim();
+	if t.is_empty() {
+		return None;
+	}
+	match unit {
+		DisplayUnit::Sats => t.parse::<u64>().ok(),
+		DisplayUnit::Btc => {
+			let btc = t.parse::<f64>().ok()?;
+			if !btc.is_finite() || btc < 0.0 {
+				return None;
+			}
+			Some((btc * 100_000_000.0).round() as u64)
+		},
+		DisplayUnit::Usd => {
+			let usd = t.parse::<f64>().ok()?;
+			let p = price?;
+			if !usd.is_finite() || usd < 0.0 || p <= 0.0 {
+				return None;
+			}
+			Some(((usd / p) * 100_000_000.0).round() as u64)
+		},
+	}
+}
+
+/// Same as [`parse_amount_to_sats`] but scaled to msats for the Lightning APIs.
+pub fn parse_amount_to_msat(input: &str, unit: DisplayUnit, price: Option<f64>) -> Option<u64> {
+	parse_amount_to_sats(input, unit, price).map(|s| s.saturating_mul(1000))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::DisplayUnit;
+
+    #[test]
+    fn sats_unit_groups_digits() {
+        assert_eq!(format_amount_sats(50_000, DisplayUnit::Sats, None), "50,000 sats");
+    }
+    #[test]
+    fn btc_unit_eight_decimals() {
+        assert_eq!(format_amount_sats(100_000_000, DisplayUnit::Btc, None), "1.00000000 BTC");
+    }
+    #[test]
+    fn usd_unit_uses_price() {
+        assert_eq!(format_amount_sats(100_000_000, DisplayUnit::Usd, Some(100_000.0)), "$100,000.00");
+    }
+    #[test]
+    fn usd_falls_back_to_sats_without_price() {
+        assert_eq!(format_amount_sats(50_000, DisplayUnit::Usd, None), "50,000 sats");
+    }
+    #[test]
+    fn usd_falls_back_to_sats_on_zero_price() {
+        assert_eq!(format_amount_sats(50_000, DisplayUnit::Usd, Some(0.0)), "50,000 sats");
+    }
+    #[test]
+    fn msat_usd_converts() {
+        assert_eq!(format_amount_msat(100_000_000_000, DisplayUnit::Usd, Some(100_000.0)), "$100,000.00");
+    }
+    #[test]
+    fn msat_sats_keeps_remainder_behavior() {
+        assert_eq!(format_amount_msat(1_500, DisplayUnit::Sats, None), "1.500 sats");
+    }
+
+    #[test]
+    fn parse_sats_is_whole_number() {
+        assert_eq!(parse_amount_to_sats("50000", DisplayUnit::Sats, None), Some(50_000));
+        assert_eq!(parse_amount_to_sats("1.5", DisplayUnit::Sats, None), None);
+    }
+    #[test]
+    fn parse_btc_scales_to_sats() {
+        assert_eq!(parse_amount_to_sats("1.5", DisplayUnit::Btc, None), Some(150_000_000));
+    }
+    #[test]
+    fn parse_usd_uses_price() {
+        assert_eq!(parse_amount_to_sats("65860", DisplayUnit::Usd, Some(65_860.0)), Some(100_000_000));
+    }
+    #[test]
+    fn parse_usd_needs_positive_price() {
+        assert_eq!(parse_amount_to_sats("10", DisplayUnit::Usd, None), None);
+        assert_eq!(parse_amount_to_sats("10", DisplayUnit::Usd, Some(0.0)), None);
+    }
+    #[test]
+    fn parse_rejects_empty_and_negative() {
+        assert_eq!(parse_amount_to_sats("   ", DisplayUnit::Sats, None), None);
+        assert_eq!(parse_amount_to_sats("-1", DisplayUnit::Btc, None), None);
+    }
+    #[test]
+    fn parse_msat_scales_by_1000() {
+        assert_eq!(parse_amount_to_msat("100", DisplayUnit::Sats, None), Some(100_000));
+    }
 }

--- a/server/lsp-server-gui/src/ui/network_graph.rs
+++ b/server/lsp-server-gui/src/ui/network_graph.rs
@@ -1,15 +1,13 @@
 use eframe::egui;
 
 use crate::app::LspServerApp;
-use crate::state::ConnectionStatus;
-use crate::ui::truncate_id;
+use crate::ui::widgets;
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("Network Graph");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to explore the network graph.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -41,13 +39,31 @@ fn render_channels_section(ui: &mut egui::Ui, app: &mut LspServerApp) {
 
 			if !resp.short_channel_ids.is_empty() {
 				ui.add_space(5.0);
+
+				// Filter box for scid list (temp memory, no AppState field)
+				let filter_id = ui.id().with("scid_filter");
+				let mut filter = ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+				ui.horizontal(|ui| {
+					ui.label("Filter:");
+					ui.text_edit_singleline(&mut filter);
+				});
+				ui.memory_mut(|m| m.data.insert_temp(filter_id, filter.clone()));
+
 				let max_display = 100.min(resp.short_channel_ids.len());
+				// Apply filter to the already-capped slice
+				let visible: Vec<&u64> = resp.short_channel_ids
+					.iter()
+					.take(max_display)
+					.filter(|scid| filter.is_empty() || scid.to_string().contains(&filter))
+					.collect();
+
 				egui::Grid::new("graph_channels_list").striped(true).show(ui, |ui| {
 					ui.label(egui::RichText::new("Short Channel ID").strong());
 					ui.end_row();
 
-					for scid in resp.short_channel_ids.iter().take(max_display) {
-						ui.label(format!("{}", scid));
+					for scid in &visible {
+						let scid_str = scid.to_string();
+						widgets::id_with_copy(ui, &scid_str, &mut app.state.status_message);
 						ui.end_row();
 					}
 				});
@@ -85,34 +101,33 @@ fn render_channels_section(ui: &mut egui::Ui, app: &mut LspServerApp) {
 		if let Some(resp) = &app.state.graph_channel_detail {
 			if let Some(ch) = &resp.channel {
 				ui.add_space(5.0);
+				// Pre-extract values before mixed borrows
+				let node_one = ch.node_one.clone();
+				let node_two = ch.node_two.clone();
+				let capacity = ch.capacity_sats;
+				let one_to_two = ch.one_to_two.clone();
+				let two_to_one = ch.two_to_one.clone();
+
+				let cap_str = capacity.map(|c| app.fmt_sats(c));
+
 				egui::Grid::new("graph_channel_detail").num_columns(2).spacing([10.0, 5.0]).show(
 					ui,
 					|ui| {
 						ui.label("Node One:");
-						ui.horizontal(|ui| {
-							ui.monospace(truncate_id(&ch.node_one, 8, 4));
-							if ui.small_button("Copy").clicked() {
-								ui.output_mut(|o| o.copied_text = ch.node_one.clone());
-							}
-						});
+						widgets::id_with_copy(ui, &node_one, &mut app.state.status_message);
 						ui.end_row();
 
 						ui.label("Node Two:");
-						ui.horizontal(|ui| {
-							ui.monospace(truncate_id(&ch.node_two, 8, 4));
-							if ui.small_button("Copy").clicked() {
-								ui.output_mut(|o| o.copied_text = ch.node_two.clone());
-							}
-						});
+						widgets::id_with_copy(ui, &node_two, &mut app.state.status_message);
 						ui.end_row();
 
-						if let Some(cap) = ch.capacity_sats {
+						if let Some(cap_fmt) = &cap_str {
 							ui.label("Capacity:");
-							ui.label(format!("{} sats", crate::ui::format_sats(cap)));
+							ui.label(format!("{} sats", cap_fmt));
 							ui.end_row();
 						}
 
-						if let Some(update) = &ch.one_to_two {
+						if let Some(update) = &one_to_two {
 							ui.label("1->2 Enabled:");
 							ui.label(if update.enabled { "Yes" } else { "No" });
 							ui.end_row();
@@ -127,7 +142,7 @@ fn render_channels_section(ui: &mut egui::Ui, app: &mut LspServerApp) {
 							ui.end_row();
 						}
 
-						if let Some(update) = &ch.two_to_one {
+						if let Some(update) = &two_to_one {
 							ui.label("2->1 Enabled:");
 							ui.label(if update.enabled { "Yes" } else { "No" });
 							ui.end_row();
@@ -169,18 +184,31 @@ fn render_nodes_section(ui: &mut egui::Ui, app: &mut LspServerApp) {
 
 			if !resp.node_ids.is_empty() {
 				ui.add_space(5.0);
+
+				// Filter box for node list (temp memory, no AppState field)
+				let filter_id = ui.id().with("node_filter");
+				let mut filter = ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+				ui.horizontal(|ui| {
+					ui.label("Filter:");
+					ui.text_edit_singleline(&mut filter);
+				});
+				ui.memory_mut(|m| m.data.insert_temp(filter_id, filter.clone()));
+
 				let max_display = 100.min(resp.node_ids.len());
+				// Apply filter to the already-capped slice
+				let visible: Vec<&String> = resp.node_ids
+					.iter()
+					.take(max_display)
+					.filter(|id| filter.is_empty() || id.contains(&filter))
+					.collect();
+
 				egui::Grid::new("graph_nodes_list").striped(true).show(ui, |ui| {
 					ui.label(egui::RichText::new("Node ID").strong());
 					ui.end_row();
 
-					for node_id in resp.node_ids.iter().take(max_display) {
-						ui.horizontal(|ui| {
-							ui.monospace(truncate_id(node_id, 8, 4));
-							if ui.small_button("Copy").clicked() {
-								ui.output_mut(|o| o.copied_text = node_id.clone());
-							}
-						});
+					for node_id in &visible {
+						let node_id_str = node_id.to_string();
+						widgets::id_with_copy(ui, &node_id_str, &mut app.state.status_message);
 						ui.end_row();
 					}
 				});
@@ -232,7 +260,9 @@ fn render_nodes_section(ui: &mut egui::Ui, app: &mut LspServerApp) {
 							ui.end_row();
 
 							ui.label("Last Update:");
-							ui.label(format!("{}", ann.last_update));
+							let ts = ann.last_update;
+							ui.label(format!("{}", ts))
+								.on_hover_text(format!("unix: {}", ts));
 							ui.end_row();
 
 							if !ann.addresses.is_empty() {

--- a/server/lsp-server-gui/src/ui/node_info.rs
+++ b/server/lsp-server-gui/src/ui/node_info.rs
@@ -4,28 +4,49 @@ use web_sys::js_sys;
 
 use crate::app::LspServerApp;
 use crate::config::ChainSourceConfig;
-use crate::state::ConnectionStatus;
-use crate::ui::connection;
+use crate::ui::widgets;
+
+// Snapshot of node_info fields extracted before any &mut app borrow.
+struct NodeInfoRow {
+	node_id: String,
+	best_block_hash: Option<String>,
+	best_block_height: Option<u32>,
+	ln_sync_ts: Option<u64>,
+	onchain_sync_ts: Option<u64>,
+	fee_rate_ts: Option<u64>,
+	rgs_ts: Option<u64>,
+	announcement_ts: Option<u64>,
+}
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("Node Information");
-	ui.add_space(10.0);
-
-	connection::render_settings(ui, app);
 	ui.add_space(10.0);
 
 	// Show chain source config if loaded
 	render_chain_source_info(ui, app);
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to view node information.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
+
+	// Pre-extract node_info fields so the immutable borrow ends before the grid
+	// calls widgets::id_with_copy (which needs &mut app.state.status_message).
+	let row: Option<NodeInfoRow> = app.state.node_info.as_ref().map(|info| NodeInfoRow {
+		node_id: info.node_id.clone(),
+		best_block_hash: info.current_best_block.as_ref().map(|b| b.block_hash.clone()),
+		best_block_height: info.current_best_block.as_ref().map(|b| b.height),
+		ln_sync_ts: info.latest_lightning_wallet_sync_timestamp,
+		onchain_sync_ts: info.latest_onchain_wallet_sync_timestamp,
+		fee_rate_ts: info.latest_fee_rate_cache_update_timestamp,
+		rgs_ts: info.latest_rgs_snapshot_timestamp,
+		announcement_ts: info.latest_node_announcement_broadcast_timestamp,
+	});
 
 	ui.group(|ui| {
 		ui.horizontal(|ui| {
 			ui.heading("Node Details");
+			widgets::status_pill(ui, "Online", egui::Color32::GREEN);
 			if app.state.tasks.node_info.is_some() {
 				ui.spinner();
 			} else if ui.button("Refresh").clicked() {
@@ -34,55 +55,49 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 		});
 		ui.add_space(5.0);
 
-		if let Some(info) = &app.state.node_info {
+		if let Some(r) = row {
 			egui::Grid::new("node_info_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
 				ui.label("Node ID:");
-				ui.horizontal(|ui| {
-					let node_id = &info.node_id;
-					ui.monospace(crate::ui::truncate_id(node_id, 12, 12));
-					if ui.small_button("Copy").clicked() {
-						ui.output_mut(|o| o.copied_text = node_id.clone());
-					}
-				});
+				widgets::id_with_copy(ui, &r.node_id, &mut app.state.status_message);
 				ui.end_row();
 
-				if let Some(block) = &info.current_best_block {
+				if let (Some(hash), Some(height)) = (r.best_block_hash, r.best_block_height) {
 					ui.label("Best Block:");
 					ui.monospace(format!(
 						"{} (height: {})",
-						crate::ui::truncate_id(&block.block_hash, 8, 8),
-						block.height
+						crate::ui::truncate_id(&hash, 8, 8),
+						height
 					));
 					ui.end_row();
 				}
 
-				if let Some(ts) = info.latest_lightning_wallet_sync_timestamp {
+				if let Some(ts) = r.ln_sync_ts {
 					ui.label("Lightning Wallet Sync:");
-					ui.label(format_timestamp(ts));
+					ui.label(format_timestamp(ts)).on_hover_text(format!("unix: {}", ts));
 					ui.end_row();
 				}
 
-				if let Some(ts) = info.latest_onchain_wallet_sync_timestamp {
+				if let Some(ts) = r.onchain_sync_ts {
 					ui.label("On-chain Wallet Sync:");
-					ui.label(format_timestamp(ts));
+					ui.label(format_timestamp(ts)).on_hover_text(format!("unix: {}", ts));
 					ui.end_row();
 				}
 
-				if let Some(ts) = info.latest_fee_rate_cache_update_timestamp {
+				if let Some(ts) = r.fee_rate_ts {
 					ui.label("Fee Rate Cache Update:");
-					ui.label(format_timestamp(ts));
+					ui.label(format_timestamp(ts)).on_hover_text(format!("unix: {}", ts));
 					ui.end_row();
 				}
 
-				if let Some(ts) = info.latest_rgs_snapshot_timestamp {
+				if let Some(ts) = r.rgs_ts {
 					ui.label("RGS Snapshot:");
-					ui.label(format_timestamp(ts));
+					ui.label(format_timestamp(ts)).on_hover_text(format!("unix: {}", ts));
 					ui.end_row();
 				}
 
-				if let Some(ts) = info.latest_node_announcement_broadcast_timestamp {
+				if let Some(ts) = r.announcement_ts {
 					ui.label("Node Announcement:");
-					ui.label(format_timestamp(ts));
+					ui.label(format_timestamp(ts)).on_hover_text(format!("unix: {}", ts));
 					ui.end_row();
 				}
 			});

--- a/server/lsp-server-gui/src/ui/onchain.rs
+++ b/server/lsp-server-gui/src/ui/onchain.rs
@@ -3,15 +3,14 @@ use egui::{ScrollArea, Ui};
 use web_sys::js_sys;
 
 use crate::app::LspServerApp;
-use crate::state::{ConnectionStatus, OnchainTab};
-use crate::ui::{format_sats, truncate_id};
+use crate::state::OnchainTab;
+use crate::ui::truncate_id;
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("On-chain Transactions");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to use on-chain transactions.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -46,6 +45,11 @@ fn render_send(ui: &mut Ui, app: &mut LspServerApp) {
 		ui.heading("Send On-chain");
 		ui.add_space(5.0);
 
+		// Pre-read amount for preview so the &self method can borrow app without conflicting with form borrow
+		let unit_label = crate::ui::unit_label(app.state.display_unit);
+		let amt = app.state.forms.onchain_send.amount_sats.clone();
+		let preview_str = app.amount_entry_preview(&amt);
+
 		let form = &mut app.state.forms.onchain_send;
 
 		egui::Grid::new("onchain_send_grid").num_columns(2).spacing([10.0, 5.0]).show(ui, |ui| {
@@ -53,8 +57,17 @@ fn render_send(ui: &mut Ui, app: &mut LspServerApp) {
 			ui.text_edit_singleline(&mut form.address);
 			ui.end_row();
 
-			ui.label("Amount (sats):");
+			ui.label(format!("Amount ({}):", unit_label));
 			ui.add_enabled(!form.send_all, egui::TextEdit::singleline(&mut form.amount_sats));
+			ui.end_row();
+
+			// Muted preview of the parsed sats amount
+			ui.label("");
+			if let Some(ref s) = preview_str {
+				ui.weak(s.as_str());
+			} else {
+				ui.label("");
+			}
 			ui.end_row();
 
 			ui.label("Send All:");
@@ -68,13 +81,30 @@ fn render_send(ui: &mut Ui, app: &mut LspServerApp) {
 
 		ui.add_space(10.0);
 
+		let send_all = app.state.forms.onchain_send.send_all;
+
 		ui.horizontal(|ui| {
 			let is_pending = app.state.tasks.onchain_send.is_some();
 			if is_pending {
 				ui.spinner();
 				ui.label("Sending...");
-			} else if ui.button("Send").clicked() {
-				app.send_onchain();
+			} else if send_all {
+				// Confirm gate for send-all: require a second checkbox before enabling
+				let id = ui.id().with("send_all_confirm");
+				let mut ok = ui.memory_mut(|m| m.data.get_temp::<bool>(id).unwrap_or(false));
+				ui.checkbox(&mut ok, "I understand this sends my entire on-chain balance");
+				ui.memory_mut(|m| m.data.insert_temp(id, ok));
+				let btn = egui::Button::new(
+					egui::RichText::new("Send All").color(egui::Color32::WHITE),
+				)
+				.fill(egui::Color32::DARK_RED);
+				if ui.add_enabled(ok, btn).clicked() {
+					app.send_onchain();
+				}
+			} else {
+				if ui.button("Send").clicked() {
+					app.send_onchain();
+				}
 			}
 		});
 
@@ -129,6 +159,11 @@ fn render_history(ui: &mut Ui, app: &mut LspServerApp) {
 
 	// Show balances summary
 	if let Some(balances) = &app.state.balances {
+		// Pre-read into locals to avoid simultaneous borrows of app
+		let total = balances.total_onchain_balance_sats;
+		let spendable = balances.spendable_onchain_balance_sats;
+		let anchor = balances.total_anchor_channels_reserve_sats;
+
 		ui.group(|ui| {
 			ui.label("Wallet Summary");
 			ui.add_space(5.0);
@@ -136,22 +171,16 @@ fn render_history(ui: &mut Ui, app: &mut LspServerApp) {
 				ui,
 				|ui| {
 					ui.label("Total Balance:");
-					ui.label(format!("{} sats", format_sats(balances.total_onchain_balance_sats)));
+					ui.label(app.fmt_sats(total));
 					ui.end_row();
 
 					ui.label("Spendable:");
-					ui.label(format!(
-						"{} sats",
-						format_sats(balances.spendable_onchain_balance_sats)
-					));
+					ui.label(app.fmt_sats(spendable));
 					ui.end_row();
 
-					if balances.total_anchor_channels_reserve_sats > 0 {
+					if anchor > 0 {
 						ui.label("Anchor Reserve:");
-						ui.label(format!(
-							"{} sats",
-							format_sats(balances.total_anchor_channels_reserve_sats)
-						));
+						ui.label(app.fmt_sats(anchor));
 						ui.end_row();
 					}
 				},
@@ -162,81 +191,84 @@ fn render_history(ui: &mut Ui, app: &mut LspServerApp) {
 
 		// Show pending sweeps if any
 		if !balances.pending_balances_from_channel_closures.is_empty() {
+			// Pre-collect sweep data to avoid holding the balances borrow into render_pending_sweep
+			let sweeps: Vec<_> = balances
+				.pending_balances_from_channel_closures
+				.iter()
+				.filter_map(|s| s.balance_type.clone())
+				.collect();
+
 			ui.group(|ui| {
 				ui.label("Pending Sweeps");
 				ui.add_space(5.0);
-				for sweep in &balances.pending_balances_from_channel_closures {
-					if let Some(balance_type) = &sweep.balance_type {
-						render_pending_sweep(ui, balance_type);
-						ui.add_space(3.0);
-					}
+				for balance_type in &sweeps {
+					render_pending_sweep(ui, app, balance_type);
+					ui.add_space(3.0);
 				}
 			});
 			ui.add_space(10.0);
 		}
 	}
 
-	// Note about transaction history
-	ui.group(|ui| {
+	// Neutral informational callout — not an error, so use Frame::group not error_banner
+	egui::Frame::group(ui.style()).show(ui, |ui| {
 		ui.label(egui::RichText::new("Transaction History").strong());
 		ui.add_space(5.0);
-		ui.label("Full on-chain transaction history is not yet available.");
-		ui.label(
-			egui::RichText::new(
-				"ldk-node does not currently expose BDK wallet transaction history.",
-			)
-			.small()
-			.color(egui::Color32::GRAY),
+		ui.weak("Full on-chain transaction history is not yet available.");
+		ui.weak(
+			"ldk-node does not currently expose BDK wallet transaction history.",
 		);
-
-		if let Some(txid) = &app.state.last_txid {
-			ui.add_space(10.0);
-			ui.separator();
-			ui.horizontal(|ui| {
-				ui.label("Last Sent TXID:");
-				ui.monospace(truncate_id(txid, 8, 8));
-				if ui.small_button("Copy").clicked() {
-					ui.output_mut(|o| o.copied_text = txid.clone());
-				}
-			});
-		}
 	});
+
+	if let Some(txid) = &app.state.last_txid {
+		ui.add_space(10.0);
+		ui.separator();
+		ui.horizontal(|ui| {
+			ui.label("Last Sent TXID:");
+			ui.monospace(truncate_id(txid, 8, 8));
+			if ui.small_button("Copy").clicked() {
+				ui.output_mut(|o| o.copied_text = txid.clone());
+			}
+		});
+	}
 }
 
 fn render_pending_sweep(
 	ui: &mut Ui,
+	app: &mut LspServerApp,
 	balance_type: &sc_rest_client::ldk_server_grpc::types::pending_sweep_balance::BalanceType,
 ) {
 	use sc_rest_client::ldk_server_grpc::types::pending_sweep_balance::BalanceType;
 
 	match balance_type {
 		BalanceType::PendingBroadcast(b) => {
+			let amt = app.fmt_sats(b.amount_satoshis);
 			ui.horizontal(|ui| {
 				ui.colored_label(egui::Color32::YELLOW, "Pending Broadcast");
-				ui.label(format!("{} sats", format_sats(b.amount_satoshis)));
+				ui.label(format!("{} sats", amt));
 			});
 		},
 		BalanceType::BroadcastAwaitingConfirmation(b) => {
+			let amt = app.fmt_sats(b.amount_satoshis);
+			let txid = b.latest_spending_txid.clone();
 			ui.horizontal(|ui| {
 				ui.colored_label(egui::Color32::YELLOW, "Awaiting Confirmation");
-				ui.label(format!("{} sats", format_sats(b.amount_satoshis)));
+				ui.label(format!("{} sats", amt));
 			});
 			ui.horizontal(|ui| {
 				ui.label("TXID:");
-				ui.monospace(truncate_id(&b.latest_spending_txid, 8, 8));
+				ui.monospace(truncate_id(&txid, 8, 8));
 				if ui.small_button("Copy").clicked() {
-					ui.output_mut(|o| o.copied_text = b.latest_spending_txid.clone());
+					ui.output_mut(|o| o.copied_text = txid.clone());
 				}
 			});
 		},
 		BalanceType::AwaitingThresholdConfirmations(b) => {
+			let amt = app.fmt_sats(b.amount_satoshis);
+			let height = b.confirmation_height;
 			ui.horizontal(|ui| {
 				ui.colored_label(egui::Color32::GREEN, "Awaiting Threshold");
-				ui.label(format!(
-					"{} sats (height {})",
-					format_sats(b.amount_satoshis),
-					b.confirmation_height
-				));
+				ui.label(format!("{} sats (height {})", amt, height));
 			});
 		},
 	}
@@ -319,7 +351,7 @@ fn render_history_table(ui: &mut Ui, app: &mut LspServerApp) {
 
 							// Amount
 							if let Some(amount) = payment.amount_msat {
-								ui.label(format!("{} sats", format_sats(amount / 1000)));
+								ui.label(app.fmt_sats(amount / 1000));
 							} else {
 								ui.label("-");
 							}

--- a/server/lsp-server-gui/src/ui/payments.rs
+++ b/server/lsp-server-gui/src/ui/payments.rs
@@ -4,15 +4,27 @@ use hex::DisplayHex;
 use web_sys::js_sys;
 
 use crate::app::LspServerApp;
-use crate::state::ConnectionStatus;
-use crate::ui::{format_msat, truncate_id};
+use crate::ui::truncate_id;
+use crate::ui::widgets;
+
+// Per-row snapshot extracted from state.payments so the state borrow is released
+// before app.fmt_msat / status_pill run in the grid body (see channels.rs).
+struct PaymentRow {
+	id: String,
+	hash: String,
+	type_label: String,
+	amount_msat: Option<u64>,
+	fee_paid_msat: Option<u64>,
+	direction: i32,
+	status: i32,
+	timestamp: u64,
+}
 
 pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 	ui.heading("Payments");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to view payments.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -23,9 +35,11 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 		} else {
 			if ui.button("Refresh").clicked() {
 				app.state.payments_page_token = None;
+				app.state.payments_appending = false;
 				app.fetch_payments();
 			}
 			if app.state.payments_page_token.is_some() && ui.button("Load More").clicked() {
+				app.state.payments_appending = true;
 				app.fetch_payments();
 			}
 		}
@@ -33,91 +47,176 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 
 	ui.add_space(10.0);
 
+	let loading = app.state.tasks.payments.is_some();
+
 	// Track which payment details button was clicked
 	let mut clicked_payment_id: Option<String> = None;
 
-	if let Some(payments_response) = &app.state.payments {
-		let payments = &payments_response.payments;
-		if payments.is_empty() {
-			ui.label("No payments found.");
+	// Pre-extract per-row data into locals so the &app.state.payments borrow is
+	// released before app.fmt_msat / status_pill below; never mutate the underlying list.
+	let rows: Option<(Vec<PaymentRow>, bool)> = app.state.payments.as_ref().map(|resp| {
+		let rows = resp
+			.payments
+			.iter()
+			.map(|p| PaymentRow {
+				id: p.id.clone(),
+				hash: p.kind.as_ref().map(payment_hash).unwrap_or_default(),
+				type_label: p
+					.kind
+					.as_ref()
+					.map(|k| format_payment_kind(k))
+					.unwrap_or_else(|| "Unknown".to_string()),
+				amount_msat: p.amount_msat,
+				fee_paid_msat: p.fee_paid_msat,
+				direction: p.direction,
+				status: p.status,
+				timestamp: p.latest_update_timestamp,
+			})
+			.collect();
+		(rows, resp.next_page_token.is_some())
+	});
+
+	if let Some((rows, more_available)) = rows {
+		if rows.is_empty() {
+			if !loading {
+				ui.label("No payments found.");
+			}
 		} else {
-			ui.label(format!("{} payment(s)", payments.len()));
+			let total = rows.len();
+
+			// Filter + sort controls live in egui temp memory (not persisted).
+			let filter_id = ui.id().with("pay_filter");
+			let status_id = ui.id().with("pay_status");
+			let dir_id = ui.id().with("pay_dir");
+			let sort_id = ui.id().with("pay_sort");
+
+			let mut filter =
+				ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+			// status filter: -1 = all, else 0/1/2 like payment.status
+			let mut status_filter =
+				ui.memory_mut(|m| m.data.get_temp::<i32>(status_id).unwrap_or(-1));
+			// direction filter: -1 = all, else 0/1 like payment.direction
+			let mut dir_filter = ui.memory_mut(|m| m.data.get_temp::<i32>(dir_id).unwrap_or(-1));
+			// sort key: (column, descending) where 0 = Amount, 1 = Date
+			let mut sort =
+				ui.memory_mut(|m| m.data.get_temp::<(u8, bool)>(sort_id).unwrap_or((1, true)));
+
+			ui.horizontal(|ui| {
+				ui.label("Filter:");
+				ui.add(egui::TextEdit::singleline(&mut filter).hint_text("id or hash"));
+				egui::ComboBox::from_id_salt(status_id)
+					.selected_text(status_label(status_filter))
+					.show_ui(ui, |ui| {
+						ui.selectable_value(&mut status_filter, -1, "All statuses");
+						ui.selectable_value(&mut status_filter, 0, "Pending");
+						ui.selectable_value(&mut status_filter, 1, "Succeeded");
+						ui.selectable_value(&mut status_filter, 2, "Failed");
+					});
+				egui::ComboBox::from_id_salt(dir_id)
+					.selected_text(direction_label(dir_filter))
+					.show_ui(ui, |ui| {
+						ui.selectable_value(&mut dir_filter, -1, "All directions");
+						ui.selectable_value(&mut dir_filter, 0, "Inbound");
+						ui.selectable_value(&mut dir_filter, 1, "Outbound");
+					});
+			});
+
+			// Build the rendered view by filtering indices into the loaded rows.
+			let needle = filter.trim().to_lowercase();
+			let mut view: Vec<usize> = (0..rows.len())
+				.filter(|&i| {
+					let r = &rows[i];
+					let matches_text = needle.is_empty()
+						|| r.id.to_lowercase().contains(&needle)
+						|| r.hash.to_lowercase().contains(&needle);
+					let matches_status = status_filter < 0 || r.status == status_filter;
+					let matches_dir = dir_filter < 0 || r.direction == dir_filter;
+					matches_text && matches_status && matches_dir
+				})
+				.collect();
+
+			// Sort the view (purely a display ordering; underlying list untouched).
+			view.sort_by(|&a, &b| {
+				let (ra, rb) = (&rows[a], &rows[b]);
+				let ord = match sort.0 {
+					0 => ra.amount_msat.unwrap_or(0).cmp(&rb.amount_msat.unwrap_or(0)),
+					_ => ra.timestamp.cmp(&rb.timestamp),
+				};
+				if sort.1 {
+					ord.reverse()
+				} else {
+					ord
+				}
+			});
+
+			ui.label(format!("{}/{} payment(s)", view.len(), total));
 			ui.add_space(5.0);
 
 			ScrollArea::both().max_height(500.0).show(ui, |ui| {
 				egui::Grid::new("payments_grid").striped(true).min_col_width(80.0).show(ui, |ui| {
-					// Header
+					// Header (Amount/Date are clickable sort toggles)
 					ui.strong("Payment ID");
 					ui.strong("Type");
-					ui.strong("Amount");
+					if ui.button(sort_header("Amount", &sort, 0)).clicked() {
+						sort = (0, if sort.0 == 0 { !sort.1 } else { true });
+					}
 					ui.strong("Fee");
 					ui.strong("Direction");
 					ui.strong("Status");
-					ui.strong("Timestamp");
+					if ui.button(sort_header("Timestamp", &sort, 1)).clicked() {
+						sort = (1, if sort.0 == 1 { !sort.1 } else { true });
+					}
 					ui.strong(""); // Details column
 					ui.end_row();
 
-					for payment in payments {
+					for &i in &view {
+						let row = &rows[i];
+
 						// Payment ID
 						ui.horizontal(|ui| {
-							ui.monospace(truncate_id(&payment.id, 5, 4));
+							ui.monospace(truncate_id(&row.id, 5, 4));
 							if ui.small_button("Copy").clicked() {
-								ui.output_mut(|o| o.copied_text = payment.id.clone());
+								ui.output_mut(|o| o.copied_text = row.id.clone());
 							}
 						});
 
 						// Type
-						let payment_type = payment
-							.kind
-							.as_ref()
-							.map(|k| format_payment_kind(k))
-							.unwrap_or_else(|| "Unknown".to_string());
-						ui.label(payment_type);
+						ui.label(&row.type_label);
 
-						// Amount
-						if let Some(amount) = payment.amount_msat {
-							ui.label(format_msat(amount));
-						} else {
-							ui.label("-");
-						}
+						// Amount (unit-aware, right-aligned)
+						ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+							match row.amount_msat {
+								Some(amount) => ui.monospace(app.fmt_msat(amount)),
+								None => ui.monospace("-"),
+							}
+						});
 
-						// Fee
-						if let Some(fee) = payment.fee_paid_msat {
-							ui.label(format_msat(fee));
-						} else {
-							ui.label("-");
-						}
+						// Fee (unit-aware, right-aligned)
+						ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+							match row.fee_paid_msat {
+								Some(fee) => ui.monospace(app.fmt_msat(fee)),
+								None => ui.monospace("-"),
+							}
+						});
 
-						// Direction (0 = Inbound, 1 = Outbound)
-						let direction = match payment.direction {
-							0 => "Inbound",
-							1 => "Outbound",
-							_ => "Unknown",
-						};
-						ui.label(direction);
-
-						// Status (0 = Pending, 1 = Succeeded, 2 = Failed)
-						match payment.status {
-							0 => {
-								ui.colored_label(egui::Color32::YELLOW, "Pending");
-							},
-							1 => {
-								ui.colored_label(egui::Color32::GREEN, "Succeeded");
-							},
-							2 => {
-								ui.colored_label(egui::Color32::RED, "Failed");
-							},
-							_ => {
-								ui.label("Unknown");
-							},
+						// Direction badge (0 = Inbound, 1 = Outbound)
+						match row.direction {
+							0 => widgets::status_pill(ui, "⬇ In", egui::Color32::LIGHT_BLUE),
+							1 => widgets::status_pill(ui, "⬆ Out", egui::Color32::GOLD),
+							_ => widgets::status_pill(ui, "Unknown", egui::Color32::GRAY),
 						};
 
-						// Timestamp
-						ui.label(format_timestamp(payment.latest_update_timestamp));
+						// Status pill (0 = Pending, 1 = Succeeded, 2 = Failed)
+						let (status_text, status_color) = status_style(row.status);
+						widgets::status_pill(ui, status_text, status_color);
+
+						// Timestamp (relative text, exact epoch on hover)
+						ui.label(format_timestamp(row.timestamp))
+							.on_hover_text(format!("unix: {}", row.timestamp));
 
 						// Details button - track click without modifying app state yet
 						if ui.small_button("Details").clicked() {
-							clicked_payment_id = Some(payment.id.clone());
+							clicked_payment_id = Some(row.id.clone());
 						}
 
 						ui.end_row();
@@ -125,13 +224,23 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 				});
 			});
 
-			if payments_response.next_page_token.is_some() {
+			if more_available {
 				ui.add_space(5.0);
 				ui.label("More payments available. Click 'Load More' to fetch.");
 			}
+
+			// Persist the control state back into temp memory.
+			ui.memory_mut(|m| {
+				m.data.insert_temp(filter_id, filter);
+				m.data.insert_temp(status_id, status_filter);
+				m.data.insert_temp(dir_id, dir_filter);
+				m.data.insert_temp(sort_id, sort);
+			});
 		}
 	} else {
-		ui.label("No payment data available. Click Refresh to fetch.");
+		if !loading {
+			ui.label("No payment data available. Click Refresh to fetch.");
+		}
 	}
 
 	// Handle the Details button click outside the borrow
@@ -140,6 +249,57 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 		app.state.payment_details = None;
 		app.state.show_payment_details_dialog = true;
 		app.fetch_payment_details(payment_id);
+	}
+}
+
+// Color/text mapping for the status pill (same colors as the old colored_label).
+fn status_style(status: i32) -> (&'static str, egui::Color32) {
+	match status {
+		0 => ("Pending", egui::Color32::YELLOW),
+		1 => ("Succeeded", egui::Color32::GREEN),
+		2 => ("Failed", egui::Color32::RED),
+		_ => ("Unknown", egui::Color32::GRAY),
+	}
+}
+
+fn status_label(filter: i32) -> &'static str {
+	match filter {
+		0 => "Pending",
+		1 => "Succeeded",
+		2 => "Failed",
+		_ => "All statuses",
+	}
+}
+
+fn direction_label(filter: i32) -> &'static str {
+	match filter {
+		0 => "Inbound",
+		1 => "Outbound",
+		_ => "All directions",
+	}
+}
+
+// Header label with a sort-direction arrow when this column is the active sort key.
+fn sort_header(label: &str, sort: &(u8, bool), col: u8) -> String {
+	if sort.0 == col {
+		format!("{} {}", label, if sort.1 { "⬇" } else { "⬆" })
+	} else {
+		label.to_string()
+	}
+}
+
+// Best-effort payment hash string for substring filtering (empty if none).
+fn payment_hash(kind: &sc_rest_client::ldk_server_grpc::types::PaymentKind) -> String {
+	use sc_rest_client::ldk_server_grpc::types::payment_kind::Kind;
+
+	match &kind.kind {
+		Some(Kind::Onchain(o)) => o.txid.clone(),
+		Some(Kind::Bolt11(b)) => b.hash.clone(),
+		Some(Kind::Bolt11Jit(j)) => j.hash.clone(),
+		Some(Kind::Bolt12Offer(o)) => o.hash.clone().unwrap_or_default(),
+		Some(Kind::Bolt12Refund(r)) => r.hash.clone().unwrap_or_default(),
+		Some(Kind::Spontaneous(s)) => s.hash.clone(),
+		None => String::new(),
 	}
 }
 
@@ -197,6 +357,33 @@ fn render_payment_details_dialog(ctx: &Context, app: &mut LspServerApp) {
 		.resizable(true)
 		.default_width(500.0)
 		.show(ctx, |ui| {
+			// Pre-format unit-aware amounts so the &app.state.payment_details borrow
+			// below doesn't conflict with app.fmt_msat (which borrows &app.state).
+			let amount_str = app
+				.state
+				.payment_details
+				.as_ref()
+				.and_then(|r| r.payment.as_ref())
+				.and_then(|p| p.amount_msat)
+				.map(|a| app.fmt_msat(a))
+				.unwrap_or_else(|| "-".to_string());
+			let fee_str = app
+				.state
+				.payment_details
+				.as_ref()
+				.and_then(|r| r.payment.as_ref())
+				.and_then(|p| p.fee_paid_msat)
+				.map(|f| app.fmt_msat(f))
+				.unwrap_or_else(|| "-".to_string());
+			let lsp_fee_str = app
+				.state
+				.payment_details
+				.as_ref()
+				.and_then(|r| r.payment.as_ref())
+				.and_then(|p| p.kind.as_ref())
+				.and_then(jit_max_total_fee_msat)
+				.map(|m| app.fmt_msat(m));
+
 			if app.state.tasks.payment_details.is_some() {
 				ui.horizontal(|ui| {
 					ui.spinner();
@@ -229,22 +416,14 @@ fn render_payment_details_dialog(ctx: &Context, app: &mut LspServerApp) {
 								ui.label(payment_type);
 								ui.end_row();
 
-								// Amount
+								// Amount (unit-aware, pre-formatted above)
 								ui.strong("Amount:");
-								if let Some(amount) = payment.amount_msat {
-									ui.label(format_msat(amount));
-								} else {
-									ui.label("-");
-								}
+								ui.label(&amount_str);
 								ui.end_row();
 
-								// Fee
+								// Fee (unit-aware, pre-formatted above)
 								ui.strong("Fee Paid:");
-								if let Some(fee) = payment.fee_paid_msat {
-									ui.label(format_msat(fee));
-								} else {
-									ui.label("-");
-								}
+								ui.label(&fee_str);
 								ui.end_row();
 
 								// Direction
@@ -257,24 +436,24 @@ fn render_payment_details_dialog(ctx: &Context, app: &mut LspServerApp) {
 								ui.label(direction);
 								ui.end_row();
 
-								// Status
+								// Status pill (same colors as the table)
 								ui.strong("Status:");
-								match payment.status {
-									0 => ui.colored_label(egui::Color32::YELLOW, "Pending"),
-									1 => ui.colored_label(egui::Color32::GREEN, "Succeeded"),
-									2 => ui.colored_label(egui::Color32::RED, "Failed"),
-									_ => ui.label("Unknown"),
-								};
+								let (status_text, status_color) = status_style(payment.status);
+								widgets::status_pill(ui, status_text, status_color);
 								ui.end_row();
 
-								// Timestamp
+								// Timestamp (relative text, exact epoch on hover)
 								ui.strong("Last Updated:");
-								ui.label(format_timestamp(payment.latest_update_timestamp));
+								ui.label(format_timestamp(payment.latest_update_timestamp))
+									.on_hover_text(format!(
+										"unix: {}",
+										payment.latest_update_timestamp
+									));
 								ui.end_row();
 
 								// Kind-specific details
 								if let Some(kind) = &payment.kind {
-									render_payment_kind_details(ui, kind);
+									render_payment_kind_details(ui, kind, &lsp_fee_str);
 								}
 							});
 					});
@@ -296,8 +475,22 @@ fn render_payment_details_dialog(ctx: &Context, app: &mut LspServerApp) {
 		});
 }
 
+// Extract the BOLT11-JIT LSP max-total opening fee (msat) for unit-aware formatting.
+fn jit_max_total_fee_msat(
+	kind: &sc_rest_client::ldk_server_grpc::types::PaymentKind,
+) -> Option<u64> {
+	use sc_rest_client::ldk_server_grpc::types::payment_kind::Kind;
+	match &kind.kind {
+		Some(Kind::Bolt11Jit(jit)) => {
+			jit.lsp_fee_limits.as_ref().and_then(|f| f.max_total_opening_fee_msat)
+		},
+		_ => None,
+	}
+}
+
 fn render_payment_kind_details(
 	ui: &mut egui::Ui, kind: &sc_rest_client::ldk_server_grpc::types::PaymentKind,
+	lsp_fee_str: &Option<String>,
 ) {
 	use sc_rest_client::ldk_server_grpc::types::payment_kind::Kind;
 
@@ -375,9 +568,9 @@ fn render_payment_kind_details(
 			}
 
 			if let Some(lsp_fee) = jit.lsp_fee_limits.as_ref() {
-				if let Some(max_total) = lsp_fee.max_total_opening_fee_msat {
+				if let Some(fee_str) = lsp_fee_str {
 					ui.strong("LSP Max Total Fee:");
-					ui.label(format_msat(max_total));
+					ui.label(fee_str);
 					ui.end_row();
 				}
 				if let Some(max_proportional) = lsp_fee.max_proportional_opening_fee_ppm_msat {

--- a/server/lsp-server-gui/src/ui/peers.rs
+++ b/server/lsp-server-gui/src/ui/peers.rs
@@ -1,7 +1,15 @@
 use eframe::egui;
 
 use crate::app::LspServerApp;
-use crate::ui::truncate_id;
+use crate::ui::widgets;
+
+// Per-row snapshot extracted from state.peers so the state borrow is released
+// before widgets::id_with_copy (needs &mut app.state.status_message) runs in the grid body.
+struct PeerRow {
+	node_id: String,
+	address: String,
+	is_connected: bool,
+}
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("Peers");
@@ -15,30 +23,50 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 
 	let mut disconnect_node_id = None;
 
-	match &app.state.peers {
-		Some(resp) => {
-			if resp.peers.is_empty() {
-				ui.label("No peers connected.");
+	// Pre-extract peer rows so the &app.state.peers borrow ends before the grid
+	// body calls widgets::id_with_copy (needs &mut app.state.status_message).
+	let rows: Option<Vec<PeerRow>> = app.state.peers.as_ref().map(|resp| {
+		resp.peers
+			.iter()
+			.map(|p| PeerRow {
+				node_id: p.node_id.clone(),
+				address: p.address.clone(),
+				is_connected: p.is_connected,
+			})
+			.collect()
+	});
+
+	match rows {
+		Some(peers) => {
+			if peers.is_empty() {
+				widgets::empty_state(ui, "👥", "No peers connected", "Click Refresh to load");
 			} else {
+				// Summary line: count connected peers
+				let connected_count = peers.iter().filter(|p| p.is_connected).count();
+				ui.label(format!("{} peers connected", connected_count));
+				ui.add_space(5.0);
+
 				egui::Grid::new("peers_table").striped(true).min_col_width(80.0).show(ui, |ui| {
 					ui.label(egui::RichText::new("Node ID").strong());
 					ui.label(egui::RichText::new("Address").strong());
-					ui.label(egui::RichText::new("Connected").strong());
+					ui.label(egui::RichText::new("Status").strong());
 					ui.label(egui::RichText::new("Actions").strong());
 					ui.end_row();
 
-					for peer in &resp.peers {
-						ui.horizontal(|ui| {
-							ui.label(
-								egui::RichText::new(truncate_id(&peer.node_id, 8, 4)).monospace(),
-							);
-							if ui.small_button("Copy").clicked() {
-								ui.output_mut(|o| o.copied_text = peer.node_id.clone());
-							}
-						});
-						ui.label(&peer.address);
-						ui.label(if peer.is_connected { "Yes" } else { "No" });
-						if ui.small_button("Disconnect").clicked() {
+					for peer in &peers {
+						widgets::id_with_copy(ui, &peer.node_id, &mut app.state.status_message);
+						ui.monospace(&peer.address);
+						if peer.is_connected {
+							widgets::status_pill(ui, "Connected", egui::Color32::GREEN);
+						} else {
+							widgets::status_pill(ui, "Disconnected", egui::Color32::GRAY);
+						}
+						// Destructive disconnect: red text small button
+						let btn = egui::Button::new(
+							egui::RichText::new("Disconnect").color(egui::Color32::RED),
+						)
+						.small();
+						if ui.add(btn).clicked() {
 							disconnect_node_id = Some(peer.node_id.clone());
 						}
 						ui.end_row();
@@ -47,7 +75,7 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			}
 		},
 		None => {
-			ui.label("Not loaded yet. Click Refresh.");
+			widgets::empty_state(ui, "👥", "No peers connected", "Click Refresh to load");
 		},
 	}
 

--- a/server/lsp-server-gui/src/ui/settings.rs
+++ b/server/lsp-server-gui/src/ui/settings.rs
@@ -1,0 +1,31 @@
+use egui::Ui;
+use crate::app::LspServerApp;
+use crate::state::DisplayUnit;
+
+pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
+	ui.heading("Settings");
+	ui.add_space(8.0);
+
+	crate::ui::widgets::section_header(ui, "Display unit");
+	ui.horizontal(|ui| {
+		let mut unit = app.state.display_unit;
+		ui.selectable_value(&mut unit, DisplayUnit::Usd, "USD");
+		ui.selectable_value(&mut unit, DisplayUnit::Btc, "BTC");
+		ui.selectable_value(&mut unit, DisplayUnit::Sats, "Sats");
+		app.state.display_unit = unit;
+	});
+	match &app.state.price {
+		Some(p) if p.price > 0.0 => { ui.weak(format!("Live rate: ${:.2} / BTC", p.price)); }
+		_ => { ui.weak("Live rate: unavailable"); }
+	}
+	ui.add_space(12.0);
+	ui.separator();
+	ui.add_space(12.0);
+
+	crate::ui::widgets::section_header(ui, "Connection");
+	#[cfg(not(target_arch = "wasm32"))]
+	if let Some(path) = &app.state.config_file_path {
+		ui.weak(format!("Loaded from: {}", path));
+	}
+	crate::ui::connection::render_settings(ui, app);
+}

--- a/server/lsp-server-gui/src/ui/stable_channels.rs
+++ b/server/lsp-server-gui/src/ui/stable_channels.rs
@@ -1,8 +1,8 @@
 use eframe::egui;
-use egui::{RichText, ScrollArea};
+use egui::{Color32, RichText, ScrollArea};
 
 use crate::app::LspServerApp;
-use crate::ui::{format_sats, truncate_id};
+use crate::ui::widgets;
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("Stable Channels");
@@ -30,19 +30,46 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 
 	ui.add_space(10.0);
 
-	// Stable channels table
-	match &app.state.stable_channels {
-		Some(resp) if !resp.channels.is_empty() => {
+	// Pre-extract row data so &app.state.stable_channels borrow is released
+	// before we call app.fmt_sats and widgets::id_with_copy below.
+	struct StableRow {
+		channel_id: String,
+		counterparty: String,
+		expected_usd: f64,
+		backing_sats: u64,
+		latest_price: f64,
+		is_stable_receiver: bool,
+		note: String,
+	}
+
+	let rows: Option<Vec<StableRow>> = app.state.stable_channels.as_ref().map(|resp| {
+		resp.channels
+			.iter()
+			.map(|ch| StableRow {
+				channel_id: ch.channel_id.clone(),
+				counterparty: ch.counterparty.clone(),
+				expected_usd: ch.expected_usd,
+				backing_sats: ch.expected_msats / 1000,
+				latest_price: ch.latest_price,
+				is_stable_receiver: ch.is_stable_receiver,
+				note: ch.note.clone(),
+			})
+			.collect()
+	});
+
+	match rows {
+		Some(ref rows) if !rows.is_empty() => {
 			ScrollArea::both().max_height(300.0).show(ui, |ui| {
-				egui::Grid::new("stable_channels_table").striped(true).min_col_width(60.0).show(
-					ui,
-					|ui| {
+				egui::Grid::new("stable_channels_table")
+					.striped(true)
+					.min_col_width(60.0)
+					.show(ui, |ui| {
 						// Headers
 						for h in [
 							"Channel ID",
 							"Counterparty",
 							"Stable $",
-							"Backing Sats",
+							"Backing",
 							"Price",
 							"Role",
 							"Note",
@@ -51,51 +78,48 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 						}
 						ui.end_row();
 
-						// Rows
-						for ch in &resp.channels {
-							// Channel ID (truncated + copy)
-							ui.horizontal(|ui| {
-								ui.label(
-									RichText::new(truncate_id(&ch.channel_id, 8, 4)).monospace(),
-								);
-								if ui.small_button("Copy").clicked() {
-									ui.output_mut(|o| o.copied_text = ch.channel_id.clone());
-								}
-							});
-
-							// Counterparty (truncated)
-							ui.label(
-								RichText::new(truncate_id(&ch.counterparty, 8, 4)).monospace(),
+						for row in rows {
+							// Channel ID — monospace truncated + copy-to-clipboard
+							widgets::id_with_copy(
+								ui,
+								&row.channel_id,
+								&mut app.state.status_message,
 							);
 
-							// Expected USD - green highlight
+							// Counterparty — truncated + copy
+							widgets::id_with_copy(
+								ui,
+								&row.counterparty,
+								&mut app.state.status_message,
+							);
+
+							// Expected USD — green, always dollars (USD target)
 							ui.label(
-								RichText::new(format!("${:.2}", ch.expected_usd))
-									.color(egui::Color32::from_rgb(34, 139, 34))
+								RichText::new(format!("${:.2}", row.expected_usd))
+									.color(Color32::from_rgb(34, 139, 34))
 									.strong(),
 							);
 
-							// Backing sats
-							ui.label(format_sats(ch.expected_msats / 1000));
+							// Backing sats — unit-aware via app.fmt_sats
+							ui.label(app.fmt_sats(row.backing_sats));
 
-							// Latest price
-							ui.label(format!("${:.0}", ch.latest_price));
+							// Latest price — always dollars (it is a BTC/USD price)
+							ui.label(format!("${:.0}", row.latest_price));
 
-							// Role
-							let role = if ch.is_stable_receiver { "Receiver" } else { "Provider" };
-							ui.label(role);
+							// Role — status pill
+							let (role_text, role_color) = if row.is_stable_receiver {
+								("Receiver", Color32::from_rgb(0xF7, 0x93, 0x1A))
+							} else {
+								("Provider", Color32::from_rgb(0x5B, 0x9B, 0xD5))
+							};
+							widgets::status_pill(ui, role_text, role_color);
 
 							// Note
-							ui.label(if ch.note.is_empty() {
-								"---".to_string()
-							} else {
-								ch.note.clone()
-							});
+							ui.label(if row.note.is_empty() { "---" } else { &row.note });
 
 							ui.end_row();
 						}
-					},
-				);
+					});
 			});
 		},
 		Some(_) => {
@@ -106,37 +130,4 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 		},
 	}
 
-	ui.add_space(15.0);
-	ui.separator();
-	ui.add_space(5.0);
-
-	// Edit form
-	ui.heading("Edit Stable Channel");
-	ui.add_space(5.0);
-
-	let form = &mut app.state.forms.edit_stable_channel;
-
-	ui.horizontal(|ui| {
-		ui.label("Channel ID:");
-		ui.text_edit_singleline(&mut form.channel_id);
-	});
-
-	ui.horizontal(|ui| {
-		ui.label("Target USD:");
-		ui.text_edit_singleline(&mut form.expected_usd);
-	});
-
-	ui.horizontal(|ui| {
-		ui.label("Note:");
-		ui.text_edit_singleline(&mut form.note);
-	});
-
-	ui.add_space(5.0);
-
-	let is_loading = app.state.tasks.edit_stable_channel.is_some();
-	ui.add_enabled_ui(!is_loading, |ui| {
-		if ui.button("Submit").clicked() {
-			app.edit_stable_channel();
-		}
-	});
 }

--- a/server/lsp-server-gui/src/ui/tools.rs
+++ b/server/lsp-server-gui/src/ui/tools.rs
@@ -1,14 +1,13 @@
 use eframe::egui;
 
 use crate::app::LspServerApp;
-use crate::state::ConnectionStatus;
+use crate::ui::widgets;
 
 pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	ui.heading("Tools");
 	ui.add_space(10.0);
 
-	if !matches!(app.state.connection_status, ConnectionStatus::Connected) {
-		ui.label("Connect to a server to use tools.");
+	if app.render_disconnected_gate(ui) {
 		return;
 	}
 
@@ -49,14 +48,17 @@ fn render_sign_message(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			ui.add_space(10.0);
 			ui.separator();
 			ui.label("Signature:");
+			// Pre-extract to avoid borrow conflict between TextEdit and copy button
+			let sig_clone = signature.clone();
 			ui.add(
-				egui::TextEdit::multiline(&mut signature.as_str())
+				egui::TextEdit::multiline(&mut sig_clone.as_str())
 					.desired_rows(2)
 					.desired_width(f32::INFINITY)
 					.interactive(false),
 			);
 			if ui.button("Copy Signature").clicked() {
-				ui.output_mut(|o| o.copied_text = signature.clone());
+				ui.output_mut(|o| o.copied_text = sig_clone.clone());
+				app.state.status_message = Some(crate::state::StatusMessage::success("Copied"));
 			}
 		}
 	});
@@ -84,7 +86,10 @@ fn render_export_pathfinding_scores(ui: &mut egui::Ui, app: &mut LspServerApp) {
 		if let Some(result) = &app.state.export_scores_result {
 			ui.add_space(10.0);
 			ui.separator();
-			ui.label(format!("Scores data: {} bytes", result.scores.len()));
+			let n = result.scores.len();
+			ui.horizontal(|ui| {
+				widgets::status_pill(ui, &format!("Exported {} bytes", n), egui::Color32::GREEN);
+			});
 		}
 	});
 }
@@ -128,11 +133,13 @@ fn render_verify_signature(ui: &mut egui::Ui, app: &mut LspServerApp) {
 
 		if let Some(valid) = &app.state.verify_result {
 			ui.add_space(5.0);
-			if *valid {
-				ui.colored_label(egui::Color32::GREEN, "Signature is VALID");
-			} else {
-				ui.colored_label(egui::Color32::RED, "Signature is INVALID");
-			}
+			ui.horizontal(|ui| {
+				if *valid {
+					widgets::status_pill(ui, "VALID", egui::Color32::GREEN);
+				} else {
+					widgets::status_pill(ui, "INVALID", egui::Color32::RED);
+				}
+			});
 		}
 	});
 }

--- a/server/lsp-server-gui/src/ui/widgets.rs
+++ b/server/lsp-server-gui/src/ui/widgets.rs
@@ -1,0 +1,100 @@
+use egui::{Color32, RichText, Ui};
+
+const AMBER: Color32 = Color32::from_rgb(0xF7, 0x93, 0x1A);
+
+/// A big headline figure with a small muted secondary line, in a framed card.
+pub fn stat_card(ui: &mut Ui, title: &str, big_value: &str, secondary: &str) {
+    egui::Frame::group(ui.style()).show(ui, |ui| {
+        ui.vertical(|ui| {
+            ui.label(RichText::new(title).small().weak());
+            ui.label(RichText::new(big_value).size(24.0).strong());
+            if !secondary.is_empty() {
+                ui.label(RichText::new(secondary).small().weak());
+            }
+        });
+    });
+}
+
+/// A small filled status pill.
+pub fn status_pill(ui: &mut Ui, text: &str, color: Color32) {
+    let bg = color.linear_multiply(0.25);
+    egui::Frame::none()
+        .fill(bg)
+        .rounding(egui::Rounding::same(8.0))
+        .inner_margin(egui::Margin::symmetric(8.0, 2.0))
+        .show(ui, |ui| {
+            ui.label(RichText::new(text).color(color).small().strong());
+        });
+}
+
+/// Monospace truncated id + a copy button that confirms via the status bar.
+pub fn id_with_copy(ui: &mut Ui, full_id: &str, status: &mut Option<crate::state::StatusMessage>) {
+    ui.horizontal(|ui| {
+        let short = super::truncate_id(full_id, 8, 8);
+        ui.monospace(&short).on_hover_text(full_id);
+        if ui.small_button("Copy").clicked() {
+            ui.output_mut(|o| o.copied_text = full_id.to_string());
+            *status = Some(crate::state::StatusMessage::success("Copied to clipboard"));
+        }
+    });
+}
+
+/// Centered empty-state placeholder.
+pub fn empty_state(ui: &mut Ui, icon: &str, title: &str, hint: &str) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(24.0);
+        ui.label(RichText::new(icon).size(32.0));
+        ui.label(RichText::new(title).strong());
+        ui.label(RichText::new(hint).small().weak());
+        ui.add_space(24.0);
+    });
+}
+
+/// Spinner + label loading row.
+pub fn loading_row(ui: &mut Ui, label: &str) {
+    ui.horizontal(|ui| {
+        ui.spinner();
+        ui.label(label);
+    });
+}
+
+/// Amber section header.
+pub fn section_header(ui: &mut Ui, text: &str) {
+    ui.label(RichText::new(text).color(AMBER).strong());
+}
+
+pub enum NotConnectedAction {
+    None,
+    OpenSettings,
+    Retry,
+}
+
+/// Centered "not connected" state with actions, used by every screen's connection gate.
+pub fn not_connected(ui: &mut Ui, status: &crate::state::ConnectionStatus, server_url: &str) -> NotConnectedAction {
+    let mut action = NotConnectedAction::None;
+    ui.vertical_centered(|ui| {
+        ui.add_space(40.0);
+        match status {
+            crate::state::ConnectionStatus::Error(e) => {
+                ui.label(RichText::new("⚠").size(32.0));
+                ui.label(RichText::new(format!("Can't reach the LSP at {}", server_url)).strong());
+                ui.label(RichText::new(e).small().weak());
+                ui.label(RichText::new("Make sure the daemon is running.").small().weak());
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("⚙ Open Settings").clicked() { action = NotConnectedAction::OpenSettings; }
+                    if ui.button("⟳ Retry").clicked() { action = NotConnectedAction::Retry; }
+                });
+            },
+            _ => {
+                ui.label(RichText::new("🔌").size(32.0));
+                ui.label(RichText::new("Not connected to an LSP").strong());
+                ui.label(RichText::new("Open Settings to configure the connection.").small().weak());
+                ui.add_space(8.0);
+                if ui.button("⚙ Open Settings").clicked() { action = NotConnectedAction::OpenSettings; }
+            },
+        }
+        ui.add_space(40.0);
+    });
+    action
+}

--- a/server/sc-rest-client/Cargo.toml
+++ b/server/sc-rest-client/Cargo.toml
@@ -15,7 +15,7 @@ prost = { version = "0.11.6", default-features = false, features = ["std", "pros
 bitcoin_hashes = "0.14"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["native-tls", "http2"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { version = "0.12", default-features = false }

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -11,7 +11,7 @@ ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev
 # ldk-node is pulled transitively by stable-channels but we need it as a direct
 # dep so we can name `ldk_node::lightning::ln::types::ChannelId` etc. in our
 # module path. The rev must match the root Cargo.toml.
-ldk-node          = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
+ldk-node          = { git = "https://github.com/lightningdevkit/ldk-node", rev = "47dad6d909af0fbb53e76d07740c04df5abdde3b" }
 hex               = "0.4"
 
 # Async trait support for &dyn LdkServerCalls (stable Rust async-fn-in-trait

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -70,6 +70,8 @@ pub struct StableChannelManager {
     pub stable_channels: Vec<StableChannel>,
     db: Arc<Database>,
     data_dir: PathBuf,
+    /// Per-channel consecutive low-balance tick count for the balance-truth backstop debounce (ignores transient in-flight HTLCs).
+    spend_debounce: std::collections::HashMap<u128, u8>,
 }
 
 /// Outcome of an `edit_stable_channel` call.
@@ -89,6 +91,7 @@ impl StableChannelManager {
             stable_channels: Vec::new(),
             db,
             data_dir,
+            spend_debounce: std::collections::HashMap::new(),
         }
     }
 
@@ -239,6 +242,9 @@ impl StableChannelManager {
                 format!("{}", sc.user_channel_id) != user_channel_id
             }
         });
+        if let Some(t) = target {
+            self.spend_debounce.remove(&t);
+        }
         if let Err(e) = self.db.mark_channel_closed(&user_channel_id) {
             tracing::error!(
                 "[stable] handle_channel_closed: db.mark_channel_closed failed for {}: {}",
@@ -512,6 +518,10 @@ impl StableChannelManager {
         let dollar_threshold = stable_channels::constants::STABILITY_THRESHOLD_USD;
         let cooldown = stable_channels::constants::STABILITY_PAYMENT_COOLDOWN_SECS as i64;
 
+        // (uid, new_expected_usd, counterparty_hex) for backstop SYNCs sent after the iter_mut borrow ends.
+        let mut backstop_syncs: Vec<(u128, f64, String)> = Vec::new();
+        const BACKSTOP_DEBOUNCE_TICKS: u8 = 2;
+
         for sc in self.stable_channels.iter_mut() {
             if sc.expected_usd.0 < 0.01 {
                 continue;
@@ -527,6 +537,46 @@ impl StableChannelManager {
             sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
             sc.latest_price = btc_price;
 
+            // Balance-truth backstop: live balance below backing means a spend went unreconciled (no PaymentForwarded) — deduct + SYNC. Debounced since outbound_capacity excludes in-flight HTLCs.
+            let uid = sc.user_channel_id;
+            if their_sats < sc.backing_sats {
+                let count = {
+                    let cnt = self.spend_debounce.entry(uid).or_insert(0);
+                    *cnt = cnt.saturating_add(1);
+                    *cnt
+                };
+                if count >= BACKSTOP_DEBOUNCE_TICKS {
+                    self.spend_debounce.remove(&uid);
+                    if let Some(usd_deducted) =
+                        stable_channels::stable::reconcile_outgoing(sc, btc_price)
+                    {
+                        stable_channels::audit::audit_event(
+                            "BACKSTOP_STABLE_DEDUCTED",
+                            serde_json::json!({
+                                "user_channel_id": format!("{}", uid),
+                                "their_sats": their_sats,
+                                "usd_deducted": usd_deducted,
+                                "new_expected_usd": sc.expected_usd.0,
+                                "new_backing_sats": sc.backing_sats,
+                            }),
+                        );
+                        if let Err(e) = self.db.save_channel(
+                            &c.channel_id,
+                            &format!("{}", uid),
+                            sc.expected_usd.0,
+                            sc.backing_sats,
+                            sc.native_sats,
+                            sc.note.as_deref(),
+                        ) {
+                            tracing::error!("[stable] backstop save_channel failed: {}", e);
+                        }
+                        backstop_syncs.push((uid, sc.expected_usd.0, sc.counterparty.to_string()));
+                    }
+                }
+            } else {
+                self.spend_debounce.remove(&uid);
+            }
+
             let stable_usd_value = if sc.backing_sats > 0 {
                 (sc.backing_sats as f64 / 100_000_000.0) * btc_price
             } else {
@@ -539,6 +589,16 @@ impl StableChannelManager {
             if percent_from_par < percent_threshold
                 || dollars_from_par < dollar_threshold
             {
+                continue;
+            }
+            if sc.risk_level > stable_channels::constants::MAX_RISK_LEVEL {
+                stable_channels::audit::audit_event(
+                    "STABILITY_SKIP_HIGH_RISK",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", sc.user_channel_id),
+                        "risk_level": sc.risk_level,
+                    }),
+                );
                 continue;
             }
             if now - sc.last_stability_payment < cooldown {
@@ -641,6 +701,10 @@ impl StableChannelManager {
                     }),
                 );
             }
+        }
+
+        for (uid, expected_usd, counterparty) in backstop_syncs {
+            self.send_sync_message(ldk, uid, expected_usd, &counterparty).await;
         }
     }
 
@@ -1023,8 +1087,9 @@ impl StableChannelManager {
         let their_sats = chan.channel_value_sats.saturating_sub(our_sats);
         let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
         let new_expected = payload.expected_usd;
-        // Cannot stabilize more than the user holds. Residual drift self-heals via the tick.
-        if new_expected > receiver_usd {
+        // Epsilon absorbs f64 boundary rounding so a spend-driven push landing at ~receiver_usd is admitted; residual drift self-heals.
+        let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
+        if new_expected > ceiling {
             stable_channels::audit::audit_event(
                 "TRADE_EXCEEDS_BALANCE",
                 serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd }),
@@ -1752,6 +1817,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_tick_skips_high_risk_channel() {
+        let mut mgr = make_manager();
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 50_000, 0, 50_000, 100_000.0);
+        mgr.stable_channels[0].risk_level = stable_channels::constants::MAX_RISK_LEVEL + 1;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        // Price drops 20% -> would normally pay lsp_to_user; high risk must skip.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+        assert!(
+            fake.sends.lock().unwrap().is_empty(),
+            "a channel above MAX_RISK_LEVEL must not trigger a stability send"
+        );
+    }
+
+    #[tokio::test]
+    async fn backstop_deducts_and_syncs_after_two_low_ticks() {
+        let mut mgr = make_manager();
+        // expected $10 -> backing 10_000; receiver 50_000 (native 40_000) at $100k.
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        // Live balance dropped to 5_000 (< backing 10_000): a spend the forwarded event missed.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+        )]);
+
+        // Tick 1: debounce only.
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "tick 1 must not deduct");
+        assert!(fake.sends.lock().unwrap().is_empty(), "tick 1 must not SYNC");
+
+        // Tick 2: act.
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        let exp = mgr.stable_channels[0].expected_usd.0;
+        assert!((exp - 5.0).abs() < 0.01, "tick 2 must deduct ~$5 (10_000-5_000 sats), got {}", exp);
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1, "tick 2 must send exactly one SYNC");
+        assert_eq!(sends[0].custom_tlvs.len(), 1, "SYNC must carry exactly one stable TLV");
+        assert_eq!(
+            sends[0].custom_tlvs[0].type_num,
+            stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+            "SYNC TLV must be the stable-channel type",
+        );
+    }
+
+    #[tokio::test]
+    async fn backstop_single_tick_dip_does_not_deduct() {
+        let mut mgr = make_manager();
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        // Tick 1: transient dip to 5_000 (in-flight outbound HTLC; outbound_capacity excludes it).
+        let dip = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+        )]);
+        mgr.run_tick(&dip as &dyn LdkServerCalls, &push, 100_000.0).await;
+        // Tick 2: balance restored to 50_000 (HTLC resolved without spending stable).
+        let restored = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        mgr.run_tick(&restored as &dyn LdkServerCalls, &push, 100_000.0).await;
+
+        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "a transient dip must not deduct");
+        assert!(restored.sends.lock().unwrap().is_empty(), "no SYNC for a transient dip");
+    }
+
+    #[tokio::test]
+    async fn backstop_noop_when_balance_healthy() {
+        let mut mgr = make_manager();
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        // Healthy: their 50_000 >= backing 10_000.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
+        assert!(fake.sends.lock().unwrap().is_empty(), "no backstop action when healthy");
+    }
+
+    #[tokio::test]
     async fn reconcile_hydrates_channel_with_decimal_user_channel_id() {
         let mut mgr = make_manager();
         // Persist a row whose user_channel_id is the realistic decimal form.
@@ -1929,6 +2084,27 @@ mod tests {
         mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6); // unchanged
+    }
+
+    #[tokio::test]
+    async fn trade_admits_at_balance_boundary_within_epsilon() {
+        let mut mgr = make_manager();
+        // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+        // A wallet-push lands at receiver_usd plus a sub-epsilon overshoot (independent f64 paths).
+        let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert!(
+            (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
+            "a target within epsilon of the balance must be admitted, got {}",
+            mgr.stable_channels[0].expected_usd.0
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Fixes stable-channel book divergence after an overflow Lightning send, revamps the LSP operator GUI, and aligns the daemon's ldk-node with the workspace root.

## Changes
- **Stable-book sync**:  when an outgoing Lightning send overflows into the USD-pegged portion, the wallet now pushes its new `expected_usd` to the LSP via a signed TLV keysend. The LSP's stability tick gains a balance-truth backstop that self-heals and re-syncs the wallet when a spend went unreconciled, plus an epsilon on the trade balance ceiling and a risk / in-flight-HTLC debounce guard.
- **LSP operator GUI**: dark + amber theme, universal USD/BTC/sats display toggle with unit-aware amount entry, dedicated Settings page, Channels tab gets a two-color liquidity bar, text/status filter, and sortable columns, Payments/Forwarded pagination fixed (no empty-page flicker) with proper loading states; per-tab refresh (removed the global reload). Connection uses native-tls (accepts the daemon's self-signed cert) and the gtk3 file-dialog backend. No daemon API or behavior change.
- **Dependencies**: align the daemon's `ldk-node` rev with the root crate so the workspace builds on current main.