### PR TITLE
Robust, searchable audit log

### DIFF
--- a/server/lsp-server-gui/Cargo.toml
+++ b/server/lsp-server-gui/Cargo.toml
@@ -16,6 +16,7 @@ sc-protos = { path = "../sc-protos" }
 futures-util = "0.3"
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 hex = { package = "hex-conservative", version = "0.2", default-features = false, features = ["std"] }
 bytes = "1.4.0"
 

--- a/server/lsp-server-gui/src/app.rs
+++ b/server/lsp-server-gui/src/app.rs
@@ -286,7 +286,34 @@ impl LspServerApp {
 		if let Some(client) = &self.state.client {
 			let client = client.clone();
 			self.state.tasks.ldk_log = Some(self.spawn_task(async move {
-				client.ldk_log(LogRequest { max_lines }).await.map_err(|e| e.to_string())
+				client.ldk_log(LogRequest { max_lines, filter: String::new(), full: false }).await.map_err(|e| e.to_string())
+			}));
+		}
+	}
+
+	pub fn fetch_audit_log(&mut self) {
+		if self.state.tasks.audit_log.is_some() {
+			return;
+		}
+		let max_lines = self.state.forms.audit_log.max_lines.parse::<u32>().unwrap_or(200);
+		if let Some(client) = &self.state.client {
+			let client = client.clone();
+			self.state.tasks.audit_log = Some(self.spawn_task(async move {
+				client.audit_log(LogRequest { max_lines, filter: String::new(), full: false }).await.map_err(|e| e.to_string())
+			}));
+		}
+	}
+
+	/// Complete history for the filtered id, oldest-first (server `full` mode, ignores max_lines).
+	pub fn fetch_channel_history(&mut self) {
+		if self.state.tasks.channel_history.is_some() {
+			return;
+		}
+		let filter = self.state.forms.channel_history.filter.clone();
+		if let Some(client) = &self.state.client {
+			let client = client.clone();
+			self.state.tasks.channel_history = Some(self.spawn_task(async move {
+				client.audit_log(LogRequest { max_lines: 0, filter, full: true }).await.map_err(|e| e.to_string())
 			}));
 		}
 	}
@@ -1058,6 +1085,14 @@ impl LspServerApp {
 			self.state.ldk_log = Some(v);
 		});
 
+		poll_task!(self.state.tasks.audit_log => |v| {
+			self.state.audit_log = Some(v);
+		});
+
+		poll_task!(self.state.tasks.channel_history => |v| {
+			self.state.channel_history = Some(v);
+		});
+
 		poll_task!(self.state.tasks.payment_details => |v| {
 			self.state.payment_details = Some(v);
 		});
@@ -1356,7 +1391,7 @@ impl App for LspServerApp {
 				ActiveTab::StableChannels => ui::stable_channels::render(ui, self),
 				ActiveTab::Tools => ui::tools::render(ui, self),
 				ActiveTab::NetworkGraph => ui::network_graph::render(ui, self),
-				ActiveTab::Logs => ui::ldk_log::render(ui, self),
+				ActiveTab::Logs => ui::logs::render(ui, self),
 				ActiveTab::Settings => ui::settings::render(ui, self),
 			});
 		});

--- a/server/lsp-server-gui/src/state.rs
+++ b/server/lsp-server-gui/src/state.rs
@@ -184,11 +184,12 @@ pub struct GraphGetNodeForm {
 #[derive(Clone)]
 pub struct LogForm {
 	pub max_lines: String,
+	pub filter: String,
 }
 
 impl Default for LogForm {
 	fn default() -> Self {
-		Self { max_lines: "200".to_string() }
+		Self { max_lines: "200".to_string(), filter: String::new() }
 	}
 }
 
@@ -267,6 +268,8 @@ pub struct Forms {
 	pub graph_get_channel: GraphGetChannelForm,
 	pub graph_get_node: GraphGetNodeForm,
 	pub ldk_log: LogForm,
+	pub audit_log: LogForm,
+	pub channel_history: LogForm,
 	#[allow(dead_code)]
 	pub chain_source: ChainSourceForm,
 }
@@ -340,6 +343,8 @@ pub struct AsyncTasks {
 	pub list_stable_channels: Option<ChannelTaskHandle<ListStableChannelsResponse>>,
 	pub list_settlement_payments: Option<ChannelTaskHandle<ListSettlementPaymentsResponse>>,
 	pub ldk_log: Option<ChannelTaskHandle<LogResponse>>,
+	pub audit_log: Option<ChannelTaskHandle<LogResponse>>,
+	pub channel_history: Option<ChannelTaskHandle<LogResponse>>,
 }
 
 impl Default for AsyncTasks {
@@ -378,6 +383,8 @@ impl Default for AsyncTasks {
 			list_stable_channels: None,
 			list_settlement_payments: None,
 			ldk_log: None,
+			audit_log: None,
+			channel_history: None,
 		}
 	}
 }
@@ -417,6 +424,8 @@ impl AsyncTasks {
 			|| self.list_stable_channels.is_some()
 			|| self.list_settlement_payments.is_some()
 			|| self.ldk_log.is_some()
+			|| self.audit_log.is_some()
+			|| self.channel_history.is_some()
 	}
 }
 
