### PR TITLE
Gate GUI deps behind a gui feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.9.0"
 edition = "2021"
 
 [features]
-default = []
+default = ["gui"]
+gui = ["dep:eframe", "dep:egui", "dep:egui_extras", "dep:qrcode", "dep:image"]
 user = []
 lsp = []
 exchange = []
@@ -28,12 +29,12 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 zip = "0.6"
 openssl = { version = "0.10", default-features = false, features = ["vendored"] }
 
-# GUI dependencies
-eframe = { version = "0.31.0" }
-egui = { version = "0.31.0", default-features = false, features = ["default_fonts", "color-hex"] }
-egui_extras = { version = "0.31.0", features = ["default"] }
-qrcode = { version = "0.14" }
-image = { version = "0.24" }
+# GUI dependencies (optional), gated behind the `gui` feature so headless consumers (the LSP daemon) skip the egui stack
+eframe = { version = "0.31.0", optional = true }
+egui = { version = "0.31.0", default-features = false, features = ["default_fonts", "color-hex"], optional = true }
+egui_extras = { version = "0.31.0", features = ["default"], optional = true }
+qrcode = { version = "0.14", optional = true }
+image = { version = "0.24", optional = true }
 
 # backend HTTP API stack 
 anyhow = "1.0"

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # Workspace crates
-stable-channels   = { path = "../.." }
+stable-channels   = { path = "../..", default-features = false }
 sc-protos         = { path = "../sc-protos" }
 ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev = "0e4434d7083ae9926c73f26e7cd52f00bde44d37", features = ["serde"], default-features = false }
 # ldk-node is pulled transitively by stable-channels but we need it as a direct


### PR DESCRIPTION
The headless LSP daemon pulled in the entire desktop GUI stack `(eframe/egui/winit/glow/image/qrcode)` because the root stable-channels crate's GUI deps were non-optional.

Fix (manifest-only):
- Mark those 5 deps optional, gated behind a new gui feature (kept in default, so the wallet is unaffected).
- Daemon depends on stable-channels with default-features = false.

The lib is GUI-free, only the wallet bin uses egui, so nothing needed `#[cfg]` gating.

Verified with from-scratch builds:
- cargo build -p stable-channels-lsp -> 0 GUI crates (108 fewer crates total).
- cargo build --bin stable-channels -> still builds with egui.