### PR TITLE
feat(android): UI Polish, Explorer Links, and Status Capsule Updates

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1511,8 +1511,7 @@ class AppState(private val context: Context) : ViewModel() {
         // Clear closing flag once lightning balance fully resolves, or if a new channel is opened
         // Don't clear pendingClosePaymentId here — let detectOnchainDeposit()
         // handle it when the on-chain funds arrive
-        val isOpeningChannel = _stableChannel.value.userChannelId.isNotEmpty() && !hasReady
-        if (isChannelClosing && (lightning == 0L || hasReady || isOpeningChannel)) {
+        if (isChannelClosing && lightning == 0L) {
             isChannelClosing = false
         }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -76,9 +76,15 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _totalBalanceSats: MutableStateFlow<Long>
     val totalBalanceSats: StateFlow<Long> get() = _totalBalanceSats
-
     private val _hasReadyChannel = MutableStateFlow(false)
     val hasReadyChannel: StateFlow<Boolean> get() = _hasReadyChannel
+
+    private val _onchainReceiveAddress = MutableStateFlow<String?>(null)
+    val onchainReceiveAddress: StateFlow<String?> get() = _onchainReceiveAddress
+
+    private val _lastReceiveTxid = MutableStateFlow<String?>(null)
+    val lastReceiveTxid: StateFlow<String?> get() = _lastReceiveTxid
+
 
     private val _spendableOnchainSats = MutableStateFlow(0L)
     val spendableOnchainSats: StateFlow<Long> get() = _spendableOnchainSats
@@ -93,7 +99,10 @@ class AppState(private val context: Context) : ViewModel() {
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
         _totalBalanceSats = MutableStateFlow(cachedLightning + cachedOnchain)
-        _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
+                _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
+        _onchainReceiveAddress.value = prefs.getString("onchain_receive_address", null)
+        _lastReceiveTxid.value = prefs.getString("last_receive_txid", null)
+
 
         // Restore cached channel state so UI shows correct slider position immediately
         val cachedChannelId = prefs.getString("cached_channel_id", null)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -85,6 +85,22 @@ class AppState(private val context: Context) : ViewModel() {
     private val _lastReceiveTxid = MutableStateFlow<String?>(null)
     val lastReceiveTxid: StateFlow<String?> get() = _lastReceiveTxid
 
+    private val _lastCloseTxid = MutableStateFlow<String?>(null)
+    val lastCloseTxid: StateFlow<String?> get() = _lastCloseTxid
+
+    fun setLastCloseTxid(txid: String?) {
+        _lastCloseTxid.value = txid
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        if (txid != null) {
+            editor.putString("last_close_txid", txid)
+            editor.putLong("last_close_txid_at", System.currentTimeMillis())
+        } else {
+            editor.remove("last_close_txid")
+            editor.remove("last_close_txid_at")
+        }
+        editor.apply()
+    }
+
 
     private val _spendableOnchainSats = MutableStateFlow(
         context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).getLong("cached_spendable_sats", 0L)
@@ -104,6 +120,16 @@ class AppState(private val context: Context) : ViewModel() {
                 _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
         _onchainReceiveAddress.value = prefs.getString("onchain_receive_address", null)
         _lastReceiveTxid.value = prefs.getString("last_receive_txid", null)
+
+        val closeAt = prefs.getLong("last_close_txid_at", 0L)
+        if (System.currentTimeMillis() - closeAt < 7 * 86400 * 1000L) {
+            _lastCloseTxid.value = prefs.getString("last_close_txid", null)
+        } else {
+            prefs.edit()
+                .remove("last_close_txid")
+                .remove("last_close_txid_at")
+                .apply()
+        }
 
 
         // Restore cached channel state so UI shows correct slider position immediately
@@ -251,6 +277,12 @@ class AppState(private val context: Context) : ViewModel() {
                     if (pendingCloseId != null) {
                         pendingClosePaymentId = pendingCloseId
                         isChannelClosing = true
+                        if (_lastCloseTxid.value == null) {
+                            val dbTxid = databaseService?.getPaymentTxid(pendingCloseId)
+                            if (!dbTxid.isNullOrEmpty()) {
+                                setLastCloseTxid(dbTxid)
+                            }
+                        }
                     }
                     detectOnchainDeposit()
                     
@@ -966,6 +998,7 @@ class AppState(private val context: Context) : ViewModel() {
                     chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
                     onResolved = { _, txid ->
                         Log.d("AppState", "Close TX resolved: $txid")
+                        setLastCloseTxid(txid)
                     }
                 )
                 viewModelScope.launch(Dispatchers.IO) {
@@ -1247,12 +1280,15 @@ class AppState(private val context: Context) : ViewModel() {
             // Attempt to resolve txid if we have an address but no txid yet (handles app restarts)
             val address = _onchainReceiveAddress.value
             if (address != null && _lastReceiveTxid.value == null) {
-                val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
-                val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
-                if (txid != null) {
-                    _lastReceiveTxid.value = txid
-                    context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                        .putString("last_receive_txid", txid).apply()
+                // Run txid resolution in the background so it doesn't block the polling loop
+                launch {
+                    val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
+                    val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
+                    if (txid != null) {
+                        _lastReceiveTxid.value = txid
+                        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+                            .putString("last_receive_txid", txid).apply()
+                    }
                 }
             }
 
@@ -1433,10 +1469,11 @@ class AppState(private val context: Context) : ViewModel() {
         _spendableOnchainSats.value = spendable
 
 
-        // Clear closing flag once lightning balance fully resolves
+        // Clear closing flag once lightning balance fully resolves, or if a new channel is opened
         // Don't clear pendingClosePaymentId here — let detectOnchainDeposit()
         // handle it when the on-chain funds arrive
-        if (isChannelClosing && lightning == 0L) {
+        val isOpeningChannel = _stableChannel.value.userChannelId.isNotEmpty() && !hasReady
+        if (isChannelClosing && (lightning == 0L || hasReady || isOpeningChannel)) {
             isChannelClosing = false
         }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -281,6 +281,26 @@ class AppState(private val context: Context) : ViewModel() {
                             val dbTxid = databaseService?.getPaymentTxid(pendingCloseId)
                             if (!dbTxid.isNullOrEmpty()) {
                                 setLastCloseTxid(dbTxid)
+                            } else {
+                                // Resume background resolver if it hasn't found the TX yet
+                                val closeFundingTxid = fundingTxid
+                                if (closeFundingTxid != null && databaseService != null) {
+                                    val resolver = CloseTxidResolver(
+                                        chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
+                                        onResolved = { _, txid ->
+                                            Log.d("AppState", "Close TX resolved on restart: $txid")
+                                            setLastCloseTxid(txid)
+                                        }
+                                    )
+                                    viewModelScope.launch(Dispatchers.IO) {
+                                        resolver.resolve(
+                                            paymentId = pendingCloseId,
+                                            fundingTxid = closeFundingTxid,
+                                            vout = 0,
+                                            databaseService = databaseService!!
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -992,8 +1012,14 @@ class AppState(private val context: Context) : ViewModel() {
             )
 
             // Start background resolver to find the close TX
+            // Fall back to the prefs-persisted value in case in-memory fundingTxid raced to null
             val closeFundingTxid = fundingTxid
+                ?: context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
+                    .getString("closing_funding_txid", null)
             if (closeFundingTxid != null && databaseService != null) {
+                // Clear the pref now that we've consumed it
+                context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
+                    .edit().remove("closing_funding_txid").apply()
                 val resolver = CloseTxidResolver(
                     chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
                     onResolved = { _, txid ->
@@ -1462,6 +1488,19 @@ class AppState(private val context: Context) : ViewModel() {
         val lightning = balances.totalLightningBalanceSats.toLong()
         val onchain = balances.totalOnchainBalanceSats.toLong()
         val hasReady = nodeService.channels.any { it.isChannelReady }
+
+        // Sync fundingTxid directly from the LDK node's channel details
+        // to gracefully handle out-of-band splices (e.g. LSP-initiated)
+        val channel = nodeService.channels.firstOrNull()
+        if (channel != null) {
+            val txo = channel.fundingTxo
+            if (txo != null) {
+                val currentTxid = txo.txid
+                if (currentTxid != null && currentTxid != fundingTxid) {
+                    fundingTxid = currentTxid
+                }
+            }
+        }
         _lightningBalanceSats.value = lightning
         _onchainBalanceSats.value = onchain
         _hasReadyChannel.value = hasReady

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -86,8 +86,10 @@ class AppState(private val context: Context) : ViewModel() {
     val lastReceiveTxid: StateFlow<String?> get() = _lastReceiveTxid
 
 
-    private val _spendableOnchainSats = MutableStateFlow(0L)
-    val spendableOnchainSats: StateFlow<Long> get() = _spendableOnchainSats
+    private val _spendableOnchainSats = MutableStateFlow(
+        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).getLong("cached_spendable_sats", 0L)
+    )
+    val spendableOnchainSats: StateFlow<Long> = _spendableOnchainSats
 
     private val _nativeSats: MutableStateFlow<Long>
     val nativeSats: StateFlow<Long> get() = _nativeSats
@@ -251,6 +253,12 @@ class AppState(private val context: Context) : ViewModel() {
                         isChannelClosing = true
                     }
                     detectOnchainDeposit()
+                    
+                    // Resume pending deposit polling if an unconfirmed deposit exists from a previous session
+                    if (_onchainBalanceSats.value > 0L && _spendableOnchainSats.value == 0L) {
+                        startPendingDepositPolling()
+                    }
+                    
                     reregisterPushTokenIfNeeded()
                     processPendingPushPayment()
                     startStabilityTimer()
@@ -1236,9 +1244,31 @@ class AppState(private val context: Context) : ViewModel() {
     private fun startPendingDepositPolling() {
         pendingDepositJob?.cancel()
         pendingDepositJob = viewModelScope.launch(Dispatchers.IO) {
+            // Attempt to resolve txid if we have an address but no txid yet (handles app restarts)
+            val address = _onchainReceiveAddress.value
+            if (address != null && _lastReceiveTxid.value == null) {
+                val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
+                val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
+                if (txid != null) {
+                    _lastReceiveTxid.value = txid
+                    context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+                        .putString("last_receive_txid", txid).apply()
+                }
+            }
+
             while (isActive && _spendableOnchainSats.value == 0L && _onchainBalanceSats.value > 0) {
                 delay(10_000)
                 refreshBalances()
+            }
+            
+            // Deposit confirmed — aggressively clear stale txid and address from state and cache
+            if (isActive && _spendableOnchainSats.value > 0L) {
+                _lastReceiveTxid.value = null
+                _onchainReceiveAddress.value = null
+                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+                    .remove("last_receive_txid")
+                    .remove("onchain_receive_address")
+                    .apply()
             }
         }
     }
@@ -1431,6 +1461,7 @@ class AppState(private val context: Context) : ViewModel() {
         context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
             .putLong("cached_lightning_sats", lightning)
             .putLong("cached_onchain_sats", onchain)
+            .putLong("cached_spendable_sats", spendable)
             .putLong("cached_native_sats", native)
             .apply()
     }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -150,7 +150,6 @@ class AppState(private val context: Context) : ViewModel() {
     private val _paymentFlash = MutableStateFlow(false)
     val paymentFlash: StateFlow<Boolean> = _paymentFlash
 
-    var onchainReceiveAddress: String? = null
 
     private val _isSpliceInFlight = MutableStateFlow(false)
     val isSpliceInFlightFlow: StateFlow<Boolean> get() = _isSpliceInFlight
@@ -1370,6 +1369,24 @@ class AppState(private val context: Context) : ViewModel() {
             node.connect(Constants.DEFAULT_LSP_PUBKEY, Constants.DEFAULT_LSP_ADDRESS, true)
         } catch (e: Exception) {
             AuditService.log("LSP_CONNECT_FAILED", mapOf("error" to (e.message ?: "")))
+        }
+    }
+
+    fun setOnchainReceiveAddress(address: String?) {
+        if (address == null) return
+        _onchainReceiveAddress.value = address
+        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+            .putString("onchain_receive_address", address).apply()
+        
+        // Start polling for this address to be hit
+        viewModelScope.launch {
+            val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
+            val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
+            if (txid != null) {
+                _lastReceiveTxid.value = txid
+                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+                    .putString("last_receive_txid", txid).apply()
+            }
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -20,6 +20,9 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 import kotlin.math.roundToLong
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.TimeoutCancellationException
 
 class StabilityProcessingService : Service() {
 
@@ -243,7 +246,11 @@ class StabilityProcessingService : Service() {
 
         while (System.currentTimeMillis() < deadline) {
             try {
-                val event = node.nextEvent()
+                val event = try {
+                    runBlocking { withTimeout(1000L) { node.nextEventAsync() } }
+                } catch (e: TimeoutCancellationException) {
+                    continue
+                }
                 when (event) {
                     is Event.PaymentReceived -> {
                         Log.d(TAG, "Payment received: ${event.amountMsat} msat")
@@ -408,7 +415,11 @@ class StabilityProcessingService : Service() {
 
         while (System.currentTimeMillis() < deadline) {
             try {
-                val event = node.nextEvent()
+                val event = try {
+                    runBlocking { withTimeout(1000L) { node.nextEventAsync() } }
+                } catch (e: TimeoutCancellationException) {
+                    continue
+                }
                 when (event) {
                     is Event.PaymentReceived -> {
                         Log.d(TAG, "Payment received: ${event.amountMsat} msat")

--- a/android/app/src/main/java/com/stablechannels/app/services/CloseTxidResolver.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/CloseTxidResolver.kt
@@ -73,18 +73,16 @@ class CloseTxidResolver(
             try {
                 val url = "${baseURL.trimEnd('/')}/tx/$fundingTxid/outspend/$vout"
                 val request = Request.Builder().url(url).build()
-                val response = client.newCall(request).execute()
-                val body = response.body?.string() ?: continue
-
-                if (!response.isSuccessful) continue
-
-                val json = JSONObject(body)
-                val spent = json.optBoolean("spent", false)
-
-                if (spent) {
-                    val txid = json.optString("txid", "")
-                    if (txid.isNotEmpty() && isValidTxid(txid)) {
-                        return txid
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val json = JSONObject(body)
+                    val spent = json.optBoolean("spent", false)
+                    if (spent) {
+                        val txid = json.optString("txid", "")
+                        if (txid.isNotEmpty() && isValidTxid(txid)) {
+                            return txid
+                        }
                     }
                 }
             } catch (e: Exception) {

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -508,6 +508,14 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         return cursor.use { if (it.moveToFirst()) it.getString(0) else null }
     }
 
+    fun getPaymentTxid(paymentId: String): String? {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT txid FROM payments WHERE payment_id = ?",
+            arrayOf(paymentId)
+        )
+        return cursor.use { if (it.moveToFirst()) it.getString(0) else null }
+    }
+
     fun setPendingSpliceTxid(txid: String) {
         writableDatabase.execSQL(
             "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'splice_in' AND status IN ('pending','failed') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)",

--- a/android/app/src/main/java/com/stablechannels/app/services/OnchainTxidResolver.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/OnchainTxidResolver.kt
@@ -1,0 +1,61 @@
+package com.stablechannels.app.services
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import java.util.concurrent.TimeUnit
+
+object OnchainTxidResolver {
+
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build()
+
+    /**
+     * Polls the block explorer for a transaction hitting the specified address.
+     * Searches both mempool and chain endpoints. Retries with exponential backoff.
+     */
+    suspend fun resolve(address: String, chainUrl: String): String? {
+        return withContext(Dispatchers.IO) {
+            val backoffs = listOf(2L, 8L, 30L, 60L, 120L, 300L)
+            
+            for (delaySecs in backoffs) {
+                delay(delaySecs * 1000)
+                
+                val baseUrl = chainUrl.trimEnd('/')
+                val endpoints = listOf(
+                    "$baseUrl/address/$address/txs/chain",
+                    "$baseUrl/address/$address/txs/mempool"
+                )
+                
+                for (url in endpoints) {
+                    try {
+                        val request = Request.Builder().url(url).build()
+                        val response = httpClient.newCall(request).execute()
+                        
+                        if (response.isSuccessful) {
+                            val bodyStr = response.body?.string()
+                            if (!bodyStr.isNullOrBlank()) {
+                                val jsonArray = JSONArray(bodyStr)
+                                if (jsonArray.length() > 0) {
+                                    val firstTx = jsonArray.getJSONObject(0)
+                                    val txid = firstTx.optString("txid")
+                                    if (txid.isNotBlank()) {
+                                        return@withContext txid
+                                    }
+                                }
+                            }
+                        }
+                    } catch (e: Exception) {
+                        // Ignore network/parsing errors, try next endpoint/iteration
+                    }
+                }
+            }
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/OnchainTxidResolver.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/OnchainTxidResolver.kt
@@ -35,17 +35,17 @@ object OnchainTxidResolver {
                 for (url in endpoints) {
                     try {
                         val request = Request.Builder().url(url).build()
-                        val response = httpClient.newCall(request).execute()
-                        
-                        if (response.isSuccessful) {
-                            val bodyStr = response.body?.string()
-                            if (!bodyStr.isNullOrBlank()) {
-                                val jsonArray = JSONArray(bodyStr)
-                                if (jsonArray.length() > 0) {
-                                    val firstTx = jsonArray.getJSONObject(0)
-                                    val txid = firstTx.optString("txid")
-                                    if (txid.isNotBlank()) {
-                                        return@withContext txid
+                        httpClient.newCall(request).execute().use { response ->
+                            if (response.isSuccessful) {
+                                val bodyStr = response.body?.string()
+                                if (!bodyStr.isNullOrBlank()) {
+                                    val jsonArray = JSONArray(bodyStr)
+                                    if (jsonArray.length() > 0) {
+                                        val firstTx = jsonArray.getJSONObject(0)
+                                        val txid = firstTx.optString("txid")
+                                        if (txid.isNotBlank()) {
+                                            return@withContext txid
+                                        }
                                     }
                                 }
                             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/components/StatusCapsule.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/StatusCapsule.kt
@@ -22,7 +22,8 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun StatusCapsule(
     message: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null
 ) {
     AnimatedVisibility(
         visible = message.isNotEmpty(),
@@ -39,7 +40,9 @@ fun StatusCapsule(
         Surface(
             shape = RoundedCornerShape(50),
             tonalElevation = 3.dp,
-            color = MaterialTheme.colorScheme.surface
+            color = MaterialTheme.colorScheme.surface,
+            onClick = { onClick?.invoke() },
+            modifier = if (onClick != null) Modifier else Modifier
         ) {
             Text(
                 text = message,

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -15,6 +15,9 @@ import com.stablechannels.app.util.shortString
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.isSystemInDarkTheme
 import com.stablechannels.app.util.Constants
+import androidx.compose.ui.platform.LocalContext
+import android.content.Intent
+import android.net.Uri
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -123,6 +126,20 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         val displayTxid = if (txid.length > 16) txid.take(8) + "..." + txid.takeLast(8) else txid
                         CopyableDetailRow("TXID", displayTxid, txid)
+                        val context = LocalContext.current
+                        val onchainTypes = setOf("channel_close", "onchain", "splice_in", "splice_out")
+                        if (payment.paymentType in onchainTypes) {
+                            TextButton(
+                                onClick = {
+                                    val cleanTxid = txid.substringBefore(":")
+                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://mempool.space/tx/$cleanTxid"))
+                                    context.startActivity(intent)
+                                },
+                                contentPadding = PaddingValues(0.dp)
+                            ) {
+                                Text("View on explorer", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
                     }
                     
                     payment.address?.let { addr ->

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
@@ -52,6 +52,7 @@ fun BalanceBar(
     nativeSats: Long,
     totalSats: Long,
     btcPrice: Double,
+    showBtcFormat: Boolean = false,
     modifier: Modifier = Modifier,
     onDragStarted: (() -> Unit)? = null,
     onTradeRequest: ((TradeDirection, Double) -> Unit)? = null
@@ -265,13 +266,14 @@ fun BalanceBar(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             // Left: USD label + amount
+            val stableSats = if (btcPrice > 0) (stableUSD / btcPrice * Constants.SATS_IN_BTC).toLong() else 0L
             Column {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     Icon(Icons.Default.Shield, contentDescription = null, tint = stableColor, modifier = Modifier.size(12.dp))
                     Text("USD", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = stableColor)
                 }
                 Text(
-                    stableUSD.usdFormatted(),
+                    if (showBtcFormat) stableSats.btcSpacedFormatted() else stableUSD.usdFormatted(),
                     style = MaterialTheme.typography.labelSmall,
                     color = if (btcPrice > 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -284,7 +286,8 @@ fun BalanceBar(
                     Icon(Icons.Default.CurrencyBitcoin, contentDescription = null, tint = nativeColor, modifier = Modifier.size(12.dp))
                 }
                 Text(
-                    if (btcPrice > 0) nativeUSD.usdFormatted() else "...",
+                    if (showBtcFormat) nativeSats.btcSpacedFormatted()
+                    else if (btcPrice > 0) nativeUSD.usdFormatted() else "...",
                     style = MaterialTheme.typography.labelSmall,
                     color = if (btcPrice > 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
@@ -59,8 +59,8 @@ fun BalanceBar(
 
     val stableFraction = (stableUSD / totalUSD).coerceIn(0.0, 1.0).toFloat()
     val interactive = onTradeRequest != null
-    val barHeight = if (interactive) 20.dp else 12.dp
-    val thumbDiameter = 28.dp
+    val barHeight = if (interactive) 12.dp else 8.dp
+    val thumbDiameter = 22.dp
     val minTradeUSD = 1.0
 
     var barWidthPx by remember { mutableFloatStateOf(0f) }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/BalanceBar.kt
@@ -14,6 +14,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
@@ -224,20 +227,33 @@ fun BalanceBar(
 
                 // Percentage label while dragging
                 if (isDragging) {
-                    Box(
-                        modifier = Modifier
-                            .offset(x = thumbOffsetDp - 30.dp, y = (-34).dp)
-                            .background(
-                                MaterialTheme.colorScheme.surfaceVariant,
-                                RoundedCornerShape(12.dp)
-                            )
-                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    val barWidthDp = with(density) { barWidthPx.toDp() }
+                    val labelWidth = 105.dp
+                    val labelX = (thumbOffsetDp - (labelWidth / 2) + (thumbDiameter / 2))
+                        .coerceIn(0.dp, maxOf(0.dp, barWidthDp - labelWidth))
+
+                    val xPx = with(density) { labelX.roundToPx() }
+                    val yPx = with(density) { (-40).dp.roundToPx() }
+
+                    Popup(
+                        alignment = Alignment.TopStart,
+                        offset = IntOffset(xPx, yPx),
+                        properties = PopupProperties(clippingEnabled = false)
                     ) {
-                        Text(
-                            "$usdPct% USD  $btcPct% BTC",
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Bold
-                        )
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    MaterialTheme.colorScheme.surfaceVariant,
+                                    RoundedCornerShape(12.dp)
+                                )
+                                .padding(horizontal = 8.dp, vertical = 6.dp)
+                        ) {
+                            Text(
+                                "$usdPct% USD  $btcPct% BTC",
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/FundWalletScreen.kt
@@ -34,6 +34,7 @@ fun FundWalletScreen(appState: AppState, onBack: () -> Unit) {
     LaunchedEffect(Unit) {
         try {
             address = appState.nodeService.newOnchainAddress()
+            appState.setOnchainReceiveAddress(address)
         } catch (_: Exception) {}
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -390,7 +390,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             } else {
                                 "Deposit confirming..."
                             }
-                            PendingRow(text, lastRxTxid, context)
+                            PendingRow(text, if (pendingCloseId != null) null else lastRxTxid, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -280,6 +280,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     nativeSats = nativeSatsCached,
                     totalSats = lightningSats,
                     btcPrice = btcPrice,
+                    showBtcFormat = showBTC,
                     modifier = Modifier.padding(horizontal = 18.dp),
                     onDragStarted = { appState.ensureLSPConnected() },
                     onTradeRequest = if (hasReadyChannel) { direction, amountUSD ->
@@ -342,23 +343,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         } else if (isChannelClosing) {
                             // 2. Channel closing
                             Spacer(Modifier.height(8.dp))
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Icon(
-                                    Icons.Default.Warning,
-                                    contentDescription = "Closing",
-                                    tint = Color(0xFFF59E0B),
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(Modifier.width(6.dp))
-                                Text(
-                                    "Channel closing — funds will arrive onchain",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+                            PendingRow("Channel closing\u2026", lastCloseTxid, context)
                         } else if (hasReadyChannel && spendableOnchainSats > 0) {
                             // Has channel + confirmed funds — offer to sweep
                             Spacer(Modifier.height(8.dp))
@@ -379,19 +364,25 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                     },
                                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
                                 ) {
-                                    Text("Swap", fontSize = 13.sp)
+                                    Text("Move", fontSize = 13.sp)
                                 }
                             }
                         } else if (spendableOnchainSats == 0L) {
                             // 3. Unconfirmed deposit (with or without channel)
                             Spacer(Modifier.height(8.dp))
                             val pendingCloseId = appState.pendingClosePaymentId
-                            val text = if (pendingCloseId != null) {
-                                "Channel closed - pending confirmation"
-                            } else {
-                                "Deposit confirming..."
+                            // Prefer close txid if known — pendingClosePaymentId may already be
+                            // cleared by detectOnchainDeposit even while funds are still unconfirmed
+                            val effectiveTxid = lastCloseTxid ?: lastRxTxid
+                            val isClosePending = pendingCloseId != null || lastCloseTxid != null
+                            // Use short text when txid is known (button fits on same row, matches iOS)
+                            // Use longer text when no txid yet (shown as two-line subtitle)
+                            val text = when {
+                                isClosePending && effectiveTxid != null -> "Channel closing\u2026"
+                                isClosePending -> "Channel closed"
+                                else -> "Deposit confirming..."
                             }
-                            PendingRow(text, if (pendingCloseId != null) lastCloseTxid else lastRxTxid, context)
+                            PendingRow(text, effectiveTxid, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,
@@ -688,23 +679,36 @@ fun ActionButton(title: String, icon: ImageVector, color: Color, modifier: Modif
 
 @Composable
 private fun PendingRow(text: String, txid: String?, context: android.content.Context) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Text("\u231B", fontSize = 14.sp)
-        Spacer(Modifier.width(6.dp))
-        Text(text, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Spacer(Modifier.weight(1f))
-        txid?.let {
+    if (txid != null) {
+        // Has txid — short text + button in one row (matches iOS layout)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("\u231B", fontSize = 14.sp)
+            Spacer(Modifier.width(6.dp))
+            Text(text, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(1f))
             TextButton(
                 onClick = {
-                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/${it.substringBefore(":")}"))
+                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/${txid.substringBefore(":")}"))
                     context.startActivity(intent)
                 },
-                contentPadding = PaddingValues(0.dp)
+                contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp)
             ) {
                 Text("View on explorer", fontSize = 12.sp)
+            }
+        }
+    } else {
+        // No txid yet — show text with "pending confirmation" below
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("\u231B", fontSize = 14.sp)
+            Spacer(Modifier.width(6.dp))
+            Column {
+                Text(text, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("pending confirmation", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f))
             }
         }
     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -71,6 +71,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val sc by appState.stableChannel.collectAsState()
     val nativeSatsCached by appState.nativeSats.collectAsState()
     val lastRxTxid by appState.lastReceiveTxid.collectAsState()
+    val lastCloseTxid by appState.lastCloseTxid.collectAsState()
     val statusMessage by appState.statusMessage.collectAsState()
     val onchainSats by appState.onchainBalanceSats.collectAsState()
     val hasReadyChannel by appState.hasReadyChannel.collectAsState()
@@ -390,7 +391,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             } else {
                                 "Deposit confirming..."
                             }
-                            PendingRow(text, if (pendingCloseId != null) null else lastRxTxid, context)
+                            PendingRow(text, if (pendingCloseId != null) lastCloseTxid else lastRxTxid, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -45,6 +45,10 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.PermissionChecker
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.stablechannels.app.models.TradeRecord
+import com.stablechannels.app.ui.history.OrderDetailBottomSheet
+import com.stablechannels.app.models.PaymentRecord
+import com.stablechannels.app.ui.history.PaymentDetailBottomSheet
 import com.stablechannels.app.AppState
 import com.stablechannels.app.ui.components.StatusCapsule
 import com.stablechannels.app.ui.trade.BuyScreen
@@ -76,6 +80,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val isChannelClosing by appState.isChannelClosingFlow.collectAsState()
 
     var showSend by remember { mutableStateOf(false) }
+    var selectedTrade by remember { mutableStateOf<TradeRecord?>(null) }
+    var selectedPayment by remember { mutableStateOf<PaymentRecord?>(null) }
     var showReceive by remember { mutableStateOf(false) }
     var showBuy by remember { mutableStateOf(false) }
     var showSell by remember { mutableStateOf(false) }
@@ -392,14 +398,13 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             }
                         } else {
                             // 4. No channel, confirmed deposit — just needs Lightning
-                            Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(4.dp))
                             Text("Receive over Lightning to create your Trading and Spending Account",
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 }
-                Spacer(Modifier.height(8.dp))
             }
 
             // Price chart
@@ -443,9 +448,31 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 
             // Status capsule
             if (statusMessage.isNotEmpty()) {
-                Spacer(Modifier.height(8.dp))
                 StatusCapsule(
-                    message = statusMessage
+                    message = statusMessage,
+                    onClick = {
+                        val msg = statusMessage.lowercase()
+                        val isTrade = msg.contains("buy") || msg.contains("sell") || msg.contains("trade") || msg.contains("order")
+                        val isPayment = msg.contains("payment") || msg.contains("swap") || msg.contains("channel") || msg.contains("moving")
+                        
+                        if (isTrade || isPayment) {
+                            scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                                if (isTrade) {
+                                    val trades = appState.databaseService?.getRecentTrades(1)
+                                    if (!trades.isNullOrEmpty()) {
+                                        selectedTrade = trades.first()
+                                    }
+                                } else {
+                                    val payments = appState.databaseService?.getRecentPayments(1)
+                                    if (!payments.isNullOrEmpty()) {
+                                        selectedPayment = payments.first()
+                                    }
+                                }
+                            }
+                        } else {
+                            appState.setStatus("")
+                        }
+                    }
                 )
             }
             // Bottom padding for nav bar
@@ -605,6 +632,17 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 SellScreen(appState, prefillAmountUSD = prefillTradeAmount) { showSell = false; prefillTradeAmount = 0.0 }
             }
         }
+    }
+
+    selectedTrade?.let { trade ->
+        OrderDetailBottomSheet(trade = trade, onDismiss = { selectedTrade = null })
+    }
+    selectedPayment?.let { payment ->
+        PaymentDetailBottomSheet(
+            payment = payment,
+            currentPrice = btcPrice,
+            onDismiss = { selectedPayment = null }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -338,15 +338,15 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         }
                         if (isSweeping) {
                             // 1. Splice-in in progress
-                            Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(4.dp))
                             PendingRow("Swap pending...", appState.spliceTxid, context)
                         } else if (isChannelClosing) {
                             // 2. Channel closing
-                            Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(4.dp))
                             PendingRow("Channel closing\u2026", lastCloseTxid, context)
                         } else if (hasReadyChannel && spendableOnchainSats > 0) {
                             // Has channel + confirmed funds — offer to sweep
-                            Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(4.dp))
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.SpaceBetween,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -66,6 +66,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val btcPrice by appState.priceService.currentPrice.collectAsState()
     val sc by appState.stableChannel.collectAsState()
     val nativeSatsCached by appState.nativeSats.collectAsState()
+    val lastRxTxid by appState.lastReceiveTxid.collectAsState()
     val statusMessage by appState.statusMessage.collectAsState()
     val onchainSats by appState.onchainBalanceSats.collectAsState()
     val hasReadyChannel by appState.hasReadyChannel.collectAsState()
@@ -151,7 +152,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(16.dp),
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // Title
@@ -314,7 +315,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
                     elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                 ) {
-                    Column(Modifier.padding(12.dp)) {
+                    Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -383,7 +384,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             } else {
                                 "Deposit confirming..."
                             }
-                            PendingRow(text, null, context)
+                            PendingRow(text, lastRxTxid, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,
@@ -398,7 +399,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                         }
                     }
                 }
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(8.dp))
             }
 
             // Price chart
@@ -408,7 +409,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     databaseService = appState.databaseService,
                     currentPrice = btcPrice
                 )
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(8.dp))
             }
 
             // Hint text when no channel
@@ -439,7 +440,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
 
             // Status capsule
             if (statusMessage.isNotEmpty()) {
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(8.dp))
                 StatusCapsule(
                     message = statusMessage
                 )
@@ -659,7 +660,7 @@ private fun PendingRow(text: String, txid: String?, context: android.content.Con
                     val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://mempool.space/tx/${it.substringBefore(":")}"))
                     context.startActivity(intent)
                 },
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)
+                contentPadding = PaddingValues(0.dp)
             ) {
                 Text("View on explorer", fontSize = 12.sp)
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -264,7 +264,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(8.dp))
 
             // Balance bar
             if (lightningSats > 0) {
@@ -273,14 +273,14 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     nativeSats = nativeSatsCached,
                     totalSats = lightningSats,
                     btcPrice = btcPrice,
-                    modifier = Modifier.padding(horizontal = 24.dp),
+                    modifier = Modifier.padding(horizontal = 18.dp),
                     onDragStarted = { appState.ensureLSPConnected() },
                     onTradeRequest = if (hasReadyChannel) { direction, amountUSD ->
                         prefillTradeAmount = amountUSD
                         if (direction == TradeDirection.BUY) showBuy = true else showSell = true
                     } else null
                 )
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(4.dp))
             }
 
             // Syncing indicator
@@ -315,7 +315,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
                     elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                 ) {
-                    Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                    Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -409,7 +409,6 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                     databaseService = appState.databaseService,
                     currentPrice = btcPrice
                 )
-                Spacer(Modifier.height(8.dp))
             }
 
             // Hint text when no channel
@@ -425,8 +424,10 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("Send", Icons.Default.ArrowCircleUp, Color(0xFF3B82F6), Modifier.weight(1f)) { showSend = true }
-                ActionButton("Receive", Icons.Default.ArrowCircleDown, Color(0xFF10B981), Modifier.weight(1f), pulse = !hasReadyChannel) { showReceive = true }
+                val sendColor = if (isSystemInDarkTheme()) Color(0xFF0A84FF) else Color(0xFF007AFF)
+                val receiveColor = if (isSystemInDarkTheme()) Color(0xFF30D158) else Color(0xFF34C759)
+                ActionButton("Send", Icons.Default.ArrowCircleUp, sendColor, Modifier.weight(1f)) { showSend = true }
+                ActionButton("Receive", Icons.Default.ArrowCircleDown, receiveColor, Modifier.weight(1f), pulse = !hasReadyChannel) { showReceive = true }
             }
 
             Spacer(Modifier.height(8.dp))
@@ -434,8 +435,10 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                ActionButton("USD → BTC", Icons.Default.ArrowCircleUp, Color(0xFFF59E0B), Modifier.weight(1f), rotation = 45f, enabled = hasReadyChannel) { showBuy = true }
-                ActionButton("BTC → USD", Icons.Default.ArrowCircleDown, Color(0xFF8B5CF6), Modifier.weight(1f), rotation = -45f, enabled = hasReadyChannel) { showSell = true }
+                val buyColor = if (isSystemInDarkTheme()) Color(0xFFFF9F0A) else Color(0xFFFF9500)
+                val sellColor = if (isSystemInDarkTheme()) Color(0xFFBF5AF2) else Color(0xFFAF52DE)
+                ActionButton("USD → BTC", Icons.Default.ArrowCircleUp, buyColor, Modifier.weight(1f), rotation = 45f, enabled = hasReadyChannel) { showBuy = true }
+                ActionButton("BTC → USD", Icons.Default.ArrowCircleDown, sellColor, Modifier.weight(1f), rotation = -45f, enabled = hasReadyChannel) { showSell = true }
             }
 
             // Status capsule

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -383,7 +383,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             } else {
                                 "Deposit confirming..."
                             }
-                            PendingRow(text, appState.fundingTxid, context)
+                            PendingRow(text, null, context)
                             if (!hasReadyChannel) {
                                 Text("Receive over Lightning to create your Trading and Spending Account",
                                     style = MaterialTheme.typography.labelSmall,

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -184,8 +184,6 @@ fun PriceChart(
                 }
             }
 
-            Spacer(Modifier.height(4.dp))
-
             // Period selector pills — scrollable
             Row(
                 modifier = Modifier

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/PriceChart.kt
@@ -128,7 +128,7 @@ fun PriceChart(
             containerColor = MaterialTheme.colorScheme.background
         )
     ) {
-        Column(Modifier.padding(16.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
             // Price header
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -184,7 +184,7 @@ fun PriceChart(
                 }
             }
 
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(4.dp))
 
             // Period selector pills — scrollable
             Row(
@@ -212,7 +212,7 @@ fun PriceChart(
                 }
             }
 
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(4.dp))
 
             if (priceHistory.size >= 2) {
                 val prices = priceHistory.map { it.price }

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -336,6 +336,17 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
                     appState.setLastCloseTxid(null) // Clear any previous close txid from cache
+                    // Snapshot the true fundingTxid NOW, while the channel still exists
+                    val liveTxid = appState.nodeService.channels
+                        .firstOrNull { it.userChannelId == sc.userChannelId || it.isChannelReady }
+                        ?.fundingTxo?.txid
+                    if (liveTxid != null) {
+                        appState.fundingTxid = liveTxid
+                        // Also persist to prefs so handleChannelClosed can recover it
+                        // even if the in-memory value is cleared by a race
+                        context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
+                            .edit().putString("closing_funding_txid", liveTxid).apply()
+                    }
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -335,6 +335,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                 TextButton(onClick = {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
+                    appState.setLastCloseTxid(null) // Clear any previous close txid from cache
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -171,7 +171,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                 Spacer(Modifier.height(16.dp))
                 Button(
                     onClick = {
-                        if (amountUSD <= 0 || amountUSD > maxSellUSD) {
+                        if (amountUSD <= 0 || amountUSD > maxSellUSD + 0.01) {
                             error = "Enter an amount between $0 and ${maxSellUSD.usdFormatted()}"
                         } else {
                             error = null


### PR DESCRIPTION
This PR introduces:
1. Reduced spacing across HomeScreen components (BalanceBar, PriceChart, etc.) for a more compact and modern aesthetic.
2. A completely robust draggable tooltip via a Compose Popup window to prevent clipping at the screen edges.
3. Smart routing for the Status Capsule to open either Trade or Payment Details depending on message context (including channel closes).
4. A new OnchainTxidResolver that automatically adds clickable Mempool.space explorer links to pending on-chain deposit cards.