### PR TITLE
Label stable-channel settlement payments in the operator GUI

### DIFF
--- a/server/lsp-server-gui/src/app.rs
+++ b/server/lsp-server-gui/src/app.rs
@@ -17,7 +17,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	SpliceInRequest, SpliceOutRequest, SpontaneousSendRequest, UpdateChannelConfigRequest,
 	VerifySignatureRequest,
 };
-use sc_rest_client::sc_protos::stable::{GetPriceRequest, ListStableChannelsRequest, LogRequest};
+use sc_rest_client::sc_protos::stable::{GetPriceRequest, ListSettlementPaymentsRequest, ListStableChannelsRequest, LogRequest};
 use sc_rest_client::ldk_server_grpc::types::{
 	bolt11_invoice_description, Bolt11InvoiceDescription, ChannelConfig,
 };
@@ -247,6 +247,7 @@ impl LspServerApp {
 					.map_err(|e| e.to_string())
 			}));
 		}
+		self.fetch_settlement_payments();
 	}
 
 	pub fn fetch_peers(&mut self) {
@@ -753,6 +754,21 @@ impl LspServerApp {
 		}
 	}
 
+	pub fn fetch_settlement_payments(&mut self) {
+		if self.state.tasks.list_settlement_payments.is_some() {
+			return;
+		}
+		if let Some(client) = &self.state.client {
+			let client = client.clone();
+			self.state.tasks.list_settlement_payments = Some(self.spawn_task(async move {
+				client
+					.list_settlement_payments(ListSettlementPaymentsRequest {})
+					.await
+					.map_err(|e| e.to_string())
+			}));
+		}
+	}
+
 	pub fn disconnect_peer(&mut self, node_pubkey: String) {
 		if self.state.tasks.disconnect_peer.is_some() {
 			return;
@@ -1149,6 +1165,17 @@ impl LspServerApp {
 
 		poll_task!(self.state.tasks.list_stable_channels => |v| {
 			self.state.stable_channels = Some(v);
+		});
+
+		poll_task!(self.state.tasks.list_settlement_payments => |v| {
+			self.state.settlement_kinds = Some(
+				v.settlements
+					.into_iter()
+					.filter_map(|p| {
+						crate::state::SettlementKind::parse(&p.kind).map(|k| (p.payment_id, k))
+					})
+					.collect(),
+			);
 		});
 
 		poll_task!(self.state.tasks.disconnect_peer => |_v| {

--- a/server/lsp-server-gui/src/state.rs
+++ b/server/lsp-server-gui/src/state.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::collections::HashMap;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -17,7 +18,7 @@ use sc_rest_client::ldk_server_grpc::api::{
 	SpliceOutResponse, SpontaneousSendResponse, UpdateChannelConfigResponse,
 	VerifySignatureResponse,
 };
-use sc_rest_client::sc_protos::stable::{GetPriceResponse, ListStableChannelsResponse, LogResponse};
+use sc_rest_client::sc_protos::stable::{GetPriceResponse, ListSettlementPaymentsResponse, ListStableChannelsResponse, LogResponse};
 use sc_rest_client::ldk_server_grpc::types::PageToken;
 
 #[derive(Clone, PartialEq, Default)]
@@ -52,6 +53,24 @@ pub enum DisplayUnit {
 	Usd,
 	Btc,
 	Sats,
+}
+
+/// Stable-channel settlement classification recorded by the daemon, keyed by payment_id.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SettlementKind {
+	Stability,
+	Sync,
+}
+
+impl SettlementKind {
+	/// Parse the daemon's `kind` string; unknown strings are ignored.
+	pub fn parse(s: &str) -> Option<Self> {
+		match s {
+			"stability" => Some(Self::Stability),
+			"sync" => Some(Self::Sync),
+			_ => None,
+		}
+	}
 }
 
 #[derive(Default, Clone)]
@@ -319,6 +338,7 @@ pub struct AsyncTasks {
 	pub export_pathfinding_scores: Option<ChannelTaskHandle<ExportPathfindingScoresResponse>>,
 	pub get_price: Option<ChannelTaskHandle<GetPriceResponse>>,
 	pub list_stable_channels: Option<ChannelTaskHandle<ListStableChannelsResponse>>,
+	pub list_settlement_payments: Option<ChannelTaskHandle<ListSettlementPaymentsResponse>>,
 	pub ldk_log: Option<ChannelTaskHandle<LogResponse>>,
 }
 
@@ -356,6 +376,7 @@ impl Default for AsyncTasks {
 			export_pathfinding_scores: None,
 			get_price: None,
 			list_stable_channels: None,
+			list_settlement_payments: None,
 			ldk_log: None,
 		}
 	}
@@ -394,6 +415,7 @@ impl AsyncTasks {
 			|| self.export_pathfinding_scores.is_some()
 			|| self.get_price.is_some()
 			|| self.list_stable_channels.is_some()
+			|| self.list_settlement_payments.is_some()
 			|| self.ldk_log.is_some()
 	}
 }
@@ -430,6 +452,8 @@ pub struct AppState {
 	pub payment_details: Option<GetPaymentDetailsResponse>,
 	pub price: Option<GetPriceResponse>,
 	pub stable_channels: Option<ListStableChannelsResponse>,
+	// payment_id (hex) -> settlement classification, fetched alongside payments.
+	pub settlement_kinds: Option<HashMap<String, SettlementKind>>,
 	pub ldk_log: Option<LogResponse>,
 
 	// Operation results
@@ -520,6 +544,7 @@ impl Default for AppState {
 			payment_details: None,
 			price: None,
 			stable_channels: None,
+			settlement_kinds: None,
 			ldk_log: None,
 
 			onchain_address: None,

--- a/server/lsp-server-gui/src/ui/payments.rs
+++ b/server/lsp-server-gui/src/ui/payments.rs
@@ -13,6 +13,7 @@ struct PaymentRow {
 	id: String,
 	hash: String,
 	type_label: String,
+	settlement_kind: Option<crate::state::SettlementKind>,
 	amount_msat: Option<u64>,
 	fee_paid_msat: Option<u64>,
 	direction: i32,
@@ -54,6 +55,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 
 	// Pre-extract per-row data into locals so the &app.state.payments borrow is
 	// released before app.fmt_msat / status_pill below; never mutate the underlying list.
+	let settlement_kinds = app.state.settlement_kinds.as_ref();
 	let rows: Option<(Vec<PaymentRow>, bool)> = app.state.payments.as_ref().map(|resp| {
 		let rows = resp
 			.payments
@@ -66,6 +68,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 					.as_ref()
 					.map(|k| format_payment_kind(k))
 					.unwrap_or_else(|| "Unknown".to_string()),
+				settlement_kind: settlement_kinds.and_then(|m| m.get(&p.id).copied()),
 				amount_msat: p.amount_msat,
 				fee_paid_msat: p.fee_paid_msat,
 				direction: p.direction,
@@ -180,8 +183,8 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 							}
 						});
 
-						// Type
-						ui.label(&row.type_label);
+						// Type — settlement keysends override the generic label
+						ui.label(payment_type_label_str(&row.type_label, row.settlement_kind));
 
 						// Amount (unit-aware, right-aligned)
 						ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -314,6 +317,15 @@ fn format_payment_kind(kind: &sc_rest_client::ldk_server_grpc::types::PaymentKin
 		Some(Kind::Bolt12Refund(_)) => "BOLT12 Refund".to_string(),
 		Some(Kind::Spontaneous(_)) => "Spontaneous".to_string(),
 		None => "Unknown".to_string(),
+	}
+}
+
+/// Grid display wrapper: the kind label is precomputed into `type_label`; apply only the override.
+fn payment_type_label_str(type_label: &str, settlement: Option<crate::state::SettlementKind>) -> String {
+	match settlement {
+		Some(crate::state::SettlementKind::Stability) => "Stability".to_string(),
+		Some(crate::state::SettlementKind::Sync) => "Sync".to_string(),
+		None => type_label.to_string(),
 	}
 }
 
@@ -695,5 +707,22 @@ fn render_payment_kind_details(
 			}
 		},
 		None => {},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::state::SettlementKind;
+
+	#[test]
+	fn settlement_overrides_label() {
+		assert_eq!(payment_type_label_str("Spontaneous", Some(SettlementKind::Stability)), "Stability");
+		assert_eq!(payment_type_label_str("Spontaneous", Some(SettlementKind::Sync)), "Sync");
+	}
+
+	#[test]
+	fn non_settlement_passes_through() {
+		assert_eq!(payment_type_label_str("Spontaneous", None), "Spontaneous");
 	}
 }

--- a/server/sc-protos/src/stable.rs
+++ b/server/sc-protos/src/stable.rs
@@ -101,6 +101,27 @@ pub struct LogResponse {
 	pub content: ::prost::alloc::string::String,
 }
 
+// Settlement payments
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSettlementPaymentsRequest {}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SettlementPayment {
+	#[prost(string, tag = "1")]
+	pub payment_id: ::prost::alloc::string::String,
+	#[prost(string, tag = "2")]
+	pub kind: ::prost::alloc::string::String,
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListSettlementPaymentsResponse {
+	#[prost(message, repeated, tag = "1")]
+	pub settlements: ::prost::alloc::vec::Vec<SettlementPayment>,
+}
+
 // SC-specific REST route paths.
 pub const GET_PRICE_PATH: &str = "GetPrice";
 pub const LIST_STABLE_CHANNELS_PATH: &str = "ListStableChannels";
@@ -108,3 +129,24 @@ pub const EDIT_STABLE_CHANNEL_PATH: &str = "EditStableChannel";
 pub const REGISTER_PUSH_PATH: &str = "RegisterPush";
 pub const AUDIT_LOG_PATH: &str = "AuditLog";
 pub const LDK_LOG_PATH: &str = "LdkLog";
+pub const LIST_SETTLEMENT_PAYMENTS_PATH: &str = "ListSettlementPayments";
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use prost::Message;
+
+	#[test]
+	fn settlement_messages_roundtrip() {
+		let resp = ListSettlementPaymentsResponse {
+			settlements: vec![
+				SettlementPayment { payment_id: "pay_a".into(), kind: "stability".into() },
+				SettlementPayment { payment_id: "pay_b".into(), kind: "sync".into() },
+			],
+		};
+		let bytes = resp.encode_to_vec();
+		let decoded = ListSettlementPaymentsResponse::decode(&bytes[..]).unwrap();
+		assert_eq!(decoded, resp);
+		assert_eq!(decoded.settlements[0].kind, "stability");
+	}
+}

--- a/server/sc-rest-client/src/client.rs
+++ b/server/sc-rest-client/src/client.rs
@@ -43,8 +43,9 @@ use ldk_server_client::ldk_server_grpc::endpoints::{
 use ldk_server_client::ldk_server_grpc::error::{ErrorCode, ErrorResponse};
 use sc_protos::stable::{
 	EditStableChannelRequest, EditStableChannelResponse, GetPriceRequest, GetPriceResponse,
-	ListStableChannelsRequest, ListStableChannelsResponse, LogRequest, LogResponse,
-	EDIT_STABLE_CHANNEL_PATH, GET_PRICE_PATH, LDK_LOG_PATH, LIST_STABLE_CHANNELS_PATH,
+	ListSettlementPaymentsRequest, ListSettlementPaymentsResponse, ListStableChannelsRequest,
+	ListStableChannelsResponse, LogRequest, LogResponse, EDIT_STABLE_CHANNEL_PATH,
+	GET_PRICE_PATH, LDK_LOG_PATH, LIST_SETTLEMENT_PAYMENTS_PATH, LIST_STABLE_CHANNELS_PATH,
 };
 use prost::Message;
 use reqwest::header::CONTENT_TYPE;
@@ -492,6 +493,14 @@ impl LspRestClient {
 		&self, request: ListStableChannelsRequest,
 	) -> Result<ListStableChannelsResponse, LspRestError> {
 		let url = self.build_url(LIST_STABLE_CHANNELS_PATH);
+		self.post_request(&request, &url).await
+	}
+
+	/// Lists settlement payments recorded by the SC daemon.
+	pub async fn list_settlement_payments(
+		&self, request: ListSettlementPaymentsRequest,
+	) -> Result<ListSettlementPaymentsResponse, LspRestError> {
+		let url = self.build_url(LIST_SETTLEMENT_PAYMENTS_PATH);
 		self.post_request(&request, &url).await
 	}
 

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -69,7 +69,9 @@ async fn dispatch(
             }
         },
         Some(EventVariant::PaymentReceived(e)) => {
-            mgr.handle_payment_received(e.custom_records, ldk, btc_price).await;
+            let payment_id = e.payment.as_ref().map(|p| p.id.clone());
+            mgr.handle_payment_received(e.custom_records, payment_id, ldk, btc_price)
+                .await;
         },
         Some(EventVariant::PaymentForwarded(e)) => {
             if let Some(fp) = e.forwarded_payment {

--- a/server/stable-channels-lsp/src/handlers/stable_channels.rs
+++ b/server/stable-channels-lsp/src/handlers/stable_channels.rs
@@ -5,12 +5,13 @@ use axum::extract::State;
 use axum::response::Response;
 
 use sc_protos::stable::{
-    EditStableChannelRequest, EditStableChannelResponse, ListStableChannelsRequest,
-    ListStableChannelsResponse, StableChannelInfo,
+    EditStableChannelRequest, EditStableChannelResponse, ListSettlementPaymentsRequest,
+    ListSettlementPaymentsResponse, ListStableChannelsRequest, ListStableChannelsResponse,
+    SettlementPayment, StableChannelInfo,
 };
 use stable_channels::price_feeds::get_cached_price_no_fetch;
 
-use crate::handlers::{decode_body, ok_response};
+use crate::handlers::{decode_body, error_response, ok_response};
 use crate::stable_manager::EditOutcome;
 use crate::state::AppState;
 
@@ -67,4 +68,30 @@ pub async fn edit_stable_channel(
     };
 
     ok_response(EditStableChannelResponse { ok, status })
+}
+
+pub async fn list_settlement_payments(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Response {
+    if let Err(resp) = decode_body::<ListSettlementPaymentsRequest>(&body) {
+        return resp;
+    }
+
+    let rows = match state.db.list_settlements() {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                ldk_server_client::ldk_server_grpc::error::ErrorCode::InternalServerError,
+                format!("list_settlements failed: {}", e),
+            )
+        }
+    };
+
+    let settlements = rows
+        .into_iter()
+        .map(|(payment_id, kind)| SettlementPayment { payment_id, kind })
+        .collect::<Vec<_>>();
+
+    ok_response(ListSettlementPaymentsResponse { settlements })
 }

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -21,7 +21,7 @@ use ldk_server_client::client::LdkServerClient;
 use ldk_server_client::config as ldk_config;
 use sc_protos::stable::{
     AUDIT_LOG_PATH, EDIT_STABLE_CHANNEL_PATH, GET_PRICE_PATH, LDK_LOG_PATH,
-    LIST_STABLE_CHANNELS_PATH, REGISTER_PUSH_PATH,
+    LIST_SETTLEMENT_PAYMENTS_PATH, LIST_STABLE_CHANNELS_PATH, REGISTER_PUSH_PATH,
 };
 use ldk_server_client::ldk_server_grpc::endpoints::{
     BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
@@ -202,6 +202,10 @@ async fn main() -> Result<()> {
         .route(
             &format!("/{}", LDK_LOG_PATH),
             post(handlers::ldk_log::ldk_log),
+        )
+        .route(
+            &format!("/{}", LIST_SETTLEMENT_PAYMENTS_PATH),
+            post(handlers::stable_channels::list_settlement_payments),
         )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -452,6 +452,7 @@ impl StableChannelManager {
     pub async fn handle_payment_received(
         &mut self,
         custom_records: Vec<CustomTlvRecord>,
+        payment_id: Option<String>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
@@ -478,7 +479,20 @@ impl StableChannelManager {
                 serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE }),
             );
             let raw = raw.to_string();
-            self.handle_trade_message(&raw, ldk, btc_price).await;
+            if crate::messages::parse_envelope(&raw).is_some() {
+                if let Some(pid) = payment_id.as_deref() {
+                    if let Err(e) = self.db.record_settlement(pid, "sync") {
+                        tracing::error!("[stable] record_settlement (inbound sync) failed: {}", e);
+                    }
+                }
+                self.handle_trade_message(&raw, ldk, btc_price).await;
+            } else {
+                if let Some(pid) = payment_id.as_deref() {
+                    if let Err(e) = self.db.record_settlement(pid, "stability") {
+                        tracing::error!("[stable] record_settlement (inbound stability) failed: {}", e);
+                    }
+                }
+            }
             return;
         }
         // No stable TLV: plain payment, balance catch-up handled by run_tick + reconcile_from_grpc.
@@ -628,6 +642,16 @@ impl StableChannelManager {
                     let note_for_db = sc.note.clone();
                     match ldk.spontaneous_send(send_req).await {
                         Ok(resp) => {
+                            if !resp.payment_id.is_empty() {
+                                if let Err(e) =
+                                    self.db.record_settlement(&resp.payment_id, "stability")
+                                {
+                                    tracing::error!(
+                                        "[stable] record_settlement (stability) failed: {}",
+                                        e
+                                    );
+                                }
+                            }
                             sc.last_stability_payment = now;
                             // Reset backing_sats to equilibrium so the next tick doesn't re-pay the same drift forever. Native is recomputed on the next balance refresh.
                             sc.backing_sats =
@@ -748,13 +772,23 @@ impl StableChannelManager {
             }],
         };
         match ldk.spontaneous_send(req).await {
-            Ok(_) => stable_channels::audit::audit_event(
-                "SYNC_MESSAGE_SENT",
-                serde_json::json!({
-                    "user_channel_id": format!("{}", user_channel_id),
-                    "expected_usd": expected_usd,
-                }),
-            ),
+            Ok(resp) => {
+                if !resp.payment_id.is_empty() {
+                    if let Err(e) = self.db.record_settlement(&resp.payment_id, "sync") {
+                        tracing::error!(
+                            "[stable] record_settlement (outbound sync) failed: {}",
+                            e
+                        );
+                    }
+                }
+                stable_channels::audit::audit_event(
+                    "SYNC_MESSAGE_SENT",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", user_channel_id),
+                        "expected_usd": expected_usd,
+                    }),
+                );
+            },
             Err(e) => stable_channels::audit::audit_event(
                 "SYNC_MESSAGE_FAILED",
                 serde_json::json!({
@@ -1475,9 +1509,13 @@ mod tests {
             type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
             value: env.into_bytes().into(),
         }];
-        mgr.handle_payment_received(records, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(records, Some("pay_test_1".to_string()), &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
+        assert_eq!(
+            mgr.db.list_settlements().unwrap(),
+            vec![("pay_test_1".to_string(), "sync".to_string())]
+        );
     }
 
     #[tokio::test]
@@ -1486,9 +1524,33 @@ mod tests {
         let fake = FakeLdkServer::new(vec![]);
         seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
 
-        mgr.handle_payment_received(vec![], &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(vec![], None, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // untouched
+        assert!(mgr.db.list_settlements().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn payment_received_marker_records_settlement() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+        let records = vec![CustomTlvRecord {
+            type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+            value: vec![1u8].into(),
+        }];
+        let before = mgr.stable_channels[0].expected_usd.0;
+        mgr.handle_payment_received(records, Some("pay_settlement_1".to_string()), &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        // the 1-byte marker is not an envelope, so it records stability and applies no trade
+        assert_eq!(
+            mgr.db.list_settlements().unwrap(),
+            vec![("pay_settlement_1".to_string(), "stability".to_string())]
+        );
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, before);
     }
 
     // Seed a stable channel: 100k value, 50k user side, $10 at $100k/BTC, giving backing 10k + native 40k.

--- a/src/db.rs
+++ b/src/db.rs
@@ -218,6 +218,16 @@ impl Database {
             [],
         )?;
 
+        // Settlement payments - records stable-channel settlement keysends by payment_id + kind
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS settlement_payments (
+                payment_id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                recorded_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            )",
+            [],
+        )?;
+
         Ok(())
     }
 
@@ -861,6 +871,27 @@ impl Database {
 
         rows.collect()
     }
+
+    /// Record a settlement keysend by payment_id + kind ("stability"/"sync"). INSERT OR IGNORE so a duplicate id is a no-op.
+    pub fn record_settlement(&self, payment_id: &str, kind: &str) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO settlement_payments (payment_id, kind)
+             VALUES (?1, ?2)",
+            params![payment_id, kind],
+        )?;
+        Ok(())
+    }
+
+    /// List recorded settlements as (payment_id, kind) pairs, oldest first.
+    pub fn list_settlements(&self) -> SqliteResult<Vec<(String, String)>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT payment_id, kind FROM settlement_payments ORDER BY recorded_at ASC",
+        )?;
+        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        rows.collect()
+    }
 }
 
 // =============================================================================
@@ -952,6 +983,18 @@ mod tests {
     fn test_open_in_memory() {
         let db = Database::open_in_memory().unwrap();
         assert!(db.conn.lock().is_ok());
+    }
+
+    #[test]
+    fn test_record_and_list_settlements() {
+        let db = Database::open_in_memory().unwrap();
+        db.record_settlement("pay_a", "stability").unwrap();
+        db.record_settlement("pay_b", "sync").unwrap();
+        db.record_settlement("pay_a", "stability").unwrap(); // duplicate is a no-op
+        let list = db.list_settlements().unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.contains(&("pay_a".to_string(), "stability".to_string())));
+        assert!(list.contains(&("pay_b".to_string(), "sync".to_string())));
     }
 
     #[test]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -464,7 +464,11 @@ pub fn check_stability(
     }
 
     let amt = USD::to_msats(dollars_from_par, sc.latest_price);