@@ -455,6 +464,8 @@ pub struct AppState {
 	// payment_id (hex) -> settlement classification, fetched alongside payments.
 	pub settlement_kinds: Option<HashMap<String, SettlementKind>>,
 	pub ldk_log: Option<LogResponse>,
+	pub audit_log: Option<LogResponse>,
+	pub channel_history: Option<LogResponse>,
 
 	// Operation results
 	pub onchain_address: Option<String>,
@@ -487,6 +498,7 @@ pub struct AppState {
 	pub config_paste_text: String,
 	pub lightning_tab: LightningTab,
 	pub onchain_tab: OnchainTab,
+	pub logs_tab: LogsTab,
 	pub graph_channels: Option<GraphListChannelsResponse>,
 	pub graph_channel_detail: Option<GraphGetChannelResponse>,
 	pub graph_nodes: Option<GraphListNodesResponse>,
@@ -515,6 +527,14 @@ pub enum OnchainTab {
 	Send,
 	Receive,
 	History,
+}
+
+#[derive(Clone, Copy, PartialEq, Default)]
+pub enum LogsTab {
+	#[default]
+	Audit,
+	ChannelHistory,
+	Ldk,
 }
 
 impl Default for AppState {
@@ -546,6 +566,8 @@ impl Default for AppState {
 			stable_channels: None,
 			settlement_kinds: None,
 			ldk_log: None,
+			audit_log: None,
+			channel_history: None,
 
 			onchain_address: None,
 			generated_invoice: None,
@@ -574,6 +596,7 @@ impl Default for AppState {
 			config_paste_text: String::new(),
 			lightning_tab: LightningTab::default(),
 			onchain_tab: OnchainTab::default(),
+			logs_tab: LogsTab::default(),
 			graph_channels: None,
 			graph_channel_detail: None,
 			graph_nodes: None,

--- a/server/lsp-server-gui/src/ui/audit_log.rs
+++ b/server/lsp-server-gui/src/ui/audit_log.rs
@@ -1,0 +1,126 @@
+use eframe::egui;
+
+use crate::app::LspServerApp;
+use crate::ui::widgets;
+
+/// Render one audit JSON line (`{ts,event,data}`) as a compact single line. Non-JSON returns unchanged.
+pub fn format_audit_line(line: &str) -> String {
+	let v: serde_json::Value = match serde_json::from_str(line) {
+		Ok(v) => v,
+		Err(_) => return line.to_string(),
+	};
+	let ts = v.get("ts").and_then(|t| t.as_str()).unwrap_or("");
+	let event = v.get("event").and_then(|e| e.as_str()).unwrap_or("?");
+	let data = v.get("data");
+
+	let mut kv: Vec<String> = Vec::new();
+	if let Some(obj) = data.and_then(|d| d.as_object()) {
+		for (k, val) in obj {
+			kv.push(format!("{}={}", k, compact_val(val)));
+		}
+	}
+	kv.sort();
+
+	let force = event == "CHANNEL_CLOSED"
+		&& data
+			.and_then(|d| d.get("reason_kind"))
+			.and_then(|k| k.as_str())
+			.map(|k| k.contains("FORCE_CLOSED"))
+			.unwrap_or(false);
+	let marker = if force { "⚠ " } else { "" };
+
+	if kv.is_empty() {
+		format!("{}  {}{}", ts, marker, event)
+	} else {
+		format!("{}  {}{}  {}", ts, marker, event, kv.join(" "))
+	}
+}
+
+fn compact_val(v: &serde_json::Value) -> String {
+	match v {
+		serde_json::Value::String(s) => s.clone(),
+		serde_json::Value::Null => "null".to_string(),
+		other => other.to_string(),
+	}
+}
+
+pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
+	ui.heading("Audit Log");
+	ui.add_space(5.0);
+
+	ui.horizontal(|ui| {
+		ui.label("Lines:");
+		ui.add(egui::TextEdit::singleline(&mut app.state.forms.audit_log.max_lines).desired_width(80.0));
+		let loading = app.state.tasks.audit_log.is_some();
+		if ui.add_enabled(!loading, egui::Button::new("Refresh")).clicked() {
+			app.fetch_audit_log();
+		}
+		if loading {
+			ui.spinner();
+		}
+	});
+
+	let formatted: String = app
+		.state
+		.audit_log
+		.as_ref()
+		.map(|r| r.content.lines().map(format_audit_line).collect::<Vec<_>>().join("\n"))
+		.unwrap_or_default();
+
+	let (filter, wrap, follow) = crate::ui::log_view::controls(ui, "audit_log", &formatted);
+
+	ui.add_space(10.0);
+
+	match &app.state.audit_log {
+		Some(resp) if resp.content.is_empty() => {
+			ui.label("Empty audit log.");
+		},
+		Some(_) => {
+			let display: String = if filter.is_empty() {
+				formatted.clone()
+			} else {
+				formatted.lines().filter(|line| line.contains(&filter)).collect::<Vec<_>>().join("\n")
+			};
+			crate::ui::log_view::text_area(ui, &display, wrap, follow);
+		},
+		None => {
+			widgets::empty_state(ui, "📜", "No audit log loaded", "Click Refresh to load");
+		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn force_close_line_has_marker_and_fields() {
+		let line = r#"{"ts":"2026-06-29T14:12:48Z","event":"CHANNEL_CLOSED","data":{"channel_id":"5a9c","closure_initiator":"REMOTE","reason_kind":"COUNTERPARTY_FORCE_CLOSED"}}"#;
+		let out = format_audit_line(line);
+		assert!(out.contains("⚠"));
+		assert!(out.contains("CHANNEL_CLOSED"));
+		assert!(out.contains("closure_initiator=REMOTE"));
+		assert!(out.contains("reason_kind=COUNTERPARTY_FORCE_CLOSED"));
+	}
+
+	#[test]
+	fn plain_event_has_no_marker() {
+		let line = r#"{"ts":"t","event":"TRADE_APPLIED","data":{"expected_usd":44.38}}"#;
+		let out = format_audit_line(line);
+		assert!(out.contains("TRADE_APPLIED"));
+		assert!(out.contains("expected_usd=44.38"));
+		assert!(!out.contains("⚠"));
+	}
+
+	#[test]
+	fn non_json_passes_through() {
+		assert_eq!(format_audit_line("not json at all"), "not json at all");
+	}
+
+	#[test]
+	fn empty_data_has_no_trailing_separator() {
+		let line = r#"{"ts":"t","event":"TRADE_PARSE_PAYLOAD_FAILED","data":{}}"#;
+		let out = format_audit_line(line);
+		assert_eq!(out, "t  TRADE_PARSE_PAYLOAD_FAILED");
+	}
+}

--- a/server/lsp-server-gui/src/ui/channel_history.rs
+++ b/server/lsp-server-gui/src/ui/channel_history.rs
@@ -1,0 +1,57 @@
+use eframe::egui;
+
+use crate::app::LspServerApp;
+use crate::ui::audit_log::format_audit_line;
+use crate::ui::widgets;
+
+pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
+	ui.heading("Channel History");
+	ui.add_space(5.0);
+	ui.label("Complete audit history for one id, oldest-first.");
+	ui.add_space(8.0);
+
+	ui.horizontal(|ui| {
+		ui.label("Channel id:");
+		ui.add(
+			egui::TextEdit::singleline(&mut app.state.forms.channel_history.filter)
+				.desired_width(360.0)
+				.hint_text("user_channel_id / channel_id / payment_id"),
+		);
+		let has_id = !app.state.forms.channel_history.filter.trim().is_empty();
+		let loading = app.state.tasks.channel_history.is_some();
+		if ui.add_enabled(!loading && has_id, egui::Button::new("Load")).clicked() {
+			app.fetch_channel_history();
+		}
+		if loading {
+			ui.spinner();
+		}
+	});
+
+	let formatted: String = app
+		.state
+		.channel_history
+		.as_ref()
+		.map(|r| r.content.lines().map(format_audit_line).collect::<Vec<_>>().join("\n"))
+		.unwrap_or_default();
+
+	let (filter, wrap, follow) = crate::ui::log_view::controls(ui, "channel_history", &formatted);
+
+	ui.add_space(10.0);
+
+	match &app.state.channel_history {
+		Some(resp) if resp.content.is_empty() => {
+			ui.label("No events for that id.");
+		},
+		Some(_) => {
+			let display: String = if filter.is_empty() {
+				formatted.clone()
+			} else {
+				formatted.lines().filter(|line| line.contains(&filter)).collect::<Vec<_>>().join("\n")
+			};
+			crate::ui::log_view::text_area(ui, &display, wrap, follow);
+		},
+		None => {
+			widgets::empty_state(ui, "🧵", "No channel loaded", "Enter an id and click Load");
+		},
+	}
+}

--- a/server/lsp-server-gui/src/ui/channels.rs
+++ b/server/lsp-server-gui/src/ui/channels.rs
@@ -76,7 +76,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 				ui.label("Filter:");
 				ui.add(
 					egui::TextEdit::singleline(&mut filter)
-						.hint_text("channel id or counterparty"),
+						.hint_text("channel id, user channel id, or counterparty"),
 				);
 				egui::ComboBox::from_id_salt(status_id)
 					.selected_text(channel_status_label(status_filter))
@@ -94,6 +94,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 					let r = &rows[i];
 					let matches_text = needle.is_empty()
 						|| r.channel_id.to_lowercase().contains(&needle)
+						|| r.user_channel_id.to_lowercase().contains(&needle)
 						|| r.counterparty_node_id.to_lowercase().contains(&needle);
 					let matches_status = match status_filter {
 						0 => r.is_channel_ready,
@@ -129,6 +130,7 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 					|ui| {
 						// Header (values now carry their own unit).
 						ui.strong("Channel ID");
+						ui.strong("User Channel ID");
 						ui.strong("Counterparty");
 						ui.strong("Funding Tx");
 						if ui.button(sort_header("Capacity", &sort, 0)).clicked() {
@@ -152,6 +154,13 @@ pub fn render(ui: &mut Ui, app: &mut LspServerApp) {
 							widgets::id_with_copy(
 								ui,
 								&ch.channel_id,
+								&mut app.state.status_message,
+							);
+
+							// User Channel ID
+							widgets::id_with_copy(
+								ui,
+								&ch.user_channel_id,
 								&mut app.state.status_message,
 							);
 

--- a/server/lsp-server-gui/src/ui/ldk_log.rs
+++ b/server/lsp-server-gui/src/ui/ldk_log.rs
@@ -22,33 +22,8 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 		}
 	});
 
-	// Log controls — all stored in egui temp memory, no AppState fields
-	let filter_id = ui.id().with("log_filter");
-	let wrap_id = ui.id().with("log_wrap");
-	let follow_id = ui.id().with("log_follow");
-
-	let mut filter = ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
-	let mut wrap = ui.memory_mut(|m| m.data.get_temp::<bool>(wrap_id).unwrap_or(false));
-	let mut follow = ui.memory_mut(|m| m.data.get_temp::<bool>(follow_id).unwrap_or(true));
-
-	ui.horizontal(|ui| {
-		ui.label("Filter:");
-		ui.text_edit_singleline(&mut filter);
-
-		if ui.button("Copy all").clicked() {
-			if let Some(resp) = &app.state.ldk_log {
-				let content = resp.content.clone();
-				ui.output_mut(|o| o.copied_text = content);
-			}
-		}
-
-		ui.checkbox(&mut wrap, "Wrap");
-		ui.checkbox(&mut follow, "Follow tail");
-	});
-
-	ui.memory_mut(|m| m.data.insert_temp(filter_id, filter.clone()));
-	ui.memory_mut(|m| m.data.insert_temp(wrap_id, wrap));
-	ui.memory_mut(|m| m.data.insert_temp(follow_id, follow));
+	let raw = app.state.ldk_log.as_ref().map(|r| r.content.clone()).unwrap_or_default();
+	let (filter, wrap, follow) = crate::ui::log_view::controls(ui, "ldk_log", &raw);
 
 	ui.add_space(10.0);
 
@@ -65,32 +40,12 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			);
 		},
 		Some(resp) => {
-			// Build filtered display string from already-fetched content
 			let display: String = if filter.is_empty() {
 				resp.content.clone()
 			} else {
-				resp.content
-					.lines()
-					.filter(|line| line.contains(&filter))
-					.collect::<Vec<_>>()
-					.join("\n")
+				resp.content.lines().filter(|line| line.contains(&filter)).collect::<Vec<_>>().join("\n")
 			};
-
-			// Wrap=false → ScrollArea::both (horizontal scroll); wrap=true → vertical only
-			let scroll = egui::ScrollArea::both()
-				.auto_shrink([false, false])
-				.stick_to_bottom(follow);
-			scroll.show(ui, |ui| {
-				let mut binding = display.as_str();
-				// When wrap is on, constrain width to force line-wrapping
-				let desired_w = if wrap { ui.available_width() } else { f32::INFINITY };
-				ui.add(
-					egui::TextEdit::multiline(&mut binding)
-						.font(egui::TextStyle::Monospace)
-						.desired_width(desired_w)
-						.desired_rows(30),
-				);
-			});
+			crate::ui::log_view::text_area(ui, &display, wrap, follow);
 		},
 		None => {
 			widgets::empty_state(ui, "📜", "No log loaded", "Click Refresh to load");

--- a/server/lsp-server-gui/src/ui/log_view.rs
+++ b/server/lsp-server-gui/src/ui/log_view.rs
@@ -1,0 +1,42 @@
+use eframe::egui;
+
+/// Filter / Copy-all / Wrap / Follow-tail control row. State lives in egui temp memory keyed by `id_salt`.
+pub fn controls(ui: &mut egui::Ui, id_salt: &str, copy_source: &str) -> (String, bool, bool) {
+	let filter_id = ui.id().with((id_salt, "filter"));
+	let wrap_id = ui.id().with((id_salt, "wrap"));
+	let follow_id = ui.id().with((id_salt, "follow"));
+
+	let mut filter = ui.memory_mut(|m| m.data.get_temp::<String>(filter_id).unwrap_or_default());
+	let mut wrap = ui.memory_mut(|m| m.data.get_temp::<bool>(wrap_id).unwrap_or(false));
+	let mut follow = ui.memory_mut(|m| m.data.get_temp::<bool>(follow_id).unwrap_or(true));
+
+	ui.horizontal(|ui| {
+		ui.label("Filter:");
+		ui.text_edit_singleline(&mut filter);
+		if ui.button("Copy all").clicked() && !copy_source.is_empty() {
+			ui.output_mut(|o| o.copied_text = copy_source.to_string());
+		}
+		ui.checkbox(&mut wrap, "Wrap");
+		ui.checkbox(&mut follow, "Follow tail");
+	});
+
+	ui.memory_mut(|m| m.data.insert_temp(filter_id, filter.clone()));
+	ui.memory_mut(|m| m.data.insert_temp(wrap_id, wrap));
+	ui.memory_mut(|m| m.data.insert_temp(follow_id, follow));
+	(filter, wrap, follow)
+}
+
+/// Monospace, scrollable, read-only text area for already-built display text.
+pub fn text_area(ui: &mut egui::Ui, display: &str, wrap: bool, follow: bool) {
+	let scroll = egui::ScrollArea::both().auto_shrink([false, false]).stick_to_bottom(follow);
+	scroll.show(ui, |ui| {
+		let mut binding = display;
+		let desired_w = if wrap { ui.available_width() } else { f32::INFINITY };
+		ui.add(
+			egui::TextEdit::multiline(&mut binding)
+				.font(egui::TextStyle::Monospace)
+				.desired_width(desired_w)
+				.desired_rows(30),
+		);
+	});
+}

--- a/server/lsp-server-gui/src/ui/logs.rs
+++ b/server/lsp-server-gui/src/ui/logs.rs
@@ -1,0 +1,24 @@
+use eframe::egui;
+
+use crate::app::LspServerApp;
+use crate::state::LogsTab;
+
+pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
+	ui.horizontal(|ui| {
+		if ui.selectable_label(app.state.logs_tab == LogsTab::Audit, "Audit").clicked() {
+			app.state.logs_tab = LogsTab::Audit;
+		}
+		if ui.selectable_label(app.state.logs_tab == LogsTab::ChannelHistory, "Channel History").clicked() {
+			app.state.logs_tab = LogsTab::ChannelHistory;
+		}
+		if ui.selectable_label(app.state.logs_tab == LogsTab::Ldk, "LDK server").clicked() {
+			app.state.logs_tab = LogsTab::Ldk;
+		}
+	});
+	ui.separator();
+	match app.state.logs_tab {
+		LogsTab::Audit => crate::ui::audit_log::render(ui, app),
+		LogsTab::ChannelHistory => crate::ui::channel_history::render(ui, app),
+		LogsTab::Ldk => crate::ui::ldk_log::render(ui, app),
+	}
+}

--- a/server/lsp-server-gui/src/ui/mod.rs
+++ b/server/lsp-server-gui/src/ui/mod.rs
@@ -1,8 +1,12 @@
+pub mod audit_log;
+pub mod channel_history;
 pub mod balances;
 pub mod channels;
 pub mod connection;
 pub mod forwarded_payments;
 pub mod ldk_log;
+pub mod log_view;
+pub mod logs;
 pub mod lightning;
 pub mod network_graph;
 pub mod node_info;

--- a/server/lsp-server-gui/src/ui/stable_channels.rs
+++ b/server/lsp-server-gui/src/ui/stable_channels.rs
@@ -34,6 +34,7 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 	// before we call app.fmt_sats and widgets::id_with_copy below.
 	struct StableRow {
 		channel_id: String,
+		user_channel_id: String,
 		counterparty: String,
 		expected_usd: f64,
 		backing_sats: u64,
@@ -47,6 +48,7 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 			.iter()
 			.map(|ch| StableRow {
 				channel_id: ch.channel_id.clone(),
+				user_channel_id: ch.user_channel_id.clone(),
 				counterparty: ch.counterparty.clone(),
 				expected_usd: ch.expected_usd,
 				backing_sats: ch.expected_msats / 1000,
@@ -67,6 +69,7 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 						// Headers
 						for h in [
 							"Channel ID",
+							"User Channel ID",
 							"Counterparty",
 							"Stable $",
 							"Backing",
@@ -83,6 +86,13 @@ pub fn render(ui: &mut egui::Ui, app: &mut LspServerApp) {
 							widgets::id_with_copy(
 								ui,
 								&row.channel_id,
+								&mut app.state.status_message,
+							);
+
+							// User Channel ID — monospace truncated + copy-to-clipboard
+							widgets::id_with_copy(
+								ui,
+								&row.user_channel_id,
 								&mut app.state.status_message,
 							);
 

--- a/server/sc-protos/src/stable.rs
+++ b/server/sc-protos/src/stable.rs
@@ -28,6 +28,8 @@ pub struct StableChannelInfo {
 	pub note: ::prost::alloc::string::String,
 	#[prost(bool, tag = "7")]
 	pub is_stable_receiver: bool,
+	#[prost(string, tag = "8")]
+	pub user_channel_id: ::prost::alloc::string::String,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -92,6 +94,10 @@ pub struct RegisterPushResponse {
 pub struct LogRequest {
 	#[prost(uint32, tag = "1")]
 	pub max_lines: u32,
+	#[prost(string, tag = "2")]
+	pub filter: ::prost::alloc::string::String,
+	#[prost(bool, tag = "3")]
+	pub full: bool,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/server/sc-rest-client/src/client.rs
+++ b/server/sc-rest-client/src/client.rs
@@ -44,7 +44,7 @@ use ldk_server_client::ldk_server_grpc::error::{ErrorCode, ErrorResponse};
 use sc_protos::stable::{
 	EditStableChannelRequest, EditStableChannelResponse, GetPriceRequest, GetPriceResponse,
 	ListSettlementPaymentsRequest, ListSettlementPaymentsResponse, ListStableChannelsRequest,
-	ListStableChannelsResponse, LogRequest, LogResponse, EDIT_STABLE_CHANNEL_PATH,
+	ListStableChannelsResponse, LogRequest, LogResponse, AUDIT_LOG_PATH, EDIT_STABLE_CHANNEL_PATH,
 	GET_PRICE_PATH, LDK_LOG_PATH, LIST_SETTLEMENT_PAYMENTS_PATH, LIST_STABLE_CHANNELS_PATH,
 };
 use prost::Message;
@@ -499,6 +499,12 @@ impl LspRestClient {
 	/// Tail LDK Server's log file via the SC daemon.
 	pub async fn ldk_log(&self, request: LogRequest) -> Result<LogResponse, LspRestError> {
 		let url = self.build_url(LDK_LOG_PATH);
+		self.post_request(&request, &url).await
+	}
+
+	/// Tail the SC daemon's own audit log.
+	pub async fn audit_log(&self, request: LogRequest) -> Result<LogResponse, LspRestError> {
+		let url = self.build_url(AUDIT_LOG_PATH);
 		self.post_request(&request, &url).await
 	}
 

--- a/server/stable-channels-lsp/src/backfill.rs
+++ b/server/stable-channels-lsp/src/backfill.rs
@@ -1,0 +1,58 @@
+//! Reconcile-from-truth: on (re)connect, backfill audit records for forwards missed during the gap.
+
+use ldk_server_client::ldk_server_grpc::api::ListForwardedPaymentsRequest;
+use stable_channels::db::{forward_fingerprint, Database};
+
+use crate::stable_manager::LdkServerCalls;
+
+/// Page ListForwardedPayments and emit PAYMENT_FORWARDED_BACKFILL for each forward not already seen.
+/// Audit-only: does NOT touch the peg. Returns the number of backfill events emitted.
+pub async fn backfill_forwards(ldk: &dyn LdkServerCalls, db: &Database) -> usize {
+    let mut emitted = 0usize;
+    let mut page_token = None;
+    loop {
+        let resp = match ldk
+            .list_forwarded_payments(ListForwardedPaymentsRequest { page_token })
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_forwarded_payments", "context": "backfill", "error": e.to_string() }),
+                );
+                break;
+            }
+        };
+        for fp in &resp.forwarded_payments {
+            let key = forward_fingerprint(
+                &fp.prev_channel_id,
+                &fp.next_channel_id,
+                fp.outbound_amount_forwarded_msat,
+                fp.total_fee_earned_msat,
+            );
+            let is_new = db.record_forwarded_seen(&key).unwrap_or(false);
+            if is_new {
+                stable_channels::audit::audit_event(
+                    "PAYMENT_FORWARDED_BACKFILL",
+                    serde_json::json!({
+                        "prev_channel_id": fp.prev_channel_id,
+                        "next_channel_id": fp.next_channel_id,
+                        "prev_user_channel_id": fp.prev_user_channel_id,
+                        "next_user_channel_id": fp.next_user_channel_id,
+                        "prev_node_id": fp.prev_node_id,
+                        "next_node_id": fp.next_node_id,
+                        "outbound_amount_msat": fp.outbound_amount_forwarded_msat,
+                        "total_fee_msat": fp.total_fee_earned_msat,
+                    }),
+                );
+                emitted += 1;
+            }
+        }
+        match resp.next_page_token {
+            Some(t) => page_token = Some(t),
+            None => break,
+        }
+    }
+    emitted
+}

--- a/server/stable-channels-lsp/src/channel_close.rs
+++ b/server/stable-channels-lsp/src/channel_close.rs
@@ -1,0 +1,166 @@
+//! Maps ldk-server channel state-change events into audit-log JSON.
+
+use ldk_server_client::ldk_server_grpc::events::{
+    channel_state_change_reason::Details, ChannelClosureInitiator, ChannelState,
+    ChannelStateChangeReason, ChannelStateChangeReasonKind,
+};
+use serde_json::{json, Value};
+
+/// Strip a prost enum's screaming prefix for readability.
+fn short(name: &str, prefix: &str) -> String {
+    name.strip_prefix(prefix).unwrap_or(name).to_string()
+}
+
+/// Build the audit `data` object for a channel close/open-fail from the ldk-server event fields.
+pub fn close_audit_data(
+    channel_id: &str,
+    user_channel_id: &str,
+    counterparty_node_id: Option<&str>,
+    funding_txo: Option<&str>,
+    closure_initiator: i32,
+    reason: Option<&ChannelStateChangeReason>,
+) -> Value {
+    let initiator = ChannelClosureInitiator::from_i32(closure_initiator)
+        .map(|i| short(i.as_str_name(), "CHANNEL_CLOSURE_INITIATOR_"))
+        .unwrap_or_else(|| format!("UNKNOWN({})", closure_initiator));
+
+    let mut data = json!({
+        "channel_id": channel_id,
+        "user_channel_id": user_channel_id,
+        "closure_initiator": initiator,
+    });
+    if let Some(cp) = counterparty_node_id {
+        data["counterparty_node_id"] = json!(cp);
+    }
+    if let Some(txo) = funding_txo {
+        data["funding_txo"] = json!(txo);
+    }
+    if let Some(r) = reason {
+        let kind = ChannelStateChangeReasonKind::from_i32(r.kind)
+            .map(|k| short(k.as_str_name(), "CHANNEL_STATE_CHANGE_REASON_KIND_"))
+            .unwrap_or_else(|| format!("UNKNOWN({})", r.kind));
+        data["reason_kind"] = json!(kind);
+        if !r.message.is_empty() {
+            data["reason_message"] = json!(r.message);
+        }
+        if let Some(d) = &r.details {
+            data["details"] = details_value(d);
+        }
+    }
+    data
+}
+
+/// Build the audit `data` for an unrecognized channel-state transition (defense against enum drift).
+pub fn unknown_state_audit_data(
+    channel_id: &str,
+    user_channel_id: &str,
+    counterparty_node_id: Option<&str>,
+    state: i32,
+) -> Value {
+    let state_name = ChannelState::from_i32(state)
+        .map(|s| short(s.as_str_name(), "CHANNEL_STATE_"))
+        .unwrap_or_else(|| format!("UNKNOWN({})", state));
+    let mut data = json!({
+        "channel_id": channel_id,
+        "user_channel_id": user_channel_id,
+        "state": state_name,
+    });
+    if let Some(cp) = counterparty_node_id {
+        data["counterparty_node_id"] = json!(cp);
+    }
+    data
+}
+
+// Serialize the variant-specific closure details into JSON.
+fn details_value(d: &Details) -> Value {
+    match d {
+        Details::CounterpartyForceClosed(x) => json!({ "peer_msg": x.peer_msg }),
+        Details::HolderForceClosed(x) => json!({
+            "broadcasted_latest_txn": x.broadcasted_latest_txn,
+            "message": x.message,
+        }),
+        Details::ProcessingError(x) => json!({ "err": x.err }),
+        Details::HtlcsTimedOut(x) => json!({ "payment_hash": x.payment_hash }),
+        Details::PeerFeerateTooLow(x) => json!({
+            "peer_feerate_sat_per_kw": x.peer_feerate_sat_per_kw,
+            "required_feerate_sat_per_kw": x.required_feerate_sat_per_kw,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ldk_server_client::ldk_server_grpc::events::CounterpartyForceClosedDetails;
+
+    #[test]
+    fn force_close_maps_full_reason() {
+        let reason = ChannelStateChangeReason {
+            kind: ChannelStateChangeReasonKind::CounterpartyForceClosed as i32,
+            message: "peer broadcast commitment".to_string(),
+            details: Some(Details::CounterpartyForceClosed(CounterpartyForceClosedDetails {
+                peer_msg: "commitment tx confirmed".to_string(),
+            })),
+        };
+        let v = close_audit_data(
+            "abcd",
+            "1842",
+            Some("02deadbeef"),
+            Some("txid:0"),
+            ChannelClosureInitiator::Remote as i32,
+            Some(&reason),
+        );
+        assert_eq!(v["channel_id"], "abcd");
+        assert_eq!(v["user_channel_id"], "1842");
+        assert_eq!(v["counterparty_node_id"], "02deadbeef");
+        assert_eq!(v["funding_txo"], "txid:0");
+        assert_eq!(v["closure_initiator"], "REMOTE");
+        assert_eq!(v["reason_kind"], "COUNTERPARTY_FORCE_CLOSED");
+        assert_eq!(v["reason_message"], "peer broadcast commitment");
+        assert_eq!(v["details"]["peer_msg"], "commitment tx confirmed");
+    }
+
+    #[test]
+    fn no_reason_omits_reason_fields() {
+        let v = close_audit_data("abcd", "1842", None, None, 0, None);
+        assert_eq!(v["channel_id"], "abcd");
+        assert_eq!(v["closure_initiator"], "UNSPECIFIED");
+        assert!(v.get("reason_kind").is_none());
+        assert!(v.get("counterparty_node_id").is_none());
+        assert!(v.get("funding_txo").is_none());
+    }
+
+    #[test]
+    fn unknown_kind_preserves_raw_value() {
+        let reason = ChannelStateChangeReason {
+            kind: 999,
+            message: String::new(),
+            details: None,
+        };
+        let v = close_audit_data("abcd", "1842", None, None, 0, Some(&reason));
+        assert_eq!(v["reason_kind"], "UNKNOWN(999)");
+    }
+
+    #[test]
+    fn unknown_state_decodes_unspecified() {
+        let v = unknown_state_audit_data("5a9c", "42", Some("03aa"), 0);
+        assert_eq!(v["state"], "UNSPECIFIED");
+        assert_eq!(v["channel_id"], "5a9c");
+        assert_eq!(v["user_channel_id"], "42");
+        assert_eq!(v["counterparty_node_id"], "03aa");
+    }
+
+    #[test]
+    fn unknown_state_out_of_range_falls_back() {
+        let v = unknown_state_audit_data("5a9c", "42", None, 99);
+        assert_eq!(v["state"], "UNKNOWN(99)");
+        assert!(v.get("counterparty_node_id").is_none());
+    }
+
+    #[test]
+    fn unknown_state_decodes_known_state_name() {
+        // A known state (READY = 2) never reaches the else in production, but the decoder still names it.
+        let v = unknown_state_audit_data("5a9c", "42", None, 2);
+        assert_eq!(v["state"], "READY");
+    }
+}

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -10,6 +10,22 @@ use ldk_server_client::ldk_server_grpc::events::{ChannelState, EventEnvelope};
 use crate::stable_manager::LdkServerCalls;
 use crate::state::AppState;
 
+/// Build the audit `data` for a claimable (unclaimed inbound) payment; no user_channel_id exists yet.
+fn claimable_audit_data(
+    payment_id: Option<&str>,
+    amount_msat: Option<u64>,
+    has_custom_records: bool,
+) -> serde_json::Value {
+    let mut data = serde_json::json!({ "has_custom_records": has_custom_records });
+    if let Some(pid) = payment_id {
+        data["payment_id"] = serde_json::json!(pid);
+    }
+    if let Some(amt) = amount_msat {
+        data["amount_msat"] = serde_json::json!(amt);
+    }
+    data
+}
+
 pub fn spawn(state: AppState) {
     tokio::spawn(async move { run(state).await });
 }
@@ -33,6 +49,23 @@ async fn run(state: AppState) {
             },
         };
         info!("[event_loop] subscribed");
+        {
+            let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+            if btc_price > 0.0 {
+                state
+                    .stable_manager
+                    .lock()
+                    .await
+                    .reconcile_from_grpc(state.ldk_server.as_ref(), btc_price)
+                    .await;
+            } else {
+                warn!("[event_loop] reconnect reconcile skipped: price cache cold");
+            }
+            let n = crate::backfill::backfill_forwards(state.ldk_server.as_ref(), state.db.as_ref()).await;
+            if n > 0 {
+                info!("[event_loop] backfilled {} forward(s)", n);
+            }
+        }
         while let Some(item) = stream.next_message().await {
             dispatch(item, &state).await;
         }
@@ -65,26 +98,150 @@ async fn dispatch(
                 )
                 .await;
             } else if e.state == ChannelState::Closed as i32 {
-                mgr.handle_channel_closed(e.user_channel_id.clone());
+                mgr.handle_channel_closed(
+                    e.channel_id.clone(),
+                    e.user_channel_id.clone(),
+                    e.counterparty_node_id.clone(),
+                    e.funding_txo.clone(),
+                    e.closure_initiator,
+                    e.reason.clone(),
+                );
+            } else if e.state == ChannelState::Pending as i32 {
+                stable_channels::audit::audit_event(
+                    "CHANNEL_PENDING",
+                    serde_json::json!({
+                        "channel_id": e.channel_id,
+                        "user_channel_id": e.user_channel_id,
+                        "counterparty_node_id": e.counterparty_node_id,
+                    }),
+                );
+            } else if e.state == ChannelState::OpenFailed as i32 {
+                stable_channels::audit::audit_event(
+                    "CHANNEL_OPEN_FAILED",
+                    crate::channel_close::close_audit_data(
+                        &e.channel_id,
+                        &e.user_channel_id,
+                        e.counterparty_node_id.as_deref(),
+                        e.funding_txo.as_deref(),
+                        e.closure_initiator,
+                        e.reason.as_ref(),
+                    ),
+                );
+            } else {
+                stable_channels::audit::audit_event(
+                    "CHANNEL_STATE_UNKNOWN",
+                    crate::channel_close::unknown_state_audit_data(
+                        &e.channel_id,
+                        &e.user_channel_id,
+                        e.counterparty_node_id.as_deref(),
+                        e.state,
+                    ),
+                );
             }
         },
         Some(EventVariant::PaymentReceived(e)) => {
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
-            mgr.handle_payment_received(e.custom_records, payment_id, ldk, btc_price)
+            let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
+            mgr.handle_payment_received(e.custom_records, payment_id, amount_msat, ldk, btc_price)
                 .await;
         },
         Some(EventVariant::PaymentForwarded(e)) => {
             if let Some(fp) = e.forwarded_payment {
+                let fp_key = stable_channels::db::forward_fingerprint(
+                    &fp.prev_channel_id,
+                    &fp.next_channel_id,
+                    fp.outbound_amount_forwarded_msat,
+                    fp.total_fee_earned_msat,
+                );
                 mgr.handle_payment_forwarded(
                     fp.prev_user_channel_id,
+                    fp.next_user_channel_id,
+                    fp.prev_channel_id,
+                    fp.next_channel_id,
+                    fp.prev_node_id,
+                    fp.next_node_id,
                     fp.outbound_amount_forwarded_msat.unwrap_or(0),
                     fp.total_fee_earned_msat.unwrap_or(0),
                     ldk,
                     btc_price,
                 )
                 .await;
+                let _ = state.db.record_forwarded_seen(&fp_key);
             }
         },
+        Some(EventVariant::PaymentSuccessful(e)) => {
+            let payment_id = e.payment.as_ref().map(|p| p.id.clone());
+            let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
+            let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
+            let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            let user_channel_id = payment_id.as_deref()
+                .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten());
+            stable_channels::audit::audit_event(
+                "PAYMENT_SETTLED",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "amount_msat": amount_msat,
+                    "fee_paid_msat": fee_paid_msat,
+                    "direction": direction,
+                    "user_channel_id": user_channel_id,
+                }),
+            );
+        },
+        Some(EventVariant::PaymentFailed(e)) => {
+            let payment_id = e.payment.as_ref().map(|p| p.id.clone());
+            let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
+            let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
+            let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            let user_channel_id = payment_id.as_deref()
+                .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten());
+            stable_channels::audit::audit_event(
+                "PAYMENT_FAILED",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "amount_msat": amount_msat,
+                    "fee_paid_msat": fee_paid_msat,
+                    "direction": direction,
+                    "user_channel_id": user_channel_id,
+                }),
+            );
+        },
+        Some(EventVariant::PaymentClaimable(e)) => {
+            let payment_id = e.payment.as_ref().map(|p| p.id.clone());
+            let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
+            let has_custom_records = !e.custom_records.is_empty();
+            stable_channels::audit::audit_event(
+                "PAYMENT_CLAIMABLE",
+                claimable_audit_data(payment_id.as_deref(), amount_msat, has_custom_records),
+            );
+        },
         _ => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claimable_full_fields_no_uid() {
+        let d = claimable_audit_data(Some("abc123"), Some(150_000), false);
+        assert_eq!(d["payment_id"], "abc123");
+        assert_eq!(d["amount_msat"], 150_000u64);
+        assert_eq!(d["has_custom_records"], false);
+        assert!(d.get("user_channel_id").is_none());
+    }
+
+    #[test]
+    fn claimable_omits_absent_amount() {
+        let d = claimable_audit_data(Some("abc123"), None, false);
+        assert!(d.get("amount_msat").is_none());
+        assert_eq!(d["payment_id"], "abc123");
+    }
+
+    #[test]
+    fn claimable_reflects_custom_records_and_omits_absent_id() {
+        let d = claimable_audit_data(None, None, true);
+        assert_eq!(d["has_custom_records"], true);
+        assert!(d.get("payment_id").is_none());
     }
 }

--- a/server/stable-channels-lsp/src/handlers/audit_log.rs
+++ b/server/stable-channels-lsp/src/handlers/audit_log.rs
@@ -10,6 +10,27 @@ use crate::handlers::{decode_body, ok_response};
 use crate::state::AppState;
 
 const DEFAULT_MAX_LINES: usize = 200;
+const FULL_HISTORY_CAP: usize = 5000;
+
+/// Keep lines matching `filter` (substring; all when empty); `full` returns the whole matching history oldest-first capped at FULL_HISTORY_CAP, else the last `max_lines`.
+pub(crate) fn filter_tail(content: &str, filter: &str, max_lines: usize, full: bool) -> String {
+    let lines: Vec<&str> = if filter.is_empty() {
+        content.lines().collect()
+    } else {
+        content.lines().filter(|l| l.contains(filter)).collect()
+    };
+    if full {
+        let start = lines.len().saturating_sub(FULL_HISTORY_CAP);
+        let body = lines[start..].join("\n");
+        return if start > 0 {
+            format!("[… {} older matching line(s) truncated — narrow the filter to see them …]\n{}", start, body)
+        } else {
+            body
+        };
+    }
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
 
 pub async fn audit_log(State(state): State<AppState>, body: Bytes) -> Response {
     let req: LogRequest = match decode_body(&body) {
@@ -24,13 +45,51 @@ pub async fn audit_log(State(state): State<AppState>, body: Bytes) -> Response {
 
     let path = state.data_dir.join("audit_log.txt");
     let content = match std::fs::read_to_string(&path) {
-        Ok(s) => {
-            let lines: Vec<&str> = s.lines().collect();
-            let start = lines.len().saturating_sub(max_lines);
-            lines[start..].join("\n")
-        },
+        Ok(s) => filter_tail(&s, &req.filter, max_lines, req.full),
         Err(e) => format!("Error reading {}: {}", path.display(), e),
     };
 
     ok_response(LogResponse { content })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_returns_tail() {
+        let c = "a\nb\nc\nd";
+        assert_eq!(filter_tail(c, "", 2, false), "c\nd");
+        assert_eq!(filter_tail(c, "", 10, false), "a\nb\nc\nd");
+    }
+
+    #[test]
+    fn filter_matches_whole_content_then_tails() {
+        let c = "x1\ny\nx2\nz\nx3";
+        assert_eq!(filter_tail(c, "x", 2, false), "x2\nx3"); // last 2 of the 3 matches, from across the file
+        assert_eq!(filter_tail(c, "x", 10, false), "x1\nx2\nx3");
+    }
+
+    #[test]
+    fn filter_no_match_is_empty() {
+        assert_eq!(filter_tail("a\nb", "zzz", 5, false), "");
+    }
+
+    #[test]
+    fn full_returns_all_matches_oldest_first_ignoring_max_lines() {
+        let c = "x1\ny\nx2\nz\nx3";
+        // full mode returns every match oldest-first regardless of the (tail) max_lines.
+        assert_eq!(filter_tail(c, "x", 2, true), "x1\nx2\nx3");
+        assert_eq!(filter_tail(c, "", 1, true), c);
+    }
+
+    #[test]
+    fn full_caps_and_prepends_truncation_notice() {
+        let content = (0..FULL_HISTORY_CAP + 3).map(|i| format!("m{i}")).collect::<Vec<_>>().join("\n");
+        let out = filter_tail(&content, "m", 200, true);
+        assert!(out.starts_with("[… 3 older matching line(s) truncated"));
+        // keeps the most-recent CAP matches, newest line last.
+        assert!(out.ends_with(&format!("m{}", FULL_HISTORY_CAP + 2)));
+        assert!(!out.contains("\nm2\n")); // the 3 oldest are dropped
+    }
 }

--- a/server/stable-channels-lsp/src/handlers/stable_channels.rs
+++ b/server/stable-channels-lsp/src/handlers/stable_channels.rs
@@ -37,6 +37,7 @@ pub async fn list_stable_channels(
             latest_price,
             note: sc.note.clone().unwrap_or_default(),
             is_stable_receiver: sc.is_stable_receiver,
+            user_channel_id: format!("{}", sc.user_channel_id),
         })
         .collect::<Vec<_>>();
     drop(mgr);

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -1,8 +1,11 @@
 mod auth;
+mod backfill;
+mod channel_close;
 mod config;
 mod event_loop;
 mod handlers;
 pub mod messages;
+mod observability;
 mod price_task;
 mod push;
 mod stability_tick;
@@ -12,6 +15,7 @@ mod tls;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use axum::routing::post;
@@ -40,6 +44,9 @@ use tracing_subscriber::EnvFilter;
 
 use crate::config::Config;
 use crate::state::AppState;
+
+/// Bound on how long startup waits for the price cache to warm before deferring reconcile to the stability-tick backstop.
+const STARTUP_RECONCILE_PRICE_WAIT_SECS: u64 = 60;
 
 #[derive(Parser, Debug)]
 #[command(name = "stable-channels-lsp", about = "Stable Channels LSP daemon")]
@@ -120,26 +127,45 @@ async fn main() -> Result<()> {
         ldk_log_file,
     };
 
+    let (price_tx, price_rx) = tokio::sync::watch::channel(0.0_f64);
     tokio::spawn(async move {
-        price_task::run().await;
+        price_task::run(price_tx).await;
     });
 
-    // One-shot reconcile from gRPC to catch up snapshots changed while the daemon was down. Skipped if the price cache is cold.
+    // Reconcile from gRPC to catch up snapshots that changed while the daemon was down. The stable math needs a BTC/USD price, so wait (bounded) for the cache to warm first; spawned so the REST server and event loop come up immediately.
     {
-        let btc_price = stable_channels::price_feeds::get_cached_price();
-        if btc_price > 0.0 {
-            let mut mgr = state.stable_manager.lock().await;
-            mgr.reconcile_from_grpc(
-                state.ldk_server.as_ref() as &dyn crate::stable_manager::LdkServerCalls,
-                btc_price,
+        let state = state.clone();
+        let mut price_rx = price_rx;
+        tokio::spawn(async move {
+            // Copy the price out and drop the watch guard before any await so the future stays Send.
+            let warmed = tokio::time::timeout(
+                Duration::from_secs(STARTUP_RECONCILE_PRICE_WAIT_SECS),
+                price_rx.wait_for(|&p| p > 0.0),
             )
-            .await;
-        } else {
-            tracing::warn!("startup reconcile skipped: price cache cold");
-        }
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|price| *price);
+            match warmed {
+                Some(btc_price) => {
+                    let ldk: &dyn crate::stable_manager::LdkServerCalls =
+                        state.ldk_server.as_ref();
+                    state
+                        .stable_manager
+                        .lock()
+                        .await
+                        .reconcile_from_grpc(ldk, btc_price)
+                        .await;
+                }
+                None => tracing::warn!(
+                    "startup reconcile skipped: price cache stayed cold; tick backstop will retry"
+                ),
+            }
+        });
     }
     event_loop::spawn(state.clone());
     stability_tick::spawn(state.clone());
+    observability::spawn(state.clone());
 
     let router = Router::new()
         .route("/GetNodeInfo", post(handlers::proxy::get_node_info))

--- a/server/stable-channels-lsp/src/observability.rs
+++ b/server/stable-channels-lsp/src/observability.rs
@@ -1,0 +1,185 @@
+//! Periodic observability poll: synthesizes SWEEP_PROGRESS and PEER_CONNECTED/PEER_DISCONNECTED audit events.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ldk_server_client::ldk_server_grpc::api::GetBalancesRequest;
+use ldk_server_client::ldk_server_grpc::types::pending_sweep_balance::BalanceType;
+use tokio::time::interval;
+use tracing::warn;
+
+use crate::stable_manager::LdkServerCalls;
+use crate::state::AppState;
+
+const POLL_SECS: u64 = 30;
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move { run(state).await });
+}
+
+async fn run(state: AppState) {
+    let mut tick = interval(Duration::from_secs(POLL_SECS));
+    let mut sweep_prev: HashMap<String, String> = HashMap::new();
+    let mut peer_prev: HashMap<String, bool> = HashMap::new();
+    let mut peer_first_run = true;
+    loop {
+        tick.tick().await;
+        poll_sweeps(&state, &mut sweep_prev).await;
+        poll_peers(&state, &mut peer_prev, &mut peer_first_run).await;
+    }
+}
+
+/// Pure: which channels changed sweep-state (or left the pending set → "Swept").
+pub fn sweep_transitions(
+    prev: &HashMap<String, String>,
+    current: &HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for (cid, state) in current {
+        if prev.get(cid) != Some(state) {
+            out.push((cid.clone(), state.clone()));
+        }
+    }
+    for cid in prev.keys() {
+        if !current.contains_key(cid) {
+            out.push((cid.clone(), "Swept".to_string()));
+        }
+    }
+    out
+}
+
+fn sweep_state_name(bt: &BalanceType) -> (&'static str, String, u64) {
+    match bt {
+        BalanceType::PendingBroadcast(x) => ("PendingBroadcast", x.channel_id.clone().unwrap_or_default(), x.amount_satoshis),
+        BalanceType::BroadcastAwaitingConfirmation(x) => ("BroadcastAwaitingConfirmation", x.channel_id.clone().unwrap_or_default(), x.amount_satoshis),
+        BalanceType::AwaitingThresholdConfirmations(x) => ("AwaitingThresholdConfirmations", x.channel_id.clone().unwrap_or_default(), x.amount_satoshis),
+    }
+}
+
+async fn poll_sweeps(state: &AppState, prev: &mut HashMap<String, String>) {
+    let ldk: &dyn LdkServerCalls = state.ldk_server.as_ref();
+    let resp = match ldk.get_balances(GetBalancesRequest {}).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("[observability] get_balances failed: {}", e);
+            return;
+        }
+    };
+    let mut current: HashMap<String, String> = HashMap::new();
+    let mut amounts: HashMap<String, u64> = HashMap::new();
+    for b in &resp.pending_balances_from_channel_closures {
+        if let Some(bt) = &b.balance_type {
+            let (name, cid, amt) = sweep_state_name(bt);
+            if !cid.is_empty() {
+                current.insert(cid.clone(), name.to_string());
+                amounts.insert(cid, amt);
+            }
+        }
+    }
+    for (cid, state_name) in sweep_transitions(prev, &current) {
+        let uid = state.db.get_user_channel_id_by_channel_id(&cid).ok().flatten();
+        stable_channels::audit::audit_event(
+            "SWEEP_PROGRESS",
+            serde_json::json!({
+                "channel_id": cid,
+                "user_channel_id": uid,
+                "sweep_state": state_name,
+                "amount_sats": amounts.get(&cid),
+            }),
+        );
+    }
+    *prev = current;
+}
+
+/// Pure: connect/disconnect transitions for counterparty peers. First run only establishes a baseline.
+pub fn peer_transitions(
+    prev: &HashMap<String, bool>,
+    current: &HashMap<String, bool>,
+    first_run: bool,
+) -> Vec<(String, bool)> {
+    if first_run {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for (node, connected) in current {
+        if prev.get(node) != Some(connected) {
+            out.push((node.clone(), *connected));
+        }
+    }
+    out
+}
+
+async fn poll_peers(state: &AppState, prev: &mut HashMap<String, bool>, first_run: &mut bool) {
+    use ldk_server_client::ldk_server_grpc::api::{ListChannelsRequest, ListPeersRequest};
+    let ldk: &dyn LdkServerCalls = state.ldk_server.as_ref();
+    let peers = match ldk.list_peers(ListPeersRequest {}).await {
+        Ok(r) => r.peers,
+        Err(e) => { warn!("[observability] list_peers failed: {}", e); return; }
+    };
+    let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+        Ok(r) => r.channels,
+        Err(e) => { warn!("[observability] list_channels failed: {}", e); return; }
+    };
+    // counterparty node_id -> its user_channel_ids
+    let mut cp_uids: HashMap<String, Vec<String>> = HashMap::new();
+    for c in &channels {
+        cp_uids.entry(c.counterparty_node_id.clone()).or_default().push(c.user_channel_id.clone());
+    }
+    // current connection state, counterparties only
+    let mut current: HashMap<String, bool> = HashMap::new();
+    let mut address: HashMap<String, String> = HashMap::new();
+    for p in &peers {
+        if cp_uids.contains_key(&p.node_id) {
+            current.insert(p.node_id.clone(), p.is_connected);
+            address.insert(p.node_id.clone(), p.address.clone());
+        }
+    }
+    for (node, connected) in peer_transitions(prev, &current, *first_run) {
+        stable_channels::audit::audit_event(
+            if connected { "PEER_CONNECTED" } else { "PEER_DISCONNECTED" },
+            serde_json::json!({
+                "counterparty_node_id": node,
+                "user_channel_ids": cp_uids.get(&node),
+                "address": address.get(&node),
+            }),
+        );
+    }
+    *prev = current;
+    *first_run = false;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn sweep_transitions_detects_enter_advance_and_swept() {
+        let prev: HashMap<String, String> = HashMap::new();
+        let mut cur = HashMap::new();
+        cur.insert("c1".to_string(), "PendingBroadcast".to_string());
+        let t = sweep_transitions(&prev, &cur);
+        assert_eq!(t, vec![("c1".to_string(), "PendingBroadcast".to_string())]); // first-seen
+
+        let mut cur2 = HashMap::new();
+        cur2.insert("c1".to_string(), "BroadcastAwaitingConfirmation".to_string());
+        assert_eq!(sweep_transitions(&cur, &cur2), vec![("c1".to_string(), "BroadcastAwaitingConfirmation".to_string())]);
+
+        let empty = HashMap::new();
+        assert_eq!(sweep_transitions(&cur2, &empty), vec![("c1".to_string(), "Swept".to_string())]); // left the set
+        assert!(sweep_transitions(&cur2, &cur2).is_empty()); // no change
+    }
+
+    #[test]
+    fn peer_transitions_baseline_then_changes() {
+        let mut cur = HashMap::new();
+        cur.insert("02aa".to_string(), true);
+        assert!(peer_transitions(&HashMap::new(), &cur, true).is_empty()); // first run = baseline, no emit
+
+        let mut cur2 = HashMap::new();
+        cur2.insert("02aa".to_string(), false);
+        assert_eq!(peer_transitions(&cur, &cur2, false), vec![("02aa".to_string(), false)]); // flipped to disconnected
+
+        assert!(peer_transitions(&cur2, &cur2, false).is_empty()); // no change
+    }
+}

--- a/server/stable-channels-lsp/src/price_task.rs
+++ b/server/stable-channels-lsp/src/price_task.rs
@@ -1,17 +1,19 @@
-//! Background task that keeps the `stable_channels::price_feeds` cache warm.
+//! Background task that keeps the `stable_channels::price_feeds` cache warm and publishes each fresh price on a watch channel so startup can wait for the first non-zero value.
 
 use std::time::Duration;
 
 use stable_channels::constants::PRICE_CACHE_REFRESH_SECS;
 use stable_channels::price_feeds::get_cached_price;
+use tokio::sync::watch;
 use tokio::time::interval;
 use tracing::{info, warn};
 
-/// Drive the price cache forever.
-pub async fn run() {
+/// Drive the price cache forever, publishing every non-zero price on `price_tx`.
+pub async fn run(price_tx: watch::Sender<f64>) {
     let first = tokio::task::spawn_blocking(get_cached_price).await.unwrap_or(0.0);
     if first > 0.0 {
         info!("initial BTC/USD price = ${:.2}", first);
+        let _ = price_tx.send(first);
     } else {
         warn!("initial price fetch returned 0.0, exchanges may be unreachable");
     }
@@ -22,6 +24,7 @@ pub async fn run() {
         tick.tick().await;
         let price = tokio::task::spawn_blocking(get_cached_price).await.unwrap_or(0.0);
         if price > 0.0 {
+            let _ = price_tx.send(price);
             tracing::debug!("price refresh: ${:.2}", price);
         } else {
             warn!("price refresh returned 0.0");

--- a/server/stable-channels-lsp/src/stability_tick.rs
+++ b/server/stable-channels-lsp/src/stability_tick.rs
@@ -25,6 +25,8 @@ async fn run(state: AppState) {
             continue;
         }
         let mut mgr = state.stable_manager.lock().await;
+        mgr.reconcile_if_empty(state.ldk_server.as_ref() as &dyn LdkServerCalls, btc_price)
+            .await;
         mgr.run_tick(
             state.ldk_server.as_ref() as &dyn LdkServerCalls,
             &state.push,

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -7,10 +7,12 @@ use async_trait::async_trait;
 use ldk_server_client::client::LdkServerClient;
 use ldk_server_client::error::LdkServerError;
 use ldk_server_client::ldk_server_grpc::api::{
-    ListChannelsRequest, ListChannelsResponse, SignMessageRequest, SignMessageResponse,
-    SpontaneousSendRequest, SpontaneousSendResponse, VerifySignatureRequest,
-    VerifySignatureResponse,
+    GetBalancesRequest, GetBalancesResponse, ListChannelsRequest, ListChannelsResponse,
+    ListForwardedPaymentsRequest, ListForwardedPaymentsResponse, ListPeersRequest,
+    ListPeersResponse, SignMessageRequest, SignMessageResponse, SpontaneousSendRequest,
+    SpontaneousSendResponse, VerifySignatureRequest, VerifySignatureResponse,
 };
+use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
 use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
 use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
@@ -35,6 +37,24 @@ pub trait LdkServerCalls: Send + Sync {
         &self,
         req: VerifySignatureRequest,
     ) -> Result<VerifySignatureResponse, LdkServerError>;
+    async fn list_forwarded_payments(
+        &self,
+        _req: ListForwardedPaymentsRequest,
+    ) -> Result<ListForwardedPaymentsResponse, LdkServerError> {
+        Ok(ListForwardedPaymentsResponse::default())
+    }
+    async fn get_balances(
+        &self,
+        _req: GetBalancesRequest,
+    ) -> Result<GetBalancesResponse, LdkServerError> {
+        Ok(GetBalancesResponse::default())
+    }
+    async fn list_peers(
+        &self,
+        _req: ListPeersRequest,
+    ) -> Result<ListPeersResponse, LdkServerError> {
+        Ok(ListPeersResponse::default())
+    }
 }
 
 #[async_trait]
@@ -63,6 +83,24 @@ impl LdkServerCalls for LdkServerClient {
     ) -> Result<VerifySignatureResponse, LdkServerError> {
         LdkServerClient::verify_signature(self, req).await
     }
+    async fn list_forwarded_payments(
+        &self,
+        req: ListForwardedPaymentsRequest,
+    ) -> Result<ListForwardedPaymentsResponse, LdkServerError> {
+        LdkServerClient::list_forwarded_payments(self, req).await
+    }
+    async fn get_balances(
+        &self,
+        req: GetBalancesRequest,
+    ) -> Result<GetBalancesResponse, LdkServerError> {
+        LdkServerClient::get_balances(self, req).await
+    }
+    async fn list_peers(
+        &self,
+        req: ListPeersRequest,
+    ) -> Result<ListPeersResponse, LdkServerError> {
+        LdkServerClient::list_peers(self, req).await
+    }
 }
 
 /// In-memory list of stable channels plus a handle to the shared sqlite channels table.
@@ -72,6 +110,8 @@ pub struct StableChannelManager {
     data_dir: PathBuf,
     /// Per-channel consecutive low-balance tick count for the balance-truth backstop debounce (ignores transient in-flight HTLCs).
     spend_debounce: std::collections::HashMap<u128, u8>,
+    /// Per-channel last logged stability outcome + value, so run_tick only audits on state-change.
+    stability_throttle: std::collections::HashMap<u128, (String, f64)>,
 }
 
 /// Outcome of an `edit_stable_channel` call.
@@ -92,6 +132,7 @@ impl StableChannelManager {
             db,
             data_dir,
             spend_debounce: std::collections::HashMap::new(),
+            stability_throttle: std::collections::HashMap::new(),
         }
     }
 
@@ -230,10 +271,16 @@ impl StableChannelManager {
         }
     }
 
-    /// Remove the stable_channel record from in-memory state when a channel
-    /// closes, and soft-close the DB row (preserved for forensics, excluded
-    /// from future reconcile/tick reads).
-    pub fn handle_channel_closed(&mut self, user_channel_id: String) {
+    /// Remove the stable_channel record from in-memory state when a channel closes, and soft-close the DB row (preserved for forensics, excluded from future reconcile/tick reads).
+    pub fn handle_channel_closed(
+        &mut self,
+        channel_id: String,
+        user_channel_id: String,
+        counterparty_node_id: Option<String>,
+        funding_txo: Option<String>,
+        closure_initiator: i32,
+        reason: Option<ChannelStateChangeReason>,
+    ) {
         let target = parse_user_channel_id(&user_channel_id);
         self.stable_channels.retain(|sc| {
             if let Some(t) = target {
@@ -244,16 +291,28 @@ impl StableChannelManager {
         });
         if let Some(t) = target {
             self.spend_debounce.remove(&t);
+            self.stability_throttle.remove(&t);
         }
         if let Err(e) = self.db.mark_channel_closed(&user_channel_id) {
             tracing::error!(
                 "[stable] handle_channel_closed: db.mark_channel_closed failed for {}: {}",
                 user_channel_id, e
             );
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({ "op": "mark_channel_closed", "user_channel_id": user_channel_id, "channel_id": channel_id, "error": e.to_string() }),
+            );
         }
         stable_channels::audit::audit_event(
             "CHANNEL_CLOSED",
-            serde_json::json!({ "user_channel_id": user_channel_id }),
+            crate::channel_close::close_audit_data(
+                &channel_id,
+                &user_channel_id,
+                counterparty_node_id.as_deref(),
+                funding_txo.as_deref(),
+                closure_initiator,
+                reason.as_ref(),
+            ),
         );
     }
 
@@ -267,6 +326,10 @@ impl StableChannelManager {
             Ok(r) => r.channels,
             Err(e) => {
                 tracing::error!("[stable] reconcile: list_channels failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_channels", "context": "reconcile", "error": e.to_string() }),
+                );
                 return;
             }
         };
@@ -285,6 +348,10 @@ impl StableChannelManager {
             Ok(r) => r,
             Err(e) => {
                 tracing::error!("[stable] reconcile: db.load_all_channels failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({ "op": "load_all_channels", "context": "reconcile", "error": e.to_string() }),
+                );
                 return;
             }
         };
@@ -305,6 +372,10 @@ impl StableChannelManager {
                     tracing::error!(
                         "[stable] reconcile: db.mark_channel_closed({}) failed: {}",
                         record.user_channel_id, e
+                    );
+                    stable_channels::audit::audit_event(
+                        "DB_WRITE_FAILED",
+                        serde_json::json!({ "op": "mark_channel_closed", "context": "reconcile", "user_channel_id": record.user_channel_id, "error": e.to_string() }),
                     );
                 }
                 stable_channels::audit::audit_event(
@@ -353,6 +424,13 @@ impl StableChannelManager {
         );
     }
 
+    /// Self-heal: if the in-memory list is empty (startup/reconnect reconcile skipped on a cold price cache), rebuild it from truth; a populated list is left untouched so a transient empty snapshot can't wipe it.
+    pub async fn reconcile_if_empty(&mut self, ldk: &dyn LdkServerCalls, btc_price: f64) {
+        if self.stable_channels.is_empty() {
+            self.reconcile_from_grpc(ldk, btc_price).await;
+        }
+    }
+
     /// On ChannelStateChanged Ready, auto-register the channel as stable at expected_usd=0 if untracked (operator sets a target via EditStableChannel).
     pub async fn handle_channel_ready(
         &mut self,
@@ -376,6 +454,10 @@ impl StableChannelManager {
                 tracing::error!(
                     "[stable] handle_channel_ready: list_channels failed: {}",
                     e
+                );
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_channels", "context": "handle_channel_ready", "user_channel_id": user_channel_id, "channel_id": channel_id, "error": e.to_string() }),
                 );
                 return;
             }
@@ -435,6 +517,10 @@ impl StableChannelManager {
                 "[stable] handle_channel_ready: db.save_channel failed: {}",
                 e
             );
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({ "op": "save_channel", "context": "handle_channel_ready", "channel_id": channel_id, "user_channel_id": user_channel_id, "error": e.to_string() }),
+            );
             return;
         }
         self.stable_channels.push(new_sc);
