### PR TITLE
Bound HTTP client timeouts (wallet, FCM push, REST client)

### DIFF
--- a/server/sc-rest-client/src/client.rs
+++ b/server/sc-rest-client/src/client.rs
@@ -91,6 +91,8 @@ impl LspRestClient {
 
 		let client = Client::builder()
 			.add_root_certificate(cert)
+			.connect_timeout(std::time::Duration::from_secs(10))
+			.timeout(std::time::Duration::from_secs(60))
 			.build()
 			.map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 

--- a/server/stable-channels-lsp/src/push/fcm.rs
+++ b/server/stable-channels-lsp/src/push/fcm.rs
@@ -71,7 +71,11 @@ impl FcmService {
             }
         });
 
-        match reqwest::Client::new()
+        let client = match http_client() {
+            Ok(c) => c,
+            Err(e) => { error!("[fcm] Failed to build HTTP client: {}", e); return; }
+        };
+        match client
             .post(&url)
             .bearer_auth(&access_token)
             .json(&body)
@@ -90,6 +94,14 @@ impl FcmService {
             Err(e) => error!("[fcm] Request failed: {}", e),
         }
     }
+}
+
+/// reqwest client with bounded connect + overall timeouts so a stalled FCM/OAuth endpoint can't hang the push task.
+fn http_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
 }
 
 async fn generate_access_token(creds: &FcmCredentials) -> Option<String> {
@@ -111,7 +123,7 @@ async fn generate_access_token(creds: &FcmCredentials) -> Option<String> {
     let key = jsonwebtoken::EncodingKey::from_rsa_pem(creds.private_key.as_bytes()).ok()?;
     let jwt = jsonwebtoken::encode(&header, &claims, &key).ok()?;
 
-    let client = reqwest::Client::new();
+    let client = http_client().ok()?;
     let resp = client
         .post("https://oauth2.googleapis.com/token")
         .form(&[

--- a/src/price_feeds.rs
+++ b/src/price_feeds.rs
@@ -82,6 +82,14 @@ pub fn set_price_feeds() -> Vec<PriceFeed> {
     get_default_price_feeds()
 }
 
+/// ureq agent with bounded connect + overall timeouts so a hung/geo-blocked endpoint can't stall the caller.
+pub fn bounded_agent() -> Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+}
+
 pub fn fetch_prices(
     agent: &Agent,
     price_feeds: &[PriceFeed],

--- a/src/user.rs
+++ b/src/user.rs
@@ -727,7 +727,12 @@ impl UserApp {
 
             loop {
                 // Fetch price (network call) OUTSIDE of lock
-                let price = match stable_channels::price_feeds::get_latest_price(&ureq::Agent::new())
+                // Bounded timeouts so a geo-blocked/hanging price feed can't freeze this loop.
+                let price_agent = ureq::AgentBuilder::new()
+                    .timeout_connect(Duration::from_secs(5))
+                    .timeout(Duration::from_secs(10))
+                    .build();
+                let price = match stable_channels::price_feeds::get_latest_price(&price_agent)
                 {
                     Ok(p) if p > 0.0 => p,
                     _ => stable_channels::price_feeds::get_cached_price(),
@@ -2919,7 +2924,7 @@ impl UserApp {
     fn lookup_funding_output_sats_esplora(txid: &str, vout: u32) -> Option<u64> {
         let url = format!("{}/tx/{}", DEFAULT_CHAIN_URL, txid);
 
-        let response = ureq::Agent::new().get(&url).call().ok()?;
+        let response = stable_channels::price_feeds::bounded_agent().get(&url).call().ok()?;
 
         let json: serde_json::Value = response.into_json().ok()?;
         let vouts = json["vout"].as_array()?;
@@ -3247,7 +3252,7 @@ impl UserApp {
     /// Fetch daily OHLC data from Kraken API (up to 720 days)
     fn fetch_kraken_daily_data(&mut self) {
         println!("[Chart] Fetching Kraken OHLC data...");
-        let agent = ureq::Agent::new();
+        let agent = stable_channels::price_feeds::bounded_agent();
 
         // Fetch without 'since' to get the most recent 720 days
         match stable_channels::price_feeds::fetch_kraken_ohlc(&agent, None) {
@@ -3288,7 +3293,7 @@ impl UserApp {
             "[Chart] Backfilling intraday prices from Kraken (have {} points)...",
             existing.len()
         );
-        let agent = ureq::Agent::new();
+        let agent = stable_channels::price_feeds::bounded_agent();
         match stable_channels::price_feeds::fetch_kraken_intraday(&agent) {
             Ok(prices) => {
                 // Build a set of existing timestamps (rounded to nearest minute) to avoid dupes
@@ -3390,7 +3395,7 @@ impl UserApp {
         let db = self.db.clone();
 
         std::thread::spawn(move || {
-            let agent = ureq::Agent::new();
+            let agent = stable_channels::price_feeds::bounded_agent();
             match stable_channels::price_feeds::fetch_kraken_ohlc(&agent, since) {
                 Ok(prices) => {
                     for (date, open, high, low, close, volume) in prices {
@@ -4450,8 +4455,11 @@ impl UserApp {
                         // Force a fresh price fetch in the background, then
                         // refresh balances from LDK + recompute USD values.
                         std::thread::spawn(|| {
-                            let _ =
-                                stable_channels::price_feeds::get_latest_price(&ureq::Agent::new());
+                            let agent = ureq::AgentBuilder::new()
+                                .timeout_connect(Duration::from_secs(5))
+                                .timeout(Duration::from_secs(10))
+                                .build();
+                            let _ = stable_channels::price_feeds::get_latest_price(&agent);
                         });
                         self.update_balances();
                         self.show_toast("Refreshing…", "~");
@@ -8716,7 +8724,7 @@ impl UserApp {
         self.fee_rate_receiver = Some(rx);
 
         std::thread::spawn(move || {
-            let agent = ureq::Agent::new();
+            let agent = stable_channels::price_feeds::bounded_agent();
             let url = format!("{}/fee-estimates", DEFAULT_CHAIN_URL);
             if let Ok(response) = agent.get(&url).call() {
                 if let Ok(json) = response.into_json::<serde_json::Value>() {


### PR DESCRIPTION
`ureq::Agent::new()` and reqwest's default client build with no timeout, so a hung/geo-blocked endpoint blocks forever. This is what froze the wallet's stability tick when a price feed stopped responding (geo-blocked Bitstamp), the fetch never returned, so the loop never ticked.

Adds bounded connect + overall timeouts to every live HTTP client:

- Wallet (price_feeds.rs, user.rs): new shared bounded_agent() (5s connect / 15s) for the esplora + Kraken chart/fee fetches; the per-tick price agents keep their tighter 5s/10s.
- Daemon FCM push (fcm.rs): new http_client() helper (10s / 20s) for both the push send and the OAuth token request.
- REST client (sc-rest-client): 10s connect / 60s on the client builder.