### PR TITLE
feat(iOS): appstore readiness

### DIFF
--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -11,7 +11,7 @@ import SQLite3
 class NotificationService: UNNotificationServiceExtension {
     private static let appGroup = "group.com.stablechannels.app"
     private static let lspPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
-    private static let lspAddress = "ec2-34-198-44-89.compute-1.amazonaws.com:9735"
+    private static let lspAddress = "lsp.stablechannels.com:9735"
     private static let stableChannelTLVType: UInt64 = 13_377_331
     private static let syncMessageType = "SYNC_V1"
     private static let satsInBTC: Double = 100_000_000.0

--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -277,8 +277,6 @@ class NotificationService: UNNotificationServiceExtension {
                 nseLog("Event: \(event)")
                 switch event {
                 case .paymentReceived(let paymentId, let paymentHash, let amountMsat, let customRecords):
-                    let isStabilityPayment = customRecords
-                        .contains { $0.typeNum == Self.stableChannelTLVType && $0.value == Data([1]) }
                     // Always provide a non-nil ID for dedup so replays don't insert duplicates.
                     let payId = paymentId.map { "\($0)" } ?? "\(paymentHash)"
                     if price <= 0 { price = Self.fetchBTCPrice() }

--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -11,7 +11,7 @@ import SQLite3
 class NotificationService: UNNotificationServiceExtension {
     private static let appGroup = "group.com.stablechannels.app"
     private static let lspPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
-    private static let lspAddress = "34.198.44.89:9735"
+    private static let lspAddress = "ec2-34-198-44-89.compute-1.amazonaws.com:9735"
     private static let stableChannelTLVType: UInt64 = 13_377_331
     private static let syncMessageType = "SYNC_V1"
     private static let satsInBTC: Double = 100_000_000.0
@@ -277,6 +277,8 @@ class NotificationService: UNNotificationServiceExtension {
                 nseLog("Event: \(event)")
                 switch event {
                 case .paymentReceived(let paymentId, let paymentHash, let amountMsat, let customRecords):
+                    let isStabilityPayment = customRecords
+                        .contains { $0.typeNum == Self.stableChannelTLVType && $0.value == Data([1]) }
                     // Always provide a non-nil ID for dedup so replays don't insert duplicates.
                     let payId = paymentId.map { "\($0)" } ?? "\(paymentHash)"
                     if price <= 0 { price = Self.fetchBTCPrice() }

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		4923802D2FB51864007D9419 /* InvoiceScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923802C2FB51864007D9419 /* InvoiceScanView.swift */; };
+		49514E7B2FF83F2E0004C92D /* BackgroundTaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49514E7A2FF83F2E0004C92D /* BackgroundTaskManager.swift */; };
 		496A44432FCD4F75005AF12F /* QRInputToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44422FCD4F75005AF12F /* QRInputToolbar.swift */; };
 		496A44442FCD4F75005AF12F /* QRCodeExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */; };
 		496A44462FCD5845005AF12F /* InputSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A44452FCD5845005AF12F /* InputSanitizer.swift */; };
@@ -137,6 +138,7 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		4923802C2FB51864007D9419 /* InvoiceScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceScanView.swift; sourceTree = "<group>"; };
+		49514E7A2FF83F2E0004C92D /* BackgroundTaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskManager.swift; sourceTree = "<group>"; };
 		496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeExtractor.swift; sourceTree = "<group>"; };
 		496A44422FCD4F75005AF12F /* QRInputToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRInputToolbar.swift; sourceTree = "<group>"; };
 		496A44452FCD5845005AF12F /* InputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSanitizer.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 			isa = PBXGroup;
 			children = (
 				FFC40949E35E9317ACA30E35 /* AppState.swift */,
+				49514E7A2FF83F2E0004C92D /* BackgroundTaskManager.swift */,
 				D62A82EA774DC10F10A6574A /* ContentView.swift */,
 				623F41D841B312F0C9AE01E6 /* MainTabView.swift */,
 				B785A33E02FD999CB62019AD /* StableChannelsApp.swift */,
@@ -609,6 +612,7 @@
 				6949A1E4AC3016EB41A5832A /* AuditService.swift in Sources */,
 				49E4D8A62FED9FF3002AF338 /* BackupSettingsSupportBanner.swift in Sources */,
 				49E4D8A72FED9FF3002AF338 /* BackupSettingsICloudSection.swift in Sources */,
+				49514E7B2FF83F2E0004C92D /* BackgroundTaskManager.swift in Sources */,
 				49AD1B4B2FEE77F40015A7D9 /* SeedDisplayView.swift in Sources */,
 				49AD1B512FEE812E0015A7D9 /* NativeTimerAlert.swift in Sources */,
 				581786C32C021D8FB9E63DC2 /* BalanceBarView.swift in Sources */,

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -839,7 +839,7 @@ class AppState {
             do {
                 let (_, response) = try await URLSession.shared.data(for: request)
                 if let http = response as? HTTPURLResponse {
-                    print("[Push] Re-registered with node_id: \(http.statusCode)")
+                    print("[Push] Re-registered with node_id: \(nodeId.prefix(16))...")
                 }
             } catch {
                 print("[Push] Re-registration failed: \(error.localizedDescription)")

--- a/ios/StableChannels/StableChannels/App/BackgroundTaskManager.swift
+++ b/ios/StableChannels/StableChannels/App/BackgroundTaskManager.swift
@@ -1,0 +1,75 @@
+import Foundation
+import BackgroundTasks
+import UIKit
+
+final class BackgroundTaskManager: @unchecked Sendable {
+    static let shared = BackgroundTaskManager()
+
+    static let keepAliveIdentifier = "com.stablechannels.app.keepAlive"
+
+    private init() {
+        register()
+    }
+
+    private func register() {
+        do {
+            try BGTaskScheduler.shared.register(
+                forTaskWithIdentifier: Self.keepAliveIdentifier,
+                using: nil
+            ) { [weak self] task in
+                self?.handleKeepAlive(task: task)
+            }
+            print("[BGTask] Registered keep-alive task")
+        } catch {
+            print("[BGTask] Registration failed: \(error.localizedDescription)")
+        }
+    }
+
+    func scheduleKeepAlive() {
+        let request = BGProcessingTaskRequest(identifier: Self.keepAliveIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = false
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            print("[BGTask] Keep-alive scheduled")
+        } catch {
+            print("[BGTask] Schedule failed: \(error.localizedDescription)")
+        }
+    }
+
+    func cancelKeepAlive() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.keepAliveIdentifier)
+        print("[BGTask] Keep-alive cancelled")
+    }
+
+    private func handleKeepAlive(task: BGTask) {
+        guard let processingTask = task as? BGProcessingTask else { return }
+
+        processingTask.expirationHandler = { [weak self] in
+            print("[BGTask] Expiration — cancelling keep-alive")
+            self?.cancelKeepAlive()
+        }
+
+        print("[BGTask] Fired — isRunning: \(NodeService.shared.isRunning)")
+
+        if NodeService.shared.isRunning {
+            NodeService.shared.refreshChannels()
+            let allUsable = !NodeService.shared.channels.isEmpty
+                && NodeService.shared.channels.allSatisfy(\.isUsable)
+            if !allUsable {
+                Task {
+                    try? await NodeService.shared.node?.connect(
+                        nodeId: Constants.defaultLSPPubkey,
+                        address: Constants.defaultLSPAddress,
+                        persist: true
+                    )
+                }
+            }
+        }
+
+        scheduleKeepAlive()
+        processingTask.setTaskCompleted(success: true)
+    }
+}

--- a/ios/StableChannels/StableChannels/App/BackgroundTaskManager.swift
+++ b/ios/StableChannels/StableChannels/App/BackgroundTaskManager.swift
@@ -5,7 +5,7 @@ import UIKit
 final class BackgroundTaskManager: @unchecked Sendable {
     static let shared = BackgroundTaskManager()
 
-    static let keepAliveIdentifier = "com.stablechannels.app.keepAlive"
+    static let channelSyncIdentifier = "com.stablechannels.app.channelSync"
 
     private init() {
         register()
@@ -14,42 +14,42 @@ final class BackgroundTaskManager: @unchecked Sendable {
     private func register() {
         do {
             try BGTaskScheduler.shared.register(
-                forTaskWithIdentifier: Self.keepAliveIdentifier,
+                forTaskWithIdentifier: Self.channelSyncIdentifier,
                 using: nil
             ) { [weak self] task in
-                self?.handleKeepAlive(task: task)
+                self?.handleChannelSync(task: task)
             }
-            print("[BGTask] Registered keep-alive task")
+            print("[BGTask] Registered channel sync task")
         } catch {
             print("[BGTask] Registration failed: \(error.localizedDescription)")
         }
     }
 
-    func scheduleKeepAlive() {
-        let request = BGProcessingTaskRequest(identifier: Self.keepAliveIdentifier)
+    func scheduleChannelSync() {
+        let request = BGProcessingTaskRequest(identifier: Self.channelSyncIdentifier)
         request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
         request.requiresNetworkConnectivity = true
         request.requiresExternalPower = false
 
         do {
             try BGTaskScheduler.shared.submit(request)
-            print("[BGTask] Keep-alive scheduled")
+            print("[BGTask] Channel sync scheduled")
         } catch {
             print("[BGTask] Schedule failed: \(error.localizedDescription)")
         }
     }
 
-    func cancelKeepAlive() {
-        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.keepAliveIdentifier)
-        print("[BGTask] Keep-alive cancelled")
+    func cancelChannelSync() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.channelSyncIdentifier)
+        print("[BGTask] Channel sync cancelled")
     }
 
-    private func handleKeepAlive(task: BGTask) {
+    private func handleChannelSync(task: BGTask) {
         guard let processingTask = task as? BGProcessingTask else { return }
 
         processingTask.expirationHandler = { [weak self] in
-            print("[BGTask] Expiration — cancelling keep-alive")
-            self?.cancelKeepAlive()
+            print("[BGTask] Expiration — cancelling channel sync")
+            self?.cancelChannelSync()
         }
 
         print("[BGTask] Fired — isRunning: \(NodeService.shared.isRunning)")
@@ -69,7 +69,7 @@ final class BackgroundTaskManager: @unchecked Sendable {
             }
         }
 
-        scheduleKeepAlive()
+        scheduleChannelSync()
         processingTask.setTaskCompleted(success: true)
     }
 }

--- a/ios/StableChannels/StableChannels/App/StableChannelsApp.swift
+++ b/ios/StableChannels/StableChannels/App/StableChannelsApp.swift
@@ -18,12 +18,12 @@ struct StableChannelsApp: App {
                 .onReceive(NotificationCenter.default
                     .publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
                         appState.stopNodeForBackground()
-                        BackgroundTaskManager.shared.scheduleKeepAlive()
+                        BackgroundTaskManager.shared.scheduleChannelSync()
                 }
                 .onReceive(NotificationCenter.default
                     .publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                         Task { await appState.restartNodeFromForeground() }
-                        BackgroundTaskManager.shared.cancelKeepAlive()
+                        BackgroundTaskManager.shared.cancelChannelSync()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
                     appState.stop()
@@ -53,7 +53,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 application.registerForRemoteNotifications()
             }
 
-            // Register BGProcessingTask for periodic background keep-alive
+            // Register BGProcessingTask for periodic background channel sync
             BackgroundTaskManager.shared
 
             if !granted {

--- a/ios/StableChannels/StableChannels/App/StableChannelsApp.swift
+++ b/ios/StableChannels/StableChannels/App/StableChannelsApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import UserNotifications
+import BackgroundTasks
 
 @main
 struct StableChannelsApp: App {
@@ -17,10 +18,12 @@ struct StableChannelsApp: App {
                 .onReceive(NotificationCenter.default
                     .publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
                         appState.stopNodeForBackground()
+                        BackgroundTaskManager.shared.scheduleKeepAlive()
                 }
                 .onReceive(NotificationCenter.default
                     .publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                         Task { await appState.restartNodeFromForeground() }
+                        BackgroundTaskManager.shared.cancelKeepAlive()
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
                     appState.stop()
@@ -49,6 +52,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             DispatchQueue.main.async {
                 application.registerForRemoteNotifications()
             }
+
+            // Register BGProcessingTask for periodic background keep-alive
+            BackgroundTaskManager.shared
+
             if !granted {
                 print("[Push] Permission denied — stability payments require notifications")
             }
@@ -155,10 +162,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse {
-                print("[Push] LSP registration response: \(http.statusCode) node_id: \(nodeId.prefix(16))...")
+                print("[Push] Re-registered with node_id: \(nodeId.prefix(16))...")
             }
         } catch {
-            print("[Push] LSP registration failed: \(error.localizedDescription)")
+            print("[Push] Re-registration failed: \(error.localizedDescription)")
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Features/Home/HomeView.swift
+++ b/ios/StableChannels/StableChannels/Features/Home/HomeView.swift
@@ -371,8 +371,8 @@ struct HomeView: View {
                 }
                 if !hasReadyChannel {
                     Text(String(
-                        localized: "hint_create_account",
-                        defaultValue: "Receive over Lightning to create your Stable Account"
+                        localized: "hint_create_wallet",
+                        defaultValue: "Receive over Lightning to create your Stable Wallet"
                     ))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -380,8 +380,8 @@ struct HomeView: View {
             } else {
                 // 4. No channel, confirmed deposit — just needs a Lightning receive
                 Text(String(
-                    localized: "hint_create_account",
-                    defaultValue: "Receive over Lightning to create your Stable Account"
+                    localized: "hint_create_wallet",
+                    defaultValue: "Receive over Lightning to create your Stable Wallet"
                 ))
                 .font(.caption2)
                 .foregroundStyle(.secondary)

--- a/ios/StableChannels/StableChannels/Features/Settings/ExportImportSheet.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/ExportImportSheet.swift
@@ -119,14 +119,14 @@ struct ExportImportSheet: View {
         VStack(spacing: 16) {
             passphraseCard(
                 label: String(localized: "passphrase", defaultValue: "Passphrase"),
-                placeholder: String(localized: "enter_passphrase", defaultValue: "Enter passphrase"),
+                prompt: String(localized: "enter_passphrase", defaultValue: "Enter passphrase"),
                 text: $passphrase,
                 isNew: true
             )
 
             passphraseCard(
                 label: String(localized: "confirm_passphrase", defaultValue: "Confirm Passphrase"),
-                placeholder: String(localized: "confirm_passphrase_hint", defaultValue: "Confirm your passphrase"),
+                prompt: String(localized: "confirm_passphrase_hint", defaultValue: "Confirm your passphrase"),
                 text: $confirmPassphrase,
                 isNew: true
             )
@@ -184,7 +184,7 @@ struct ExportImportSheet: View {
             if selectedFileURL != nil {
                 passphraseCard(
                     label: String(localized: "passphrase", defaultValue: "Passphrase"),
-                    placeholder: String(localized: "enter_backup_passphrase", defaultValue: "Enter backup passphrase"),
+                    prompt: String(localized: "enter_backup_passphrase", defaultValue: "Enter backup passphrase"),
                     text: $passphrase,
                     isNew: false
                 )
@@ -274,13 +274,13 @@ struct ExportImportSheet: View {
 
     // MARK: - Passphrase Card
 
-    private func passphraseCard(label: String, placeholder: String, text: Binding<String>, isNew: Bool) -> some View {
+    private func passphraseCard(label: String, prompt: String, text: Binding<String>, isNew: Bool) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            SecureField(placeholder, text: text)
+            SecureField(prompt, text: text)
                 .textContentType(isNew ? .newPassword : .password)
                 .padding(16)
                 .background(Color(uiColor: .secondarySystemGroupedBackground))

--- a/ios/StableChannels/StableChannels/Info.plist
+++ b/ios/StableChannels/StableChannels/Info.plist
@@ -20,7 +20,7 @@
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-<key>NSCameraUsageDescription</key>
+	<key>NSCameraUsageDescription</key>
 	<string>Camera is used to scan QR codes for Lightning invoices and Bitcoin addresses.</string>
 	<key>UIBackgroundModes</key>
 	<array>
@@ -30,7 +30,7 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.stablechannels.app.refresh</string>
+		<string>com.stablechannels.app.keepAlive</string>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/ios/StableChannels/StableChannels/Info.plist
+++ b/ios/StableChannels/StableChannels/Info.plist
@@ -30,7 +30,7 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.stablechannels.app.keepAlive</string>
+		<string>com.stablechannels.app.channelSync</string>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/ios/StableChannels/StableChannels/Localizable.xcstrings
+++ b/ios/StableChannels/StableChannels/Localizable.xcstrings
@@ -1323,13 +1323,13 @@
         }
       }
     },
-    "hint_create_account" : {
+    "hint_create_wallet" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Receive over Lightning to create your Stable Account"
+            "value" : "Receive over Lightning to create your Stable Wallet"
           }
         }
       }

--- a/ios/StableChannels/StableChannels/PrivacyInfo.xcprivacy
+++ b/ios/StableChannels/StableChannels/PrivacyInfo.xcprivacy
@@ -12,11 +12,11 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-      		<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
-      		<key>NSPrivacyAccessedAPITypeReasons</key>
-      		<array>
-          		<string>35F9.1</string>
-      		</array>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
 		</dict>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
@@ -32,6 +32,22 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryActiveKeyboard</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1B7A.1</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -34,7 +34,7 @@ enum Constants {
     }
 
     static let defaultLSPPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
-    static let defaultLSPAddress = "ec2-34-198-44-89.compute-1.amazonaws.com:9735"
+    static let defaultLSPAddress = "lsp.stablechannels.com:9735"
     static let defaultGatewayPubkey = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"
     static let defaultGatewayAddress = "gateway.stablechannels.com:9735"
 

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -34,9 +34,9 @@ enum Constants {
     }
 
     static let defaultLSPPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
-    static let defaultLSPAddress = "34.198.44.89:9735"
+    static let defaultLSPAddress = "ec2-34-198-44-89.compute-1.amazonaws.com:9735"
     static let defaultGatewayPubkey = "03da1c27ca77872ac5b3e568af30673e599a47a5e4497f85c7b5da42048807b3ed"
-    static let defaultGatewayAddress = "213.174.156.80:9735"
+    static let defaultGatewayAddress = "gateway.stablechannels.com:9735"
 
     // MARK: - Timing
 


### PR DESCRIPTION
## Summary

Addresses greenlight critical findings and prepares iOS app for first App Store submission. Fixes privacy manifest gaps, centralizes background task management, and replaces raw IPs with hostnames.

---

## Problem

greenlight preflight rejection risks:
- Privacy manifest missing required API declarations
- Background task identifiers inconsistent between Info.plist and code
- Raw IP addresses for LSP/gateway (hostname-only production-ready)
- Push re-registration log showed HTTP status code instead of node_id

## Solution

Targeted fixes across privacy, background task, networking, and UI layers.
---

## Verification

- [x] greenlight preflight: critical File Timestamp issue resolved
- [x] BGTask identifier consistent across Info.plist and code
- [x] All LSP/gateway references use hostnames
- [x] Background task properly wired into app lifecycle
- [x] UI copy updates verified

## Related

- Closes #156 
