### PR TITLE
feat(android): classify incoming rebalancing payments using custom TLVs

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -341,8 +341,11 @@ class AppState(private val context: Context) : ViewModel() {
         }
 
         val price = priceService.currentPrice.value
+        val isStabilityPayment = customRecords.any { it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() }
+        val paymentType = if (isStabilityPayment) "stability" else "lightning"
+
         databaseService?.recordPayment(
-            paymentId = paymentId, paymentType = "lightning", direction = "received",
+            paymentId = paymentId, paymentType = paymentType, direction = "received",
             amountMsat = amountMsat, amountUSD = (amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * price,
             btcPrice = price, counterparty = _stableChannel.value.counterparty
         )

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -189,8 +189,10 @@ class StabilityProcessingService : Service() {
                         Log.d(TAG, "Payment received: ${event.amountMsat} msat")
                         node.eventHandled()
                         if (price <= 0) price = fetchMedianPrice()
+                        val isStability = event.customRecords.any { it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() }
+                        val paymentType = if (isStability) "stability" else "lightning"
                         recordPaymentInDB(
-                            dbPath, null, "lightning", "received",
+                            dbPath, null, paymentType, "received",
                             event.amountMsat.toLong(), price
                         )
                         received = true


### PR DESCRIPTION
Classifies incoming Lightning payments containing the custom TLV marker (type 13377331) as stability payments instead of lightning. This ensures alignment with iOS and recent LSP-side updates that tag rebalancing keysends with a custom TLV marker byte, allowing correct classification as Settlement in the payment history.