### PR TITLE
fix(android): show payment status updates in real-time on send screen

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -52,6 +52,14 @@ class AppState(private val context: Context) : ViewModel() {
     private val _statusMessage = MutableStateFlow("")
     val statusMessage: StateFlow<String> = _statusMessage
 
+    // Track last payment result for SendScreen UI updates
+    private val _lastPaymentResult = MutableStateFlow<String?>(null)
+    val lastPaymentResult: StateFlow<String?> = _lastPaymentResult
+
+    fun clearLastPaymentResult() {
+        _lastPaymentResult.value = null
+    }
+
     private val _lightningBalanceSats: MutableStateFlow<Long>
     val lightningBalanceSats: StateFlow<Long> get() = _lightningBalanceSats
 
@@ -295,6 +303,7 @@ class AppState(private val context: Context) : ViewModel() {
                         }
                         val reason = event.reason?.toString() ?: "unknown"
                         _statusMessage.value = "Payment failed: $reason"
+                        _lastPaymentResult.value = "Payment failed: $reason"
                         AuditService.log("PAYMENT_FAILED", mapOf(
                             "payment_id" to (pid ?: ""),
                             "payment_hash" to (event.paymentHash ?: ""),
@@ -421,7 +430,9 @@ class AppState(private val context: Context) : ViewModel() {
                 }
             }
             saveChannelToDB()
-            _statusMessage.value = if (displayVal != null) "Payment sent: $displayVal" else "Payment confirmed"
+            val successMsg = if (displayVal != null) "Payment sent: $displayVal" else "Payment confirmed"
+            _statusMessage.value = successMsg
+            _lastPaymentResult.value = successMsg
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -68,6 +68,24 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     val btcPrice by appState.priceService.currentPrice.collectAsState()
     val lightningSats by appState.lightningBalanceSats.collectAsState()
     val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
+    val lastPaymentResult by appState.lastPaymentResult.collectAsState()
+
+    // Watch for payment success or failure while result screen is showing
+    LaunchedEffect(lastPaymentResult, result) {
+        if (result != null && lastPaymentResult != null) {
+            when {
+                lastPaymentResult!!.startsWith("Payment failed") -> {
+                    result = null
+                    error = lastPaymentResult
+                    appState.clearLastPaymentResult()
+                }
+                lastPaymentResult!!.startsWith("Payment sent") || lastPaymentResult!!.startsWith("Payment confirmed") -> {
+                    result = lastPaymentResult
+                    appState.clearLastPaymentResult()
+                }
+            }
+        }
+    }
 
     val inputType = remember(input) {
         val lower = input.trim().lowercase()
@@ -275,14 +293,27 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
 
         if (result != null) {
             Spacer(Modifier.height(40.dp))
-            Icon(
-                imageVector = Icons.Filled.CheckCircle,
-                contentDescription = "Success",
-                tint = Color(0xFF10B981),
-                modifier = Modifier.size(64.dp)
-            )
+            val isSending = result!!.startsWith("Sending")
+            if (isSending) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(64.dp),
+                    color = Color(0xFFF59E0B),
+                    strokeWidth = 4.dp
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = "Success",
+                    tint = Color(0xFF10B981),
+                    modifier = Modifier.size(64.dp)
+                )
+            }
             Spacer(Modifier.height(16.dp))
-            Text("Sent!", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+            Text(
+                text = if (isSending) "Sending..." else "Sent!",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
             Spacer(Modifier.height(12.dp))
             Card(
                 colors = CardDefaults.cardColors(
@@ -494,7 +525,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             amountUSD = if (price > 0) (actualMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price else null,
                                             btcPrice = if (price > 0) price else null
                                         )
-                                        result = "Payment sent"
+                                        result = "Sending payment..."
                                     }
                                     InputType.BOLT12 -> {
                                         val sats = manualAmountSats


### PR DESCRIPTION
## Problem

1. "Payment sent" confirmation showed immediately after `sendPayment()` returned, before the payment actually confirmed. If the payment failed later (e.g., routing issue), the balance reverted but the user already saw the success screen.
2. When a payment failed in the background, the send screen stayed stuck on "Sending..." forever — no error was shown.
3. When a payment succeeded in the background, the send screen never updated to show success.

## Solution

Added `lastPaymentResult` StateFlow to AppState that tracks the result of the last payment:
- Set to "Payment sent: $X.XX" when LDK confirms payment
- Set to "Payment failed: $reason" when LDK reports failure
- Cleared after SendScreen reads it

SendScreen now watches `lastPaymentResult` and updates the UI in real-time:
- **While sending:** Spinner + "Sending payment..."
- **After LDK confirms:** Checkmark + "Payment sent: $X.XX"
- **After LDK rejects:** Error message

## Files Changed
- `AppState.kt` — added `lastPaymentResult` StateFlow and `clearLastPaymentResult()`
- `SendScreen.kt` — watches `lastPaymentResult` for real-time updates
