### PR TITLE
fix(android): return STABLE when backingSats is zero

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
@@ -84,11 +84,12 @@ object StabilityService {
             return StabilityCheckResult(StabilityAction.STABLE, 0.0, 0.0, targetUSD, 0.0)
         }
 
-        val stableUSDValue = if (sc.backingSats > 0) {
-            (sc.backingSats.toDouble() / Constants.SATS_IN_BTC) * price
-        } else {
-            sc.stableReceiverUSD.amount
+        // No backing means no stable position — nothing to drift
+        if (sc.backingSats == 0L) {
+            return StabilityCheckResult(StabilityAction.STABLE, 0.0, 0.0, targetUSD, 0.0)
         }
+
+        val stableUSDValue = (sc.backingSats.toDouble() / Constants.SATS_IN_BTC) * price
 
         val dollarsFromPar = stableUSDValue - targetUSD
         val percentFromPar = if (targetUSD > 0) abs(dollarsFromPar / targetUSD) * 100.0 else 0.0


### PR DESCRIPTION
## Problem

When `backingSats == 0` and `expectedUSD > 0` (edge case), `checkStabilityAction` falls back to `stableReceiverUSD.amount` (total channel balance) for the drift calculation. This gives an incorrect drift value and could trigger unnecessary stability payments.

## Fix

Return `STABLE` immediately when `backingSats == 0` — no backing means no stable position, so there's no drift to correct.

## Files Changed
- `StabilityService.kt` — added early return when `backingSats == 0`
