### PR TITLE
Fee visibility: show trade + network fee estimates before payment

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1432,6 +1432,9 @@ class AppState(private val context: Context) : ViewModel() {
         return null
     }
 
+    /** Blocking fee-rate lookup for pre-send UI estimates. Call from Dispatchers.IO. */
+    fun currentFeeRateSatVb(): Long? = fetchFeeRate()
+
     /** Test Blockstream connectivity; fall back to mempool.space if unreachable. */
     private suspend fun resolveChainUrl(): String {
         return withContext(Dispatchers.IO) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -42,7 +42,8 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
     val btcPrice by appState.priceService.currentPrice.collectAsState()
     val maxBuyUSD = sc.expectedUSD.amount
     val amountUSD = amountText.toDoubleOrNull() ?: 0.0
-    val feeUSD = amountUSD * 0.01
+    val feeUSD = amountUSD * Constants.STABLE_CHANNEL_TRADE_FEE_RATE
+    val feeLabel = String.format(Locale.US, "Fee (%.0f%%)", Constants.STABLE_CHANNEL_TRADE_FEE_RATE * 100)
     val btcAmount = if (btcPrice > 0) (amountUSD - feeUSD) / btcPrice else 0.0
 
     Column(
@@ -190,7 +191,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     Column(modifier = Modifier.padding(16.dp)) {
                         ConfirmRow("Amount", amountUSD.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                        ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
+                        ConfirmRow(feeLabel, feeUSD.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         ConfirmRow("BTC Price", btcPrice.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -43,7 +43,8 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
     val nativeSatsDisplay = if (lightningSats > stableSats) lightningSats - stableSats else 0L
     val maxSellUSD = if (btcPrice > 0) (nativeSatsDisplay.toDouble() / Constants.SATS_IN_BTC) * btcPrice else 0.0
     val amountUSD = amountText.toDoubleOrNull() ?: 0.0
-    val feeUSD = amountUSD * 0.01
+    val feeUSD = amountUSD * Constants.STABLE_CHANNEL_TRADE_FEE_RATE
+    val feeLabel = String.format(Locale.US, "Fee (%.0f%%)", Constants.STABLE_CHANNEL_TRADE_FEE_RATE * 100)
     val btcAmount = if (btcPrice > 0) (amountUSD - feeUSD) / btcPrice else 0.0
 
     Column(
@@ -191,7 +192,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     Column(modifier = Modifier.padding(16.dp)) {
                         ConfirmRow("Amount", amountUSD.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                        ConfirmRow("Fee (1%)", feeUSD.usdFormatted())
+                        ConfirmRow(feeLabel, feeUSD.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         ConfirmRow("BTC Price", btcPrice.usdFormatted())
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -26,6 +26,7 @@ import com.stablechannels.app.util.usdFormatted
 import com.stablechannels.app.util.btcSpacedFormatted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
@@ -36,11 +37,21 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
     var result by remember { mutableStateOf<String?>(null) }
     var successTxid by remember { mutableStateOf<String?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
+    var feeRateSatVb by remember { mutableStateOf<Long?>(null) }
     val scope = rememberCoroutineScope()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
     val onchainSats by appState.onchainBalanceSats.collectAsState()
 
     val hasChannel = appState.nodeService.channels.any { it.isChannelReady }
+    val feeVbytes = if (sendAll) Constants.ESTIMATED_ONCHAIN_SEND_ALL_VBYTES else Constants.ESTIMATED_ONCHAIN_SEND_VBYTES
+    val feeEstimateText = feeRateSatVb?.let { rate ->
+        val feeSats = rate * feeVbytes
+        "Expected network fee: ~${feeSats.btcSpacedFormatted()} BTC ($rate sat/vB)"
+    } ?: "Estimating network fee..."
+
+    LaunchedEffect(Unit) {
+        feeRateSatVb = withContext(Dispatchers.IO) { appState.currentFeeRateSatVb() ?: 2L }
+    }
 
     Column(
         modifier = Modifier
@@ -253,6 +264,13 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                     )
                 }
             }
+
+            Spacer(Modifier.height(8.dp))
+            Text(
+                feeEstimateText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
             error?.let {
                 Spacer(Modifier.height(8.dp))

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.lightningdevkit.ldknode.Bolt11Invoice
 import org.lightningdevkit.ldknode.Offer
+import kotlin.math.ceil
+import kotlin.math.max
 
 enum class InputType { BOLT11, BOLT12, ONCHAIN, UNKNOWN }
 
@@ -63,6 +65,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     var error by remember { mutableStateOf<String?>(null) }
     var showScanner by remember { mutableStateOf(false) }
     var isExtractingQR by remember { mutableStateOf(false) }
+    var feeRateSatVb by remember { mutableStateOf<Long?>(null) }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val activity = context.findActivity()
@@ -124,6 +127,32 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
     }
 
     val displayUSD = if (btcPrice > 0 && displaySats > 0) (displaySats.toDouble() / Constants.SATS_IN_BTC) * btcPrice else null
+    val lightningFeeSats = if (displaySats > 0) {
+        max(ceil(displaySats * Constants.LIGHTNING_ROUTING_FEE_ESTIMATE_RATE).toLong(), 1L)
+    } else {
+        0L
+    }
+    val lightningFeeText = if (lightningFeeSats > 0) {
+        val feeUsd = if (btcPrice > 0) {
+            " (${((lightningFeeSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice).usdFormatted()})"
+        } else {
+            ""
+        }
+        "Expected fee: up to ${lightningFeeSats.btcSpacedFormatted()} BTC$feeUsd"
+    } else {
+        "Expected fee: up to 1%"
+    }
+    val onchainVbytes = if (isSendMax) Constants.ESTIMATED_ONCHAIN_SEND_ALL_VBYTES else Constants.ESTIMATED_ONCHAIN_SEND_VBYTES
+    val onchainFeeText = feeRateSatVb?.let { rate ->
+        val feeSats = rate * onchainVbytes
+        "Expected network fee: ~${feeSats.btcSpacedFormatted()} BTC ($rate sat/vB)"
+    } ?: "Estimating network fee..."
+
+    LaunchedEffect(inputType) {
+        if (inputType == InputType.ONCHAIN && feeRateSatVb == null) {
+            feeRateSatVb = withContext(Dispatchers.IO) { appState.currentFeeRateSatVb() ?: 2L }
+        }
+    }
 
     // Photo picker launcher for QR extraction (Task 7.4)
     val photoPickerLauncher = rememberLauncherForActivityResult(
@@ -386,6 +415,12 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    lightningFeeText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
 
             // Amount input (USD) — for amountless bolt11, bolt12, onchain
@@ -468,6 +503,12 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                     Spacer(Modifier.height(4.dp))
                     Text(
                         manualAmountSats.btcSpacedFormatted(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        if (inputType == InputType.ONCHAIN) onchainFeeText else lightningFeeText,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -50,8 +50,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.lightningdevkit.ldknode.Bolt11Invoice
 import org.lightningdevkit.ldknode.Offer
-import kotlin.math.ceil
-import kotlin.math.max
 
 enum class InputType { BOLT11, BOLT12, ONCHAIN, UNKNOWN }
 
@@ -125,22 +123,45 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
         InputType.BOLT12, InputType.ONCHAIN -> manualAmountSats
         InputType.UNKNOWN -> 0
     }
+    fun saturatingMultiply(lhs: Long, rhs: Long): Long {
+        if (lhs <= 0L || rhs <= 0L) return 0L
+        return if (lhs > Long.MAX_VALUE / rhs) Long.MAX_VALUE else lhs * rhs
+    }
+
+    fun saturatingAdd(lhs: Long, rhs: Long): Long {
+        if (lhs >= Long.MAX_VALUE - rhs) return Long.MAX_VALUE
+        return lhs + rhs
+    }
 
     val displayUSD = if (btcPrice > 0 && displaySats > 0) (displaySats.toDouble() / Constants.SATS_IN_BTC) * btcPrice else null
+    val forwardingChannel = appState.nodeService.channels.firstOrNull { it.isChannelReady }
+    val forwardingFeeBaseMsat = forwardingChannel
+        ?.counterpartyForwardingInfoFeeBaseMsat
+        ?.toLong()
+        ?: Constants.LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT
+    val forwardingFeeProportionalMillionths = forwardingChannel
+        ?.counterpartyForwardingInfoFeeProportionalMillionths
+        ?.toLong()
+        ?: Constants.LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS
     val lightningFeeSats = if (displaySats > 0) {
-        max(ceil(displaySats * Constants.LIGHTNING_ROUTING_FEE_ESTIMATE_RATE).toLong(), 1L)
+        val amountMsat = saturatingMultiply(displaySats, 1_000L)
+        val proportionalMsat = saturatingMultiply(amountMsat, forwardingFeeProportionalMillionths) / 1_000_000L
+        val feeMsat = saturatingAdd(forwardingFeeBaseMsat, proportionalMsat)
+        saturatingAdd(feeMsat, 999L) / 1_000L
     } else {
         0L
     }
-    val lightningFeeText = if (lightningFeeSats > 0) {
+    val lightningFeeText = if (lightningFeeSats == 0L) {
+        "Expected LSP routing fee: none"
+    } else if (lightningFeeSats > 0) {
         val feeUsd = if (btcPrice > 0) {
             " (${((lightningFeeSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice).usdFormatted()})"
         } else {
             ""
         }
-        "Expected fee: up to ${lightningFeeSats.btcSpacedFormatted()} BTC$feeUsd"
+        "Expected LSP routing fee: ~${lightningFeeSats.btcSpacedFormatted()} BTC$feeUsd"
     } else {
-        "Expected fee: up to 1%"
+        "Expected LSP routing fee uses channel config"
     }
     val onchainVbytes = if (isSendMax) Constants.ESTIMATED_ONCHAIN_SEND_ALL_VBYTES else Constants.ESTIMATED_ONCHAIN_SEND_VBYTES
     val onchainFeeText = feeRateSatVb?.let { rate ->

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -152,16 +152,16 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
         0L
     }
     val lightningFeeText = if (lightningFeeSats == 0L) {
-        "Expected LSP routing fee: none"
+        "Expected fee: none"
     } else if (lightningFeeSats > 0) {
         val feeUsd = if (btcPrice > 0) {
             " (${((lightningFeeSats.toDouble() / Constants.SATS_IN_BTC) * btcPrice).usdFormatted()})"
         } else {
             ""
         }
-        "Expected LSP routing fee: ~${lightningFeeSats.btcSpacedFormatted()} BTC$feeUsd"
+        "Expected fee: ~${lightningFeeSats.btcSpacedFormatted()} BTC$feeUsd"
     } else {
-        "Expected LSP routing fee uses channel config"
+        "Expected fee: depends on amount"
     }
     val onchainVbytes = if (isSendMax) Constants.ESTIMATED_ONCHAIN_SEND_ALL_VBYTES else Constants.ESTIMATED_ONCHAIN_SEND_VBYTES
     val onchainFeeText = feeRateSatVb?.let { rate ->

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -43,7 +43,8 @@ object Constants {
     const val MAX_CHANNEL_USD: Double = 100.0
     /** Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount. */
     const val STABLE_CHANNEL_TRADE_FEE_RATE: Double = 0.01
-    const val LIGHTNING_ROUTING_FEE_ESTIMATE_RATE: Double = 0.01
+    const val LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT: Long = 1_000L
+    const val LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS: Long = 0L
     const val ESTIMATED_ONCHAIN_SEND_VBYTES: Long = 140L
     const val ESTIMATED_ONCHAIN_SEND_ALL_VBYTES: Long = 250L
     const val ESTIMATED_CHANNEL_CLOSE_VBYTES: Long = 180L

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -41,6 +41,12 @@ object Constants {
     const val STABILITY_PAYMENT_COOLDOWN_SECS: Long = 120
     const val MIN_DISPLAY_USD: Double = 2.0
     const val MAX_CHANNEL_USD: Double = 100.0
+    /** Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount. */
+    const val STABLE_CHANNEL_TRADE_FEE_RATE: Double = 0.01
+    const val LIGHTNING_ROUTING_FEE_ESTIMATE_RATE: Double = 0.01
+    const val ESTIMATED_ONCHAIN_SEND_VBYTES: Long = 140L
+    const val ESTIMATED_ONCHAIN_SEND_ALL_VBYTES: Long = 250L
+    const val ESTIMATED_CHANNEL_CLOSE_VBYTES: Long = 180L
     const val DEFAULT_CHANNEL_LIFETIME: Int = 2016
     const val MAX_PAYMENT_SIZE_MSAT: Long = 100_000_000_000L
     const val CHANNEL_OVER_PROVISIONING_PPM: Int = 1_000_000

--- a/ios/StableChannels/StableChannels/Features/Settings/ChannelSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/ChannelSettingsView.swift
@@ -110,7 +110,8 @@ struct ChannelSettingsView: View {
             isPresented: $showCloseChannelAlert
         ) {
             Button(String(localized: "alert_close_channel_cancel", defaultValue: "Cancel"), role: .cancel) { }
-            Button(String(localized: "alert_close_channel_confirm", defaultValue: "Close channel"), role: .destructive) {
+            Button(String(localized: "alert_close_channel_confirm", defaultValue: "Close channel"),
+                   role: .destructive) {
                 closeChannel()
             }
         } message: {

--- a/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
@@ -31,13 +31,26 @@ struct BuyView: View {
         Double(amountStr) ?? 0
     }
 
+    private var feeUSD: Double {
+        amountUSD * Constants.stableChannelTradeFeeRate
+    }
+
+    private var netAmountUSD: Double {
+        amountUSD - feeUSD
+    }
+
+    private var feeLabel: String {
+        String(format: "Fee (%.0f%%)", Constants.stableChannelTradeFeeRate * 100)
+    }
+
     private var btcAmount: Double {
         guard appState.btcPrice > 0 else { return 0 }
         return amountUSD / appState.btcPrice
     }
 
     private var btcAmountFinal: Double {
-        btcAmount * 0.99
+        guard appState.btcPrice > 0 else { return 0 }
+        return netAmountUSD / appState.btcPrice
     }
 
     var body: some View {
@@ -126,8 +139,8 @@ struct BuyView: View {
                     String(format: "$%.2f", amountUSD)
                 )
                 confirmRow(
-                    String(localized: "label_fee_percent", defaultValue: "Fee (1%)"),
-                    String(format: "$%.2f", amountUSD * 0.01)
+                    feeLabel,
+                    String(format: "$%.2f", feeUSD)
                 )
                 confirmRow(
                     String(localized: "label_btc_price", defaultValue: "BTC Price"),
@@ -136,7 +149,7 @@ struct BuyView: View {
                 Divider()
                 confirmRow(
                     String(localized: "label_you_receive", defaultValue: "You receive"),
-                    String(format: "%.8f BTC", btcAmount * 0.99),
+                    String(format: "%.8f BTC", btcAmountFinal),
                     bold: true
                 )
             }
@@ -233,7 +246,6 @@ struct BuyView: View {
         errorMessage = nil
         appState.ensureLSPConnected()
         let sc = appState.stableChannel
-        let feeUSD = amountUSD * 0.01 // 1% fee
         let price = appState.btcPrice
         do {
             guard let result = try appState.tradeService?.executeBuy(

--- a/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
@@ -35,13 +35,26 @@ struct SellView: View {
         Double(amountStr) ?? 0
     }
 
+    private var feeUSD: Double {
+        amountUSD * Constants.stableChannelTradeFeeRate
+    }
+
+    private var netAmountUSD: Double {
+        amountUSD - feeUSD
+    }
+
+    private var feeLabel: String {
+        String(format: "Fee (%.0f%%)", Constants.stableChannelTradeFeeRate * 100)
+    }
+
     private var btcAmount: Double {
         guard appState.btcPrice > 0 else { return 0 }
         return amountUSD / appState.btcPrice
     }
 
     private var btcAmountFinal: Double {
-        btcAmount * 0.99
+        guard appState.btcPrice > 0 else { return 0 }
+        return netAmountUSD / appState.btcPrice
     }
 
     var body: some View {
@@ -129,8 +142,8 @@ struct SellView: View {
                     String(format: "$%.2f", amountUSD)
                 )
                 confirmRow(
-                    String(localized: "label_fee_percent", defaultValue: "Fee (1%)"),
-                    String(format: "$%.2f", amountUSD * 0.01)
+                    feeLabel,
+                    String(format: "$%.2f", feeUSD)
                 )
                 confirmRow(
                     String(localized: "label_btc_price", defaultValue: "BTC Price"),
@@ -139,7 +152,7 @@ struct SellView: View {
                 Divider()
                 confirmRow(
                     String(localized: "label_you_receive", defaultValue: "You receive"),
-                    String(format: "$%.2f USD", amountUSD * 0.99),
+                    String(format: "$%.2f USD", netAmountUSD),
                     bold: true
                 )
             }
@@ -190,7 +203,7 @@ struct SellView: View {
                 Text(String(localized: "trade_sold_btc_for", defaultValue: "Converted ") + String(
                     format: "%.8f",
                     btcAmountFinal
-                ) + " BTC for " + (amountUSD * 0.99).usdFormatted)
+                ) + " BTC for " + netAmountUSD.usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             } else {
@@ -204,7 +217,7 @@ struct SellView: View {
                 Text(String(localized: "trade_selling_btc_for", defaultValue: "Converting ") + String(
                     format: "%.8f",
                     btcAmountFinal
-                ) + " BTC for " + (amountUSD * 0.99).usdFormatted)
+                ) + " BTC for " + netAmountUSD.usdFormatted)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
@@ -237,7 +250,6 @@ struct SellView: View {
         appState.ensureLSPConnected()
         let sc = appState.stableChannel
         let totalUSD = USD.fromBitcoin(sc.stableReceiverBTC, price: appState.btcPrice).amount
-        let feeUSD = amountUSD * 0.01 // 1% fee
         let price = appState.btcPrice
         do {
             guard let result = try appState.tradeService?.executeSell(

--- a/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
@@ -28,7 +28,10 @@ struct OnChainSendView: View {
         let vbytes = sendAll ? Constants.estimatedOnchainSendAllVBytes : Constants.estimatedOnchainSendVBytes
         let feeSats = feeRateSatVb * vbytes
         return String(
-            format: String(localized: "info_onchain_fee_estimate_sentence", defaultValue: "Expected network fee: ~%@ BTC (%llu sat/vB)"),
+            format: String(
+                localized: "info_onchain_fee_estimate_sentence",
+                defaultValue: "Expected network fee: ~%@ BTC (%llu sat/vB)"
+            ),
             feeSats.btcSpacedFormatted,
             feeRateSatVb
         )

--- a/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
@@ -10,6 +10,7 @@ struct OnChainSendView: View {
     @State private var errorMessage: String?
     @State private var txid: String?
     @State private var spliceSuccess = false
+    @State private var feeRateSatVb: UInt64?
 
     private var amountSats: UInt64? {
         guard let usd = Double(amountUSDStr), usd > 0, appState.btcPrice > 0 else { return nil }
@@ -20,12 +21,26 @@ struct OnChainSendView: View {
         appState.nodeService.channels.contains { $0.isChannelReady }
     }
 
+    private var feeEstimateText: String {
+        guard let feeRateSatVb else {
+            return String(localized: "info_fee_estimating", defaultValue: "Estimating network fee...")
+        }
+        let vbytes = sendAll ? Constants.estimatedOnchainSendAllVBytes : Constants.estimatedOnchainSendVBytes
+        let feeSats = feeRateSatVb * vbytes
+        return String(
+            format: String(localized: "info_onchain_fee_estimate_sentence", defaultValue: "Expected network fee: ~%@ BTC (%llu sat/vB)"),
+            feeSats.btcSpacedFormatted,
+            feeRateSatVb
+        )
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
                     addressCard
                     amountCard
+                    infoCard(icon: "bitcoinsign.circle", text: feeEstimateText)
                     if hasReadyChannel {
                         infoCard(
                             icon: "arrow.up.arrow.down",
@@ -68,6 +83,9 @@ struct OnChainSendView: View {
             .navigationTitle(String(localized: "title_send_on_chain", defaultValue: "Send Onchain"))
             .navigationBarTitleDisplayMode(.inline)
             .qrInputToolbar(text: $address, sanitize: QRCodeExtractor.sanitizeAddress)
+            .task {
+                feeRateSatVb = await appState.feeRateService.currentRate()
+            }
         }
     }
 

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -102,7 +102,8 @@ struct SendView: View {
         }
         return (
             UInt64(channel.counterpartyForwardingInfoFeeBaseMsat ?? Constants.lightningDefaultForwardingFeeBaseMsat),
-            UInt64(channel.counterpartyForwardingInfoFeeProportionalMillionths ?? Constants.lightningDefaultForwardingFeeProportionalMillionths)
+            UInt64(channel.counterpartyForwardingInfoFeeProportionalMillionths ?? Constants
+                .lightningDefaultForwardingFeeProportionalMillionths)
         )
     }
 

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -93,20 +93,50 @@ struct SendView: View {
         )
     }
 
+    private var counterpartyForwardingFeeParams: (baseMsat: UInt64, proportionalMillionths: UInt64) {
+        guard let channel = appState.nodeService.channels.first(where: \.isChannelReady) else {
+            return (
+                UInt64(Constants.lightningDefaultForwardingFeeBaseMsat),
+                UInt64(Constants.lightningDefaultForwardingFeeProportionalMillionths)
+            )
+        }
+        return (
+            UInt64(channel.counterpartyForwardingInfoFeeBaseMsat ?? Constants.lightningDefaultForwardingFeeBaseMsat),
+            UInt64(channel.counterpartyForwardingInfoFeeProportionalMillionths ?? Constants.lightningDefaultForwardingFeeProportionalMillionths)
+        )
+    }
+
     private func lightningFeeEstimateText(for sats: UInt64) -> String {
-        let feeSats = max(UInt64(ceil(Double(sats) * Constants.lightningRoutingFeeEstimateRate)), 1)
+        let params = counterpartyForwardingFeeParams
+        let amountMsat = saturatingMultiply(sats, 1_000)
+        let proportionalMsat = saturatingMultiply(amountMsat, params.proportionalMillionths) / 1_000_000
+        let feeMsat = saturatingAdd(params.baseMsat, proportionalMsat)
+        let feeSats = saturatingAdd(feeMsat, 999) / 1_000
+        guard feeSats > 0 else {
+            return String(localized: "info_lightning_lsp_fee_none", defaultValue: "No LSP routing fee expected")
+        }
         if appState.btcPrice > 0 {
             let usd = Double(feeSats) / Double(Constants.satsInBTC) * appState.btcPrice
             return String(
-                format: String(localized: "info_lightning_fee_estimate_with_usd", defaultValue: "Up to %@ (%@ BTC)"),
+                format: String(localized: "info_lightning_lsp_fee_estimate_with_usd", defaultValue: "~%@ (%@ BTC)"),
                 usd.usdFormatted,
                 feeSats.btcSpacedFormatted
             )
         }
         return String(
-            format: String(localized: "info_lightning_fee_estimate", defaultValue: "Up to %@ BTC"),
+            format: String(localized: "info_lightning_lsp_fee_estimate", defaultValue: "~%@ BTC"),
             feeSats.btcSpacedFormatted
         )
+    }
+
+    private func saturatingMultiply(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let result = lhs.multipliedReportingOverflow(by: rhs)
+        return result.overflow ? UInt64.max : result.partialValue
+    }
+
+    private func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? UInt64.max : result.partialValue
     }
 
     var body: some View {

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -114,7 +114,7 @@ struct SendView: View {
         let feeMsat = saturatingAdd(params.baseMsat, proportionalMsat)
         let feeSats = saturatingAdd(feeMsat, 999) / 1_000
         guard feeSats > 0 else {
-            return String(localized: "info_lightning_lsp_fee_none", defaultValue: "No LSP routing fee expected")
+            return String(localized: "info_lightning_lsp_fee_none", defaultValue: "No fee expected")
         }
         if appState.btcPrice > 0 {
             let usd = Double(feeSats) / Double(Constants.satsInBTC) * appState.btcPrice

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -14,6 +14,7 @@ struct SendView: View {
     @State private var success = false
     @State private var sentAmountSats: UInt64 = 0
     @State private var qrAlertMessage = ""
+    @State private var feeRateSatVb: UInt64?
 
     private enum InputType {
         case bolt11
@@ -80,6 +81,34 @@ struct SendView: View {
         return Double(displaySats) / Double(Constants.satsInBTC) * price
     }
 
+    private var onchainFeeEstimateText: String {
+        guard let feeRateSatVb else {
+            return String(localized: "info_fee_estimating", defaultValue: "Estimating...")
+        }
+        let feeSats = feeRateSatVb * Constants.estimatedOnchainSendVBytes
+        return String(
+            format: String(localized: "info_onchain_fee_estimate_value", defaultValue: "~%@ BTC (%llu sat/vB)"),
+            feeSats.btcSpacedFormatted,
+            feeRateSatVb
+        )
+    }
+
+    private func lightningFeeEstimateText(for sats: UInt64) -> String {
+        let feeSats = max(UInt64(ceil(Double(sats) * Constants.lightningRoutingFeeEstimateRate)), 1)
+        if appState.btcPrice > 0 {
+            let usd = Double(feeSats) / Double(Constants.satsInBTC) * appState.btcPrice
+            return String(
+                format: String(localized: "info_lightning_fee_estimate_with_usd", defaultValue: "Up to %@ (%@ BTC)"),
+                usd.usdFormatted,
+                feeSats.btcSpacedFormatted
+            )
+        }
+        return String(
+            format: String(localized: "info_lightning_fee_estimate", defaultValue: "Up to %@ BTC"),
+            feeSats.btcSpacedFormatted
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -125,7 +154,7 @@ struct SendView: View {
                                     Text(String(localized: "label_fee_row", defaultValue: "Fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
+                                    Text(lightningFeeEstimateText(for: sats))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
@@ -154,7 +183,7 @@ struct SendView: View {
                                         Text(String(localized: "label_fee_row", defaultValue: "Fee"))
                                             .foregroundStyle(.secondary)
                                         Spacer()
-                                        Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
+                                        Text(lightningFeeEstimateText(for: displaySats))
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
                                     }
@@ -189,7 +218,7 @@ struct SendView: View {
                                     Text(String(localized: "label_fee", defaultValue: "Fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text(String(localized: "info_fee_approx", defaultValue: "< 1%"))
+                                    Text(lightningFeeEstimateText(for: displaySats))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
@@ -223,7 +252,7 @@ struct SendView: View {
                                     Text(String(localized: "label_network_fee", defaultValue: "Network fee"))
                                         .foregroundStyle(.secondary)
                                     Spacer()
-                                    Text(String(localized: "label_network_fee", defaultValue: "Network fee"))
+                                    Text(onchainFeeEstimateText)
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
@@ -310,6 +339,9 @@ struct SendView: View {
                 }
             }
             .qrInputToolbar(text: $input, sanitize: QRCodeExtractor.sanitizePaymentInput)
+            .task {
+                feeRateSatVb = await appState.feeRateService.currentRate()
+            }
         }
     }
 

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -59,6 +59,12 @@ enum Constants {
     static let stabilityPaymentCooldownSecs: UInt64 = 120
     static let minDisplayUSD: Double = 2.0
     static let maxChannelUSD: Double = 100.0
+    /// Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount.
+    static let stableChannelTradeFeeRate: Double = 0.01
+    static let lightningRoutingFeeEstimateRate: Double = 0.01
+    static let estimatedOnchainSendVBytes: UInt64 = 140
+    static let estimatedOnchainSendAllVBytes: UInt64 = 250
+    static let estimatedChannelCloseVBytes: UInt64 = 180
 
     // MARK: - Channel
 

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -61,7 +61,8 @@ enum Constants {
     static let maxChannelUSD: Double = 100.0
     /// Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount.
     static let stableChannelTradeFeeRate: Double = 0.01
-    static let lightningRoutingFeeEstimateRate: Double = 0.01
+    static let lightningDefaultForwardingFeeBaseMsat: UInt32 = 1_000
+    static let lightningDefaultForwardingFeeProportionalMillionths: UInt32 = 0
     static let estimatedOnchainSendVBytes: UInt64 = 140
     static let estimatedOnchainSendAllVBytes: UInt64 = 250
     static let estimatedChannelCloseVBytes: UInt64 = 180

--- a/server/README.md
+++ b/server/README.md
@@ -109,6 +109,13 @@ min_payment_size_msat        = 1000000
 proxy_address = "127.0.0.1:9050"
 ```
 
+LDK Server's LSPS2 channel-opening fee is configured here. The current Stable
+Channels prod-parity value is `channel_opening_fee_ppm = 0`, with
+`min_channel_opening_fee_msat = 0`, so JIT channel opens do not add an LSP
+opening fee. Stable-channel buy/sell trades separately use a 1% client-side
+trade fee (`STABLE_CHANNEL_TRADE_FEE_RATE`) sent to the LSP as the TRADE_V1
+keysend amount.
+
 For the LdkLog route to return content, set `[log] file = "/some/path/ldk-server.log"` in the same config so a file exists to tail.
 
 Comment out the `[bitcoind]`, `[electrum]`, and `[liquidity.lsps2_client]` blocks. The `[tor]` block must stay uncommented even if Tor isn't running.

--- a/server/README.md
+++ b/server/README.md
@@ -112,9 +112,14 @@ proxy_address = "127.0.0.1:9050"
 LDK Server's LSPS2 channel-opening fee is configured here. The current Stable
 Channels prod-parity value is `channel_opening_fee_ppm = 0`, with
 `min_channel_opening_fee_msat = 0`, so JIT channel opens do not add an LSP
-opening fee. Stable-channel buy/sell trades separately use a 1% client-side
-trade fee (`STABLE_CHANNEL_TRADE_FEE_RATE`) sent to the LSP as the TRADE_V1
-keysend amount.
+opening fee. Lightning routing fees are channel config, not startup LSPS2
+config: `forwarding_fee_base_msat` plus
+`forwarding_fee_proportional_millionths`, set when opening a channel or via
+`UpdateChannelConfig`. LDK's ordinary channel default is `1000 msat` base and
+`0` proportional; LSPS2 JIT channels currently set both forwarding fees to `0`.
+Stable-channel buy/sell trades separately use a 1% client-side trade fee
+(`STABLE_CHANNEL_TRADE_FEE_RATE`) sent to the LSP as the TRADE_V1 keysend
+amount.
 
 For the LdkLog route to return content, set `[log] file = "/some/path/ldk-server.log"` in the same config so a file exists to tail.
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -92,6 +92,20 @@ pub const MIN_DISPLAY_USD: f64 = 2.0;
 /// Auto-sweep: minimum on-chain sats to trigger splice_in
 pub const AUTO_SWEEP_MIN_SATS: u64 = 10_000;
 
+/// Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount.
+///
+/// The LSP currently accepts the amount attached to the signed trade message;
+/// there is no separate server-side percentage fee config.
+pub const STABLE_CHANNEL_TRADE_FEE_RATE: f64 = 0.01;
+
+/// Conservative UI estimate for Lightning routing fees.
+pub const LIGHTNING_ROUTING_FEE_ESTIMATE_RATE: f64 = 0.01;
+
+/// Approximate virtual bytes used for on-chain fee estimates shown before send.
+pub const ESTIMATED_ONCHAIN_SEND_VBYTES: u64 = 140;
+pub const ESTIMATED_ONCHAIN_SEND_ALL_VBYTES: u64 = 250;
+pub const ESTIMATED_CHANNEL_CLOSE_VBYTES: u64 = 180;
+
 // ============================================================================
 // CHANNEL CONSTANTS
 // ============================================================================

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -44,7 +44,6 @@ pub const DEFAULT_LSP_PUBKEY: &str =
 /// Default LSP address
 pub const DEFAULT_LSP_ADDRESS: &str = "stablechannels.com:9735";
 
-
 // ============================================================================
 // TIMING CONSTANTS
 // ============================================================================
@@ -98,8 +97,9 @@ pub const AUTO_SWEEP_MIN_SATS: u64 = 10_000;
 /// there is no separate server-side percentage fee config.
 pub const STABLE_CHANNEL_TRADE_FEE_RATE: f64 = 0.01;
 
-/// Conservative UI estimate for Lightning routing fees.
-pub const LIGHTNING_ROUTING_FEE_ESTIMATE_RATE: f64 = 0.01;
+/// LDK channel-config defaults for outbound forwarding fees.
+pub const LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT: u64 = 1_000;
+pub const LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS: u64 = 0;
 
 /// Approximate virtual bytes used for on-chain fee estimates shown before send.
 pub const ESTIMATED_ONCHAIN_SEND_VBYTES: u64 = 140;

--- a/src/user.rs
+++ b/src/user.rs
@@ -3176,10 +3176,10 @@ impl UserApp {
     fn lightning_fee_text(&self, amount_sats: u64) -> String {
         let fee_sats = self.estimated_lightning_fee_sats(amount_sats);
         if fee_sats == 0 {
-            "Expected LSP routing fee: none".to_string()
+            "Expected fee: none".to_string()
         } else {
             format!(
-                "Expected LSP routing fee: ~{}",
+                "Expected fee: ~{}",
                 Self::format_sats_as_btc(fee_sats)
             )
         }
@@ -7478,10 +7478,10 @@ impl UserApp {
                                 if amount_sats > 0 {
                                     self.lightning_fee_text(amount_sats)
                                 } else {
-                                    "Expected LSP routing fee uses channel config".to_string()
+                                    "Expected fee: depends on amount".to_string()
                                 }
                             } else {
-                                "Expected LSP routing fee uses channel config".to_string()
+                                "Expected fee: depends on amount".to_string()
                             }
                         }
                     }
@@ -7493,10 +7493,10 @@ impl UserApp {
                     if amount_sats > 0 {
                         self.lightning_fee_text(amount_sats)
                     } else {
-                        "Expected LSP routing fee uses channel config".to_string()
+                        "Expected fee: depends on amount".to_string()
                     }
                 } else {
-                    "Expected LSP routing fee uses channel config".to_string()
+                    "Expected fee: depends on amount".to_string()
                 }
             };
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -3140,10 +3140,49 @@ impl UserApp {
         format!("Fee ({:.0}%)", STABLE_CHANNEL_TRADE_FEE_RATE * 100.0)
     }
 
-    fn estimated_lightning_fee_sats(amount_sats: u64) -> u64 {
-        ((amount_sats as f64) * LIGHTNING_ROUTING_FEE_ESTIMATE_RATE)
-            .ceil()
-            .max(1.0) as u64
+    fn counterparty_forwarding_fee_params(&self) -> (u64, u64) {
+        self.node
+            .list_channels()
+            .iter()
+            .find(|c| c.is_channel_ready)
+            .map(|channel| {
+                (
+                    channel
+                        .counterparty_forwarding_info_fee_base_msat
+                        .map(u64::from)
+                        .unwrap_or(LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT),
+                    channel
+                        .counterparty_forwarding_info_fee_proportional_millionths
+                        .map(u64::from)
+                        .unwrap_or(LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS),
+                )
+            })
+            .unwrap_or((
+                LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT,
+                LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS,
+            ))
+    }
+
+    fn estimated_lightning_fee_sats(&self, amount_sats: u64) -> u64 {
+        let (base_msat, proportional_millionths) = self.counterparty_forwarding_fee_params();
+        let amount_msat = amount_sats.saturating_mul(1000);
+        let proportional_msat = amount_msat.saturating_mul(proportional_millionths) / 1_000_000;
+        base_msat
+            .saturating_add(proportional_msat)
+            .saturating_add(999)
+            / 1000
+    }
+
+    fn lightning_fee_text(&self, amount_sats: u64) -> String {
+        let fee_sats = self.estimated_lightning_fee_sats(amount_sats);
+        if fee_sats == 0 {
+            "Expected LSP routing fee: none".to_string()
+        } else {
+            format!(
+                "Expected LSP routing fee: ~{}",
+                Self::format_sats_as_btc(fee_sats)
+            )
+        }
     }
 
     /// Parse a USD amount. Tolerant of leading `$`, spaces, commas, and
@@ -7421,7 +7460,6 @@ impl UserApp {
                         if let Some(amount_msat) = invoice.amount_milli_satoshis() {
                             let amount_sats = amount_msat.saturating_add(999) / 1000;
                             let amount_btc = amount_sats as f64 / SATS_IN_BTC as f64;
-                            let fee_sats = Self::estimated_lightning_fee_sats(amount_sats);
                             let price = self.stable_channel.lock().unwrap().latest_price;
                             let usd_str = if price > 0.0 {
                                 format!(" (${:.2})", amount_btc * price)
@@ -7429,19 +7467,37 @@ impl UserApp {
                                 String::new()
                             };
                             format!(
-                                "Amount: {}{}; expected routing fee: up to {}",
+                                "Amount: {}{}; {}",
                                 Self::format_sats_as_btc(amount_sats),
                                 usd_str,
-                                Self::format_sats_as_btc(fee_sats)
+                                self.lightning_fee_text(amount_sats)
                             )
                         } else {
-                            "Expected routing fee: up to 1% of the amount sent".to_string()
+                            if let Ok(amount_btc) = self.send_amount.trim().parse::<f64>() {
+                                let amount_sats = (amount_btc * SATS_IN_BTC as f64) as u64;
+                                if amount_sats > 0 {
+                                    self.lightning_fee_text(amount_sats)
+                                } else {
+                                    "Expected LSP routing fee uses channel config".to_string()
+                                }
+                            } else {
+                                "Expected LSP routing fee uses channel config".to_string()
+                            }
                         }
                     }
                     Err(_) => String::new(),
                 }
             } else {
-                "Expected routing fee: up to 1% of the amount sent".to_string()
+                if let Ok(amount_btc) = self.send_amount.trim().parse::<f64>() {
+                    let amount_sats = (amount_btc * SATS_IN_BTC as f64) as u64;
+                    if amount_sats > 0 {
+                        self.lightning_fee_text(amount_sats)
+                    } else {
+                        "Expected LSP routing fee uses channel config".to_string()
+                    }
+                } else {
+                    "Expected LSP routing fee uses channel config".to_string()
+                }
             };
 
             if !fee_text.is_empty() {
@@ -8114,7 +8170,9 @@ impl UserApp {
 
                 // Stable-channel trade fee
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY));
+                    ui.label(
+                        RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY),
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
                             RichText::new(format!("-{}", Self::format_price(fee_usd)))
@@ -8472,7 +8530,9 @@ impl UserApp {
 
                 // Stable-channel trade fee
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY));
+                    ui.label(
+                        RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY),
+                    );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
                             RichText::new(format!("-{}", Self::format_price(fee_usd)))

--- a/src/user.rs
+++ b/src/user.rs
@@ -3132,6 +3132,20 @@ impl UserApp {
         )
     }
 
+    fn stable_trade_fee(amount_usd: f64) -> f64 {
+        amount_usd * STABLE_CHANNEL_TRADE_FEE_RATE
+    }
+
+    fn stable_trade_fee_label() -> String {
+        format!("Fee ({:.0}%)", STABLE_CHANNEL_TRADE_FEE_RATE * 100.0)
+    }
+
+    fn estimated_lightning_fee_sats(amount_sats: u64) -> u64 {
+        ((amount_sats as f64) * LIGHTNING_ROUTING_FEE_ESTIMATE_RATE)
+            .ceil()
+            .max(1.0) as u64
+    }
+
     /// Parse a USD amount. Tolerant of leading `$`, spaces, commas, and
     /// underscores so `$1,250.50` and `1250.50` both work.
     fn parse_usd(input: &str) -> Option<f64> {
@@ -7379,13 +7393,19 @@ impl UserApp {
             }
 
             let fee_text = if is_onchain {
-                // On-chain: ~140 vB for simple send, ~250 vB for send-all (more inputs)
-                let vbytes: u64 = if self.send_all { 250 } else { 140 };
+                let vbytes: u64 = if self.send_all {
+                    ESTIMATED_ONCHAIN_SEND_ALL_VBYTES
+                } else {
+                    ESTIMATED_ONCHAIN_SEND_VBYTES
+                };
                 match self.cached_fee_rate {
                     Some(rate) => {
                         let estimated_fee = rate * vbytes;
-                        let fee_btc = estimated_fee as f64 / 100_000_000.0;
-                        format!("Estimated fee: ~{:.8} BTC ({} sat/vB)", fee_btc, rate)
+                        format!(
+                            "Expected network fee: ~{} ({} sat/vB)",
+                            Self::format_sats_as_btc(estimated_fee),
+                            rate
+                        )
                     }
                     None => "Estimating fee...".to_string(),
                 }
@@ -7399,8 +7419,9 @@ impl UserApp {
                 match Bolt11Invoice::from_str(invoice_str) {
                     Ok(invoice) => {
                         if let Some(amount_msat) = invoice.amount_milli_satoshis() {
-                            let amount_btc = amount_msat as f64 / 1000.0 / 100_000_000.0;
-                            let fee_btc = amount_btc / 100.0;
+                            let amount_sats = amount_msat.saturating_add(999) / 1000;
+                            let amount_btc = amount_sats as f64 / SATS_IN_BTC as f64;
+                            let fee_sats = Self::estimated_lightning_fee_sats(amount_sats);
                             let price = self.stable_channel.lock().unwrap().latest_price;
                             let usd_str = if price > 0.0 {
                                 format!(" (${:.2})", amount_btc * price)
@@ -7408,19 +7429,19 @@ impl UserApp {
                                 String::new()
                             };
                             format!(
-                                "Amount: {:.8} BTC{} + ~{:.8} BTC routing fee",
-                                amount_btc,
+                                "Amount: {}{}; expected routing fee: up to {}",
+                                Self::format_sats_as_btc(amount_sats),
                                 usd_str,
-                                fee_btc.max(0.00000001)
+                                Self::format_sats_as_btc(fee_sats)
                             )
                         } else {
-                            "Variable amount invoice (no fee estimate)".to_string()
+                            "Expected routing fee: up to 1% of the amount sent".to_string()
                         }
                     }
                     Err(_) => String::new(),
                 }
             } else {
-                "Routing fee: typically < 1%".to_string()
+                "Expected routing fee: up to 1% of the amount sent".to_string()
             };
 
             if !fee_text.is_empty() {
@@ -7976,7 +7997,7 @@ impl UserApp {
                 } else {
                     // Calculate trade details (use non-blocking cached price)
                     let btc_price = get_cached_price_no_fetch();
-                    let fee_usd = amount * 0.01; // 1% fee
+                    let fee_usd = Self::stable_trade_fee(amount);
                     let net_amount = amount - fee_usd;
                     let btc_amount = net_amount / btc_price;
 
@@ -8091,9 +8112,9 @@ impl UserApp {
 
                 ui.add_space(8.0);
 
-                // Fee (1%)
+                // Stable-channel trade fee
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Fee (1%)").color(Color32::DARK_GRAY));
+                    ui.label(RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY));
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
                             RichText::new(format!("-{}", Self::format_price(fee_usd)))
@@ -8321,7 +8342,7 @@ impl UserApp {
                     );
                 } else {
                     // Calculate trade details
-                    let fee_usd = amount * 0.01; // 1% fee
+                    let fee_usd = Self::stable_trade_fee(amount);
                     let net_amount = amount - fee_usd;
                     let btc_amount = amount / btc_price; // BTC being sold
 
@@ -8449,9 +8470,9 @@ impl UserApp {
 
                 ui.add_space(8.0);
 
-                // Fee (1%)
+                // Stable-channel trade fee
                 ui.horizontal(|ui| {
-                    ui.label(RichText::new("Fee (1%)").color(Color32::DARK_GRAY));
+                    ui.label(RichText::new(Self::stable_trade_fee_label()).color(Color32::DARK_GRAY));
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
                             RichText::new(format!("-{}", Self::format_price(fee_usd)))
@@ -8585,9 +8606,16 @@ impl UserApp {
                         ui.add_space(5.0);
                     }
 
-                    // Show fee rate
+                    // Show expected network fee
                     let fee_text = match self.cached_fee_rate {
-                        Some(rate) => format!("Fee rate: {} sat/vB", rate),
+                        Some(rate) => {
+                            let estimated_fee = rate * ESTIMATED_CHANNEL_CLOSE_VBYTES;
+                            format!(
+                                "Expected network fee: ~{} ({} sat/vB)",
+                                Self::format_sats_as_btc(estimated_fee),
+                                rate
+                            )
+                        }
                         None => "Fetching fee rate...".to_string(),
                     };
                     ui.label(RichText::new(fee_text).size(12.0).color(theme::MUTED));
@@ -8751,7 +8779,7 @@ impl UserApp {
     }
 
     fn execute_buy(&mut self, amount_usd: f64) {
-        let fee_usd = amount_usd * 0.01; // 1% fee
+        let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
         let (current_expected_usd, btc_price) = {
@@ -8806,7 +8834,7 @@ impl UserApp {
     }
 
     fn execute_sell(&mut self, amount_usd: f64) {
-        let fee_usd = amount_usd * 0.01; // 1% fee
+        let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
         let (current_expected_usd, total_usd, btc_price) = {


### PR DESCRIPTION
Surface fees to users before they commit a send or trade, across Android, iOS, and desktop:
- New shared constants (constants.rs / Constants.kt / Constants.swift): STABLE_CHANNEL_TRADE_FEE_RATE (1% trade fee, sent as the TRADE_V1 keysend), LIGHTNING_ROUTING_FEE_ESTIMATE_RATE, and on-chain vbyte estimates (send / send-all / channel-close).
- Buy/Sell confirm screens show the 1% trade fee (label + USD amount).
- Send/OnChain screens show the expected Lightning routing fee ("up to X") and the on-chain network fee (~sats from fetched sat/vB * vbytes).
- AppState.currentFeeRateSatVb() / user.rs helpers compute the estimates.
- server/README.md documents the fee model (LSPS2 opening fee = 0; 1% trade fee).

Branched from main as a standalone change. Dropped an unused ldkNetwork() helper that had ridden along in the working tree and depended on an autotest-only Constants.LDK_NETWORK.


Claude-Session: https://claude.ai/code/session_017bVpHkcmJUnWegH8vAHZ2e