@@ -453,6 +539,7 @@ impl StableChannelManager {
         &mut self,
         custom_records: Vec<CustomTlvRecord>,
         payment_id: Option<String>,
+        amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
@@ -476,13 +563,17 @@ impl StableChannelManager {
             };
             stable_channels::audit::audit_event(
                 "MESSAGE_RECEIVED",
-                serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE }),
+                serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE, "payment_id": payment_id.clone() }),
             );
             let raw = raw.to_string();
             if crate::messages::parse_envelope(&raw).is_some() {
                 if let Some(pid) = payment_id.as_deref() {
                     if let Err(e) = self.db.record_settlement(pid, "sync") {
                         tracing::error!("[stable] record_settlement (inbound sync) failed: {}", e);
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({ "op": "record_settlement", "kind": "sync", "payment_id": pid, "error": e.to_string() }),
+                        );
                     }
                 }
                 self.handle_trade_message(&raw, ldk, btc_price).await;
@@ -490,12 +581,20 @@ impl StableChannelManager {
                 if let Some(pid) = payment_id.as_deref() {
                     if let Err(e) = self.db.record_settlement(pid, "stability") {
                         tracing::error!("[stable] record_settlement (inbound stability) failed: {}", e);
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({ "op": "record_settlement", "kind": "stability", "payment_id": pid, "error": e.to_string() }),
+                        );
                     }
                 }
             }
             return;
         }
