### PR TITLE
feat(android): implement LDK background grace period (60s)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,5 +44,9 @@
         <service android:name=".push.StabilityProcessingService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <service android:name=".services.LdkBackgroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1,7 +1,6 @@
 package com.stablechannels.app
 
 import android.content.Context
-import android.os.PowerManager
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -136,6 +135,7 @@ class AppState(private val context: Context) : ViewModel() {
     private var prevOnchainSats: Long = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
         .getLong("cached_onchain_sats", 0L)
     private var stabilityJob: Job? = null
+    private var heartbeatJob: Job? = null
     private var pendingDepositJob: Job? = null
 
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
@@ -245,6 +245,7 @@ class AppState(private val context: Context) : ViewModel() {
     fun stop() {
         cancelBackgroundStop()
         stabilityJob?.cancel()
+        heartbeatJob?.cancel()
         pendingDepositJob?.cancel()
         priceService.stopAutoRefresh()
         nodeService.stop()
@@ -259,7 +260,7 @@ class AppState(private val context: Context) : ViewModel() {
 
         Log.d("AppState", "Scheduling node stop after 60s grace period")
         backgroundStopJob?.cancel()
-        
+
         // Start Foreground Service to keep CPU and network active
         try {
             LdkBackgroundService.start(context)
@@ -293,12 +294,14 @@ class AppState(private val context: Context) : ViewModel() {
         } catch (e: Exception) {
             Log.e("AppState", "Failed to stop LdkBackgroundService", e)
         }
-        if (!nodeService.isRunning) return
-        Log.d("AppState", "Stopping node for background")
+        heartbeatJob?.cancel()
+        heartbeatJob = null
         stabilityJob?.cancel()
         stabilityJob = null
         pendingDepositJob?.cancel()
         pendingDepositJob = null
+        if (!nodeService.isRunning) return
+        Log.d("AppState", "Stopping node for background")
         nodeService.stop()
     }
 
@@ -313,6 +316,7 @@ class AppState(private val context: Context) : ViewModel() {
             cancelBackgroundStop()
             if (nodeService.isRunning) {
                 Log.d("AppState", "Node still running (grace period), reconnecting")
+                loadChannelFromDB()
                 ensureLSPConnected()
                 refreshBalances()
                 updateStableBalances()
@@ -321,6 +325,7 @@ class AppState(private val context: Context) : ViewModel() {
             Log.d("AppState", "Restarting node from foreground")
             waitForBackgroundService()
             try {
+                loadChannelFromDB()
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, null)
                 _phase.value = Phase.WALLET
@@ -634,10 +639,18 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     private fun startStabilityTimer() {
+        heartbeatJob?.cancel()
+        FCMService.updateHeartbeat(context)
+        heartbeatJob = viewModelScope.launch(Dispatchers.IO) {
+            while (isActive) {
+                delay(5_000)
+                FCMService.updateHeartbeat(context)
+            }
+        }
+
         stabilityJob = viewModelScope.launch(Dispatchers.IO) {
             while (isActive) {
                 delay(Constants.STABILITY_CHECK_INTERVAL_SECS * 1000)
-                FCMService.updateHeartbeat(context)
                 ensureLSPConnected()
                 recordCurrentPrice()
                 runStabilityCheck()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1,6 +1,7 @@
 package com.stablechannels.app
 
 import android.content.Context
+import android.os.PowerManager
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -42,6 +43,12 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing
+
+    private var isInitialized = false
+    private var backgroundStopJob: Job? = null
+
+    @Volatile
+    var isWaitingForPayment = false
 
     private val _errorMessage = MutableStateFlow("")
     val errorMessage: StateFlow<String> = _errorMessage
@@ -236,10 +243,100 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     fun stop() {
+        cancelBackgroundStop()
         stabilityJob?.cancel()
         pendingDepositJob?.cancel()
         priceService.stopAutoRefresh()
         nodeService.stop()
+    }
+
+    fun stopNodeForBackground() {
+        if (!isWaitingForPayment) {
+            Log.d("AppState", "Stopping node immediately (no active payment request)")
+            performBackgroundStop()
+            return
+        }
+
+        Log.d("AppState", "Scheduling node stop after 60s grace period")
+        backgroundStopJob?.cancel()
+        
+        // Start Foreground Service to keep CPU and network active
+        try {
+            LdkBackgroundService.start(context)
+        } catch (e: Exception) {
+            Log.e("AppState", "Failed to start LdkBackgroundService", e)
+        }
+
+        backgroundStopJob = viewModelScope.launch(Dispatchers.IO) {
+            delay(60000L) // 60 seconds delay
+            performBackgroundStop()
+        }
+    }
+
+    fun cancelBackgroundStop() {
+        if (backgroundStopJob != null) {
+            backgroundStopJob?.cancel()
+            backgroundStopJob = null
+            Log.d("AppState", "Cancelled pending background stop")
+        }
+        try {
+            LdkBackgroundService.stop(context)
+        } catch (e: Exception) {
+            Log.e("AppState", "Failed to stop LdkBackgroundService", e)
+        }
+    }
+
+    private fun performBackgroundStop() {
+        backgroundStopJob = null
+        try {
+            LdkBackgroundService.stop(context)
+        } catch (e: Exception) {
+            Log.e("AppState", "Failed to stop LdkBackgroundService", e)
+        }
+        if (!nodeService.isRunning) return
+        Log.d("AppState", "Stopping node for background")
+        stabilityJob?.cancel()
+        stabilityJob = null
+        pendingDepositJob?.cancel()
+        pendingDepositJob = null
+        nodeService.stop()
+    }
+
+    fun restartNodeFromForeground() {
+        isWaitingForPayment = false
+        viewModelScope.launch(Dispatchers.IO) {
+            if (!isInitialized) {
+                isInitialized = true
+                start()
+                return@launch
+            }
+            cancelBackgroundStop()
+            if (nodeService.isRunning) {
+                Log.d("AppState", "Node still running (grace period), reconnecting")
+                ensureLSPConnected()
+                refreshBalances()
+                updateStableBalances()
+                return@launch
+            }
+            Log.d("AppState", "Restarting node from foreground")
+            waitForBackgroundService()
+            try {
+                _phase.value = Phase.SYNCING
+                nodeService.start(Network.BITCOIN, chainUrl, null)
+                _phase.value = Phase.WALLET
+                refreshBalances()
+                updateStableBalances()
+                val sc = StabilityService.reconcileIncoming(_stableChannel.value)
+                _stableChannel.value = sc
+                saveChannelToDB()
+                reregisterPushTokenIfNeeded()
+                startStabilityTimer()
+            } catch (e: Exception) {
+                Log.e("AppState", "Node restart failed", e)
+                _phase.value = Phase.ERROR
+                _errorMessage.value = e.message ?: "Restart failed"
+            }
+        }
     }
 
     private fun handleEvent(event: Event) {
@@ -333,6 +430,7 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     private fun handlePaymentReceived(paymentId: String?, amountMsat: Long, paymentHash: String, customRecords: List<CustomTlvRecord>) {
+        isWaitingForPayment = false
         // Check for sync message
         if (handleSyncMessage(customRecords, paymentHash)) {
             refreshBalances()

--- a/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.launch
 
 class MainActivity : FragmentActivity() {
 
+    private lateinit var appState: AppState
+
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { _ -> }
 
@@ -35,6 +37,8 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         requestNotificationPermission()
+
+        appState = AppState(applicationContext)
 
         // Lock on launch if app unlock is enabled
         if (AppAccessPreferencesManager.isAppUnlockEnabled(this)) {
@@ -50,7 +54,7 @@ class MainActivity : FragmentActivity() {
                     if (isLocked) {
                         AuthLockOverlay()
                     } else {
-                        ContentView()
+                        ContentView(appState)
                     }
                 }
             }
@@ -60,20 +64,28 @@ class MainActivity : FragmentActivity() {
     override fun onPause() {
         super.onPause()
         lastBackgroundedTime = System.currentTimeMillis()
+        appState.stopNodeForBackground()
     }
 
     override fun onResume() {
         super.onResume()
         if (isFirstResume) {
             isFirstResume = false
+            appState.restartNodeFromForeground()
             return
         }
+        appState.restartNodeFromForeground()
         if (AppAccessPreferencesManager.isAppUnlockEnabled(this)) {
             val elapsed = System.currentTimeMillis() - lastBackgroundedTime
             if (elapsed > 5000L) {
                 isLocked = true
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        appState.stop()
     }
 
     @Composable

--- a/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
@@ -36,9 +36,8 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        requestNotificationPermission()
-
         appState = AppState(applicationContext)
+        requestNotificationPermission()
 
         // Lock on launch if app unlock is enabled
         if (AppAccessPreferencesManager.isAppUnlockEnabled(this)) {
@@ -64,11 +63,14 @@ class MainActivity : FragmentActivity() {
     override fun onPause() {
         super.onPause()
         lastBackgroundedTime = System.currentTimeMillis()
-        appState.stopNodeForBackground()
+        if (::appState.isInitialized) {
+            appState.stopNodeForBackground()
+        }
     }
 
     override fun onResume() {
         super.onResume()
+        if (!::appState.isInitialized) return
         if (isFirstResume) {
             isFirstResume = false
             appState.restartNodeFromForeground()
@@ -85,7 +87,9 @@ class MainActivity : FragmentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        appState.stop()
+        if (::appState.isInitialized) {
+            appState.stop()
+        }
     }
 
     @Composable

--- a/android/app/src/main/java/com/stablechannels/app/services/LdkBackgroundService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/LdkBackgroundService.kt
@@ -1,0 +1,77 @@
+package com.stablechannels.app.services
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.stablechannels.app.R
+
+class LdkBackgroundService : Service() {
+
+    companion object {
+        private const val TAG = "LdkBackgroundService"
+        private const val NOTIFICATION_ID = 2002
+        private const val CHANNEL_ID = "ldk_background_channel"
+
+        fun start(context: Context) {
+            Log.d(TAG, "Starting LdkBackgroundService")
+            val intent = Intent(context, LdkBackgroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            Log.d(TAG, "Stopping LdkBackgroundService")
+            val intent = Intent(context, LdkBackgroundService::class.java)
+            context.stopService(intent)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Keeping connection active")
+            .setContentText("Stable Channels is waiting for your payment to complete...")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "LDK Background Sync",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Keeps LDK network connection active to receive background payments"
+            }
+            val manager = getSystemService(NotificationManager::class.java)
+            manager?.createNotificationChannel(channel)
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
@@ -14,17 +14,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.stablechannels.app.AppState
 import com.stablechannels.app.Phase
 import com.stablechannels.app.R
 
 @Composable
-fun ContentView() {
-    val context = LocalContext.current
-    val appState = remember { AppState(context) }
+fun ContentView(appState: AppState) {
 
-    LaunchedEffect(Unit) { appState.start() }
-    DisposableEffect(Unit) { onDispose { appState.stop() } }
 
     val phase by appState.phase.collectAsState()
     val errorMessage by appState.errorMessage.collectAsState()

--- a/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
@@ -10,14 +10,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import android.util.Log
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.stablechannels.app.AppState
 import com.stablechannels.app.Phase
 import com.stablechannels.app.R
@@ -118,4 +113,3 @@ private fun ErrorView(message: String, onRetry: () -> Unit) {
         }
     }
 }
-

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
@@ -258,6 +258,7 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
                             }
                             invoiceAmountSats = if (sats > 0) sats else null
                             invoice = inv.toString()
+                            appState.isWaitingForPayment = true
                         } catch (e: Exception) {
                             error = e.message ?: "Failed to generate invoice"
                         }
@@ -282,6 +283,7 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
                                 val inv = appState.nodeService.receiveVariablePayment("Stable Channels")
                                 invoiceAmountSats = null
                                 invoice = inv.toString()
+                                appState.isWaitingForPayment = true
                             } catch (e: Exception) {
                                 error = e.message ?: "Failed to generate invoice"
                             }


### PR DESCRIPTION
### Goal
Implements a 60-second background grace period on Android to keep the LDK node connected to the LSP and allow incoming payments to complete successfully when the app is minimized.

### Changes
1. **Activity-level AppState Scoping**: Hoisted AppState management to MainActivity.kt to prevent Compose-remembered AppState from being destroyed/recreated when the biometric lock screen overlay triggers.
2. **Foreground Service (LdkBackgroundService)**: Created a short-lived Foreground Service (dataSync type) to hold network sockets open and bypass Android background network restrictions.
3. **Instant status bar notification**: Configured the FGS notification with high priority and default importance channel to bypass Android 12+ 10-second notification postponement.
4. **Context-aware grace period**: Tracked active receive invoices in AppState so the 60-second grace period only activates when waiting for a payment, stopping LDK instantly on standard exits to save battery.

### Verification
- Manually tested receiving lightning payments in the background from a third-party wallet (Wallet of Satoshi) which succeeds instantly on the first try.
- Confirmed that standard minimizes shut down immediately without showing notifications.

### Video


https://github.com/user-attachments/assets/42813129-d3ee-4a4f-8c94-278b9d8f5379

