### PR TITLE
feat(android): floating nav bar, rolling digit animation, auto-dismiss receive sheet

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/MainTabView.kt
@@ -1,15 +1,29 @@
 package com.stablechannels.app.ui
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
-import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
 import com.stablechannels.app.ui.history.HistoryScreen
 import com.stablechannels.app.ui.home.HomeScreen
@@ -24,41 +38,89 @@ enum class Tab(val label: String, val icon: ImageVector) {
 @Composable
 fun MainTabView(appState: AppState) {
     var selectedTab by remember { mutableStateOf(Tab.HOME) }
+    val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
 
-    Scaffold(
-        bottomBar = {
-            Column {
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant,
-                    thickness = 0.5.dp
-                )
-                NavigationBar(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 0.dp
-                ) {
-                    Tab.entries.forEach { tab ->
-                        NavigationBarItem(
-                            icon = { Icon(tab.icon, contentDescription = tab.label) },
-                            label = { Text(tab.label) },
-                            selected = selectedTab == tab,
-                            onClick = { selectedTab = tab },
-                            colors = NavigationBarItemDefaults.colors(
-                                selectedIconColor = MaterialTheme.colorScheme.primary,
-                                selectedTextColor = MaterialTheme.colorScheme.primary,
-                                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                indicatorColor = androidx.compose.ui.graphics.Color.Transparent
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(systemBarsPadding)
+    ) {
+        when (selectedTab) {
+            Tab.HOME -> HomeScreen(appState)
+            Tab.HISTORY -> HistoryScreen(appState)
+            Tab.SETTINGS -> SettingsNavHost(appState)
+        }
+        ModernBottomNavBar(
+            selectedTab = selectedTab,
+            onTabSelected = { selectedTab = it },
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+}
+
+@Composable
+fun ModernBottomNavBar(
+    selectedTab: Tab,
+    onTabSelected: (Tab) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isDark = isSystemInDarkTheme()
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 92.dp, vertical = 12.dp)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (isDark) Modifier.border(
+                        width = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        shape = RoundedCornerShape(20.dp)
+                    ) else Modifier
+                ),
+            shape = RoundedCornerShape(20.dp),
+            shadowElevation = if (isDark) 0.dp else 12.dp,
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Tab.entries.forEach { tab ->
+                    val isSelected = selectedTab == tab
+                    val animatedColor by animateColorAsState(
+                        targetValue = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        animationSpec = tween(200),
+                        label = "color"
+                    )
+
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .size(44.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) { onTabSelected(tab) }
+                            .background(
+                                color = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent,
+                                shape = RoundedCornerShape(12.dp)
                             )
+                    ) {
+                        Icon(
+                            tab.icon,
+                            contentDescription = tab.label,
+                            tint = animatedColor,
+                            modifier = Modifier.size(22.dp)
                         )
                     }
                 }
             }
-        }
-    ) { padding ->
-        when (selectedTab) {
-            Tab.HOME -> HomeScreen(appState, Modifier.padding(padding))
-            Tab.HISTORY -> HistoryScreen(appState, Modifier.padding(padding))
-            Tab.SETTINGS -> SettingsNavHost(appState, Modifier.padding(padding))
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -152,6 +152,8 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
                             }
                         }
                     }
+                    // Bottom padding for nav bar
+                    item { Spacer(Modifier.height(80.dp)) }
                 }
             }
         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -77,6 +77,15 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     var prefillTradeAmount by remember { mutableDoubleStateOf(0.0) }
     var showBTC by remember { mutableStateOf(false) }
 
+    // Auto-dismiss receive sheet when payment arrives
+    val scrollState = rememberScrollState()
+    LaunchedEffect(isFlashing) {
+        if (isFlashing && showReceive) {
+            showReceive = false
+            scrollState.animateScrollTo(0)
+        }
+    }
+
     val context = LocalContext.current
     var notificationsEnabled by remember { mutableStateOf(true) }
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -134,7 +143,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -206,18 +215,22 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 )
                 Spacer(Modifier.height(4.dp))
                 if (showBTC) {
-                    Text(
+                    RollingDigitText(
                         text = totalSats.btcSpacedFormatted() + " BTC",
-                        fontSize = 32.sp,
-                        fontWeight = FontWeight.Bold,
-                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                        style = MaterialTheme.typography.headlineLarge.copy(
+                            fontSize = 32.sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                        )
                     )
                 } else {
                     if (btcPrice > 0) {
-                        Text(
+                        RollingDigitText(
                             text = totalUSD.usdFormatted(),
-                            fontSize = 36.sp,
-                            fontWeight = FontWeight.Bold
+                            style = MaterialTheme.typography.headlineLarge.copy(
+                                fontSize = 36.sp,
+                                fontWeight = FontWeight.Bold
+                            )
                         )
                     } else if (totalSats > 0) {
                         Text(
@@ -397,6 +410,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     message = statusMessage
                 )
             }
+            // Bottom padding for nav bar
+            Spacer(Modifier.height(80.dp))
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/RollingDigitText.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/RollingDigitText.kt
@@ -1,0 +1,68 @@
+package com.stablechannels.app.ui.home
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+
+/**
+ * A text composable that animates each digit independently,
+ * like a mechanical counter or alarm clock.
+ * Non-digit characters (commas, dots, spaces) stay static.
+ */
+@Composable
+fun RollingDigitText(
+    text: String,
+    style: TextStyle,
+    color: Color = Color.Unspecified,
+    modifier: Modifier = Modifier
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val measuredHeight = textMeasurer.measure("0", style).size.height
+    val heightDp = with(density) { measuredHeight.toDp() }
+
+    Row(modifier = modifier) {
+        text.forEach { char ->
+            if (char.isDigit()) {
+                Box(modifier = Modifier.height(heightDp)) {
+                    AnimatedContent(
+                        targetState = char,
+                        transitionSpec = {
+                            slideInVertically(animationSpec = tween(400)) { height -> height } togetherWith
+                                slideOutVertically(animationSpec = tween(400)) { height -> -height } using
+                                SizeTransform(clip = true)
+                        },
+                        label = "digit-${char.hashCode()}"
+                    ) { targetChar ->
+                        Text(
+                            text = targetChar.toString(),
+                            style = style,
+                            color = color
+                        )
+                    }
+                }
+            } else {
+                // Non-digit characters (commas, dots, spaces) stay static
+                Text(
+                    text = char.toString(),
+                    style = style,
+                    color = color
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

### 1. Floating Bottom Navigation Bar
- Removed Scaffold wrapper — icons float above content
- Rounded corners (20dp), shadow elevation (12dp)
- Dark mode: shadow removed, subtle border added instead
- Compact icons (22dp) with animated color transitions

### 2. Rolling Digit Animation
- Created `RollingDigitText` composable
- Each digit slides independently like a mechanical counter
- Old digit clips and doesn't show above new one
- 400ms animation duration

### 3. Auto-dismiss Receive Sheet
- When payment arrives while receive sheet is open, it auto-dismisses
- Home screen scrolls to top so balance is visible
- Payment flash animation shows on home screen

### 4. Bottom Padding
- Added 80dp padding to HomeScreen and HistoryScreen
- Content won't be hidden by the floating nav bar

## Files Changed
- `MainTabView.kt` — floating nav bar with dark mode support
- `RollingDigitText.kt` — NEW: rolling digit animation
- `HomeScreen.kt` — auto-dismiss receive sheet + rolling digits + bottom padding
- `HistoryScreen.kt` — bottom padding
