### PR TITLE
Fix/android UI issues

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
     <application
         android:name=".StableChannelsApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="Stable Channels"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -768,7 +768,7 @@ class AppState(private val context: Context) : ViewModel() {
                         amountUSD = (splice.amountSats.toDouble() / Constants.SATS_IN_BTC) * price,
                         // bare txid (not the "txid:vout" outpoint) so completeSplice
                         // txid lookups match this row
-                        btcPrice = price, txid = txid, address = splice.address
+                        btcPrice = price, status = "pending", txid = txid, address = splice.address
                     )
                 }
             }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -220,7 +220,6 @@ class AppState(private val context: Context) : ViewModel() {
                     _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
-                    detectOnchainDeposit()
                     // Restore fundingTxid
                     fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
                         .getString("funding_txid", null)
@@ -231,11 +230,13 @@ class AppState(private val context: Context) : ViewModel() {
                     ) {
                         databaseService?.completeSplice(spliceCompletionCandidate)
                     }
-                    // Restore pending splice state
+                    // Restore pending splice state BEFORE detectOnchainDeposit() so the
+                    // deposit detector correctly ignores unconfirmed splice outputs on startup
                     if (databaseService?.hasPendingSplice() == true) {
                         isSweeping = true
                         spliceTxid = databaseService?.getPendingSpliceTxid() ?: fundingTxid
                     }
+                    detectOnchainDeposit()
                     reregisterPushTokenIfNeeded()
                     processPendingPushPayment()
                     startStabilityTimer()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1134,11 +1134,16 @@ class AppState(private val context: Context) : ViewModel() {
         }
         val sweepAmount = spendable
 
+        // Set isSweeping=true BEFORE calling spliceInWithAll so that if LDK fires
+        // a ChannelReady event synchronously during the call, the event handler
+        // correctly identifies it as still in-flight and does not prematurely clear
+        // the sweep state and re-show the Swap button.
+        isSweeping = true
+        pendingSplice = PendingSplice("in", sweepAmount)
+
         try {
             nodeService.spliceInWithAll(channel.userChannelId, channel.counterpartyNodeId)
-            isSweeping = true
             sweepOnchainStart = spendable
-            pendingSplice = PendingSplice("in", sweepAmount)
             _statusMessage.value = "Moving all onchain funds to channel..."
             val price = priceService.currentPrice.value
             val amountUSD = if (price > 0) (sweepAmount.toDouble() / Constants.SATS_IN_BTC) * price else null
@@ -1153,6 +1158,7 @@ class AppState(private val context: Context) : ViewModel() {
             ))
         } catch (e: Exception) {
             isSweeping = false
+            pendingSplice = null
             _statusMessage.value = "Sweep failed: ${e.message}"
             AuditService.log("SWEEP_FAILED", mapOf("error" to (e.message ?: "")))
             return

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -141,9 +141,13 @@ class AppState(private val context: Context) : ViewModel() {
 
     var onchainReceiveAddress: String? = null
 
-    private var isSweeping = false
+    private val _isSpliceInFlight = MutableStateFlow(false)
+    val isSpliceInFlightFlow: StateFlow<Boolean> get() = _isSpliceInFlight
     /** True when any splice (in or out) is in flight — prevents concurrent splices. */
-    val isSpliceInFlight: Boolean get() = isSweeping
+    val isSpliceInFlight: Boolean get() = _isSpliceInFlight.value
+    private var isSweeping: Boolean
+        get() = _isSpliceInFlight.value
+        set(value) { _isSpliceInFlight.value = value }
     private var sweepOnchainStart: Long = 0
     private var prevOnchainSats: Long = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
         .getLong("cached_onchain_sats", 0L)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -216,12 +216,7 @@ class AppState(private val context: Context) : ViewModel() {
                     // Restore fundingTxid
                     fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
                         .getString("funding_txid", null)
-                    // Restore pending splice state
-                    if (databaseService?.hasPendingSplice() == true) {
-                        isSweeping = true
-                        spliceTxid = databaseService?.getPendingSpliceTxid() ?: fundingTxid
-                        spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
-                    }
+                    resumePendingSpliceConfirmation()
                     reregisterPushTokenIfNeeded()
                     processPendingPushPayment()
                     startStabilityTimer()
@@ -354,6 +349,7 @@ class AppState(private val context: Context) : ViewModel() {
                 ensureLSPConnected()
                 refreshBalances()
                 updateStableBalances()
+                resumePendingSpliceConfirmation()
                 return@launch
             }
             Log.d("AppState", "Restarting node from foreground")
@@ -373,6 +369,7 @@ class AppState(private val context: Context) : ViewModel() {
                 val sc = StabilityService.reconcileIncoming(_stableChannel.value)
                 _stableChannel.value = sc
                 saveChannelToDB()
+                resumePendingSpliceConfirmation()
                 reregisterPushTokenIfNeeded()
                 startStabilityTimer()
             } catch (e: Exception) {
@@ -821,6 +818,13 @@ class AppState(private val context: Context) : ViewModel() {
                 delay(30_000)
             }
         }
+    }
+
+    private fun resumePendingSpliceConfirmation() {
+        if (databaseService?.hasPendingSplice() != true) return
+        isSweeping = true
+        spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid ?: fundingTxid
+        spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
     }
 
     private fun isTxConfirmed(txid: String): Boolean {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -240,6 +240,12 @@ class AppState(private val context: Context) : ViewModel() {
                         isSweeping = true
                         spliceTxid = databaseService?.getPendingSpliceTxid() ?: fundingTxid
                     }
+                    // Restore channel-closing state if a close is still pending on-chain
+                    val pendingCloseId = databaseService?.getPendingChannelClosePaymentId()
+                    if (pendingCloseId != null) {
+                        pendingClosePaymentId = pendingCloseId
+                        isChannelClosing = true
+                    }
                     detectOnchainDeposit()
                     reregisterPushTokenIfNeeded()
                     processPendingPushPayment()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -137,6 +137,7 @@ class AppState(private val context: Context) : ViewModel() {
     private var stabilityJob: Job? = null
     private var heartbeatJob: Job? = null
     private var pendingDepositJob: Job? = null
+    private var nodeStartRetryJob: Job? = null
 
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
     var chainUrl: String = Constants.PRIMARY_CHAIN_URL
@@ -197,9 +198,15 @@ class AppState(private val context: Context) : ViewModel() {
                     } else {
                         _phase.value = Phase.SYNCING
                     }
-                    waitForBackgroundService()
+                    if (!waitForBackgroundService()) {
+                        _isSyncing.value = false
+                        scheduleNodeStartRetry()
+                        return@launch
+                    }
                     loadChannelFromDB()  // reload — SPS may have incremented backingSats while we waited
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    nodeStartRetryJob?.cancel()
+                    nodeStartRetryJob = null
                     _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
@@ -268,6 +275,8 @@ class AppState(private val context: Context) : ViewModel() {
         stabilityJob?.cancel()
         heartbeatJob?.cancel()
         pendingDepositJob?.cancel()
+        nodeStartRetryJob?.cancel()
+        nodeStartRetryJob = null
         priceService.stopAutoRefresh()
         nodeService.stop()
     }
@@ -321,6 +330,8 @@ class AppState(private val context: Context) : ViewModel() {
         stabilityJob = null
         pendingDepositJob?.cancel()
         pendingDepositJob = null
+        nodeStartRetryJob?.cancel()
+        nodeStartRetryJob = null
         if (!nodeService.isRunning) return
         Log.d("AppState", "Stopping node for background")
         nodeService.stop()
@@ -344,11 +355,16 @@ class AppState(private val context: Context) : ViewModel() {
                 return@launch
             }
             Log.d("AppState", "Restarting node from foreground")
-            waitForBackgroundService()
+            if (!waitForBackgroundService()) {
+                scheduleNodeStartRetry()
+                return@launch
+            }
             try {
                 loadChannelFromDB()
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, null)
+                nodeStartRetryJob?.cancel()
+                nodeStartRetryJob = null
                 _phase.value = Phase.WALLET
                 refreshBalances()
                 updateStableBalances()
@@ -1331,15 +1347,37 @@ class AppState(private val context: Context) : ViewModel() {
         }
     }
 
-    private fun waitForBackgroundService() {
-        if (!StabilityProcessingService.isRunning) return
+    private fun backgroundServiceOwnsLdk(): Boolean =
+        StabilityProcessingService.isRunning ||
+            LdkNodeOwner.isOwnedBy(LdkNodeOwner.STABILITY_SERVICE)
+
+    private fun waitForBackgroundService(): Boolean {
+        if (!backgroundServiceOwnsLdk()) return true
         Log.d("AppState", "Waiting for background stability service to finish...")
         val deadline = System.currentTimeMillis() + 30_000
-        while (StabilityProcessingService.isRunning && System.currentTimeMillis() < deadline) {
+        while (backgroundServiceOwnsLdk() && System.currentTimeMillis() < deadline) {
             Thread.sleep(500)
         }
-        if (StabilityProcessingService.isRunning) {
-            Log.w("AppState", "Background service still running after 30s, proceeding anyway")
+        if (backgroundServiceOwnsLdk()) {
+            val owner = LdkNodeOwner.currentOwner() ?: "background service"
+            Log.w("AppState", "Background service still owns LDK after 30s (owner=$owner); skipping node start")
+            _statusMessage.value = "Finishing background sync..."
+            FCMService.flagPendingPayment(context)
+            return false
+        }
+        return true
+    }
+
+    private fun scheduleNodeStartRetry() {
+        if (nodeStartRetryJob?.isActive == true) return
+        nodeStartRetryJob = viewModelScope.launch(Dispatchers.IO) {
+            while (isActive && backgroundServiceOwnsLdk()) {
+                delay(1_000)
+            }
+            if (!isActive || nodeService.isRunning) return@launch
+            Log.d("AppState", "Retrying node start after LDK owner released")
+            _statusMessage.value = "Syncing wallet..."
+            restartNodeFromForeground()
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1201,6 +1201,7 @@ class AppState(private val context: Context) : ViewModel() {
             if (closeId != null) {
                 databaseService?.updatePaymentStatus(closeId, "completed")
                 pendingClosePaymentId = null
+                isChannelClosing = false
                 AuditService.log("CHANNEL_CLOSE_CONFIRMED", mapOf("sats" to depositSats))
             } else {
                 // No pending close — record as new on-chain deposit

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -113,7 +113,20 @@ class AppState(private val context: Context) : ViewModel() {
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
     var isChannelClosing: Boolean
         get() = _isChannelClosing.value
-        set(value) { _isChannelClosing.value = value }
+        set(value) { 
+            _isChannelClosing.value = value
+            if (value) {
+                channelCloseJob?.cancel()
+                channelCloseJob = viewModelScope.launch(Dispatchers.IO) {
+                    while (isActive && _isChannelClosing.value) {
+                        delay(10_000)
+                        refreshBalances()
+                    }
+                }
+            } else {
+                channelCloseJob?.cancel()
+            }
+        }
     var pendingClosePaymentId: String? = null
     var spliceTxid: String? = null
     var fundingTxid: String? = null
@@ -137,7 +150,7 @@ class AppState(private val context: Context) : ViewModel() {
     private var stabilityJob: Job? = null
     private var heartbeatJob: Job? = null
     private var pendingDepositJob: Job? = null
-
+    private var channelCloseJob: Job? = null
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
     var chainUrl: String = Constants.PRIMARY_CHAIN_URL
         private set

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -858,8 +858,9 @@ class AppState(private val context: Context) : ViewModel() {
         val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
         for (baseUrl in urls) {
             try {
+                val normalizedTxid = txid.substringBefore(":")
                 val request = Request.Builder()
-                    .url("${baseUrl.trimEnd('/')}/tx/$txid/status")
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
                     .build()
                 httpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@use

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -138,6 +138,8 @@ class AppState(private val context: Context) : ViewModel() {
     private var heartbeatJob: Job? = null
     private var pendingDepositJob: Job? = null
     private var nodeStartRetryJob: Job? = null
+    private var spliceConfirmationJob: Job? = null
+    private var monitoredSpliceTxid: String? = null
 
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
     var chainUrl: String = Constants.PRIMARY_CHAIN_URL
@@ -214,17 +216,11 @@ class AppState(private val context: Context) : ViewModel() {
                     // Restore fundingTxid
                     fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
                         .getString("funding_txid", null)
-                    val pendingSpliceTxid = databaseService?.getPendingSpliceTxid()
-                    val spliceCompletionCandidate = pendingSpliceTxid ?: fundingTxid
-                    if (!spliceCompletionCandidate.isNullOrBlank() &&
-                        currentChannelFundingTxidMatches(spliceCompletionCandidate)
-                    ) {
-                        databaseService?.completeSplice(spliceCompletionCandidate)
-                    }
                     // Restore pending splice state
                     if (databaseService?.hasPendingSplice() == true) {
                         isSweeping = true
                         spliceTxid = databaseService?.getPendingSpliceTxid() ?: fundingTxid
+                        spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
                     }
                     reregisterPushTokenIfNeeded()
                     processPendingPushPayment()
@@ -277,6 +273,9 @@ class AppState(private val context: Context) : ViewModel() {
         pendingDepositJob?.cancel()
         nodeStartRetryJob?.cancel()
         nodeStartRetryJob = null
+        spliceConfirmationJob?.cancel()
+        spliceConfirmationJob = null
+        monitoredSpliceTxid = null
         priceService.stopAutoRefresh()
         nodeService.stop()
     }
@@ -332,6 +331,9 @@ class AppState(private val context: Context) : ViewModel() {
         pendingDepositJob = null
         nodeStartRetryJob?.cancel()
         nodeStartRetryJob = null
+        spliceConfirmationJob?.cancel()
+        spliceConfirmationJob = null
+        monitoredSpliceTxid = null
         if (!nodeService.isRunning) return
         Log.d("AppState", "Stopping node for background")
         nodeService.stop()
@@ -397,37 +399,31 @@ class AppState(private val context: Context) : ViewModel() {
             }
             is Event.ChannelReady -> {
                 val sc = _stableChannel.value.copy()
-                // Splices keep the channel_id stable in current LDK, so a changed
-                // channel_id can't be the splice signal. Match the channel's actual
-                // funding txid against a recorded splice row instead; completeSplice
-                // is exact-match and idempotent, so replayed events are no-ops.
+                // In 0-conf channels, ChannelReady can fire before the splice tx confirms.
+                // Treat it as metadata only; the splice stays pending until the tx has 1 conf.
                 val channelIdChanged = sc.userChannelId == event.userChannelId && sc.channelId.isNotEmpty() && sc.channelId != event.channelId
                 sc.channelId = event.channelId
-                var completedSplice = false
+                var pendingSpliceCandidate: String? = null
                 if (sc.userChannelId == event.userChannelId) {
                     nodeService.refreshChannels()
                     val channelFundingTxid = nodeService.channels
                         .firstOrNull { it.userChannelId == event.userChannelId }
                         ?.fundingTxo?.txid
-                    for (candidate in listOfNotNull(channelFundingTxid, spliceTxid)) {
-                        if (candidate.isNotEmpty() && databaseService?.completeSplice(candidate) == true) {
-                            completedSplice = true
-                            break
-                        }
+                    pendingSpliceCandidate = listOfNotNull(
+                        databaseService?.getPendingSpliceTxid(),
+                        spliceTxid
+                    ).firstOrNull { candidate ->
+                        candidate.isNotEmpty() && candidate == channelFundingTxid
                     }
                 }
-                val isSplice = completedSplice || channelIdChanged
+                val isSplice = pendingSpliceCandidate != null || channelIdChanged
                 if (isSplice) {
-                    isSweeping = false
-                    spliceTxid = null
-                    if (!completedSplice) databaseService?.completeLatestSplice(fundingTxid)
-                    val price = priceService.currentPrice.value
-                    val result = StabilityService.reconcileOutgoing(sc, price)
-                    val reconciled = result.first
-                    if (result.second != null) {
-                        reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
-                    }
-                    _stableChannel.value = reconciled
+                    isSweeping = true
+                    val txid = pendingSpliceCandidate ?: spliceTxid ?: fundingTxid
+                    spliceTxid = txid
+                    txid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
+                    _stableChannel.value = sc
+                    _statusMessage.value = "Swap pending confirmation"
                 } else {
                     _stableChannel.value = sc
                 }
@@ -489,6 +485,9 @@ class AppState(private val context: Context) : ViewModel() {
             is Event.SpliceNegotiationFailed -> {
                 isSweeping = false
                 spliceTxid = null
+                spliceConfirmationJob?.cancel()
+                spliceConfirmationJob = null
+                monitoredSpliceTxid = null
                 pendingSplice = null
                 databaseService?.failLatestPendingSplice()
                 AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
@@ -757,6 +756,7 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun handleSplicePending(channelId: String, userChannelId: String, newFundingTxo: String) {
         val txid = newFundingTxo.split(":").firstOrNull() ?: newFundingTxo
+        isSweeping = true
         spliceTxid = txid
         fundingTxid = txid
         val splice = pendingSplice
@@ -784,6 +784,90 @@ class AppState(private val context: Context) : ViewModel() {
         }
         refreshBalances()
         updateStableBalances()
+        _statusMessage.value = "Swap pending confirmation"
+        startSpliceConfirmationMonitor(txid)
+    }
+
+    fun beginSpliceOut(amountSats: Long, address: String) {
+        if (isSweeping) {
+            throw IllegalStateException("A splice is already in progress — try again shortly")
+        }
+        isSweeping = true
+        pendingSplice = PendingSplice("out", amountSats, address)
+        _statusMessage.value = "Swap pending..."
+    }
+
+    fun cancelPendingSpliceStart() {
+        if (spliceTxid == null) {
+            isSweeping = false
+            pendingSplice = null
+            _statusMessage.value = ""
+        }
+    }
+
+    private fun startSpliceConfirmationMonitor(txid: String) {
+        val normalizedTxid = txid.trim()
+        if (normalizedTxid.isEmpty()) return
+        if (spliceConfirmationJob?.isActive == true && monitoredSpliceTxid == normalizedTxid) return
+
+        spliceConfirmationJob?.cancel()
+        monitoredSpliceTxid = normalizedTxid
+        spliceConfirmationJob = viewModelScope.launch(Dispatchers.IO) {
+            while (isActive) {
+                if (isTxConfirmed(normalizedTxid)) {
+                    completeConfirmedSplice(normalizedTxid)
+                    break
+                }
+                delay(30_000)
+            }
+        }
+    }
+
+    private fun isTxConfirmed(txid: String): Boolean {
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$txid/status")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    if (JSONObject(body).optBoolean("confirmed", false)) return true
+                }
+            } catch (e: Exception) {
+                Log.w("AppState", "Splice confirmation check failed: ${e.message}")
+            }
+        }
+        return false
+    }
+
+    private fun completeConfirmedSplice(txid: String) {
+        val completed = databaseService?.completeSplice(txid) == true
+        refreshBalances()
+        updateStableBalances()
+
+        val price = priceService.currentPrice.value
+        val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
+        val reconciled = result.first
+        if (result.second != null) {
+            reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
+        }
+        _stableChannel.value = reconciled
+        saveChannelToDB()
+
+        isSweeping = false
+        pendingSplice = null
+        sweepOnchainStart = 0
+        if (spliceTxid == txid) spliceTxid = null
+        monitoredSpliceTxid = null
+        spliceConfirmationJob = null
+        _statusMessage.value = "Swap confirmed"
+
+        AuditService.log("SPLICE_CONFIRMED", mapOf(
+            "txid" to txid,
+            "completed_row" to completed
+        ))
     }
 
     private fun handleChannelClosed(channelId: String, userChannelId: String, reason: String?) {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -148,6 +148,10 @@ class AppState(private val context: Context) : ViewModel() {
     private var isSweeping: Boolean
         get() = _isSpliceInFlight.value
         set(value) { _isSpliceInFlight.value = value }
+    // True after a splice completes but before LDK's on-chain balance settles to 0.
+    // Keeps the UI in 'Swap pending...' instead of re-showing the Swap button.
+    private val _spliceJustCompleted = MutableStateFlow(false)
+    val spliceJustCompletedFlow: StateFlow<Boolean> get() = _spliceJustCompleted
     private var sweepOnchainStart: Long = 0
     private var prevOnchainSats: Long = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
         .getLong("cached_onchain_sats", 0L)
@@ -422,6 +426,7 @@ class AppState(private val context: Context) : ViewModel() {
                 if (isSplice) {
                     isSweeping = false
                     spliceTxid = null
+                    _spliceJustCompleted.value = true
                     if (!completedSplice) databaseService?.completeLatestSplice(fundingTxid)
                     val price = priceService.currentPrice.value
                     val result = StabilityService.reconcileOutgoing(sc, price)
@@ -1228,7 +1233,12 @@ class AppState(private val context: Context) : ViewModel() {
         _lightningBalanceSats.value = lightning
         _onchainBalanceSats.value = onchain
         _hasReadyChannel.value = hasReady
-        _spendableOnchainSats.value = balances.spendableOnchainBalanceSats.toLong()
+        val spendable = balances.spendableOnchainBalanceSats.toLong()
+        _spendableOnchainSats.value = spendable
+        // Once LDK confirms the on-chain balance is zero after a splice, clear the flag
+        if (_spliceJustCompleted.value && spendable == 0L) {
+            _spliceJustCompleted.value = false
+        }
 
         // Clear closing flag once lightning balance fully resolves
         // Don't clear pendingClosePaymentId here — let detectOnchainDeposit()

--- a/android/app/src/main/java/com/stablechannels/app/push/FCMService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/FCMService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.stablechannels.app.services.LdkNodeOwner
 import com.stablechannels.app.util.Constants
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -108,6 +109,12 @@ class FCMService : FirebaseMessagingService() {
         if (now - lastActive < HEARTBEAT_THRESHOLD_SECS) {
             // Main app is running — let it handle on next stability cycle
             Log.d(TAG, "Main app active, flagging pending payment")
+            flagPendingPayment(this)
+            return
+        }
+
+        if (LdkNodeOwner.isOwnedBy(LdkNodeOwner.MAIN_APP) || StabilityProcessingService.isRunning) {
+            Log.d(TAG, "LDK node already owned in-process, flagging pending payment")
             flagPendingPayment(this)
             return
         }

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.stablechannels.app.R
 import com.stablechannels.app.StableChannelsApp
+import com.stablechannels.app.services.LdkNodeOwner
 import com.stablechannels.app.services.TradeService
 import com.stablechannels.app.util.Constants
 import okhttp3.OkHttpClient
@@ -27,6 +28,7 @@ class StabilityProcessingService : Service() {
     /** Thrown when a stability payment DB write fails permanently; the polling catch re-throws
      *  this so it escapes handleLspToUser and reaches onStartCommand's flagPendingPayment path. */
     private class BackingUpdateFailed(msg: String) : Exception(msg)
+    private class NodeOwnerBusy(msg: String) : Exception(msg)
 
     companion object {
         private const val TAG = "StabilityBgService"
@@ -125,6 +127,9 @@ class StabilityProcessingService : Service() {
             try {
                 processStability(direction)
                 FCMService.clearPendingPayment(this)
+            } catch (e: NodeOwnerBusy) {
+                Log.d(TAG, "Deferring stability processing: ${e.message}")
+                FCMService.flagPendingPayment(this)
             } catch (e: Exception) {
                 Log.e(TAG, "Stability processing failed", e)
                 FCMService.flagPendingPayment(this)
@@ -149,57 +154,65 @@ class StabilityProcessingService : Service() {
             return
         }
 
-        // Strip gossip from SQLite to avoid OOM in the foreground service.
-        // The NSE doesn't need gossip (it only routes to the LSP, a direct peer).
-        stripGossipFromDB(dataDir)
+        if (!LdkNodeOwner.tryAcquire(LdkNodeOwner.STABILITY_SERVICE)) {
+            throw NodeOwnerBusy(
+                "LDK node data is already owned by ${LdkNodeOwner.currentOwner() ?: "another owner"}"
+            )
+        }
 
-        // Build lightweight LDK node (no RGS, no LSPS2)
-        val anchorConfig = AnchorChannelsConfig(
-            trustedPeersNoReserve = listOf(Constants.DEFAULT_LSP_PUBKEY),
-            perChannelReserveSats = 25_000UL
-        )
+        var node: Node? = null
+        try {
+            // Strip gossip from SQLite to avoid OOM in the foreground service.
+            // The service doesn't need gossip (it only routes to the LSP, a direct peer).
+            stripGossipFromDB(dataDir)
 
-        val config = Config(
-            storageDirPath = dataDir.absolutePath,
-            network = Network.BITCOIN,
-            listeningAddresses = null,
-            announcementAddresses = null,
-            nodeAlias = null,
-            trustedPeers0conf = listOf(Constants.DEFAULT_LSP_PUBKEY),
-            probingLiquidityLimitMultiplier = 3UL,
-            anchorChannelsConfig = anchorConfig,
-            routeParameters = null,
-            torConfig = null,
-            hrnConfig = HumanReadableNamesConfig(
-                HrnResolverConfig.Dns(
-                    dnsServerAddress = "8.8.8.8:53",
-                    enableHrnResolutionService = false
+            // Build lightweight LDK node (no RGS, no LSPS2)
+            val anchorConfig = AnchorChannelsConfig(
+                trustedPeersNoReserve = listOf(Constants.DEFAULT_LSP_PUBKEY),
+                perChannelReserveSats = 25_000UL
+            )
+
+            val config = Config(
+                storageDirPath = dataDir.absolutePath,
+                network = Network.BITCOIN,
+                listeningAddresses = null,
+                announcementAddresses = null,
+                nodeAlias = null,
+                trustedPeers0conf = listOf(Constants.DEFAULT_LSP_PUBKEY),
+                probingLiquidityLimitMultiplier = 3UL,
+                anchorChannelsConfig = anchorConfig,
+                routeParameters = null,
+                torConfig = null,
+                hrnConfig = HumanReadableNamesConfig(
+                    HrnResolverConfig.Dns(
+                        dnsServerAddress = "8.8.8.8:53",
+                        enableHrnResolutionService = false
+                    )
                 )
             )
-        )
 
-        val builder = Builder.fromConfig(config)
-        builder.setChainSourceEsplora(Constants.PRIMARY_CHAIN_URL, null)
+            val builder = Builder.fromConfig(config)
+            builder.setChainSourceEsplora(Constants.PRIMARY_CHAIN_URL, null)
 
-        // Derive node entropy (entropy is now passed to build()): prefer the seed_phrase
-        // mnemonic if present, otherwise fall back to the existing keys_seed file.
-        val seedWords = if (seedPhraseFile.exists()) seedPhraseFile.readText().trim() else ""
-        val nodeEntropy = if (seedWords.isNotEmpty()) {
-            Log.d(TAG, "Using seed_phrase mnemonic")
-            NodeEntropy.fromBip39Mnemonic(seedWords, null)
-        } else {
-            NodeEntropy.fromSeedPath(keySeedFile.absolutePath)
-        }
-        // No RGS gossip (saves ~5s startup + ~8MB RAM)
-        // No LSPS2 (not needed for stability payments)
+            // Derive node entropy (entropy is now passed to build()): prefer the seed_phrase
+            // mnemonic if present, otherwise fall back to the existing keys_seed file.
+            val seedWords = if (seedPhraseFile.exists()) seedPhraseFile.readText().trim() else ""
+            val nodeEntropy = if (seedWords.isNotEmpty()) {
+                Log.d(TAG, "Using seed_phrase mnemonic")
+                NodeEntropy.fromBip39Mnemonic(seedWords, null)
+            } else {
+                NodeEntropy.fromSeedPath(keySeedFile.absolutePath)
+            }
+            // No RGS gossip (saves ~5s startup + ~8MB RAM)
+            // No LSPS2 (not needed for stability payments)
 
-        val node = builder.build(nodeEntropy)
-        node.start()
+            val startedNode = builder.build(nodeEntropy)
+            node = startedNode
+            startedNode.start()
 
-        try {
             // Connect to LSP
             try {
-                node.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
+                startedNode.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
             } catch (e: Exception) {
                 Log.w(TAG, "LSP connect: ${e.message}")
             }
@@ -207,13 +220,17 @@ class StabilityProcessingService : Service() {
             val dbPath = File(dataDir, "stablechannels.db").absolutePath
 
             when (direction) {
-                "lsp_to_user" -> handleLspToUser(node, dbPath)
-                "user_to_lsp" -> handleUserToLsp(node, dbPath)
-                "incoming_payment" -> handleIncomingPayment(node, dbPath)
+                "lsp_to_user" -> handleLspToUser(startedNode, dbPath)
+                "user_to_lsp" -> handleUserToLsp(startedNode, dbPath)
+                "incoming_payment" -> handleIncomingPayment(startedNode, dbPath)
                 else -> Log.w(TAG, "Unknown direction: $direction")
             }
         } finally {
-            node.stop()
+            try {
+                node?.stop()
+            } finally {
+                LdkNodeOwner.release(LdkNodeOwner.STABILITY_SERVICE)
+            }
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -532,7 +532,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
      *  so callers can use the result as the "this ChannelReady was a splice" signal. */
     fun completeSplice(txid: String): Boolean {
         val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET status = 'completed' WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status IN ('pending','failed')"
+            "UPDATE payments SET status = 'completed', confirmations = 1 WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status IN ('pending','failed')"
         )
         stmt.bindString(1, txid)
         return stmt.executeUpdateDelete() > 0
@@ -556,7 +556,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         // If the app died before SpliceNegotiated delivered a txid, there is no
         // durable in-flight splice to wait for. Let that pre-negotiation lock heal.
         // Keep with-txid rows pending: confirmation can outlive the app process,
-        // and ChannelReady is the authoritative success signal.
+        // and the splice confirmation monitor completes them after 1 conf.
         val noTxidCutoff = System.currentTimeMillis() / 1000 - 600
         writableDatabase.execSQL(
             "UPDATE payments SET status = 'failed' WHERE status = 'pending' AND payment_type IN ('splice_in','splice_out') AND txid IS NULL AND created_at < ?",

--- a/android/app/src/main/java/com/stablechannels/app/services/LdkNodeOwner.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/LdkNodeOwner.kt
@@ -1,0 +1,32 @@
+package com.stablechannels.app.services
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Process-wide guard for LDK node access.
+ *
+ * The main app and StabilityProcessingService run in the same Android process
+ * by default, but each can otherwise build its own Node against the same data
+ * directory. LDK channel state is not safe under two live Node instances, so
+ * ownership must be held for the full lifetime of any Node and for direct LDK
+ * DB mutations such as gossip stripping.
+ */
+object LdkNodeOwner {
+    const val MAIN_APP = "main-app"
+    const val STABILITY_SERVICE = "stability-service"
+
+    private val owner = AtomicReference<String?>(null)
+
+    fun tryAcquire(ownerName: String): Boolean =
+        owner.compareAndSet(null, ownerName)
+
+    fun release(ownerName: String) {
+        owner.compareAndSet(ownerName, null)
+    }
+
+    fun currentOwner(): String? = owner.get()
+
+    fun isOwned(): Boolean = owner.get() != null
+
+    fun isOwnedBy(ownerName: String): Boolean = owner.get() == ownerName
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
@@ -45,103 +45,132 @@ class NodeService(private val context: Context) {
     val eventChannel: ReceiveChannel<Pair<Event, CompletableDeferred<Boolean>>> = _eventChannel
 
     fun start(network: Network, esploraURL: String, mnemonic: String?) {
+        if (node != null || _isRunning.value) {
+            throw IllegalStateException("LDK node already running")
+        }
+        if (!LdkNodeOwner.tryAcquire(LdkNodeOwner.MAIN_APP)) {
+            throw IllegalStateException(
+                "LDK node data is already owned by ${LdkNodeOwner.currentOwner() ?: "another owner"}"
+            )
+        }
+
         val dataDir = Constants.userDataDir(context)
+        var ldkNode: Node? = null
 
-        val anchorConfig = AnchorChannelsConfig(
-            trustedPeersNoReserve = listOf(Constants.DEFAULT_LSP_PUBKEY),
-            perChannelReserveSats = 25_000UL
-        )
+        try {
+            val anchorConfig = AnchorChannelsConfig(
+                trustedPeersNoReserve = listOf(Constants.DEFAULT_LSP_PUBKEY),
+                perChannelReserveSats = 25_000UL
+            )
 
-        val config = Config(
-            storageDirPath = dataDir.absolutePath,
-            network = network,
-            listeningAddresses = null,
-            announcementAddresses = null,
-            nodeAlias = null,
-            trustedPeers0conf = listOf(Constants.DEFAULT_LSP_PUBKEY),
-            probingLiquidityLimitMultiplier = 3UL,
-            anchorChannelsConfig = anchorConfig,
-            routeParameters = null,
-            torConfig = null,
-            hrnConfig = HumanReadableNamesConfig(
-                HrnResolverConfig.Dns(
-                    dnsServerAddress = "8.8.8.8:53",
-                    enableHrnResolutionService = false
+            val config = Config(
+                storageDirPath = dataDir.absolutePath,
+                network = network,
+                listeningAddresses = null,
+                announcementAddresses = null,
+                nodeAlias = null,
+                trustedPeers0conf = listOf(Constants.DEFAULT_LSP_PUBKEY),
+                probingLiquidityLimitMultiplier = 3UL,
+                anchorChannelsConfig = anchorConfig,
+                routeParameters = null,
+                torConfig = null,
+                hrnConfig = HumanReadableNamesConfig(
+                    HrnResolverConfig.Dns(
+                        dnsServerAddress = "8.8.8.8:53",
+                        enableHrnResolutionService = false
+                    )
                 )
             )
-        )
 
-        val builder = Builder.fromConfig(config)
-        builder.setChainSourceEsplora(esploraURL, null)
+            val builder = Builder.fromConfig(config)
+            builder.setChainSourceEsplora(esploraURL, null)
 
-        val rgsUrl = when (network) {
-            Network.BITCOIN -> Constants.RGSServer.BITCOIN
-            Network.SIGNET -> Constants.RGSServer.SIGNET
-            Network.TESTNET -> Constants.RGSServer.TESTNET
-            else -> Constants.RGSServer.BITCOIN
-        }
-        builder.setGossipSourceRgs(rgsUrl)
+            val rgsUrl = when (network) {
+                Network.BITCOIN -> Constants.RGSServer.BITCOIN
+                Network.SIGNET -> Constants.RGSServer.SIGNET
+                Network.TESTNET -> Constants.RGSServer.TESTNET
+                else -> Constants.RGSServer.BITCOIN
+            }
+            builder.setGossipSourceRgs(rgsUrl)
 
-        builder.setLiquiditySourceLsps2(
-            Constants.DEFAULT_LSP_PUBKEY,
-            Constants.DEFAULT_LSP_ADDRESS,
-            null
-        )
+            builder.setLiquiditySourceLsps2(
+                Constants.DEFAULT_LSP_PUBKEY,
+                Constants.DEFAULT_LSP_ADDRESS,
+                null
+            )
 
-        val seedPhrasePath = File(Constants.userDataDir(context), "seed_phrase")
-        val keySeedPath = File(Constants.userDataDir(context), "keys_seed")
+            val seedPhrasePath = File(Constants.userDataDir(context), "seed_phrase")
+            val keySeedPath = File(Constants.userDataDir(context), "keys_seed")
 
-        // Determine which mnemonic to use
-        val words: String = if (mnemonic != null) {
-            // Restore — wipe ALL wallet data so new seed takes effect
-            wipeWalletData(context)
-            mnemonic.trim()
-        } else if (seedPhrasePath.exists()) {
-            // Existing wallet — re-read saved mnemonic
-            seedPhrasePath.readText().trim()
-        } else if (!keySeedPath.exists()) {
-            // Truly new wallet — no seed_phrase, no keys_seed
-            wipeWalletData(context)
-            generateEntropyMnemonic(null)
-        } else {
-            // Pre-upgrade wallet with only keys_seed, no mnemonic available
-            ""
-        }
+            // Determine which mnemonic to use
+            val words: String = if (mnemonic != null) {
+                // Restore — wipe ALL wallet data so new seed takes effect
+                wipeWalletData(context)
+                mnemonic.trim()
+            } else if (seedPhrasePath.exists()) {
+                // Existing wallet — re-read saved mnemonic
+                seedPhrasePath.readText().trim()
+            } else if (!keySeedPath.exists()) {
+                // Truly new wallet — no seed_phrase, no keys_seed
+                wipeWalletData(context)
+                generateEntropyMnemonic(null)
+            } else {
+                // Pre-upgrade wallet with only keys_seed, no mnemonic available
+                ""
+            }
 
-        // Save mnemonic to file and derive node entropy (entropy now passed to build()).
-        val nodeEntropy = if (words.isNotEmpty()) {
-            seedPhrasePath.writeText(words)
-            savedMnemonic = words
-            NodeEntropy.fromBip39Mnemonic(words, null)
-        } else {
-            // Pre-upgrade wallet with only keys_seed: derive entropy from that seed file.
-            NodeEntropy.fromSeedPath(keySeedPath.absolutePath)
-        }
+            // Save mnemonic to file and derive node entropy (entropy now passed to build()).
+            val nodeEntropy = if (words.isNotEmpty()) {
+                seedPhrasePath.writeText(words)
+                savedMnemonic = words
+                NodeEntropy.fromBip39Mnemonic(words, null)
+            } else {
+                // Pre-upgrade wallet with only keys_seed: derive entropy from that seed file.
+                NodeEntropy.fromSeedPath(keySeedPath.absolutePath)
+            }
 
-        val ldkNode = builder.build(nodeEntropy)
-        ldkNode.start()
+            val startedNode = builder.build(nodeEntropy)
+            ldkNode = startedNode
+            startedNode.start()
 
-        node = ldkNode
-        _isRunning.value = true
-        nodeId = ldkNode.nodeId()
+            node = startedNode
+            _isRunning.value = true
+            nodeId = startedNode.nodeId()
 
-        // Connect to LSP
-        try {
-            ldkNode.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
+            // Connect to LSP
+            try {
+                startedNode.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
+            } catch (e: Exception) {
+                Log.w("NodeService", "LSP connect failed: ${e.message}")
+            }
+
+            refreshChannels()
+            startEventLoop()
         } catch (e: Exception) {
-            Log.w("NodeService", "LSP connect failed: ${e.message}")
+            eventJob?.cancel()
+            eventJob = null
+            try {
+                ldkNode?.stop()
+            } catch (stopError: Exception) {
+                Log.w("NodeService", "Failed to stop node after start failure: ${stopError.message}")
+            }
+            node = null
+            _isRunning.value = false
+            LdkNodeOwner.release(LdkNodeOwner.MAIN_APP)
+            throw e
         }
-
-        refreshChannels()
-        startEventLoop()
     }
 
     fun stop() {
-        eventJob?.cancel()
-        eventJob = null
-        node?.stop()
-        node = null
-        _isRunning.value = false
+        try {
+            eventJob?.cancel()
+            eventJob = null
+            node?.stop()
+        } finally {
+            node = null
+            _isRunning.value = false
+            LdkNodeOwner.release(LdkNodeOwner.MAIN_APP)
+        }
     }
 
     private fun startEventLoop() {

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -65,7 +65,7 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
         Spacer(Modifier.height(12.dp))
 
         // Segmented control (like iOS Picker .segmented)
-        val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+        val isDark = MaterialTheme.colorScheme.background == Color(0xFF000000)
         val activeBg = if (isDark) Color(0xFF3A3A3C) else Color.White
         val inactiveBg = if (isDark) Color(0xFF1C1C1E) else Color(0xFFE5E5EA)
         Row(

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -379,7 +379,13 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         } else if (spendableOnchainSats == 0L) {
                             // 3. Unconfirmed deposit (with or without channel)
                             Spacer(Modifier.height(8.dp))
-                            PendingRow("Deposit confirming...", appState.fundingTxid, context)
+                            val pendingCloseId = appState.pendingClosePaymentId
+                            val text = if (pendingCloseId != null) {
+                                "Channel closed - pending confirmation"
+                            } else {
+                                "Deposit confirming..."
+                            }
+                            PendingRow(text, appState.fundingTxid, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -308,6 +308,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
             if (onchainSats > 0) {
                 val onchainUSD = (onchainSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
                 val isSweeping by appState.isSpliceInFlightFlow.collectAsState()
+                val spliceJustCompleted by appState.spliceJustCompletedFlow.collectAsState()
+                val showSwapPending = isSweeping || spliceJustCompleted
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -327,7 +329,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
-                        if (isSweeping) {
+                        if (showSwapPending) {
                             // 1. Splice-in in progress
                             Spacer(Modifier.height(8.dp))
                             PendingRow("Swap pending...", appState.spliceTxid, context)

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -359,7 +359,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Column {
-                                    Text("Move to Trading", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                    Text("Move to Stability", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                                     Text("and Spending Account", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                                 }
                                 FilledTonalButton(
@@ -649,7 +649,7 @@ private fun PendingRow(text: String, txid: String?, context: android.content.Con
         txid?.let {
             TextButton(
                 onClick = {
-                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/$it"))
+                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/${it.substringBefore(":")}"))
                     context.startActivity(intent)
                 },
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -363,7 +363,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                     Text("Move to Stability", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                                     Text("and Spending Account", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                                 }
-                                FilledTonalButton(
+                                Button(
                                     onClick = {
                                         scope.launch(Dispatchers.IO) {
                                             appState.sweepToChannel()

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -307,7 +307,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
             // On-chain section
             if (onchainSats > 0) {
                 val onchainUSD = (onchainSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice
-                val isSweeping = appState.isSpliceInFlight
+                val isSweeping by appState.isSpliceInFlightFlow.collectAsState()
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -311,7 +311,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                 ) {
                     Column(Modifier.padding(12.dp)) {
                         Row(

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -95,7 +95,7 @@ fun ChannelView(appState: AppState) {
                             Spacer(Modifier.height(8.dp))
                             TextButton(
                                 onClick = {
-                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://mempool.space/tx/$txid"))
+                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://mempool.space/tx/${txid.substringBefore(":")}"))
                                     context.startActivity(intent)
                                 },
                                 contentPadding = PaddingValues(0.dp)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -127,7 +127,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                             TextButton(onClick = {
                                 val intent = android.content.Intent(
                                     android.content.Intent.ACTION_VIEW,
-                                    android.net.Uri.parse("https://mempool.space/tx/$txid")
+                                    android.net.Uri.parse("https://mempool.space/tx/${txid.substringBefore(":")}")
                                 )
                                 context.startActivity(intent)
                             }) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -95,7 +95,16 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     TextButton(
                         onClick = { amountText = String.format(Locale.US, "%.2f", maxBuyUSD) },
-                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                        colors = ButtonDefaults.textButtonColors(
+                            containerColor = if (isSystemInDarkTheme()) {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            } else {
+                                androidx.compose.ui.graphics.Color(0xFFE5E5EA)
+                            },
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
                     ) {
                         Text("Max", style = MaterialTheme.typography.labelMedium)
                     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -77,7 +77,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                 }
             }
             Text(
-                text = if (step == TradeStep.CONFIRM) "Confirm Order" else if (step == TradeStep.DONE) "Order Confirmed" else "USD → BTC",
+                text = if (step == TradeStep.CONFIRM) "Confirm Conversion" else if (step == TradeStep.DONE) "Conversion Confirmed" else "USD → BTC",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.align(Alignment.Center)
@@ -229,7 +229,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Order")
+                    else Text("Confirm Conversion")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -247,24 +247,26 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Conversion Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your buy order has been confirmed.",
+                        "Your conversion has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Conversion Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your buy order is being processed. Balance will update when the payment confirms.",
+                        "Your conversion is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
                 Spacer(Modifier.height(16.dp))
-                Button(onClick = onDismiss) { Text("Done") }
+                if (isConfirmed) {
+                    Button(onClick = onDismiss) { Text("Done") }
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -77,7 +77,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                 }
             }
             Text(
-                text = if (step == TradeStep.CONFIRM) "Confirm Conversion" else if (step == TradeStep.DONE) "Conversion Confirmed" else "USD → BTC",
+                text = "USD → BTC",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.align(Alignment.Center)
@@ -229,7 +229,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Conversion")
+                    else Text("Confirm Order")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -247,19 +247,19 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Conversion Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your conversion has been confirmed.",
+                        "Your order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Conversion Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your conversion is being processed. Balance will update when the payment confirms.",
+                        "Your order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -78,7 +78,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                 }
             }
             Text(
-                text = if (step == TradeStep.CONFIRM) "Confirm Order" else if (step == TradeStep.DONE) "Order Confirmed" else "BTC → USD",
+                text = if (step == TradeStep.CONFIRM) "Confirm Conversion" else if (step == TradeStep.DONE) "Conversion Confirmed" else "BTC → USD",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.align(Alignment.Center)
@@ -231,7 +231,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Order")
+                    else Text("Confirm Conversion")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -249,24 +249,26 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Conversion Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your sell order has been confirmed.",
+                        "Your conversion has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Trade Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Conversion Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your sell order is being processed. Balance will update when the payment confirms.",
+                        "Your conversion is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
                 Spacer(Modifier.height(16.dp))
-                Button(onClick = onDismiss) { Text("Done") }
+                if (isConfirmed) {
+                    Button(onClick = onDismiss) { Text("Done") }
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -96,7 +96,16 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     Text("Amount (USD)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     TextButton(
                         onClick = { amountText = String.format(Locale.US, "%.2f", maxSellUSD) },
-                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                        colors = ButtonDefaults.textButtonColors(
+                            containerColor = if (isSystemInDarkTheme()) {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            } else {
+                                androidx.compose.ui.graphics.Color(0xFFE5E5EA)
+                            },
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
                     ) {
                         Text("Max", style = MaterialTheme.typography.labelMedium)
                     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -78,7 +78,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                 }
             }
             Text(
-                text = if (step == TradeStep.CONFIRM) "Confirm Conversion" else if (step == TradeStep.DONE) "Conversion Confirmed" else "BTC → USD",
+                text = "BTC → USD",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.align(Alignment.Center)
@@ -231,7 +231,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     if (isExecuting) CircularProgressIndicator(Modifier.size(20.dp))
-                    else Text("Confirm Conversion")
+                    else Text("Confirm Order")
                 }
                 Spacer(Modifier.height(8.dp))
                 TextButton(onClick = { step = TradeStep.AMOUNT }) { Text("Back") }
@@ -249,19 +249,19 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                         modifier = Modifier.size(48.dp)
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text("Conversion Confirmed", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Confirmed", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your conversion has been confirmed.",
+                        "Your order has been confirmed.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 } else {
                     CircularProgressIndicator(Modifier.size(48.dp))
                     Spacer(Modifier.height(8.dp))
-                    Text("Conversion Pending", style = MaterialTheme.typography.headlineMedium)
+                    Text("Order Pending", style = MaterialTheme.typography.headlineMedium)
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        "Your conversion is being processed. Balance will update when the payment confirms.",
+                        "Your order is being processed. Balance will update when the payment confirms.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stablechannels.app.AppState
-import com.stablechannels.app.models.PendingSplice
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
@@ -288,8 +287,13 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                 if (hasChannel) {
                                     if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
                                     val sc = appState.stableChannel.value
-                                    appState.pendingSplice = PendingSplice("out", sats, addr)
-                                    appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
+                                    appState.beginSpliceOut(sats, addr)
+                                    try {
+                                        appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
+                                    } catch (e: Exception) {
+                                        appState.cancelPendingSpliceStart()
+                                        throw e
+                                    }
                                     result = "Splice-out initiated for ${sats.satsFormatted()} sats."
                                     successTxid = null
                                 } else {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -57,6 +57,7 @@ enum class InputType { BOLT11, BOLT12, ONCHAIN, UNKNOWN }
 fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     var input by remember { mutableStateOf("") }
     var amountUSDStr by remember { mutableStateOf("") }
+    var isSendMax by remember { mutableStateOf(false) }
     var isSending by remember { mutableStateOf(false) }
     var result by remember { mutableStateOf<String?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
@@ -409,6 +410,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                 }
                             }
                             amountUSDStr = String.format(java.util.Locale.US, "%.2f", maxUSD)
+                            isSendMax = true
                         },
                         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
                     ) {
@@ -426,7 +428,10 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                     Spacer(Modifier.width(2.dp))
                     BasicTextField(
                         value = amountUSDStr,
-                        onValueChange = { amountUSDStr = it.filter { c -> c.isDigit() || c == '.' } },
+                        onValueChange = { 
+                            amountUSDStr = it.filter { c -> c.isDigit() || c == '.' }
+                            isSendMax = false
+                        },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         textStyle = TextStyle(
                             fontSize = 44.sp,
@@ -552,7 +557,11 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
                                             result = "Splice-out initiated"
                                         } else {
-                                            val txid = appState.nodeService.sendOnchain(trimmed, sats)
+                                            val txid = if (isSendMax) {
+                                                appState.nodeService.sendAllOnchain(trimmed)
+                                            } else {
+                                                appState.nodeService.sendOnchain(trimmed, sats)
+                                            }
                                             appState.databaseService?.recordPayment(
                                                 paymentId = null, paymentType = "onchain",
                                                 direction = "sent", amountMsat = sats * 1000,

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -548,8 +548,13 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         if (hasChannel) {
                                             if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
                                             val sc = appState.stableChannel.value
-                                            appState.pendingSplice = com.stablechannels.app.models.PendingSplice("out", sats, trimmed)
-                                            appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
+                                            appState.beginSpliceOut(sats, trimmed)
+                                            try {
+                                                appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
+                                            } catch (e: Exception) {
+                                                appState.cancelPendingSpliceStart()
+                                                throw e
+                                            }
                                             result = "Splice-out initiated"
                                         } else {
                                             val txid = appState.nodeService.sendOnchain(trimmed, sats)

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -337,10 +337,12 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                 )
             }
             Spacer(Modifier.weight(1f))
-            Button(
-                onClick = onDismiss
-            ) {
-                Text("Done")
+            if (!isSending) {
+                Button(
+                    onClick = onDismiss
+                ) {
+                    Text("Done")
+                }
             }
         } else {
             // Loading indicator during photo QR extraction

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -30,8 +30,7 @@ enum Constants {
     static let privacyPolicyURL = "https://stablechannels.com/privacy.html"
 
     static func txExplorerLink(for txid: String) -> URL? {
-        let cleanTxid = txid.components(separatedBy: ":").first ?? txid
-        return URL(string: "\(txExplorerURL)/\(cleanTxid)")
+        URL(string: "\(txExplorerURL)/\(txid)")
     }
 
     static let defaultLSPPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -30,7 +30,8 @@ enum Constants {
     static let privacyPolicyURL = "https://stablechannels.com/privacy.html"
 
     static func txExplorerLink(for txid: String) -> URL? {
-        URL(string: "\(txExplorerURL)/\(txid)")
+        let cleanTxid = txid.components(separatedBy: ":").first ?? txid
+        return URL(string: "\(txExplorerURL)/\(cleanTxid)")
     }
 
     static let defaultLSPPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"


### PR DESCRIPTION
This PR addresses multiple race conditions, state persistence gaps, and UI parity issues on the Android client, and incorporates the latest backend locking/architecture from the `android-force-close` branch.

### 1. Swap Race Conditions & Edge Cases
* **Merged `android-force-close`:** Successfully integrated Tony's latest commits (up to `0ae5f9b`) and resolved merge conflicts in `AppState.kt`.
* **Splice Confirmation Monitor (Tony's Fix):** We dropped our initial UI workaround (`spliceJustCompleted`) and instead integrated Tony's `startSpliceConfirmationMonitor`. The UI now remains firmly locked in "Swap pending..." by actively checking `mempool.space` for the transaction to confirm on-chain, permanently fixing the "Swap Button Flicker".
* **Prevented False Swaps on Startup**: Tony's `resumePendingSpliceConfirmation()` correctly picks up pending splices from the DB on startup and resumes the monitor, completely preventing the deposit detector from firing on unconfirmed splice change outputs.
* **Fixed the `ChannelReady` Race**: Explicitly reordered `isSweeping = true` to run *before* `spliceInWithAll()` so that if the LDK `ChannelReady` event fires synchronously, it correctly sees the sweep in progress.
* **Made `isSweeping` Reactive**: Converted it to a `StateFlow` so the UI reacts instantly to the new splice monitor without waiting for the next 10-second polling cycle.
* **CRITICAL BACKEND FIX (isTxConfirmed API Check):** Fixed a severe bug where `isTxConfirmed` was passing the `txid` with the output index attached (e.g., `:0`) to the `mempool.space` API. This resulted in continuous `400 Bad Request` errors, which falsely convinced the monitor that the swap was unconfirmed forever. This bug was permanently locking the UI in a "Swap actively in progress" state and completely blocking all outgoing Sends with a false `IllegalStateException`.

### 2. Channel Close Behavior & State Retention
* **Channel Close State Restores**: `isChannelClosing` is now safely restored from the SQLite database (`getPendingChannelClosePaymentId()`) on startup, meaning the app will never "forget" that a channel is closing if you force-quit it.
* **Perfected the Close Loading Screen**: The "Closing channel..." loading spinner on the Channel screen accurately dismisses the *moment* LDK finalizes the channel close (without waiting for the on-chain confirmation), exactly matching iOS.
* **Corrected Home Screen Terminology**: Replaced the confusing "Deposit confirming..." text with "Channel closed - pending confirmation" for the unconfirmed funds returning from a closed channel.

### 3. General UI Parity & Security
* Disabled `allowBackup` in the Manifest to prevent OS-level wallet state corruption (merged gracefully with Tony's identical fix).
* Updated Max buttons to use the correct cancel button background style.
* Standardized the Swap button to the solid primary color.
* Fixed Dark Mode background colors and static terminology across trade/home screens to perfectly match iOS.
* Safely stripped index data (`:0`) from ALL `mempool.space` block explorer links across the Home Screen and Settings Screens to prevent broken URL 404s.