-    match node.spontaneous_payment().send(amt, sc.counterparty, None) {
+    let marker = ldk_node::CustomTlvRecord {
+        type_num: crate::constants::STABLE_CHANNEL_TLV_TYPE,
+        value: vec![1u8],
+    };
+    match node.spontaneous_payment().send_with_custom_tlvs(amt, sc.counterparty, None, vec![marker]) {
         Ok(payment_id) => {
             sc.payment_made = true;
             sc.last_stability_payment = now;


### PR DESCRIPTION
Stable-channel settlement keysends now show as **Settlement** (value/peg) or **Sync**
(state message) in the Payments tab, instead of the generic "Spontaneous".

The discriminator is custom TLV `13377331`, visible only at the event layer, not in
`ListPayments`. So the daemon classifies by the marker it already carries (no new envelope):
`[0x01]` → Settlement, signed envelope (TRADE_V1/SYNC_V1) → Sync.

- Daemon records `(payment_id, kind)` → new `settlement_payments` table (`src/db.rs`)
- `ListSettlementPayments` REST endpoint → `sc-rest-client` → GUI relabels matching rows
- Desktop wallet brought onto the same marker (`src/stable.rs`)

**Caveats:** mobile *foreground* path doesn't mark yet (background does), one-line client follow-up.

**Naming** (Settlement/Sync) per #141, open to final wording.

Closes #141.