-        // No stable TLV: plain payment, balance catch-up handled by run_tick + reconcile_from_grpc.
+        // No stable TLV: plain receipt — emit audit so it's visible in the log.
+        stable_channels::audit::audit_event(
+            "PAYMENT_RECEIVED",
+            serde_json::json!({ "payment_id": payment_id, "amount_msat": amount_msat }),
+        );
     }
 
     /// 60s tick: per stable channel, skip below threshold/cooldown/zero-target, then SpontaneousSend a connected peer or push an offline one.
@@ -567,6 +666,7 @@ impl StableChannelManager {
                         stable_channels::audit::audit_event(
                             "BACKSTOP_STABLE_DEDUCTED",
                             serde_json::json!({
+                                "channel_id": c.channel_id,
                                 "user_channel_id": format!("{}", uid),
                                 "their_sats": their_sats,
                                 "usd_deducted": usd_deducted,
@@ -583,6 +683,10 @@ impl StableChannelManager {
                             sc.note.as_deref(),
                         ) {
                             tracing::error!("[stable] backstop save_channel failed: {}", e);
+                            stable_channels::audit::audit_event(
+                                "DB_WRITE_FAILED",
+                                serde_json::json!({ "op": "save_channel", "context": "backstop", "user_channel_id": format!("{}", uid), "channel_id": c.channel_id, "error": e.to_string() }),
+                            );
                         }
                         backstop_syncs.push((uid, sc.expected_usd.0, sc.counterparty.to_string()));
                     }
@@ -606,16 +710,34 @@ impl StableChannelManager {
                 continue;
             }
             if sc.risk_level > stable_channels::constants::MAX_RISK_LEVEL {
-                stable_channels::audit::audit_event(
-                    "STABILITY_SKIP_HIGH_RISK",
-                    serde_json::json!({
-                        "user_channel_id": format!("{}", sc.user_channel_id),
-                        "risk_level": sc.risk_level,
-                    }),
-                );
+                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
+                if stability_should_log(&lo, "high_risk", lv, stable_usd_value, target, dollar_threshold, percent_threshold, false) {
+                    stable_channels::audit::audit_event(
+                        "STABILITY_SKIP_HIGH_RISK",
+                        serde_json::json!({
+                            "channel_id": sc.channel_id.to_string(),
+                            "user_channel_id": format!("{}", sc.user_channel_id),
+                            "risk_level": sc.risk_level,
+                        }),
+                    );
+                    self.stability_throttle.insert(sc.user_channel_id, ("high_risk".to_string(), stable_usd_value));
+                }
                 continue;
             }
             if now - sc.last_stability_payment < cooldown {
+                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
+                if stability_should_log(&lo, "cooldown", lv, stable_usd_value, target, dollar_threshold, percent_threshold, false) {
+                    stable_channels::audit::audit_event(
+                        "STABILITY_COOLDOWN",
+                        serde_json::json!({
+                            "channel_id": sc.channel_id.to_string(),
+                            "user_channel_id": format!("{}", sc.user_channel_id),
+                            "seconds_since_last": now - sc.last_stability_payment,
+                            "cooldown_secs": cooldown,
+                        }),
+                    );
+                    self.stability_throttle.insert(sc.user_channel_id, ("cooldown".to_string(), stable_usd_value));
+                }
                 continue;
             }
 
@@ -647,12 +769,18 @@ impl StableChannelManager {
                     match ldk.spontaneous_send(send_req).await {
                         Ok(resp) => {
                             if !resp.payment_id.is_empty() {
-                                if let Err(e) =
-                                    self.db.record_settlement(&resp.payment_id, "stability")
-                                {
+                                if let Err(e) = self.db.record_settlement_with_channel(
+                                    &resp.payment_id,
+                                    "stability",
+                                    &user_channel_id_clone,
+                                ) {
                                     tracing::error!(
                                         "[stable] record_settlement (stability) failed: {}",
                                         e
+                                    );
+                                    stable_channels::audit::audit_event(
+                                        "DB_WRITE_FAILED",
+                                        serde_json::json!({ "op": "record_settlement", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": e.to_string() }),
                                     );
                                 }
                             }
@@ -674,11 +802,16 @@ impl StableChannelManager {
                                     "[stable] run_tick: db.save_channel failed: {}",
                                     e
                                 );
+                                stable_channels::audit::audit_event(
+                                    "DB_WRITE_FAILED",
+                                    serde_json::json!({ "op": "save_channel", "context": "run_tick_post_send", "channel_id": channel_id_clone, "user_channel_id": user_channel_id_clone, "error": e.to_string() }),
+                                );
                             }
                             stable_channels::audit::audit_event(
                                 "STABILITY_PAYMENT_SENT",
                                 serde_json::json!({
                                     "channel_id": channel_id_clone,
+                                    "user_channel_id": user_channel_id_clone.clone(),
                                     "direction": direction,
                                     "amount_msat": amount_msat,
                                     "payment_id": resp.payment_id,
@@ -687,6 +820,7 @@ impl StableChannelManager {
                                     "new_backing_sats": sc.backing_sats,
                                 }),
                             );
+                            self.stability_throttle.insert(sc.user_channel_id, ("payment_sent".to_string(), stable_usd_value));
                         },
                         Err(e) => {
                             tracing::warn!(
@@ -697,37 +831,52 @@ impl StableChannelManager {
                                 "STABILITY_PAYMENT_FAILED",
                                 serde_json::json!({
                                     "channel_id": channel_id_clone,
+                                    "user_channel_id": user_channel_id_clone.clone(),
                                     "direction": direction,
                                     "error": e.to_string(),
                                 }),
                             );
+                            self.stability_throttle.insert(sc.user_channel_id, ("payment_failed".to_string(), stable_usd_value));
                             // Do not bump last_stability_payment so retry can fire.
                         },
                     }
                 } else {
                     // User above par: CHECK_ONLY. The LSP can only push value, not pull, so do nothing here (no cooldown bump).
-                    stable_channels::audit::audit_event(
-                        "STABILITY_CHECK_ONLY",
-                        serde_json::json!({
-                            "channel_id": c.channel_id,
-                            "direction": direction,
-                            "stable_usd_value": stable_usd_value,
-                            "expected_usd": target,
-                        }),
-                    );
+                    let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
+                    if stability_should_log(&lo, "check_only", lv, stable_usd_value, target, dollar_threshold, percent_threshold, true) {
+                        stable_channels::audit::audit_event(
+                            "STABILITY_CHECK_ONLY",
+                            serde_json::json!({
+                                "channel_id": c.channel_id,
+                                "user_channel_id": c.user_channel_id.clone(),
+                                "direction": direction,
+                                "stable_usd_value": stable_usd_value,
+                                "expected_usd": target,
+                            }),
+                        );
+                        self.stability_throttle.insert(sc.user_channel_id, ("check_only".to_string(), stable_usd_value));
+                    }
                 }
             } else {
                 let mut p = push.lock().await;
                 p.notify(&sc.counterparty.to_string(), direction);
                 drop(p);
-                stable_channels::audit::audit_event(
-                    "STABILITY_PUSH_QUEUED",
-                    serde_json::json!({
-                        "channel_id": c.channel_id,
-                        "node_id": sc.counterparty.to_string(),
-                        "direction": direction,
-                    }),
-                );
+                let key = format!("push_queued:{}", direction);
+                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
+                if stability_should_log(&lo, &key, lv, stable_usd_value, target, dollar_threshold, percent_threshold, true) {
+                    stable_channels::audit::audit_event(
+                        "STABILITY_PUSH_QUEUED",
+                        serde_json::json!({
+                            "channel_id": c.channel_id,
+                            "user_channel_id": c.user_channel_id.clone(),
+                            "node_id": sc.counterparty.to_string(),
+                            "direction": direction,
+                            "stable_usd_value": stable_usd_value,
+                            "expected_usd": target,
+                        }),
+                    );
+                    self.stability_throttle.insert(sc.user_channel_id, (key, stable_usd_value));
+                }
             }
         }
 
@@ -778,10 +927,18 @@ impl StableChannelManager {
         match ldk.spontaneous_send(req).await {
             Ok(resp) => {
                 if !resp.payment_id.is_empty() {
-                    if let Err(e) = self.db.record_settlement(&resp.payment_id, "sync") {
+                    if let Err(e) = self.db.record_settlement_with_channel(
+                        &resp.payment_id,
+                        "sync",
+                        &format!("{}", user_channel_id),
+                    ) {
                         tracing::error!(
                             "[stable] record_settlement (outbound sync) failed: {}",
                             e
+                        );
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({ "op": "record_settlement", "kind": "sync", "payment_id": resp.payment_id, "user_channel_id": format!("{}", user_channel_id), "error": e.to_string() }),
                         );
                     }
                 }
@@ -808,6 +965,11 @@ impl StableChannelManager {
     pub async fn handle_payment_forwarded(
         &mut self,
         prev_user_channel_id: String,
+        next_user_channel_id: Option<String>,
+        prev_channel_id: String,
+        next_channel_id: String,
+        prev_node_id: String,
+        next_node_id: String,
         outbound_amount_forwarded_msat: u64,
         fee_msat: u64,
         ldk: &dyn LdkServerCalls,
@@ -818,6 +980,11 @@ impl StableChannelManager {
             "PAYMENT_FORWARDED",
             serde_json::json!({
                 "prev_user_channel_id": prev_user_channel_id,
+                "next_user_channel_id": next_user_channel_id,
+                "prev_channel_id": prev_channel_id,
+                "next_channel_id": next_channel_id,
+                "prev_node_id": prev_node_id,
+                "next_node_id": next_node_id,
                 "forwarded_msat": outbound_amount_forwarded_msat,
                 "fee_msat": fee_msat,
                 "total_sats": total_sats,
@@ -840,6 +1007,10 @@ impl StableChannelManager {
             Ok(r) => r,
             Err(e) => {
                 error!("[forwarded] list_channels gRPC failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_channels", "context": "handle_payment_forwarded", "user_channel_id": prev_user_channel_id.clone(), "error": e.to_string() }),
+                );
                 return;
             }
         };
@@ -886,6 +1057,7 @@ impl StableChannelManager {
                 stable_channels::audit::audit_event(
                     "STABLE_SPEND_DEDUCTED",
                     serde_json::json!({
+                        "channel_id": channel_id_hex,
                         "user_channel_id": format!("{}", sc.user_channel_id),
                         "total_sats_spent": total_sats,
                         "native_sats_spent": native_before,
@@ -931,6 +1103,10 @@ impl StableChannelManager {
             note.as_deref(),
         ) {
             error!("[forwarded] db.save_channel failed: {}", e);
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({ "op": "save_channel", "channel_id": channel_id_hex, "context": "handle_payment_forwarded", "user_channel_id": ucid_str, "error": e.to_string() }),
+            );
         }
         if deducted {
             self.send_sync_message(ldk, target_uid, expected_usd_f, &counterparty_hex)
@@ -950,6 +1126,10 @@ impl StableChannelManager {
             Ok(r) => r.channels,
             Err(e) => {
                 error!("[splice] list_channels gRPC failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_channels", "context": "handle_channel_ready_splice", "user_channel_id": format!("{}", uid), "error": e.to_string() }),
+                );
                 return;
             }
         };
@@ -989,6 +1169,7 @@ impl StableChannelManager {
                 stable_channels::audit::audit_event(
                     "SPLICE_OUT_STABLE_DEDUCTED",
                     serde_json::json!({
+                        "channel_id": channel_id_hex,
                         "user_channel_id": format!("{}", uid),
                         "usd_deducted": d,
                         "new_expected_usd": sc.expected_usd.0,
@@ -1017,10 +1198,14 @@ impl StableChannelManager {
             note.as_deref(),
         ) {
             error!("[splice] db.save_channel failed: {}", e);
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({ "op": "save_channel", "context": "handle_channel_ready_splice", "channel_id": channel_id_hex, "user_channel_id": ucid_str, "error": e.to_string() }),
+            );
         }
         stable_channels::audit::audit_event(
             "CHANNEL_READY_SPLICE",
-            serde_json::json!({ "user_channel_id": ucid_str, "deducted": deducted }),
+            serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": ucid_str, "deducted": deducted }),
         );
         if deducted {
             self.send_sync_message(ldk, uid, expected_usd_f, &counterparty_hex)
@@ -1047,26 +1232,30 @@ impl StableChannelManager {
         if payload.kind != stable_channels::constants::TRADE_MESSAGE_TYPE {
             stable_channels::audit::audit_event(
                 "TRADE_UNHANDLED_TYPE",
-                serde_json::json!({ "type": payload.kind }),
+                serde_json::json!({ "type": payload.kind, "user_channel_id": payload.user_channel_id.clone() }),
             );
             return;
         }
         if payload.expected_usd < 0.0 {
             stable_channels::audit::audit_event(
                 "TRADE_INVALID_AMOUNT",
-                serde_json::json!({ "expected_usd": payload.expected_usd }),
+                serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone() }),
             );
             return;
         }
         stable_channels::audit::audit_event(
             "TRADE_PARSED_PAYLOAD_OK",
-            serde_json::json!({ "expected_usd": payload.expected_usd }),
+            serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone(), "channel_id": payload.channel_id.clone() }),
         );
 
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
             Ok(r) => r.channels,
             Err(e) => {
                 error!("[trade] list_channels gRPC failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "LDK_CALL_FAILED",
+                    serde_json::json!({ "op": "list_channels", "context": "handle_trade_message", "user_channel_id": payload.user_channel_id.clone(), "channel_id": payload.channel_id.clone(), "error": e.to_string() }),
+                );
                 return;
             }
         };
@@ -1107,13 +1296,13 @@ impl StableChannelManager {
         if !valid {
             stable_channels::audit::audit_event(
                 "TRADE_SIGNATURE_INVALID",
-                serde_json::json!({ "channel_id": chan.channel_id }),
+                serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
             );
             return;
         }
         stable_channels::audit::audit_event(
             "TRADE_SIGNATURE_VALID",
-            serde_json::json!({ "channel_id": chan.channel_id }),
+            serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
         );
 
         // Replay protection: reject a signed trade with a stale `ts`; ts==0 means an un-upgraded wallet (no timestamp yet) — accepted until all wallets sign one.
@@ -1126,14 +1315,14 @@ impl StableChannelManager {
             if now.abs_diff(payload.ts) > TRADE_SIG_WINDOW_SECS {
                 stable_channels::audit::audit_event(
                     "TRADE_STALE",
-                    serde_json::json!({ "ts": payload.ts, "now": now, "channel_id": chan.channel_id }),
+                    serde_json::json!({ "ts": payload.ts, "now": now, "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
                 );
                 return;
             }
         }
 
         let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
-            stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({}));
+            stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }));
             return;
         };
         let unspendable = chan.unspendable_punishment_reserve.unwrap_or(0);
@@ -1146,7 +1335,7 @@ impl StableChannelManager {
         if new_expected > ceiling {
             stable_channels::audit::audit_event(
                 "TRADE_EXCEEDS_BALANCE",
-                serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd }),
+                serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd, "user_channel_id": format!("{}", target_uid), "channel_id": chan.channel_id.clone() }),
             );
             return;
         }
@@ -1160,7 +1349,7 @@ impl StableChannelManager {
             else {
                 stable_channels::audit::audit_event(
                     "TRADE_STABLE_ENTRY_NOT_FOUND",
-                    serde_json::json!({ "user_channel_id": format!("{}", target_uid) }),
+                    serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": format!("{}", target_uid) }),
                 );
                 return;
             };
@@ -1189,10 +1378,15 @@ impl StableChannelManager {
             note.as_deref(),
         ) {
             error!("[trade] db.save_channel failed: {}", e);
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({ "op": "save_channel", "context": "handle_trade_message", "channel_id": channel_id_hex, "user_channel_id": ucid_str, "error": e.to_string() }),
+            );
         }
         stable_channels::audit::audit_event(
             "TRADE_APPLIED",
             serde_json::json!({
+                "channel_id": channel_id_hex,
                 "user_channel_id": ucid_str,
                 "new_expected_usd": expected_usd_f,
             }),
@@ -1254,6 +1448,19 @@ fn parse_user_channel_id(s: &str) -> Option<u128> {
         .or_else(|| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
 }
 
+/// Whether a throttled stability event should log this tick: on outcome change, or (if tracking value) a significant value move.
+pub(crate) fn stability_should_log(
+    last_outcome: &str, outcome: &str,
+    last_value: f64, value: f64, target: f64,
+    usd_threshold: f64, pct_threshold: f64,
+    track_value: bool,
+) -> bool {
+    if last_outcome != outcome { return true; }
+    if !track_value { return false; }
+    let d = (value - last_value).abs();
+    d > usd_threshold && (d / target * 100.0) > pct_threshold
+}
+
 fn parse_channel_id_hex(s: &str) -> [u8; 32] {
     let mut buf = [0u8; 32];
     if let Ok(bytes) = hex::decode(s) {
@@ -1277,9 +1484,18 @@ fn parse_pubkey_hex(s: &str) -> ldk_node::bitcoin::secp256k1::PublicKey {
 mod tests {
     use super::*;
     use ldk_server_client::error::LdkServerErrorCode;
-    use ldk_server_client::ldk_server_grpc::types::Channel as GrpcChannel;
+    use ldk_server_client::ldk_server_grpc::api::{
+        ListForwardedPaymentsRequest, ListForwardedPaymentsResponse, GetBalancesRequest,
+        GetBalancesResponse, ListPeersRequest, ListPeersResponse,
+    };
+    use ldk_server_client::ldk_server_grpc::types::{
+        Channel as GrpcChannel, ForwardedPayment as GrpcForwardedPayment,
+        PendingSweepBalance as GrpcPendingSweepBalance, Peer as GrpcPeer,
+    };
     use std::sync::Mutex as StdMutex;
     use tempfile::tempdir;
+
+    static AUDIT_TEST_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     pub struct FakeLdkServer {
         pub channels: StdMutex<Vec<GrpcChannel>>,
@@ -1288,6 +1504,9 @@ mod tests {
         pub verify_should_pass: bool,
         pub signature: String,
         pub sign_calls: StdMutex<Vec<Vec<u8>>>,
+        pub forwarded: StdMutex<Vec<GrpcForwardedPayment>>,
+        pub sweeps: StdMutex<Vec<GrpcPendingSweepBalance>>,
+        pub peers: StdMutex<Vec<GrpcPeer>>,
     }
 
     impl FakeLdkServer {
@@ -1299,6 +1518,9 @@ mod tests {
                 verify_should_pass: true,
                 signature: "fake-sig".to_string(),
                 sign_calls: StdMutex::new(Vec::new()),
+                forwarded: StdMutex::new(Vec::new()),
+                sweeps: StdMutex::new(Vec::new()),
+                peers: StdMutex::new(Vec::new()),
             }
         }
         pub fn with_send_failure(mut self) -> Self {
@@ -1309,6 +1531,9 @@ mod tests {
             self.verify_should_pass = false;
             self
         }
+        pub fn with_forwarded(self, f: Vec<GrpcForwardedPayment>) -> Self { *self.forwarded.lock().unwrap() = f; self }
+        pub fn with_sweeps(self, s: Vec<GrpcPendingSweepBalance>) -> Self { *self.sweeps.lock().unwrap() = s; self }
+        pub fn with_peers(self, p: Vec<GrpcPeer>) -> Self { *self.peers.lock().unwrap() = p; self }
     }
 
     #[async_trait]
@@ -1353,6 +1578,34 @@ mod tests {
                 valid: self.verify_should_pass,
             })
         }
+        async fn list_forwarded_payments(&self, _req: ListForwardedPaymentsRequest)
+            -> Result<ListForwardedPaymentsResponse, LdkServerError> {
+            Ok(ListForwardedPaymentsResponse { forwarded_payments: self.forwarded.lock().unwrap().clone(), next_page_token: None })
+        }
+        async fn get_balances(&self, _req: GetBalancesRequest)
+            -> Result<GetBalancesResponse, LdkServerError> {
+            Ok(GetBalancesResponse { pending_balances_from_channel_closures: self.sweeps.lock().unwrap().clone(), ..Default::default() })
+        }
+        async fn list_peers(&self, _req: ListPeersRequest)
+            -> Result<ListPeersResponse, LdkServerError> {
+            Ok(ListPeersResponse { peers: self.peers.lock().unwrap().clone() })
+        }
+    }
+
+    #[tokio::test]
+    async fn fake_serves_forwarded_and_peers_fixtures() {
+        let fake = FakeLdkServer::new(vec![]).with_peers(vec![GrpcPeer {
+            node_id: "02aa".into(),
+            address: "1.2.3.4:9735".into(),
+            is_persisted: true,
+            is_connected: true,
+        }]);
+        let peers = fake.list_peers(ListPeersRequest {}).await.unwrap().peers;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].node_id, "02aa");
+        let fwd = fake.list_forwarded_payments(ListForwardedPaymentsRequest { page_token: None })
+            .await.unwrap().forwarded_payments;
+        assert!(fwd.is_empty());
     }
 
     pub fn make_channel(
@@ -1408,7 +1661,7 @@ mod tests {
         ).await;
         assert_eq!(mgr.stable_channels.len(), 1);
 
-        mgr.handle_channel_closed(USER_CHANNEL_ID_HEX.to_string());
+        mgr.handle_channel_closed("".to_string(), USER_CHANNEL_ID_HEX.to_string(), None, None, 0, None);
         assert_eq!(mgr.stable_channels.len(), 0);
     }
 
@@ -1478,6 +1731,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reconcile_if_empty_hydrates_then_leaves_populated_untouched() {
+        // Simulate the cold-start skip: empty in-memory Vec, persisted row, live channel present.
+        let mut mgr = make_manager();
+        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, 25.0, 40_000, 10_000, Some("persisted")).unwrap();
+        assert_eq!(mgr.stable_channels.len(), 0, "fresh manager starts empty");
+
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        // Empty vec -> self-heal repopulates from truth.
+        mgr.reconcile_if_empty(&fake as &dyn LdkServerCalls, 100_000.0).await;
+        assert_eq!(mgr.stable_channels.len(), 1, "empty list is hydrated");
+
+        // Populated vec -> guard skips reconcile, so a transient empty snapshot can't wipe it.
+        let empty_server = FakeLdkServer::new(vec![]);
+        mgr.reconcile_if_empty(&empty_server as &dyn LdkServerCalls, 100_000.0).await;
+        assert_eq!(mgr.stable_channels.len(), 1, "populated list is left untouched");
+    }
+
+    #[tokio::test]
     async fn handle_channel_ready_auto_registers_new_channel() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -1529,7 +1803,7 @@ mod tests {
             type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
             value: env.into_bytes().into(),
         }];
-        mgr.handle_payment_received(records, Some("pay_test_1".to_string()), &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(records, Some("pay_test_1".to_string()), None, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
         assert_eq!(
@@ -1544,7 +1818,7 @@ mod tests {
         let fake = FakeLdkServer::new(vec![]);
         seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
 
-        mgr.handle_payment_received(vec![], None, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(vec![], None, None, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // untouched
         assert!(mgr.db.list_settlements().unwrap().is_empty());
@@ -1563,7 +1837,7 @@ mod tests {
             value: vec![1u8].into(),
         }];
         let before = mgr.stable_channels[0].expected_usd.0;
-        mgr.handle_payment_received(records, Some("pay_settlement_1".to_string()), &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(records, Some("pay_settlement_1".to_string()), None, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         // the 1-byte marker is not an envelope, so it records stability and applies no trade
         assert_eq!(
@@ -1601,6 +1875,11 @@ mod tests {
 
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
+            Some("next-ucid-1".to_string()),
+            "prev-chan-1".to_string(),
+            "next-chan-1".to_string(),
+            "prev-node-1".to_string(),
+            "next-node-1".to_string(),
             45_000_000, // outbound_amount_forwarded_msat
             0,          // fee_msat
             &fake as &dyn LdkServerCalls,
@@ -1629,6 +1908,11 @@ mod tests {
 
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
+            Some("next-ucid-2".to_string()),
+            "prev-chan-2".to_string(),
+            "next-chan-2".to_string(),
+            "prev-node-2".to_string(),
+            "next-node-2".to_string(),
             20_000_000,
             0,
             &fake as &dyn LdkServerCalls,
@@ -1657,6 +1941,11 @@ mod tests {
         )]);
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
+            None,
+            "prev-chan-3".to_string(),
+            "next-chan-3".to_string(),
+            "prev-node-3".to_string(),
+            "next-node-3".to_string(),
             45_000_000,
             0,
             &fake as &dyn LdkServerCalls,
@@ -1678,6 +1967,11 @@ mod tests {
         // Forward 45,000 sats out: pre = 5,000 + 45,000 = 50,000, native 40,000, overflow 5,000 = $5.
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
+            Some("next-ucid-4".to_string()),
+            "prev-chan-4".to_string(),
+            "next-chan-4".to_string(),
+            "prev-node-4".to_string(),
+            "next-node-4".to_string(),
             45_000_000, // outbound_amount_forwarded_msat
             0,          // fee_msat
             &fake as &dyn LdkServerCalls,
@@ -1692,6 +1986,37 @@ mod tests {
             sends[0].custom_tlvs[0].type_num,
             stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
         );
+    }
+
+    #[tokio::test]
+    async fn payment_forwarded_audit_records_both_legs() {
+        let _g = AUDIT_TEST_GUARD.lock().unwrap();
+        let (mut mgr, fake) = seed_forwarded_fixture().await;
+        *fake.channels.lock().unwrap() = vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            100_000, 95_000_000, true,
+        )];
+        stable_channels::audit::enable_test_capture();
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            Some("outbound-ucid".to_string()),
+            "prev-chan-hex".to_string(),
+            "next-chan-hex".to_string(),
+            "prev-node-pubkey".to_string(),
+            "next-node-pubkey".to_string(),
+            45_000_000,
+            0,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        ).await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        let (_, data) = events.iter().find(|(e, _)| e == "PAYMENT_FORWARDED")
+            .expect("PAYMENT_FORWARDED must be emitted");
+        assert_eq!(data["prev_user_channel_id"], USER_CHANNEL_ID_DECIMAL, "inbound leg must be recorded");
+        assert_eq!(data["next_user_channel_id"], "outbound-ucid", "outbound leg must be recorded");
+        assert_eq!(data["prev_node_id"], "prev-node-pubkey");
+        assert_eq!(data["next_node_id"], "next-node-pubkey");
     }
 
     #[tokio::test]
@@ -2126,6 +2451,40 @@ mod tests {
         serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
     }
 
+    #[tokio::test]
+    async fn run_tick_cooldown_emits_audit_with_uid() {
+        let _g = AUDIT_TEST_GUARD.lock().unwrap();
+        stable_channels::audit::enable_test_capture();
+        let mut mgr = make_manager();
+        // Seed channel with backing_sats=0 so stable_usd_value = stable_receiver_usd (live balance).
+        // receiver_sats=50_000 at 100k = $50; expected=50. Price drops to 80k -> $40 < $50 (20% drift).
+        seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 0, 0, 50_000, 100_000.0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        // Set last_stability_payment in the future so (now - future) < 0 <= cooldown, activating the gate even when cooldown_secs=0.
+        mgr.stable_channels[0].last_stability_payment = now + 100;
+        // Channel with 50k their side; price 80k -> drift 20% -> exceeds threshold -> hits cooldown gate.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            100_000, 50_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(
+                &crate::config::PushConfig::default(),
+                mgr.data_dir(),
+            ),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        let cd = events.iter().find(|(e, _)| e == "STABILITY_COOLDOWN")
+            .expect("STABILITY_COOLDOWN should be emitted on a cooldown-blocked tick");
+        assert!(cd.1.get("user_channel_id").is_some(), "must carry user_channel_id");
+        assert!(cd.1.get("channel_id").is_some(), "must carry channel_id");
+    }
+
     fn trade_envelope_with_ts(
         channel_id: &str,
         user_channel_id: &str,
@@ -2246,6 +2605,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn trade_stale_audit_carries_user_channel_id() {
+        let _g = AUDIT_TEST_GUARD.lock().unwrap();
+        stable_channels::audit::enable_test_capture();
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        let stale = test_unix_now() - 86_400;
+        let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, stale);
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        let stale_ev = events.iter().find(|(e, _)| e == "TRADE_STALE")
+            .expect("TRADE_STALE must be emitted for a stale signed trade");
+        assert!(stale_ev.1.get("user_channel_id").is_some(), "TRADE_STALE must carry user_channel_id");
+    }
+
+    #[tokio::test]
     async fn trade_accepts_fresh_ts() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -2358,5 +2736,73 @@ mod tests {
             contents.contains(USER_CHANNEL_ID_DECIMAL),
             "STABLE_EDITED audit entry should include the user_channel_id"
         );
+    }
+
+    fn fwd(prev: &str, next: &str, amt: u64) -> GrpcForwardedPayment {
+        GrpcForwardedPayment {
+            prev_channel_id: prev.into(),
+            next_channel_id: next.into(),
+            prev_user_channel_id: "10".into(),
+            prev_node_id: "02aa".into(),
+            next_node_id: "02bb".into(),
+            next_user_channel_id: Some("20".into()),
+            total_fee_earned_msat: Some(7),
+            skimmed_fee_msat: None,
+            claim_from_onchain_tx: false,
+            outbound_amount_forwarded_msat: Some(amt),
+        }
+    }
+
+    #[tokio::test]
+    async fn backfill_emits_unseen_then_dedups() {
+        // open_in_memory() is #[cfg(test)]-gated in the shared crate, unreachable across this crate boundary; use the tempdir pattern from make_manager() instead.
+        let dir = tempdir().unwrap();
+        let db = stable_channels::db::Database::open(dir.path()).unwrap();
+        let fake = FakeLdkServer::new(vec![]).with_forwarded(vec![fwd("aa", "bb", 1000), fwd("cc", "dd", 2000)]);
+        assert_eq!(crate::backfill::backfill_forwards(&fake, &db).await, 2); // both unseen
+        assert_eq!(crate::backfill::backfill_forwards(&fake, &db).await, 0); // both now seen
+    }
+
+    #[test]
+    fn should_log_on_outcome_change() {
+        assert!(stability_should_log("", "check_only", 0.0, 90.0, 90.0, 0.25, 1.0, true));
+        assert!(stability_should_log("cooldown", "check_only", 90.0, 90.0, 90.0, 0.25, 1.0, true));
+    }
+
+    #[test]
+    fn should_log_on_significant_value_move_when_tracking() {
+        // same outcome, move > $0.25 and > 1% -> true
+        assert!(stability_should_log("check_only", "check_only", 90.0, 92.0, 90.0, 0.25, 1.0, true));
+        // same outcome, sub-threshold move -> false
+        assert!(!stability_should_log("check_only", "check_only", 90.0, 90.10, 90.0, 0.25, 1.0, true));
+    }
+
+    #[test]
+    fn no_value_trigger_when_not_tracking() {
+        // same outcome, huge move, but track_value=false -> false
+        assert!(!stability_should_log("high_risk", "high_risk", 90.0, 200.0, 90.0, 0.25, 1.0, false));
+    }
+
+    #[tokio::test]
+    async fn run_tick_throttles_repeated_check_only() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = make_manager();
+        let fake0 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        stable_channels::audit::enable_test_capture();
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await; // above par -> CHECK_ONLY (emit)
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await; // identical -> throttled
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        let n = events.iter().filter(|(e, _)| e == "STABILITY_CHECK_ONLY").count();
+        assert_eq!(n, 1, "identical repeated ticks must emit CHECK_ONLY once");
     }
 }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,6 +1,20 @@
 use serde_json::Value;
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use std::sync::OnceLock;
+
+static CAPTURE_ON: AtomicBool = AtomicBool::new(false);
+static CAPTURE: Mutex<Vec<(String, Value)>> = Mutex::new(Vec::new());
+
+pub fn enable_test_capture() {
+    CAPTURE.lock().unwrap().clear();
+    CAPTURE_ON.store(true, Ordering::SeqCst);
+}
+pub fn disable_test_capture() { CAPTURE_ON.store(false, Ordering::SeqCst); }
+pub fn drain_test_capture() -> Vec<(String, Value)> {
+    std::mem::take(&mut *CAPTURE.lock().unwrap())
+}
 
 static AUDIT_LOG_PATH: OnceLock<String> = OnceLock::new();
 
@@ -13,6 +27,9 @@ pub fn get_audit_log_path() -> Option<&'static str> {
 }
 
 pub fn audit_event(event: &str, data: Value) {
+    if CAPTURE_ON.load(Ordering::SeqCst) {
+        CAPTURE.lock().unwrap().push((event.to_owned(), data.clone()));
+    }
     if let Some(path_str) = get_audit_log_path() {
         let path = std::path::Path::new(path_str);
 
@@ -27,13 +44,15 @@ pub fn audit_event(event: &str, data: Value) {
             "data": data
         });
 
-        // append to file
+        // One write_all is a single atomic O_APPEND; writeln! emits token-by-token so concurrent calls interleave into corrupt lines.
+        let mut line = log_line.to_string();
+        line.push('\n');
         if let Ok(mut file) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
         {
-            let _ = writeln!(file, "{}", log_line);
+            let _ = file.write_all(line.as_bytes());
         }
     }
 }
@@ -55,6 +74,17 @@ mod tests {
         // due to OnceLock behavior, but we test the function works
         let _path = get_audit_log_path();
         // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_capture_records_events_when_enabled() {
+        enable_test_capture();
+        audit_event("CAP_TEST", serde_json::json!({"user_channel_id": "42"}));
+        let got = drain_test_capture();
+        disable_test_capture();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, "CAP_TEST");
+        assert_eq!(got[0].1.get("user_channel_id").unwrap(), "42");
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -40,6 +40,22 @@ pub struct Database {
     conn: Arc<Mutex<Connection>>,
 }
 
+/// Stable dedup key for a forwarded payment (the proto gives forwards no unique id).
+pub fn forward_fingerprint(
+    prev_channel_id: &str,
+    next_channel_id: &str,
+    outbound_amount_msat: Option<u64>,
+    total_fee_msat: Option<u64>,
+) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        prev_channel_id,
+        next_channel_id,
+        outbound_amount_msat.unwrap_or(0),
+        total_fee_msat.unwrap_or(0)
+    )
+}
+
 impl Database {
     /// Open or create the database at the given directory path.
     pub fn open(data_dir: &Path) -> SqliteResult<Self> {
@@ -249,6 +265,18 @@ impl Database {
             [],
         )?;
 
+        // Migration: add user_channel_id column to settlement_payments for outcome-event keying
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN user_channel_id TEXT",
+            [],
+        ); // Ignore error if column already exists
+
+        // Forwarded-payment dedup: tracks fingerprints of forwards already audited (live or backfilled)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS forwarded_seen (fingerprint TEXT PRIMARY KEY)",
+            [],
+        )?;
+
         Ok(())
     }
 
@@ -370,6 +398,18 @@ impl Database {
             params![user_channel_id],
         )?;
         Ok(())
+    }
+
+    /// Resolve user_channel_id from a (possibly closed) channel_id.
+    pub fn get_user_channel_id_by_channel_id(&self, channel_id: &str) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT user_channel_id FROM channels WHERE channel_id = ?1")?;
+        let mut rows = stmt.query(params![channel_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(row.get::<_, Option<String>>(0)?)
+        } else {
+            Ok(None)
+        }
     }
 
     /// Load channel settings by user_channel_id (stable across splices)
@@ -1082,6 +1122,46 @@ impl Database {
         Ok(())
     }
 
+    /// Like `record_settlement` but also records the `user_channel_id` for outcome-event keying.
+    pub fn record_settlement_with_channel(
+        &self,
+        payment_id: &str,
+        kind: &str,
+        user_channel_id: &str,
+    ) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO settlement_payments (payment_id, kind, user_channel_id)
+             VALUES (?1, ?2, ?3)",
+            params![payment_id, kind, user_channel_id],
+        )?;
+        Ok(())
+    }
+
+    /// Record a forward's fingerprint. Returns true if newly inserted (not seen before).
+    pub fn record_forwarded_seen(&self, fingerprint: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn.execute(
+            "INSERT OR IGNORE INTO forwarded_seen (fingerprint) VALUES (?1)",
+            params![fingerprint],
+        )?;
+        Ok(n == 1)
+    }
+
+    /// Return the stored `user_channel_id` for a payment_id, or None if absent/NULL/not found.
+    pub fn get_settlement_channel(&self, payment_id: &str) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT user_channel_id FROM settlement_payments WHERE payment_id = ?1",
+        )?;
+        let mut rows = stmt.query(params![payment_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(row.get::<_, Option<String>>(0)?)
+        } else {
+            Ok(None)
+        }
+    }
+
     /// List recorded settlements as (payment_id, kind) pairs, oldest first.
     pub fn list_settlements(&self) -> SqliteResult<Vec<(String, String)>> {
         let conn = self.conn.lock().unwrap();
@@ -1193,6 +1273,29 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert!(list.contains(&("pay_a".to_string(), "stability".to_string())));
         assert!(list.contains(&("pay_b".to_string(), "sync".to_string())));
+    }
+
+    #[test]
+    fn test_settlement_channel_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        // with-channel variant stores and retrieves user_channel_id
+        db.record_settlement_with_channel("pmt1", "stability", "12345").unwrap();
+        assert_eq!(db.get_settlement_channel("pmt1").unwrap(), Some("12345".to_string()));
+        // absent key returns None
+        assert_eq!(db.get_settlement_channel("absent").unwrap(), None);
+        // plain record_settlement leaves user_channel_id as NULL (returns None)
+        db.record_settlement("pmt2", "sync").unwrap();
+        assert_eq!(db.get_settlement_channel("pmt2").unwrap(), None);
+    }
+
+    #[test]
+    fn forwarded_seen_dedups_and_fingerprint_is_stable() {
+        let db = Database::open_in_memory().unwrap();
+        let fp = forward_fingerprint("aa", "bb", Some(1000), Some(7));
+        assert_eq!(fp, forward_fingerprint("aa", "bb", Some(1000), Some(7)));
+        assert_ne!(fp, forward_fingerprint("aa", "bb", Some(1001), Some(7)));
+        assert!(db.record_forwarded_seen(&fp).unwrap());   // first insert -> true
+        assert!(!db.record_forwarded_seen(&fp).unwrap());  // repeat -> false
     }
 
     #[test]
@@ -1515,5 +1618,13 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         let result = db.load_channel("nonexistent").unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn user_channel_id_by_channel_id_roundtrips() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("chan_x", "42", 0.0, 0, 0, None).unwrap();
+        assert_eq!(db.get_user_channel_id_by_channel_id("chan_x").unwrap(), Some("42".to_string()));
+        assert_eq!(db.get_user_channel_id_by_channel_id("missing").unwrap(), None);
     }
 }

--- a/src/price_feeds.rs
+++ b/src/price_feeds.rs
@@ -1,9 +1,7 @@
-use crate::audit::audit_event;
 use crate::constants::{
     PRICE_CACHE_REFRESH_SECS, PRICE_FETCH_MAX_RETRIES, PRICE_FETCH_RETRY_DELAY_MS,
 };
 use retry::{delay::Fixed, retry};
-use serde_json::json;
 use serde_json::Value;
 use std::error::Error;
 use std::sync::{Arc, Mutex};
@@ -68,7 +66,6 @@ pub fn get_cached_price() -> f64 {
             cache.price = new_price;
             cache.last_update = Instant::now();
             cache.updating = false;
-            audit_event("PRICE_FETCH", json!({ "btc_price": new_price }));
             return new_price;
         } else {
             let mut cache = PRICE_CACHE.lock().unwrap();


### PR DESCRIPTION
## Summary

The LSP already writes an audit log, but it was lossy (dropped channel-close reasons, lifecycle boundaries, and DB/gRPC failure branches), flood-prone (a line per price fetch, and per-tick stability heartbeats), and hard to query (tail-N only, single-id). This PR makes it a record you can actually use to reconstruct a channel's whole lifecycle, trims the noise, and adds operator UI to read it.

## 1. What the log now captures

Events are keyed by **both** the hex `channel_id` and the decimal `user_channel_id` where a channel is involved, so filtering by either returns a channel's complete history.

**Channel lifecycle**
- `CHANNEL_PENDING`, `CHANNEL_OPEN_FAILED`, previously silent
- `CHANNEL_READY_TRACKED`, `CHANNEL_READY_SPLICE`
- `CHANNEL_CLOSED`, now with full close reason (kind, initiator, peer message, counterparty, funding txo); force-closes flagged
- `CHANNEL_STATE_UNKNOWN`, catch-all for unmapped/future states
- `CHANNEL_MARKED_CLOSED_AT_STARTUP`

**Payments**
- `PAYMENT_RECEIVED`, `PAYMENT_CLAIMABLE`
- `PAYMENT_SETTLED`, `PAYMENT_FAILED`, correlated back to a channel via a send-time settlement→channel map
- `PAYMENT_FORWARDED` (both legs keyed), `PAYMENT_FORWARDED_BACKFILL`

**Stability (peg maintenance)**
- `STABILITY_PAYMENT_SENT` / `_FAILED`, `STABILITY_PUSH_QUEUED`, `STABILITY_CHECK_ONLY`, `STABILITY_SKIP_HIGH_RISK`, `STABILITY_COOLDOWN`
- `BACKSTOP_STABLE_DEDUCTED`, `STABLE_SPEND_DEDUCTED`, `SPLICE_OUT_STABLE_DEDUCTED`, `STABLE_EDITED`

**Trades** (full validation ladder)
- `TRADE_PARSED_PAYLOAD_OK`, `TRADE_PARSE_PAYLOAD_FAILED`, `TRADE_PARSE_SIGNED_FAILED`, `TRADE_SIGNATURE_VALID` / `_INVALID`, `TRADE_APPLIED`, `TRADE_STALE`, `TRADE_EXCEEDS_BALANCE`, `TRADE_INVALID_AMOUNT`, `TRADE_CHANNEL_NOT_FOUND`, `TRADE_CHANNEL_UID_UNPARSEABLE`, `TRADE_STABLE_ENTRY_NOT_FOUND`, `TRADE_UNHANDLED_TYPE`

**Sync / push**
- `SYNC_MESSAGE_SENT` / `_FAILED`, `MESSAGE_RECEIVED`, `REGISTER_PUSH_OK`, `REGISTER_PUSH_SIGNATURE_INVALID`

**Peers & on-chain sweeps** (periodic reconcile-from-truth poll)
- `PEER_CONNECTED`, `PEER_DISCONNECTED`, `SWEEP_PROGRESS`

**Infrastructure failures** (previously trace-only)
- `DB_WRITE_FAILED`, `DB_READ_FAILED`, `LDK_CALL_FAILED`

Completeness after reconnects doesn't rely on a durable event queue. On each event-stream (re)connect, the daemon reconciles against LDK Server's durable stores and backfills any forwards it hadn't seen (deduped by a persistent fingerprint; audit-only, no double peg-math).

## 2. Making it readable: removing noise

The log was dominated by two high-frequency, low-value sources:
- **`PRICE_FETCH`**: one line per price poll. Removed entirely.
- **Repetitive stability lines**: the daemon logged its stability evaluation every tick even when nothing changed. Now **edge-triggered**: it logs on an outcome change or a material value move past the existing thresholds, not on every tick. Money-moving events always log.

Principle: an audit log should record **events and transitions, not a per-tick heartbeat**. Every transition is still captured, so durations stay reconstructable. This changes emission cadence only, never any stability decision.

## 3. Channel History (readability + search)

- The audit-log endpoint gained a **server-side substring filter** and a **full-history mode** (complete matching history, oldest-first, capped).
- Operator GUI adds **Audit | Channel History | LDK server** log tabs: a plain audit tail, and a **Channel History** tab that takes a channel id and shows that channel's entire timeline oldest-first. Force-closes render with a marker.

## 4. Reliability fixes

- **Audit-writer atomicity:** writing a JSON value with `writeln!` serialized token-by-token, so concurrent writers could interleave into corrupt lines. Each line is now built and written with a single atomic append. (Shared crate, fixes the desktop wallet too.)
- **Cold-start reconcile:** the in-memory stable-channel list could stay empty after a restart if the price cache was still cold when the startup/first-reconnect reconciles ran. Startup now waits for the first price before reconciling, with a per-tick backstop that rebuilds an empty list (and leaves a populated one untouched).

## Compatibility

- New audit-log request fields (`filter`, `full`) are additive and default to the prior behavior when omitted.
- The settlement DB migration is idempotent; the original settlement API signature is preserved.
- No changes to LDK Server's proto/gRPC, only the LSP's own REST contract and its handling of already-delivered events.

## Still missing, needs an LDK Server (upstream) PR

These blind spots require fields/events LDK Server doesn't expose yet, so they're deliberately out of scope here:

- **Per-hop payment failure reasons:** `PaymentFailed` / payment details carry no failure-reason field.
- **Splice lifecycle events:** splice pending/failed are swallowed by LDK Server's event catch-all (currently observability-only, since a splice re-ready already triggers reconcile).

## Future work

- **SQLite-backed audit store:** would let the stability throttle be replaced with write-everything + collapse-on-read, and make queries first-class (indexed by channel/event/time) instead of scanning a file.