### PR TITLE
Fix stable-channel accounting and signed LSP synchronization

### DIFF
--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -50,7 +50,7 @@ async fn run(state: AppState) {
         };
         info!("[event_loop] subscribed");
         {
-            let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+            let btc_price = stable_channels::price_feeds::get_fresh_cached_price_no_fetch();
             if btc_price > 0.0 {
                 state
                     .stable_manager
@@ -84,7 +84,7 @@ async fn dispatch(
             return;
         },
     };
-    let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+    let btc_price = stable_channels::price_feeds::get_fresh_cached_price_no_fetch();
     let mut mgr = state.stable_manager.lock().await;
     let ldk = state.ldk_server.as_ref() as &dyn LdkServerCalls;
     match envelope.event {

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -179,6 +179,18 @@ async fn dispatch(
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
             let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            if let Some(payment_id) = payment_id.as_deref() {
+                if let Err(error) = state.db.mark_settlement_succeeded(payment_id) {
+                    stable_channels::audit::audit_event(
+                        "DB_WRITE_FAILED",
+                        serde_json::json!({
+                            "op": "mark_settlement_succeeded",
+                            "payment_id": payment_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                }
+            }
             let user_channel_id = payment_id.as_deref()
                 .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten());
             stable_channels::audit::audit_event(
@@ -197,8 +209,16 @@ async fn dispatch(
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
             let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
-            let user_channel_id = payment_id.as_deref()
-                .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten());
+            let rollback = payment_id
+                .as_deref()
+                .and_then(|payment_id| mgr.handle_failed_stability_payment(payment_id));
+            let user_channel_id = rollback
+                .as_ref()
+                .map(|rollback| rollback.user_channel_id.clone())
+                .or_else(|| {
+                    payment_id.as_deref()
+                        .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten())
+                });
             stable_channels::audit::audit_event(
                 "PAYMENT_FAILED",
                 serde_json::json!({
@@ -207,6 +227,7 @@ async fn dispatch(
                     "fee_paid_msat": fee_paid_msat,
                     "direction": direction,
                     "user_channel_id": user_channel_id,
+                    "stability_rollback_applied": rollback.map(|rollback| rollback.applied),
                 }),
             );
         },

--- a/server/stable-channels-lsp/src/handlers/price.rs
+++ b/server/stable-channels-lsp/src/handlers/price.rs
@@ -4,7 +4,7 @@ use axum::body::Bytes;
 use axum::response::Response;
 
 use sc_protos::stable::{GetPriceRequest, GetPriceResponse};
-use stable_channels::price_feeds::get_cached_price_no_fetch;
+use stable_channels::price_feeds::get_fresh_cached_price_no_fetch;
 
 use crate::handlers::{decode_body, ok_response};
 
@@ -12,6 +12,6 @@ pub async fn get_price(body: Bytes) -> Response {
     if let Err(resp) = decode_body::<GetPriceRequest>(&body) {
         return resp;
     }
-    let price = get_cached_price_no_fetch();
+    let price = get_fresh_cached_price_no_fetch();
     ok_response(GetPriceResponse { price })
 }

--- a/server/stable-channels-lsp/src/handlers/stable_channels.rs
+++ b/server/stable-channels-lsp/src/handlers/stable_channels.rs
@@ -9,7 +9,7 @@ use sc_protos::stable::{
     ListSettlementPaymentsResponse, ListStableChannelsRequest, ListStableChannelsResponse,
     SettlementPayment, StableChannelInfo,
 };
-use stable_channels::price_feeds::get_cached_price_no_fetch;
+use stable_channels::price_feeds::get_fresh_cached_price_no_fetch;
 
 use crate::handlers::{decode_body, error_response, ok_response};
 use crate::stable_manager::EditOutcome;
@@ -23,7 +23,7 @@ pub async fn list_stable_channels(
         return resp;
     }
 
-    let latest_price = get_cached_price_no_fetch();
+    let latest_price = get_fresh_cached_price_no_fetch();
 
     let mgr = state.stable_manager.lock().await;
     let channels = mgr
@@ -54,7 +54,7 @@ pub async fn edit_stable_channel(
         Err(resp) => return resp,
     };
 
-    let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+    let btc_price = get_fresh_cached_price_no_fetch();
 
     let EditOutcome { ok, status } = {
         let mut mgr = state.stable_manager.lock().await;

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -47,6 +47,7 @@ pub struct RegisterPushSigned {
 /// Build the SYNC_V1 payload string (the exact bytes the daemon signs and ships).
 pub fn build_sync_payload(
     channel_id: &str,
+    user_channel_id: &str,
     expected_usd: f64,
     backing_sats: u64,
     sync_version: u64,
@@ -54,6 +55,7 @@ pub fn build_sync_payload(
     serde_json::json!({
         "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
         "channel_id": channel_id,
+        "user_channel_id": user_channel_id,
         "expected_usd": expected_usd,
         "backing_sats": backing_sats,
         "sync_version": sync_version,
@@ -94,10 +96,11 @@ mod tests {
     #[test]
     fn sync_payload_has_expected_shape() {
         let channel_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let payload = build_sync_payload(channel_id, 25.0, 31_250, 4);
+        let payload = build_sync_payload(channel_id, "7", 25.0, 31_250, 4);
         let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
         assert_eq!(v["channel_id"], channel_id);
+        assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
         assert_eq!(v["sync_version"], 4);

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -45,12 +45,18 @@ pub struct RegisterPushSigned {
 }
 
 /// Build the SYNC_V1 payload string (the exact bytes the daemon signs and ships).
-pub fn build_sync_payload(user_channel_id: u128, expected_usd: f64, backing_sats: u64) -> String {
+pub fn build_sync_payload(
+    user_channel_id: u128,
+    expected_usd: f64,
+    backing_sats: u64,
+    sync_version: u64,
+) -> String {
     serde_json::json!({
         "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
         "user_channel_id": format!("{}", user_channel_id),
         "expected_usd": expected_usd,
         "backing_sats": backing_sats,
+        "sync_version": sync_version,
     })
     .to_string()
 }
@@ -87,12 +93,13 @@ mod tests {
 
     #[test]
     fn sync_payload_has_expected_shape() {
-        let payload = build_sync_payload(7u128, 25.0, 31_250);
+        let payload = build_sync_payload(7u128, 25.0, 31_250, 4);
         let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
         assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
+        assert_eq!(v["sync_version"], 4);
     }
 
     #[test]

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -46,14 +46,14 @@ pub struct RegisterPushSigned {
 
 /// Build the SYNC_V1 payload string (the exact bytes the daemon signs and ships).
 pub fn build_sync_payload(
-    user_channel_id: u128,
+    channel_id: &str,
     expected_usd: f64,
     backing_sats: u64,
     sync_version: u64,
 ) -> String {
     serde_json::json!({
         "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
-        "user_channel_id": format!("{}", user_channel_id),
+        "channel_id": channel_id,
         "expected_usd": expected_usd,
         "backing_sats": backing_sats,
         "sync_version": sync_version,
@@ -93,10 +93,11 @@ mod tests {
 
     #[test]
     fn sync_payload_has_expected_shape() {
-        let payload = build_sync_payload(7u128, 25.0, 31_250, 4);
+        let channel_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let payload = build_sync_payload(channel_id, 25.0, 31_250, 4);
         let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
-        assert_eq!(v["user_channel_id"], "7");
+        assert_eq!(v["channel_id"], channel_id);
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
         assert_eq!(v["sync_version"], 4);

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -22,6 +22,12 @@ pub struct TradePayload {
     #[serde(default)]
     pub user_channel_id: Option<String>,
     pub expected_usd: f64,
+    /// BTC/USD quote used by the wallet to derive the signed sat allocation.
+    #[serde(default)]
+    pub quote_price: Option<f64>,
+    /// Exact stable backing allocation after the trade-fee payment settles.
+    #[serde(default)]
+    pub backing_sats: Option<u64>,
     /// Unix seconds the wallet signed at; 0 if absent (un-upgraded wallet). Drives replay freshness.
     #[serde(default)]
     pub ts: u64,
@@ -39,11 +45,12 @@ pub struct RegisterPushSigned {
 }
 
 /// Build the SYNC_V1 payload string (the exact bytes the daemon signs and ships).
-pub fn build_sync_payload(user_channel_id: u128, expected_usd: f64) -> String {
+pub fn build_sync_payload(user_channel_id: u128, expected_usd: f64, backing_sats: u64) -> String {
     serde_json::json!({
         "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
         "user_channel_id": format!("{}", user_channel_id),
         "expected_usd": expected_usd,
+        "backing_sats": backing_sats,
     })
     .to_string()
 }
@@ -80,11 +87,12 @@ mod tests {
 
     #[test]
     fn sync_payload_has_expected_shape() {
-        let payload = build_sync_payload(7u128, 25.0);
+        let payload = build_sync_payload(7u128, 25.0, 31_250);
         let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
         assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
+        assert_eq!(v["backing_sats"], 31_250);
     }
 
     #[test]
@@ -106,6 +114,17 @@ mod tests {
             Some("189476124653200987495269098788434301048")
         );
         assert_eq!(t.expected_usd, 12.5);
+        assert_eq!(t.quote_price, None);
+        assert_eq!(t.backing_sats, None);
+    }
+
+    #[test]
+    fn trade_payload_parses_signed_allocation() {
+        let payload = r#"{"type":"TRADE_V1","user_channel_id":"7","expected_usd":25.0,"quote_price":80000.0,"backing_sats":31250,"ts":123}"#;
+        let t = parse_trade_payload(payload).unwrap();
+        assert_eq!(t.quote_price, Some(80_000.0));
+        assert_eq!(t.backing_sats, Some(31_250));
+        assert_eq!(t.ts, 123);
     }
 
     #[test]

--- a/server/stable-channels-lsp/src/price_task.rs
+++ b/server/stable-channels-lsp/src/price_task.rs
@@ -3,31 +3,33 @@
 use std::time::Duration;
 
 use stable_channels::constants::PRICE_CACHE_REFRESH_SECS;
-use stable_channels::price_feeds::get_cached_price;
+use stable_channels::price_feeds::refresh_cached_price;
 use tokio::sync::watch;
 use tokio::time::interval;
 use tracing::{info, warn};
 
-/// Drive the price cache forever, publishing every non-zero price on `price_tx`.
+/// Drive the price cache forever, publishing only freshly validated prices on `price_tx`.
 pub async fn run(price_tx: watch::Sender<f64>) {
-    let first = tokio::task::spawn_blocking(get_cached_price).await.unwrap_or(0.0);
-    if first > 0.0 {
-        info!("initial BTC/USD price = ${:.2}", first);
-        let _ = price_tx.send(first);
-    } else {
-        warn!("initial price fetch returned 0.0, exchanges may be unreachable");
+    match tokio::task::spawn_blocking(refresh_cached_price).await {
+        Ok(Ok(first)) => {
+            info!("initial BTC/USD price = ${:.2}", first);
+            let _ = price_tx.send(first);
+        }
+        Ok(Err(error)) => warn!("initial price refresh failed: {}", error),
+        Err(error) => warn!("initial price refresh task failed: {}", error),
     }
 
     let mut tick = interval(Duration::from_secs(PRICE_CACHE_REFRESH_SECS));
     tick.tick().await;
     loop {
         tick.tick().await;
-        let price = tokio::task::spawn_blocking(get_cached_price).await.unwrap_or(0.0);
-        if price > 0.0 {
-            let _ = price_tx.send(price);
-            tracing::debug!("price refresh: ${:.2}", price);
-        } else {
-            warn!("price refresh returned 0.0");
+        match tokio::task::spawn_blocking(refresh_cached_price).await {
+            Ok(Ok(price)) => {
+                let _ = price_tx.send(price);
+                tracing::debug!("price refresh: ${:.2}", price);
+            }
+            Ok(Err(error)) => warn!("price refresh rejected: {}", error),
+            Err(error) => warn!("price refresh task failed: {}", error),
         }
     }
 }

--- a/server/stable-channels-lsp/src/stability_tick.rs
+++ b/server/stable-channels-lsp/src/stability_tick.rs
@@ -19,7 +19,7 @@ async fn run(state: AppState) {
     info!("[stability_tick] running every {}s", interval_secs);
     loop {
         ticker.tick().await;
-        let btc_price = stable_channels::price_feeds::get_cached_price_no_fetch();
+        let btc_price = stable_channels::price_feeds::get_fresh_cached_price_no_fetch();
         if btc_price <= 0.0 {
             warn!("[stability_tick] price cache cold; skipping");
             continue;

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -759,8 +759,8 @@ impl StableChannelManager {
         let dollar_threshold = stable_channels::constants::STABILITY_THRESHOLD_USD;
         let cooldown = stable_channels::constants::STABILITY_PAYMENT_COOLDOWN_SECS as i64;
 
-        // (uid, new_expected_usd, counterparty_hex) for backstop SYNCs sent after the iter_mut borrow ends.
-        let mut backstop_syncs: Vec<(u128, f64, String)> = Vec::new();
+        // Accepted USD and sat allocations for backstop SYNCs sent after the iter_mut borrow ends.
+        let mut backstop_syncs: Vec<(u128, f64, u64, String)> = Vec::new();
         const BACKSTOP_DEBOUNCE_TICKS: u8 = 2;
 
         for sc in self.stable_channels.iter_mut() {
@@ -814,7 +814,12 @@ impl StableChannelManager {
                                 serde_json::json!({ "op": "save_channel", "context": "backstop", "user_channel_id": format!("{}", uid), "channel_id": c.channel_id, "error": e.to_string() }),
                             );
                         }
-                        backstop_syncs.push((uid, sc.expected_usd.0, sc.counterparty.to_string()));
+                        backstop_syncs.push((
+                            uid,
+                            sc.expected_usd.0,
+                            sc.backing_sats,
+                            sc.counterparty.to_string(),
+                        ));
                     }
                 }
             } else {
@@ -1006,8 +1011,9 @@ impl StableChannelManager {
             }
         }
 
-        for (uid, expected_usd, counterparty) in backstop_syncs {
-            self.send_sync_message(ldk, uid, expected_usd, &counterparty).await;
+        for (uid, expected_usd, backing_sats, counterparty) in backstop_syncs {
+            self.send_sync_message(ldk, uid, expected_usd, backing_sats, &counterparty)
+                .await;
         }
     }
 
@@ -1018,9 +1024,11 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         user_channel_id: u128,
         expected_usd: f64,
+        backing_sats: u64,
         counterparty: &str,
     ) {
-        let payload = crate::messages::build_sync_payload(user_channel_id, expected_usd);
+        let payload =
+            crate::messages::build_sync_payload(user_channel_id, expected_usd, backing_sats);
         let signature = match ldk
             .sign_message(SignMessageRequest {
                 message: payload.as_bytes().to_vec().into(),
@@ -1073,6 +1081,7 @@ impl StableChannelManager {
                     serde_json::json!({
                         "user_channel_id": format!("{}", user_channel_id),
                         "expected_usd": expected_usd,
+                        "backing_sats": backing_sats,
                     }),
                 );
             },
@@ -1233,7 +1242,13 @@ impl StableChannelManager {
             );
         }
         if deducted {
-            self.send_sync_message(ldk, target_uid, expected_usd_f, &counterparty_hex)
+            self.send_sync_message(
+                ldk,
+                target_uid,
+                expected_usd_f,
+                backing_sats,
+                &counterparty_hex,
+            )
                 .await;
         }
     }
@@ -1330,7 +1345,7 @@ impl StableChannelManager {
             serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": ucid_str, "deducted": deducted }),
         );
         if deducted {
-            self.send_sync_message(ldk, uid, expected_usd_f, &counterparty_hex)
+            self.send_sync_message(ldk, uid, expected_usd_f, backing, &counterparty_hex)
                 .await;
         }
     }
@@ -1358,7 +1373,7 @@ impl StableChannelManager {
             );
             return;
         }
-        if payload.expected_usd < 0.0 {
+        if payload.expected_usd < 0.0 || !payload.expected_usd.is_finite() {
             stable_channels::audit::audit_event(
                 "TRADE_INVALID_AMOUNT",
                 serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone() }),
@@ -1367,7 +1382,13 @@ impl StableChannelManager {
         }
         stable_channels::audit::audit_event(
             "TRADE_PARSED_PAYLOAD_OK",
-            serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone(), "channel_id": payload.channel_id.clone() }),
+            serde_json::json!({
+                "expected_usd": payload.expected_usd,
+                "quote_price": payload.quote_price,
+                "backing_sats": payload.backing_sats,
+                "user_channel_id": payload.user_channel_id.clone(),
+                "channel_id": payload.channel_id.clone(),
+            }),
         );
 
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
@@ -1448,8 +1469,90 @@ impl StableChannelManager {
             return;
         };
         let (our_sats, their_sats) = channel_peer_balances(&chan);
-        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
         let new_expected = payload.expected_usd;
+        let signed_allocation = match (payload.quote_price, payload.backing_sats) {
+            (Some(quote_price), Some(backing_sats)) => {
+                if payload.ts == 0
+                    || !quote_price.is_finite()
+                    || quote_price <= 0.0
+                    || !btc_price.is_finite()
+                    || btc_price <= 0.0
+                {
+                    stable_channels::audit::audit_event(
+                        "TRADE_INVALID_QUOTE",
+                        serde_json::json!({
+                            "quote_price": quote_price,
+                            "lsp_price": btc_price,
+                            "ts": payload.ts,
+                            "channel_id": chan.channel_id.clone(),
+                            "user_channel_id": chan.user_channel_id.clone(),
+                        }),
+                    );
+                    return;
+                }
+
+                // Both peers run their own price feed. Admit small observation-time differences,
+                // but reject a quote far enough away to change the economic trade materially.
+                const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
+                let quote_deviation_percent =
+                    ((quote_price - btc_price) / btc_price * 100.0).abs();
+                if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
+                    stable_channels::audit::audit_event(
+                        "TRADE_QUOTE_DEVIATION_EXCEEDED",
+                        serde_json::json!({
+                            "quote_price": quote_price,
+                            "lsp_price": btc_price,
+                            "deviation_percent": quote_deviation_percent,
+                            "maximum_percent": MAX_TRADE_QUOTE_DEVIATION_PERCENT,
+                            "channel_id": chan.channel_id.clone(),
+                            "user_channel_id": chan.user_channel_id.clone(),
+                        }),
+                    );
+                    return;
+                }
+
+                let derived_backing = stable_channels::stable::trade_backing_sats(
+                    their_sats,
+                    new_expected,
+                    quote_price,
+                );
+                if backing_sats > their_sats || backing_sats.abs_diff(derived_backing) > 1 {
+                    stable_channels::audit::audit_event(
+                        "TRADE_ALLOCATION_INVALID",
+                        serde_json::json!({
+                            "signed_backing_sats": backing_sats,
+                            "derived_backing_sats": derived_backing,
+                            "receiver_sats": their_sats,
+                            "quote_price": quote_price,
+                            "channel_id": chan.channel_id.clone(),
+                            "user_channel_id": chan.user_channel_id.clone(),
+                        }),
+                    );
+                    return;
+                }
+
+                Some((quote_price, backing_sats, quote_deviation_percent))
+            }
+            (None, None) => None,
+            _ => {
+                stable_channels::audit::audit_event(
+                    "TRADE_ALLOCATION_INCOMPLETE",
+                    serde_json::json!({
+                        "quote_price": payload.quote_price,
+                        "backing_sats": payload.backing_sats,
+                        "channel_id": chan.channel_id.clone(),
+                        "user_channel_id": chan.user_channel_id.clone(),
+                    }),
+                );
+                return;
+            }
+        };
+
+        let validation_price = signed_allocation
+            .map(|(quote_price, _, _)| quote_price)
+            .unwrap_or(btc_price);
+        let receiver_usd =
+            USD::from_bitcoin(Bitcoin::from_sats(their_sats), validation_price).0;
         // Epsilon absorbs f64 boundary rounding so a spend-driven push landing at ~receiver_usd is admitted; residual drift self-heals.
         let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
         if new_expected > ceiling {
@@ -1478,17 +1581,26 @@ impl StableChannelManager {
             sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
             sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
             sc.latest_price = btc_price;
-            stable_channels::stable::apply_trade(sc, new_expected, btc_price);
+            if let Some((_, backing_sats, _)) = signed_allocation {
+                stable_channels::stable::apply_trade_allocation(
+                    sc,
+                    new_expected,
+                    backing_sats,
+                );
+            } else {
+                stable_channels::stable::apply_trade(sc, new_expected, btc_price);
+            }
             (
                 format!("{}", sc.user_channel_id),
                 sc.expected_usd.0,
                 sc.backing_sats,
                 sc.native_sats,
                 sc.note.clone(),
+                sc.counterparty.to_string(),
             )
         };
 
-        let (ucid_str, expected_usd_f, backing, native, note) = persisted;
+        let (ucid_str, expected_usd_f, backing, native, note, counterparty) = persisted;
         if let Err(e) = self.db.save_channel(
             &channel_id_hex,
             &ucid_str,
@@ -1502,6 +1614,7 @@ impl StableChannelManager {
                 "DB_WRITE_FAILED",
                 serde_json::json!({ "op": "save_channel", "context": "handle_trade_message", "channel_id": channel_id_hex, "user_channel_id": ucid_str, "error": e.to_string() }),
             );
+            return;
         }
         stable_channels::audit::audit_event(
             "TRADE_APPLIED",
@@ -1509,8 +1622,21 @@ impl StableChannelManager {
                 "channel_id": channel_id_hex,
                 "user_channel_id": ucid_str,
                 "new_expected_usd": expected_usd_f,
+                "backing_sats": backing,
+                "native_sats": native,
+                "quote_price": signed_allocation.map(|(price, _, _)| price),
+                "lsp_price": btc_price,
+                "quote_deviation_percent": signed_allocation.map(|(_, _, deviation)| deviation),
             }),
         );
+        self.send_sync_message(
+            ldk,
+            target_uid,
+            expected_usd_f,
+            backing,
+            &counterparty,
+        )
+        .await;
     }
 }
 
@@ -1931,7 +2057,10 @@ mod tests {
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
         assert_eq!(
             mgr.db.list_settlements().unwrap(),
-            vec![("pay_test_1".to_string(), "sync".to_string())]
+            vec![
+                ("pay_test_1".to_string(), "sync".to_string()),
+                ("fake-payment-id".to_string(), "sync".to_string()),
+            ]
         );
     }
 
@@ -2515,7 +2644,13 @@ mod tests {
     async fn send_sync_message_keysends_signed_tlv() {
         let mgr = make_manager();
         let fake = FakeLdkServer::new(vec![]);
-        mgr.send_sync_message(&fake as &dyn LdkServerCalls, 7u128, 25.0, COUNTERPARTY_HEX)
+        mgr.send_sync_message(
+            &fake as &dyn LdkServerCalls,
+            7u128,
+            25.0,
+            31_250,
+            COUNTERPARTY_HEX,
+        )
             .await;
 
         let sends = fake.sends.lock().unwrap();
@@ -2536,6 +2671,7 @@ mod tests {
         assert_eq!(v["type"], "SYNC_V1");
         assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
+        assert_eq!(v["backing_sats"], 31_250);
     }
 
     #[tokio::test]
@@ -2674,6 +2810,26 @@ mod tests {
         serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
     }
 
+    fn trade_envelope_with_allocation(
+        channel_id: &str,
+        user_channel_id: &str,
+        expected_usd: f64,
+        quote_price: f64,
+        backing_sats: u64,
+    ) -> String {
+        let payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "channel_id": channel_id,
+            "user_channel_id": user_channel_id,
+            "expected_usd": expected_usd,
+            "quote_price": quote_price,
+            "backing_sats": backing_sats,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
+    }
+
     fn test_unix_now() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -2693,6 +2849,89 @@ mod tests {
         mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn trade_applies_signed_allocation_without_lsp_repricing() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_500.0,
+        );
+
+        // At the wallet quote this is exactly 49,950 backing sats. Re-deriving at the LSP's
+        // slightly newer price would produce a different allocation.
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            49.95,
+            100_000.0,
+            49_950,
+        );
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_500.0)
+            .await;
+
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
+        assert_eq!(mgr.stable_channels[0].native_sats, 50);
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1, "accepted allocation must be synced back");
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let sync = crate::messages::parse_envelope(raw).unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
+        assert_eq!(payload["backing_sats"], 49_950);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_allocation_not_derived_from_signed_quote() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            5.0,
+            5_000,
+            45_000,
+            50_000,
+            100_000.0,
+        );
+
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            49.95,
+            100_000.0,
+            49_000,
+        );
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 5.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 5_000);
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -1128,6 +1128,7 @@ impl StableChannelManager {
         };
         let payload = crate::messages::build_sync_payload(
             channel_id,
+            &format!("{}", user_channel_id),
             expected_usd,
             backing_sats,
             sync_version,
@@ -2947,6 +2948,7 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&env.payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
         assert_eq!(v["channel_id"], CHANNEL_ID_HEX);
+        assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
         assert_eq!(v["sync_version"], 1);

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -18,6 +18,8 @@ use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
 
+const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
+
 /// Return each peer's own spendable-plus-reserve balance from the fields LDK exposes for that
 /// peer. `channel_value - local_balance` is not the remote balance: on outbound channels it also
 /// assigns the funder's current commitment fee to the remote peer.
@@ -27,6 +29,53 @@ fn channel_peer_balances(channel: &Channel) -> (u64, u64) {
     let remote_sats = (channel.inbound_capacity_msat / 1000)
         .saturating_add(channel.counterparty_unspendable_punishment_reserve);
     (local_sats, remote_sats)
+}
+
+/// Reproduce the wallet's trade-fee calculation from the allocation transition. Buys reduce the
+/// target by the gross amount. Sells increase it by the net amount, so the gross amount must be
+/// recovered before applying the one-percent fee. The wallet pays whole sats, with a one-msat
+/// minimum for a zero-sat fee.
+fn expected_trade_fee_msat(
+    old_expected_usd: f64,
+    new_expected_usd: f64,
+    quote_price: f64,
+) -> Option<u64> {
+    let fee_rate = stable_channels::constants::STABLE_CHANNEL_TRADE_FEE_RATE;
+    if !old_expected_usd.is_finite()
+        || old_expected_usd < 0.0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd < 0.0
+        || !quote_price.is_finite()
+        || quote_price <= 0.0
+        || !fee_rate.is_finite()
+        || !(0.0..1.0).contains(&fee_rate)
+    {
+        return None;
+    }
+
+    let target_delta = (new_expected_usd - old_expected_usd).abs();
+    let gross_usd = if new_expected_usd > old_expected_usd {
+        target_delta / (1.0 - fee_rate)
+    } else {
+        target_delta
+    };
+    let fee_sats = gross_usd * fee_rate / quote_price * 100_000_000.0;
+    if !fee_sats.is_finite() || fee_sats < 0.0 || fee_sats > (u64::MAX / 1000) as f64 {
+        return None;
+    }
+
+    Some((fee_sats as u64).saturating_mul(1000).max(1))
+}
+
+fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
+    if has_signed_quote {
+        return 0;
+    }
+
+    // Transitional legacy wallets did not sign their quote. Admit the same maximum price skew as
+    // signed trades, plus one sat for whole-sat rounding, while still rejecting material underpay.
+    ((expected_msat as f64 * MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0).ceil() as u64)
+        .max(1000)
 }
 
 /// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
@@ -651,7 +700,8 @@ impl StableChannelManager {
                         );
                     }
                 }
-                self.handle_trade_message(&raw, ldk, btc_price).await;
+                self.handle_trade_message(&raw, amount_msat, ldk, btc_price)
+                    .await;
             } else {
                 if let Some(pid) = payment_id.as_deref() {
                     if let Err(e) = self.db.record_settlement(pid, "stability") {
@@ -1483,6 +1533,7 @@ impl StableChannelManager {
     pub async fn handle_trade_message(
         &mut self,
         raw: &str,
+        amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
@@ -1596,6 +1647,61 @@ impl StableChannelManager {
             stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }));
             return;
         };
+        let Some(current_expected_usd) = self
+            .stable_channels
+            .iter()
+            .find(|sc| sc.user_channel_id == target_uid)
+            .map(|sc| sc.expected_usd.0)
+        else {
+            stable_channels::audit::audit_event(
+                "TRADE_STABLE_ENTRY_NOT_FOUND",
+                serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": format!("{}", target_uid) }),
+            );
+            return;
+        };
+
+        let fee_price = payload.quote_price.unwrap_or(btc_price);
+        let Some(expected_fee_msat) = expected_trade_fee_msat(
+            current_expected_usd,
+            payload.expected_usd,
+            fee_price,
+        ) else {
+            stable_channels::audit::audit_event(
+                "TRADE_FEE_INVALID",
+                serde_json::json!({
+                    "reason": "fee inputs are invalid",
+                    "old_expected_usd": current_expected_usd,
+                    "new_expected_usd": payload.expected_usd,
+                    "fee_price": fee_price,
+                    "amount_msat": amount_msat,
+                    "channel_id": chan.channel_id.clone(),
+                    "user_channel_id": chan.user_channel_id.clone(),
+                }),
+            );
+            return;
+        };
+        let tolerance_msat =
+            trade_fee_tolerance_msat(expected_fee_msat, payload.quote_price.is_some());
+        let fee_matches = amount_msat
+            .map(|actual| actual.abs_diff(expected_fee_msat) <= tolerance_msat)
+            .unwrap_or(false);
+        if !fee_matches {
+            stable_channels::audit::audit_event(
+                "TRADE_FEE_INVALID",
+                serde_json::json!({
+                    "reason": if amount_msat.is_some() { "incorrect amount" } else { "missing amount" },
+                    "actual_fee_msat": amount_msat,
+                    "expected_fee_msat": expected_fee_msat,
+                    "tolerance_msat": tolerance_msat,
+                    "old_expected_usd": current_expected_usd,
+                    "new_expected_usd": payload.expected_usd,
+                    "fee_price": fee_price,
+                    "channel_id": chan.channel_id.clone(),
+                    "user_channel_id": chan.user_channel_id.clone(),
+                }),
+            );
+            return;
+        }
         let (our_sats, their_sats) = channel_peer_balances(&chan);
         let new_expected = payload.expected_usd;
         let signed_allocation = match (payload.quote_price, payload.backing_sats) {
@@ -1621,7 +1727,6 @@ impl StableChannelManager {
 
                 // Both peers run their own price feed. Admit small observation-time differences,
                 // but reject a quote far enough away to change the economic trade materially.
-                const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
                 let quote_deviation_percent =
                     ((quote_price - btc_price) / btc_price * 100.0).abs();
                 if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
@@ -2324,7 +2429,15 @@ mod tests {
             type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
             value: env.into_bytes().into(),
         }];
-        mgr.handle_payment_received(records, Some("pay_test_1".to_string()), None, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        let fee_msat = expected_trade_fee_msat(0.0, 8.0, 100_000.0).unwrap();
+        mgr.handle_payment_received(
+            records,
+            Some("pay_test_1".to_string()),
+            Some(fee_msat),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
         assert_eq!(
@@ -3118,6 +3231,52 @@ mod tests {
             .as_secs()
     }
 
+    async fn handle_trade_with_valid_fee(
+        mgr: &mut StableChannelManager,
+        envelope: &str,
+        ldk: &dyn LdkServerCalls,
+        lsp_price: f64,
+    ) {
+        let signed = crate::messages::parse_envelope(envelope).unwrap();
+        let payload = crate::messages::parse_trade_payload(&signed.payload).unwrap();
+        let current_expected = mgr
+            .stable_channels
+            .iter()
+            .find(|sc| {
+                payload
+                    .user_channel_id
+                    .as_deref()
+                    .and_then(parse_user_channel_id)
+                    == Some(sc.user_channel_id)
+            })
+            .map(|sc| sc.expected_usd.0)
+            .unwrap_or(0.0);
+        let fee_msat = expected_trade_fee_msat(
+            current_expected,
+            payload.expected_usd,
+            payload.quote_price.unwrap_or(lsp_price),
+        )
+        .unwrap();
+        mgr.handle_trade_message(envelope, Some(fee_msat), ldk, lsp_price)
+            .await;
+    }
+
+    #[test]
+    fn trade_fee_matches_wallet_buy_and_sell_rounding() {
+        assert_eq!(
+            expected_trade_fee_msat(100.0, 50.0, 100_000.0),
+            Some(500_000)
+        );
+        assert_eq!(
+            expected_trade_fee_msat(50.0, 99.5, 100_000.0),
+            Some(500_000)
+        );
+        assert_eq!(
+            expected_trade_fee_msat(50.0, 50.0, 100_000.0),
+            Some(1)
+        );
+    }
+
     #[tokio::test]
     async fn trade_applies_valid_target() {
         let mut mgr = make_manager();
@@ -3127,9 +3286,58 @@ mod tests {
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_underpaid_signed_fee() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            49.95,
+            100_000.0,
+            49_950,
+        );
+
+        mgr.handle_trade_message(
+            &env,
+            Some(1),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -3164,8 +3372,13 @@ mod tests {
             100_000.0,
             49_950,
         );
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_500.0)
-            .await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_500.0,
+        )
+        .await;
 
         assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
         assert_eq!(mgr.stable_channels[0].native_sats, 50);
@@ -3209,8 +3422,13 @@ mod tests {
             100_000.0,
             49_995,
         );
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0)
-            .await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 49_995);
@@ -3247,8 +3465,13 @@ mod tests {
             100_000.0,
             49_000,
         );
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0)
-            .await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 5.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 5_000);
@@ -3264,7 +3487,13 @@ mod tests {
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 3.0, 3_000, 47_000, 50_000, 100_000.0);
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 3.0).abs() < 1e-6); // unchanged
     }
@@ -3278,7 +3507,13 @@ mod tests {
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 999.0);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6); // unchanged
     }
@@ -3295,7 +3530,13 @@ mod tests {
         // A wallet-push lands at receiver_usd plus a sub-epsilon overshoot (independent f64 paths).
         let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!(
             (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
@@ -3311,7 +3552,13 @@ mod tests {
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // unchanged
     }
@@ -3327,7 +3574,13 @@ mod tests {
         // A captured signed trade replayed a day later must be rejected (replay protection).
         let stale = test_unix_now() - 86_400;
         let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, stale);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!(
             (mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6,
@@ -3347,7 +3600,13 @@ mod tests {
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
         let stale = test_unix_now() - 86_400;
         let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, stale);
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
         let stale_ev = events.iter().find(|(e, _)| e == "TRADE_STALE")
@@ -3365,7 +3624,13 @@ mod tests {
 
         // A trade signed just now is within the window and applies normally.
         let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, test_unix_now());
-        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "a fresh signed trade must apply");
     }

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -123,9 +123,10 @@ pub struct StableChannelManager {
     spend_debounce: std::collections::HashMap<u128, u8>,
     /// Per-channel last logged stability outcome + value, so run_tick only audits on state-change.
     stability_throttle: std::collections::HashMap<u128, (String, f64)>,
-    /// Send persisted allocations once after startup hydration. This repairs a wallet that missed
-    /// the original best-effort SYNC while keeping routine ticks free of control payments.
-    startup_sync_pending: bool,
+    /// Persisted allocations still awaiting their one-time startup SYNC. Tracking each channel
+    /// independently prevents one incoherent channel from blocking every other wallet.
+    startup_sync_pending: std::collections::HashSet<u128>,
+    startup_sync_initialized: bool,
 }
 
 /// Outcome of an `edit_stable_channel` call.
@@ -147,7 +148,8 @@ impl StableChannelManager {
             data_dir,
             spend_debounce: std::collections::HashMap::new(),
             stability_throttle: std::collections::HashMap::new(),
-            startup_sync_pending: true,
+            startup_sync_pending: std::collections::HashSet::new(),
+            startup_sync_initialized: false,
         }
     }
 
@@ -434,42 +436,56 @@ impl StableChannelManager {
             self.stable_channels.len()
         );
 
-        let startup_state_is_coherent = self
+        if !self.startup_sync_initialized && !self.stable_channels.is_empty() {
+            self.startup_sync_pending
+                .extend(self.stable_channels.iter().map(|sc| sc.user_channel_id));
+            self.startup_sync_initialized = true;
+        }
+        self.retry_startup_sync(ldk).await;
+    }
+
+    async fn retry_startup_sync(&mut self, ldk: &dyn LdkServerCalls) {
+        if self.startup_sync_pending.is_empty() {
+            return;
+        }
+        let live_ids: std::collections::HashSet<u128> = self
             .stable_channels
             .iter()
-            .all(|sc| sc.stable_receiver_btc.sats >= sc.backing_sats);
-        if self.startup_sync_pending
-            && !self.stable_channels.is_empty()
-            && startup_state_is_coherent
-        {
-            let syncs: Vec<_> = self
-                .stable_channels
-                .iter()
-                .map(|sc| {
-                    (
-                        sc.user_channel_id,
-                        sc.channel_id.to_string(),
-                        sc.expected_usd.0,
-                        sc.backing_sats,
-                        sc.counterparty.to_string(),
-                    )
-                })
-                .collect();
-            self.startup_sync_pending = false;
-            for (uid, channel_id, expected_usd, backing_sats, counterparty) in syncs {
-                if !self
-                    .send_sync_message(
-                        ldk,
-                        uid,
-                        &channel_id,
-                        expected_usd,
-                        backing_sats,
-                        &counterparty,
-                    )
-                    .await
-                {
-                    self.startup_sync_pending = true;
-                }
+            .map(|sc| sc.user_channel_id)
+            .collect();
+        self.startup_sync_pending
+            .retain(|uid| live_ids.contains(uid));
+
+        let syncs: Vec<_> = self
+            .stable_channels
+            .iter()
+            .filter(|sc| {
+                self.startup_sync_pending.contains(&sc.user_channel_id)
+                    && sc.stable_receiver_btc.sats >= sc.backing_sats
+            })
+            .map(|sc| {
+                (
+                    sc.user_channel_id,
+                    sc.channel_id.to_string(),
+                    sc.expected_usd.0,
+                    sc.backing_sats,
+                    sc.counterparty.to_string(),
+                )
+            })
+            .collect();
+        for (uid, channel_id, expected_usd, backing_sats, counterparty) in syncs {
+            if self
+                .send_sync_message(
+                    ldk,
+                    uid,
+                    &channel_id,
+                    expected_usd,
+                    backing_sats,
+                    &counterparty,
+                )
+                .await
+            {
+                self.startup_sync_pending.remove(&uid);
             }
         }
     }
@@ -478,6 +494,8 @@ impl StableChannelManager {
     pub async fn reconcile_if_empty(&mut self, ldk: &dyn LdkServerCalls, btc_price: f64) {
         if self.stable_channels.is_empty() {
             self.reconcile_from_grpc(ldk, btc_price).await;
+        } else {
+            self.retry_startup_sync(ldk).await;
         }
     }
 
@@ -489,13 +507,24 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
-        let target_uid = parse_user_channel_id(&user_channel_id);
-        if let Some(uid) = target_uid {
-            if self.stable_channels.iter().any(|sc| sc.user_channel_id == uid) {
-                self.handle_channel_ready_splice(uid, ldk, btc_price)
-                    .await;
-                return;
-            }
+        let Some(target_uid) = parse_user_channel_id(&user_channel_id) else {
+            stable_channels::audit::audit_event(
+                "CHANNEL_READY_UID_UNPARSEABLE",
+                serde_json::json!({
+                    "channel_id": channel_id,
+                    "user_channel_id": user_channel_id,
+                }),
+            );
+            return;
+        };
+        if self
+            .stable_channels
+            .iter()
+            .any(|sc| sc.user_channel_id == target_uid)
+        {
+            self.handle_channel_ready_splice(target_uid, ldk, btc_price)
+                .await;
+            return;
         }
 
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
@@ -522,13 +551,11 @@ impl StableChannelManager {
 
         let (our_sats, their_sats) = channel_peer_balances(&c);
 
-        let user_channel_id_u128 = parse_user_channel_id(&user_channel_id).unwrap_or(0);
-
         let new_sc = StableChannel {
             channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(
                 parse_channel_id_hex(&c.channel_id),
             ),
-            user_channel_id: user_channel_id_u128,
+            user_channel_id: target_uid,
             counterparty: parse_pubkey_hex(&c.counterparty_node_id),
             is_stable_receiver: false,
             expected_usd: USD::from_f64(0.0),
@@ -555,7 +582,7 @@ impl StableChannelManager {
 
         if let Err(e) = self.db.save_channel(
             &c.channel_id,
-            &user_channel_id,
+            &format!("{}", target_uid),
             0.0,
             0,
             their_sats,
@@ -1056,7 +1083,7 @@ impl StableChannelManager {
         }
 
         for (uid, channel_id, expected_usd, backing_sats, counterparty) in backstop_syncs {
-            let _ = self
+            let sent = self
                 .send_sync_message(
                     ldk,
                     uid,
@@ -1066,6 +1093,9 @@ impl StableChannelManager {
                     &counterparty,
                 )
                 .await;
+            if !sent {
+                self.startup_sync_pending.insert(uid);
+            }
         }
     }
 
@@ -1323,7 +1353,7 @@ impl StableChannelManager {
             );
         }
         if deducted {
-            let _ = self
+            let sent = self
                 .send_sync_message(
                     ldk,
                     target_uid,
@@ -1333,6 +1363,9 @@ impl StableChannelManager {
                     &counterparty_hex,
                 )
                 .await;
+            if !sent {
+                self.startup_sync_pending.insert(target_uid);
+            }
         }
     }
 
@@ -1428,7 +1461,7 @@ impl StableChannelManager {
             serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": ucid_str, "deducted": deducted }),
         );
         if deducted {
-            let _ = self
+            let sent = self
                 .send_sync_message(
                     ldk,
                     uid,
@@ -1438,6 +1471,9 @@ impl StableChannelManager {
                     &counterparty_hex,
                 )
                 .await;
+            if !sent {
+                self.startup_sync_pending.insert(uid);
+            }
         }
     }
 
@@ -1602,17 +1638,24 @@ impl StableChannelManager {
                     return;
                 }
 
-                let derived_backing = stable_channels::stable::trade_backing_sats(
-                    their_sats,
-                    new_expected,
-                    quote_price,
-                );
-                if backing_sats > their_sats || backing_sats.abs_diff(derived_backing) > 1 {
+                let signed_backing_usd = backing_sats as f64 / 100_000_000.0 * quote_price;
+                let allocation_delta_usd = (signed_backing_usd - new_expected).abs();
+                let zero_allocation_is_consistent = if new_expected < 0.01 {
+                    backing_sats == 0
+                } else {
+                    backing_sats > 0
+                };
+                if backing_sats > their_sats
+                    || !zero_allocation_is_consistent
+                    || allocation_delta_usd
+                        > stable_channels::constants::STABILITY_THRESHOLD_USD
+                {
                     stable_channels::audit::audit_event(
                         "TRADE_ALLOCATION_INVALID",
                         serde_json::json!({
                             "signed_backing_sats": backing_sats,
-                            "derived_backing_sats": derived_backing,
+                            "signed_backing_usd": signed_backing_usd,
+                            "allocation_delta_usd": allocation_delta_usd,
                             "receiver_sats": their_sats,
                             "quote_price": quote_price,
                             "channel_id": chan.channel_id.clone(),
@@ -1720,7 +1763,7 @@ impl StableChannelManager {
                 "quote_deviation_percent": signed_allocation.map(|(_, _, deviation)| deviation),
             }),
         );
-        let _ = self
+        let sent = self
             .send_sync_message(
                 ldk,
                 target_uid,
@@ -1730,6 +1773,9 @@ impl StableChannelManager {
                 &counterparty,
             )
             .await;
+        if !sent {
+            self.startup_sync_pending.insert(target_uid);
+        }
     }
 }
 
@@ -2084,7 +2130,7 @@ mod tests {
             1,
             "startup hydration must resync persisted allocation"
         );
-        assert!(!mgr.startup_sync_pending);
+        assert!(mgr.startup_sync_pending.is_empty());
     }
 
     #[tokio::test]
@@ -2112,13 +2158,13 @@ mod tests {
         let failing = FakeLdkServer::new(channels.clone()).with_send_failure();
         mgr.reconcile_from_grpc(&failing as &dyn LdkServerCalls, 100_000.0)
             .await;
-        assert!(mgr.startup_sync_pending);
+        assert!(!mgr.startup_sync_pending.is_empty());
 
         let restored = FakeLdkServer::new(channels);
         mgr.reconcile_from_grpc(&restored as &dyn LdkServerCalls, 100_000.0)
             .await;
         assert_eq!(restored.sends.lock().unwrap().len(), 1);
-        assert!(!mgr.startup_sync_pending);
+        assert!(mgr.startup_sync_pending.is_empty());
 
         mgr.reconcile_from_grpc(&restored as &dyn LdkServerCalls, 100_000.0)
             .await;
@@ -2155,7 +2201,53 @@ mod tests {
             .await;
 
         assert!(fake.sends.lock().unwrap().is_empty());
-        assert!(mgr.startup_sync_pending);
+        assert!(!mgr.startup_sync_pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn startup_reconcile_syncs_coherent_channels_independently() {
+        let mut mgr = make_manager();
+        let second_channel_id = "22".repeat(32);
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                25.0,
+                60_000,
+                0,
+                None,
+            )
+            .unwrap();
+        mgr.db
+            .save_channel(&second_channel_id, "2", 20.0, 40_000, 10_000, None)
+            .unwrap();
+        let fake = FakeLdkServer::new(vec![
+            make_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                COUNTERPARTY_HEX,
+                100_000,
+                50_000_000,
+                true,
+            ),
+            make_channel(
+                &second_channel_id,
+                "2",
+                COUNTERPARTY_HEX,
+                100_000,
+                50_000_000,
+                true,
+            ),
+        ]);
+
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+        assert!(mgr
+            .startup_sync_pending
+            .contains(&USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap()));
+        assert!(!mgr.startup_sync_pending.contains(&2));
     }
 
     #[tokio::test]
@@ -3081,6 +3173,46 @@ mod tests {
         let sync = crate::messages::parse_envelope(raw).unwrap();
         let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
         assert_eq!(payload["backing_sats"], 49_950);
+    }
+
+    #[tokio::test]
+    async fn trade_accepts_economically_consistent_full_allocation_with_balance_skew() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+
+        // The wallet signed against a receiver balance five sats below the LSP's post-settlement
+        // observation. The pair is still fully collateralized and differs by only half a cent.
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            50.0,
+            100_000.0,
+            49_995,
+        );
+        mgr.handle_trade_message(&env, &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_995);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -1027,8 +1027,26 @@ impl StableChannelManager {
         backing_sats: u64,
         counterparty: &str,
     ) {
-        let payload =
-            crate::messages::build_sync_payload(user_channel_id, expected_usd, backing_sats);
+        let sync_version = match self.db.next_sync_version(&format!("{}", user_channel_id)) {
+            Ok(version) => version,
+            Err(e) => {
+                stable_channels::audit::audit_event(
+                    "SYNC_MESSAGE_FAILED",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", user_channel_id),
+                        "stage": "reserve_version",
+                        "error": e.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let payload = crate::messages::build_sync_payload(
+            user_channel_id,
+            expected_usd,
+            backing_sats,
+            sync_version,
+        );
         let signature = match ldk
             .sign_message(SignMessageRequest {
                 message: payload.as_bytes().to_vec().into(),
@@ -1082,6 +1100,7 @@ impl StableChannelManager {
                         "user_channel_id": format!("{}", user_channel_id),
                         "expected_usd": expected_usd,
                         "backing_sats": backing_sats,
+                        "sync_version": sync_version,
                     }),
                 );
             },
@@ -2644,6 +2663,9 @@ mod tests {
     async fn send_sync_message_keysends_signed_tlv() {
         let mgr = make_manager();
         let fake = FakeLdkServer::new(vec![]);
+        mgr.db
+            .save_channel("sync-channel", "7", 25.0, 31_250, 0, None)
+            .unwrap();
         mgr.send_sync_message(
             &fake as &dyn LdkServerCalls,
             7u128,
@@ -2672,6 +2694,8 @@ mod tests {
         assert_eq!(v["user_channel_id"], "7");
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
+        assert_eq!(v["sync_version"], 1);
+        assert_eq!(mgr.db.get_sync_version("7").unwrap(), Some(1));
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -123,6 +123,9 @@ pub struct StableChannelManager {
     spend_debounce: std::collections::HashMap<u128, u8>,
     /// Per-channel last logged stability outcome + value, so run_tick only audits on state-change.
     stability_throttle: std::collections::HashMap<u128, (String, f64)>,
+    /// Send persisted allocations once after startup hydration. This repairs a wallet that missed
+    /// the original best-effort SYNC while keeping routine ticks free of control payments.
+    startup_sync_pending: bool,
 }
 
 /// Outcome of an `edit_stable_channel` call.
@@ -144,6 +147,7 @@ impl StableChannelManager {
             data_dir,
             spend_debounce: std::collections::HashMap::new(),
             stability_throttle: std::collections::HashMap::new(),
+            startup_sync_pending: true,
         }
     }
 
@@ -429,6 +433,45 @@ impl StableChannelManager {
             "[stable] reconciled {} stable channel(s) from sqlite",
             self.stable_channels.len()
         );
+
+        let startup_state_is_coherent = self
+            .stable_channels
+            .iter()
+            .all(|sc| sc.stable_receiver_btc.sats >= sc.backing_sats);
+        if self.startup_sync_pending
+            && !self.stable_channels.is_empty()
+            && startup_state_is_coherent
+        {
+            let syncs: Vec<_> = self
+                .stable_channels
+                .iter()
+                .map(|sc| {
+                    (
+                        sc.user_channel_id,
+                        sc.channel_id.to_string(),
+                        sc.expected_usd.0,
+                        sc.backing_sats,
+                        sc.counterparty.to_string(),
+                    )
+                })
+                .collect();
+            self.startup_sync_pending = false;
+            for (uid, channel_id, expected_usd, backing_sats, counterparty) in syncs {
+                if !self
+                    .send_sync_message(
+                        ldk,
+                        uid,
+                        &channel_id,
+                        expected_usd,
+                        backing_sats,
+                        &counterparty,
+                    )
+                    .await
+                {
+                    self.startup_sync_pending = true;
+                }
+            }
+        }
     }
 
     /// Self-heal: if the in-memory list is empty (startup/reconnect reconcile skipped on a cold price cache), rebuild it from truth; a populated list is left untouched so a transient empty snapshot can't wipe it.
@@ -760,7 +803,7 @@ impl StableChannelManager {
         let cooldown = stable_channels::constants::STABILITY_PAYMENT_COOLDOWN_SECS as i64;
 
         // Accepted USD and sat allocations for backstop SYNCs sent after the iter_mut borrow ends.
-        let mut backstop_syncs: Vec<(u128, f64, u64, String)> = Vec::new();
+        let mut backstop_syncs: Vec<(u128, String, f64, u64, String)> = Vec::new();
         const BACKSTOP_DEBOUNCE_TICKS: u8 = 2;
 
         for sc in self.stable_channels.iter_mut() {
@@ -816,6 +859,7 @@ impl StableChannelManager {
                         }
                         backstop_syncs.push((
                             uid,
+                            c.channel_id.clone(),
                             sc.expected_usd.0,
                             sc.backing_sats,
                             sc.counterparty.to_string(),
@@ -1011,22 +1055,32 @@ impl StableChannelManager {
             }
         }
 
-        for (uid, expected_usd, backing_sats, counterparty) in backstop_syncs {
-            self.send_sync_message(ldk, uid, expected_usd, backing_sats, &counterparty)
+        for (uid, channel_id, expected_usd, backing_sats, counterparty) in backstop_syncs {
+            let _ = self
+                .send_sync_message(
+                    ldk,
+                    uid,
+                    &channel_id,
+                    expected_usd,
+                    backing_sats,
+                    &counterparty,
+                )
                 .await;
         }
     }
 
     /// Sign a SYNC_V1 payload and keysend it (1 msat) to the counterparty in custom TLV 13377331.
-    /// Best effort: a send failure is audited, never propagated. Mutates no state.
+    /// Best effort: a send failure is audited and returned to the caller. Allocation state is
+    /// unchanged, while the monotonic sync version is durably reserved before signing.
     pub async fn send_sync_message(
         &self,
         ldk: &dyn LdkServerCalls,
         user_channel_id: u128,
+        channel_id: &str,
         expected_usd: f64,
         backing_sats: u64,
         counterparty: &str,
-    ) {
+    ) -> bool {
         let sync_version = match self.db.next_sync_version(&format!("{}", user_channel_id)) {
             Ok(version) => version,
             Err(e) => {
@@ -1034,15 +1088,16 @@ impl StableChannelManager {
                     "SYNC_MESSAGE_FAILED",
                     serde_json::json!({
                         "user_channel_id": format!("{}", user_channel_id),
+                        "channel_id": channel_id,
                         "stage": "reserve_version",
                         "error": e.to_string(),
                     }),
                 );
-                return;
+                return false;
             }
         };
         let payload = crate::messages::build_sync_payload(
-            user_channel_id,
+            channel_id,
             expected_usd,
             backing_sats,
             sync_version,
@@ -1059,11 +1114,12 @@ impl StableChannelManager {
                     "SYNC_MESSAGE_FAILED",
                     serde_json::json!({
                         "user_channel_id": format!("{}", user_channel_id),
+                        "channel_id": channel_id,
                         "stage": "sign",
                         "error": e.to_string(),
                     }),
                 );
-                return;
+                return false;
             }
         };
         let envelope = crate::messages::build_envelope(payload, signature);
@@ -1098,20 +1154,26 @@ impl StableChannelManager {
                     "SYNC_MESSAGE_SENT",
                     serde_json::json!({
                         "user_channel_id": format!("{}", user_channel_id),
+                        "channel_id": channel_id,
                         "expected_usd": expected_usd,
                         "backing_sats": backing_sats,
                         "sync_version": sync_version,
                     }),
                 );
+                true
             },
-            Err(e) => stable_channels::audit::audit_event(
-                "SYNC_MESSAGE_FAILED",
-                serde_json::json!({
-                    "user_channel_id": format!("{}", user_channel_id),
-                    "stage": "send",
-                    "error": e.to_string(),
-                }),
-            ),
+            Err(e) => {
+                stable_channels::audit::audit_event(
+                    "SYNC_MESSAGE_FAILED",
+                    serde_json::json!({
+                        "user_channel_id": format!("{}", user_channel_id),
+                        "channel_id": channel_id,
+                        "stage": "send",
+                        "error": e.to_string(),
+                    }),
+                );
+                false
+            }
         }
     }
 
@@ -1261,13 +1323,15 @@ impl StableChannelManager {
             );
         }
         if deducted {
-            self.send_sync_message(
-                ldk,
-                target_uid,
-                expected_usd_f,
-                backing_sats,
-                &counterparty_hex,
-            )
+            let _ = self
+                .send_sync_message(
+                    ldk,
+                    target_uid,
+                    &channel_id_hex,
+                    expected_usd_f,
+                    backing_sats,
+                    &counterparty_hex,
+                )
                 .await;
         }
     }
@@ -1364,7 +1428,15 @@ impl StableChannelManager {
             serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": ucid_str, "deducted": deducted }),
         );
         if deducted {
-            self.send_sync_message(ldk, uid, expected_usd_f, backing, &counterparty_hex)
+            let _ = self
+                .send_sync_message(
+                    ldk,
+                    uid,
+                    &channel_id_hex,
+                    expected_usd_f,
+                    backing,
+                    &counterparty_hex,
+                )
                 .await;
         }
     }
@@ -1648,14 +1720,16 @@ impl StableChannelManager {
                 "quote_deviation_percent": signed_allocation.map(|(_, _, deviation)| deviation),
             }),
         );
-        self.send_sync_message(
-            ldk,
-            target_uid,
-            expected_usd_f,
-            backing,
-            &counterparty,
-        )
-        .await;
+        let _ = self
+            .send_sync_message(
+                ldk,
+                target_uid,
+                &channel_id_hex,
+                expected_usd_f,
+                backing,
+                &counterparty,
+            )
+            .await;
     }
 }
 
@@ -1980,12 +2054,21 @@ mod tests {
         // Simulate a restart: empty in-memory Vec but a persisted stable channel row in sqlite.
         let mut mgr = make_manager();
         // Persist a row directly (bypass the in-memory Vec) to mimic a prior session.
-        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, 25.0, 40_000, 10_000, Some("persisted")).unwrap();
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                25.0,
+                40_000,
+                10_000,
+                Some("persisted"),
+            )
+            .unwrap();
         assert_eq!(mgr.stable_channels.len(), 0, "fresh manager starts empty");
 
         // The live LDK Server still reports the channel.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
             100_000, 50_000_000, true,
         )]);
         mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0).await;
@@ -1996,6 +2079,83 @@ mod tests {
         assert_eq!(sc.backing_sats, 40_000, "persisted backing_sats preserved");
         assert_eq!(sc.note.as_deref(), Some("persisted"), "persisted note preserved");
         assert_eq!(sc.counterparty.to_string(), COUNTERPARTY_HEX, "counterparty resolved from live channel");
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "startup hydration must resync persisted allocation"
+        );
+        assert!(!mgr.startup_sync_pending);
+    }
+
+    #[tokio::test]
+    async fn startup_reconcile_retries_failed_sync() {
+        let mut mgr = make_manager();
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                25.0,
+                40_000,
+                10_000,
+                None,
+            )
+            .unwrap();
+        let channels = vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )];
+
+        let failing = FakeLdkServer::new(channels.clone()).with_send_failure();
+        mgr.reconcile_from_grpc(&failing as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert!(mgr.startup_sync_pending);
+
+        let restored = FakeLdkServer::new(channels);
+        mgr.reconcile_from_grpc(&restored as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(restored.sends.lock().unwrap().len(), 1);
+        assert!(!mgr.startup_sync_pending);
+
+        mgr.reconcile_from_grpc(&restored as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(
+            restored.sends.lock().unwrap().len(),
+            1,
+            "successful startup sync is sent only once"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_reconcile_defers_sync_when_live_balance_is_below_backing() {
+        let mut mgr = make_manager();
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                25.0,
+                60_000,
+                0,
+                None,
+            )
+            .unwrap();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+
+        assert!(fake.sends.lock().unwrap().is_empty());
+        assert!(mgr.startup_sync_pending);
     }
 
     #[tokio::test]
@@ -2666,14 +2826,17 @@ mod tests {
         mgr.db
             .save_channel("sync-channel", "7", 25.0, 31_250, 0, None)
             .unwrap();
-        mgr.send_sync_message(
-            &fake as &dyn LdkServerCalls,
-            7u128,
-            25.0,
-            31_250,
-            COUNTERPARTY_HEX,
-        )
-            .await;
+        assert!(
+            mgr.send_sync_message(
+                &fake as &dyn LdkServerCalls,
+                7u128,
+                CHANNEL_ID_HEX,
+                25.0,
+                31_250,
+                COUNTERPARTY_HEX,
+            )
+            .await
+        );
 
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
@@ -2691,7 +2854,7 @@ mod tests {
         assert_eq!(env.signature, "fake-sig");
         let v: serde_json::Value = serde_json::from_str(&env.payload).unwrap();
         assert_eq!(v["type"], "SYNC_V1");
-        assert_eq!(v["user_channel_id"], "7");
+        assert_eq!(v["channel_id"], CHANNEL_ID_HEX);
         assert_eq!(v["expected_usd"], 25.0);
         assert_eq!(v["backing_sats"], 31_250);
         assert_eq!(v["sync_version"], 1);

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -18,6 +18,17 @@ use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
 
+/// Return each peer's own spendable-plus-reserve balance from the fields LDK exposes for that
+/// peer. `channel_value - local_balance` is not the remote balance: on outbound channels it also
+/// assigns the funder's current commitment fee to the remote peer.
+fn channel_peer_balances(channel: &Channel) -> (u64, u64) {
+    let local_sats = (channel.outbound_capacity_msat / 1000)
+        .saturating_add(channel.unspendable_punishment_reserve.unwrap_or(0));
+    let remote_sats = (channel.inbound_capacity_msat / 1000)
+        .saturating_add(channel.counterparty_unspendable_punishment_reserve);
+    (local_sats, remote_sats)
+}
+
 /// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
 #[async_trait]
 pub trait LdkServerCalls: Send + Sync {
@@ -198,9 +209,7 @@ impl StableChannelManager {
         let expected_usd = USD::from_f64(expected_usd_f);
         let expected_btc = Bitcoin::from_usd(expected_usd, btc_price);
 
-        let unspendable = channel.unspendable_punishment_reserve.unwrap_or(0);
-        let our_balance_sats = (channel.outbound_capacity_msat / 1000) + unspendable;
-        let their_balance_sats = channel.channel_value_sats.saturating_sub(our_balance_sats);
+        let (our_balance_sats, their_balance_sats) = channel_peer_balances(&channel);
 
         let stable_provider_btc = Bitcoin::from_sats(our_balance_sats);
         let stable_receiver_btc = Bitcoin::from_sats(their_balance_sats);
@@ -386,9 +395,7 @@ impl StableChannelManager {
             };
 
             // Balances come from the live channel. expected_usd/backing/native/note are the persisted intent.
-            let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-            let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-            let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+            let (our_sats, their_sats) = channel_peer_balances(c);
 
             let stable_provider_btc = Bitcoin::from_sats(our_sats);
             let stable_receiver_btc = Bitcoin::from_sats(their_sats);
@@ -470,9 +477,7 @@ impl StableChannelManager {
             return;
         };
 
-        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+        let (our_sats, their_sats) = channel_peer_balances(&c);
 
         let user_channel_id_u128 = parse_user_channel_id(&user_channel_id).unwrap_or(0);
 
@@ -657,9 +662,7 @@ impl StableChannelManager {
             }) else {
                 continue;
             };
-            let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-            let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-            let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+            let (_, their_sats) = channel_peer_balances(c);
             let drop = sc.stable_receiver_btc.sats.saturating_sub(their_sats);
             if drop > 0 && drop.abs_diff(amount_sats) <= 1 {
                 matches.push((i, c, their_sats));
@@ -766,9 +769,7 @@ impl StableChannelManager {
             }
             let Some(c) = by_user_channel_id.get(&sc.user_channel_id) else { continue; };
 
-            let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-            let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-            let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+            let (our_sats, their_sats) = channel_peer_balances(c);
             sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
             sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
             sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
@@ -1146,9 +1147,7 @@ impl StableChannelManager {
         else {
             return; // channel vanished from the server
         };
-        let unspendable = chan.unspendable_punishment_reserve.unwrap_or(0);
-        let lsp_sats = (chan.outbound_capacity_msat / 1000) + unspendable;
-        let post_user_sats = chan.channel_value_sats.saturating_sub(lsp_sats);
+        let (_, post_user_sats) = channel_peer_balances(&chan);
         let channel_id_hex = chan.channel_id.clone();
 
         let persisted = {
@@ -1264,9 +1263,7 @@ impl StableChannelManager {
         else {
             return;
         };
-        let unspendable = c.unspendable_punishment_reserve.unwrap_or(0);
-        let our_sats = (c.outbound_capacity_msat / 1000) + unspendable;
-        let their_sats = c.channel_value_sats.saturating_sub(our_sats);
+        let (our_sats, their_sats) = channel_peer_balances(&c);
         let channel_id_hex = c.channel_id.clone();
         let new_channel_id_bytes = parse_channel_id_hex(&c.channel_id);
 
@@ -1450,9 +1447,7 @@ impl StableChannelManager {
             stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }));
             return;
         };
-        let unspendable = chan.unspendable_punishment_reserve.unwrap_or(0);
-        let our_sats = (chan.outbound_capacity_msat / 1000) + unspendable;
-        let their_sats = chan.channel_value_sats.saturating_sub(our_sats);
+        let (our_sats, their_sats) = channel_peer_balances(&chan);
         let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
         let new_expected = payload.expected_usd;
         // Epsilon absorbs f64 boundary rounding so a spend-driven push landing at ~receiver_usd is admitted; residual drift self-heals.
@@ -1741,13 +1736,16 @@ mod tests {
         outbound_msat: u64,
         is_usable: bool,
     ) -> GrpcChannel {
+        let remote_sats = value_sats.saturating_sub(outbound_msat / 1000);
         GrpcChannel {
             channel_id: channel_id.to_string(),
             counterparty_node_id: counterparty.to_string(),
             user_channel_id: user_channel_id.to_string(),
             unspendable_punishment_reserve: Some(0),
+            counterparty_unspendable_punishment_reserve: 0,
             channel_value_sats: value_sats,
             outbound_capacity_msat: outbound_msat,
+            inbound_capacity_msat: remote_sats.saturating_mul(1000),
             is_usable,
             is_channel_ready: true,
             is_outbound: true,
@@ -2020,6 +2018,55 @@ mod tests {
             mgr.stable_channels[0].native_sats,
             "native_channel_btc must match native_sats after a forward",
         );
+    }
+
+    #[tokio::test]
+    async fn forwarded_overflow_uses_remote_capacity_not_commitment_fee_residual() {
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        // Exact production regression: the 151,958-sat funding output has 659 sats reserved for
+        // the funder's commitment fee. After the forward, the remote user owns 67,595 sats and
+        // the LSP owns 83,704; channel_value - LSP would incorrectly report 68,254 for the user.
+        let mut channel = make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            151_958,
+            83_704_000,
+            true,
+        );
+        channel.inbound_capacity_msat = 67_595_000;
+        let fake = FakeLdkServer::new(vec![channel]);
+        seed_channel(
+            &mut mgr,
+            uid,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            46.4,
+            70_433,
+            4_740,
+            75_173,
+            65_877.7,
+        );
+
+        mgr.handle_payment_forwarded(
+            USER_CHANNEL_ID_DECIMAL.to_string(),
+            Some("next-ucid-production-regression".to_string()),
+            CHANNEL_ID_HEX.to_string(),
+            "next-channel".to_string(),
+            COUNTERPARTY_HEX.to_string(),
+            "next-node".to_string(),
+            7_578_000,
+            0,
+            &fake as &dyn LdkServerCalls,
+            66_000.96,
+        )
+        .await;
+
+        let expected = 46.4 - (2_838.0 / 100_000_000.0 * 66_000.96);
+        let sc = &mgr.stable_channels[0];
+        assert!((sc.expected_usd.0 - expected).abs() < 1e-9);
+        assert_eq!(sc.stable_receiver_btc.sats, 67_595);
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -69,7 +69,10 @@ fn expected_trade_fee_msat(
 
 fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
     if has_signed_quote {
-        return 0;
+        // The wallet floors its USD fee to whole sats before sending. Reconstructing a sell's
+        // gross amount from the signed net target can land on the adjacent sat due to that lost
+        // fraction, so admit exactly one sat while still rejecting material underpayment.
+        return 1000;
     }
 
     // Transitional legacy wallets did not sign their quote. Admit the same maximum price skew as
@@ -188,6 +191,77 @@ pub struct EditOutcome {
 impl StableChannelManager {
     pub fn data_dir(&self) -> &std::path::Path {
         &self.data_dir
+    }
+
+    /// Consume an asynchronous failure for an outbound stability payment. The database performs
+    /// the authoritative compare-and-swap; the in-memory allocation is restored only when it is
+    /// still the exact optimistic state written by that payment.
+    pub fn handle_failed_stability_payment(
+        &mut self,
+        payment_id: &str,
+    ) -> Option<stable_channels::db::StabilityRollback> {
+        let rollback = match self.db.rollback_failed_stability_settlement(payment_id) {
+            Ok(value) => value?,
+            Err(error) => {
+                tracing::error!(
+                    "[stable] failed-payment rollback lookup failed for {}: {}",
+                    payment_id,
+                    error
+                );
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({
+                        "op": "rollback_failed_stability_settlement",
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return None;
+            }
+        };
+
+        if rollback.applied {
+            let rollback_user_channel_id = parse_user_channel_id(&rollback.user_channel_id);
+            if let Some(sc) = self
+                .stable_channels
+                .iter_mut()
+                .find(|sc| rollback_user_channel_id == Some(sc.user_channel_id))
+            {
+                if sc.backing_sats == rollback.backing_sats_after
+                    && sc.native_sats == rollback.native_sats_before
+                    && sc.expected_usd.0 == rollback.expected_usd
+                {
+                    sc.backing_sats = rollback.backing_sats_before;
+                    sc.native_sats = rollback.native_sats_before;
+                    sc.native_channel_btc = Bitcoin::from_sats(sc.native_sats);
+                    sc.last_stability_payment = rollback.last_stability_payment_before;
+                }
+            }
+            self.stability_throttle
+                .remove(&rollback_user_channel_id.unwrap_or_default());
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_ROLLED_BACK",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "user_channel_id": rollback.user_channel_id,
+                    "backing_sats_before": rollback.backing_sats_before,
+                    "backing_sats_after": rollback.backing_sats_after,
+                    "restored_native_sats": rollback.native_sats_before,
+                }),
+            );
+        } else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_ROLLBACK_SKIPPED",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "user_channel_id": rollback.user_channel_id,
+                    "expected_optimistic_backing_sats": rollback.backing_sats_after,
+                    "reason": "allocation changed after payment was sent",
+                }),
+            );
+        }
+
+        Some(rollback)
     }
 
     pub fn new(db: Arc<Database>, data_dir: PathBuf) -> Self {
@@ -1018,28 +1092,45 @@ impl StableChannelManager {
                     let user_channel_id_clone = c.user_channel_id.clone();
                     let expected_usd_for_db = sc.expected_usd.0;
                     let note_for_db = sc.note.clone();
+                    let backing_before = sc.backing_sats;
+                    let backing_after =
+                        ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
+                    let native_before = sc.native_sats;
+                    let last_stability_payment_before = sc.last_stability_payment;
                     match ldk.spontaneous_send(send_req).await {
                         Ok(resp) => {
                             if !resp.payment_id.is_empty() {
-                                if let Err(e) = self.db.record_settlement_with_channel(
+                                match self.db.record_stability_settlement_with_rollback(
                                     &resp.payment_id,
-                                    "stability",
                                     &user_channel_id_clone,
+                                    backing_before,
+                                    backing_after,
+                                    native_before,
+                                    expected_usd_for_db,
+                                    last_stability_payment_before,
                                 ) {
-                                    tracing::error!(
-                                        "[stable] record_settlement (stability) failed: {}",
-                                        e
-                                    );
-                                    stable_channels::audit::audit_event(
-                                        "DB_WRITE_FAILED",
-                                        serde_json::json!({ "op": "record_settlement", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": e.to_string() }),
-                                    );
+                                    Ok(true) => {},
+                                    Ok(false) => {
+                                        stable_channels::audit::audit_event(
+                                            "DB_WRITE_FAILED",
+                                            serde_json::json!({ "op": "record_stability_settlement_with_rollback", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": "duplicate payment id or invalid rollback metadata" }),
+                                        );
+                                    },
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "[stable] record_settlement (stability) failed: {}",
+                                            e
+                                        );
+                                        stable_channels::audit::audit_event(
+                                            "DB_WRITE_FAILED",
+                                            serde_json::json!({ "op": "record_stability_settlement_with_rollback", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": e.to_string() }),
+                                        );
+                                    },
                                 }
                             }
                             sc.last_stability_payment = now;
                             // Reset backing_sats to equilibrium so the next tick doesn't re-pay the same drift forever. Native is recomputed on the next balance refresh.
-                            sc.backing_sats =
-                                ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
+                            sc.backing_sats = backing_after;
                             let backing = sc.backing_sats;
                             let native = sc.native_sats;
                             if let Err(e) = self.db.save_channel(
@@ -2910,6 +3001,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_outbound_stability_payment_restores_backing_and_cooldown() {
+        let mut mgr = make_manager();
+        let initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let drift = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+
+        mgr.run_tick(&drift as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 62_500);
+        assert!(mgr.stable_channels[0].last_stability_payment > 0);
+
+        let rollback = mgr
+            .handle_failed_stability_payment("fake-payment-id")
+            .expect("failure should find reversible stability metadata");
+        assert!(rollback.applied);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
+        assert_eq!(mgr.stable_channels[0].native_sats, 0);
+        assert_eq!(mgr.stable_channels[0].last_stability_payment, 0);
+        assert_eq!(
+            mgr.db
+                .load_channel(USER_CHANNEL_ID_HEX)
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            50_000
+        );
+        assert!(mgr
+            .handle_failed_stability_payment("fake-payment-id")
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn run_tick_skips_high_risk_channel() {
         let mut mgr = make_manager();
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 50_000, 0, 50_000, 100_000.0);
@@ -3275,6 +3422,18 @@ mod tests {
             expected_trade_fee_msat(50.0, 50.0, 100_000.0),
             Some(1)
         );
+        assert_eq!(trade_fee_tolerance_msat(114_000, true), 1_000);
+
+        // At this boundary the wallet's original gross fee floors to 113 sats, while recovering
+        // the gross sell amount from its signed net target produces 114 sats.
+        let gross_sell_usd = 7.41;
+        let fee_usd = gross_sell_usd * stable_channels::constants::STABLE_CHANNEL_TRADE_FEE_RATE;
+        let signed_net_target = gross_sell_usd - fee_usd;
+        let wallet_fee_msat = ((fee_usd / 65_000.0 * 100_000_000.0) as u64) * 1000;
+        let reconstructed = expected_trade_fee_msat(0.0, signed_net_target, 65_000.0).unwrap();
+        assert_eq!(wallet_fee_msat, 113_000);
+        assert_eq!(reconstructed, 114_000);
+        assert!(wallet_fee_msat.abs_diff(reconstructed) <= trade_fee_tolerance_msat(reconstructed, true));
     }
 
     #[tokio::test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -93,8 +93,7 @@ pub const AUTO_SWEEP_MIN_SATS: u64 = 10_000;
 
 /// Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount.
 ///
-/// The LSP currently accepts the amount attached to the signed trade message;
-/// there is no separate server-side percentage fee config.
+/// Shared by wallet fee construction and the LSP's server-side amount validation.
 pub const STABLE_CHANNEL_TRADE_FEE_RATE: f64 = 0.01;
 
 /// LDK channel-config defaults for outbound forwarding fees.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1271,18 +1271,6 @@ impl Database {
         Ok(rows)
     }
 
-    /// Mark a splice (by funding txid) as already stable-reconciled by the SpliceNegotiated
-    /// esplora deduction, so ChannelReady's reconcile_outgoing won't double-count it.
-    pub fn mark_splice_stable_reconciled(&self, txid: &str) -> SqliteResult<usize> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "UPDATE payments SET stable_reconciled = 1
-             WHERE payment_type IN ('splice_in','splice_out') AND txid = ?1",
-            params![txid],
-        )?;
-        Ok(rows)
-    }
-
     /// Whether the splice with this funding txid was already stable-reconciled.
     pub fn is_splice_stable_reconciled(&self, txid: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
@@ -1293,6 +1281,93 @@ impl Database {
             |row| row.get(0),
         )?;
         Ok(count > 0)
+    }
+
+    /// Return the recorded splice direction ("in" or "out") for a funding transaction.
+    pub fn get_splice_direction(&self, txid: &str) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT CASE payment_type
+                        WHEN 'splice_in' THEN 'in'
+                        WHEN 'splice_out' THEN 'out'
+                    END
+             FROM payments
+             WHERE txid = ?1 AND payment_type IN ('splice_in','splice_out')
+             ORDER BY id DESC LIMIT 1",
+            params![txid],
+            |row| row.get(0),
+        )
+        .optional()
+    }
+
+    /// Atomically persist post-splice allocation state and its durable idempotency marker.
+    /// Returns false when this funding transaction was already reconciled.
+    pub fn persist_splice_reconciliation(
+        &self,
+        txid: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        note: Option<&str>,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result: SqliteResult<bool> = (|| {
+            let payment = conn
+                .query_row(
+                    "SELECT id, stable_reconciled FROM payments
+                     WHERE txid = ?1 AND payment_type IN ('splice_in','splice_out')
+                     ORDER BY id DESC LIMIT 1",
+                    params![txid],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? != 0)),
+                )
+                .optional()?
+                .ok_or(rusqlite::Error::QueryReturnedNoRows)?;
+
+            if payment.1 {
+                return Ok(false);
+            }
+
+            let updated = conn.execute(
+                "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
+                                     note = ?4, user_channel_id = ?5, native_sats = ?6,
+                                     closed_at = NULL, updated_at = strftime('%s', 'now')
+                 WHERE user_channel_id = ?5",
+                params![
+                    channel_id,
+                    expected_usd,
+                    backing_sats as i64,
+                    note,
+                    user_channel_id,
+                    native_sats as i64,
+                ],
+            )?;
+            if updated == 0 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+
+            conn.execute(
+                "UPDATE payments SET status = 'completed', stable_reconciled = 1 WHERE id = ?1",
+                params![payment.0],
+            )?;
+            Ok(true)
+        })();
+
+        match result {
+            Ok(applied) => match conn.execute_batch("COMMIT") {
+                Ok(()) => Ok(applied),
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
     }
 
     /// Update confirmations and status for a payment by txid
@@ -1583,6 +1658,96 @@ mod tests {
         // plain record_settlement leaves user_channel_id as NULL (returns None)
         db.record_settlement("pmt2", "sync").unwrap();
         assert_eq!(db.get_settlement_channel("pmt2").unwrap(), None);
+    }
+
+    #[test]
+    fn splice_reconciliation_direction_and_state_commit_once() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel(
+            "channel-before",
+            "user-channel",
+            31.4424,
+            47_615,
+            44_407,
+            None,
+        )
+        .unwrap();
+        db.record_payment(
+            None,
+            "splice_out",
+            "sent",
+            90_094_000,
+            Some(59.34),
+            Some(65_872.5),
+            None,
+            "pending",
+            None,
+            Some("tb1qexample"),
+        )
+        .unwrap();
+        assert_eq!(db.set_pending_splice_out_txid("splice-txid").unwrap(), 1);
+        assert_eq!(
+            db.get_splice_direction("splice-txid").unwrap().as_deref(),
+            Some("out")
+        );
+
+        assert!(db
+            .persist_splice_reconciliation(
+                "splice-txid",
+                "channel-after",
+                "user-channel",
+                1.224708075,
+                1_742,
+                0,
+                None,
+            )
+            .unwrap());
+        assert!(!db
+            .persist_splice_reconciliation(
+                "splice-txid",
+                "channel-after",
+                "user-channel",
+                0.0,
+                0,
+                1_742,
+                None,
+            )
+            .unwrap());
+
+        let channel = db.load_channel("user-channel").unwrap().unwrap();
+        assert!((channel.expected_usd - 1.224708075).abs() < 1e-9);
+        assert_eq!(channel.backing_sats, 1_742);
+        assert_eq!(channel.native_sats, 0);
+        assert!(db.is_splice_stable_reconciled("splice-txid").unwrap());
+
+        db.record_payment(
+            None,
+            "splice_out",
+            "sent",
+            1_000,
+            None,
+            None,
+            None,
+            "pending",
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(db.set_pending_splice_out_txid("rollback-txid").unwrap(), 1);
+        assert!(db
+            .persist_splice_reconciliation(
+                "rollback-txid",
+                "missing-channel",
+                "missing-user-channel",
+                0.0,
+                0,
+                0,
+                None,
+            )
+            .is_err());
+        assert!(!db
+            .is_splice_stable_reconciled("rollback-txid")
+            .unwrap());
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -56,6 +56,14 @@ pub fn forward_fingerprint(
     )
 }
 
+/// A still-pending trade recoverable after a restart (the in-memory pending-trade map is empty on launch).
+pub struct PendingTradeRow {
+    pub id: i64,
+    pub new_expected_usd: f64,
+    pub btc_price: f64,
+    pub action: String,
+}
+
 impl Database {
     /// Open or create the database at the given directory path.
     pub fn open(data_dir: &Path) -> SqliteResult<Self> {
@@ -113,6 +121,7 @@ impl Database {
                 amount_btc REAL NOT NULL DEFAULT 0.0,
                 btc_price REAL NOT NULL,
                 fee_usd REAL NOT NULL DEFAULT 0.0,
+                new_expected_usd REAL NOT NULL DEFAULT 0.0,
                 payment_id TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
@@ -125,6 +134,13 @@ impl Database {
             "ALTER TABLE trades ADD COLUMN amount_btc REAL NOT NULL DEFAULT 0.0",
             [],
         ); // Ignore error if column already exists
+
+        // Migration: persist new_expected_usd so a trade settling after a restart can be
+        // finalized from its pending row (the in-memory pending-trade map is empty on launch).
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN new_expected_usd REAL NOT NULL DEFAULT 0.0",
+            [],
+        );
 
         // Migration: Add stable_sats column to channels table if missing
         // stable_sats tracks the BTC backing the stable portion (excludes native BTC)
@@ -517,19 +533,45 @@ impl Database {
         amount_btc: f64,
         btc_price: f64,
         fee_usd: f64,
+        new_expected_usd: f64,
         payment_id: Option<&str>,
         status: &str,
     ) -> SqliteResult<i64> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO trades (channel_id, action, amount_usd, amount_btc, btc_price, fee_usd,
-                                 payment_id, status)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                                 new_expected_usd, payment_id, status)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
-                channel_id, action, amount_usd, amount_btc, btc_price, fee_usd, payment_id, status
+                channel_id, action, amount_usd, amount_btc, btc_price, fee_usd, new_expected_usd,
+                payment_id, status
             ],
         )?;
         Ok(conn.last_insert_rowid())
+    }
+
+    /// Look up a still-pending trade by its payment_id, for restart recovery. Only returns rows
+    /// that stored new_expected_usd (> 0), i.e. recorded on the current schema.
+    pub fn get_pending_trade_by_payment_id(
+        &self,
+        payment_id: &str,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, new_expected_usd, btc_price, action FROM trades
+             WHERE payment_id = ?1 AND status = 'pending' AND new_expected_usd > 0.0
+             ORDER BY id DESC LIMIT 1",
+            params![payment_id],
+            |row| {
+                Ok(PendingTradeRow {
+                    id: row.get(0)?,
+                    new_expected_usd: row.get(1)?,
+                    btc_price: row.get(2)?,
+                    action: row.get(3)?,
+                })
+            },
+        )
+        .optional()
     }
 
     /// Update trade status
@@ -783,6 +825,16 @@ impl Database {
     pub fn payment_exists(&self, payment_id: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare("SELECT 1 FROM payments WHERE payment_id = ?1 LIMIT 1")?;
+        let exists = stmt.exists(params![payment_id])?;
+        Ok(exists)
+    }
+
+    /// Whether a payment (by payment_id) is a recorded stability (peg-maintenance) payment.
+    pub fn is_stability_payment(&self, payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT 1 FROM payments WHERE payment_id = ?1 AND payment_type = 'stability' LIMIT 1",
+        )?;
         let exists = stmt.exists(params![payment_id])?;
         Ok(exists)
     }
@@ -1610,6 +1662,7 @@ mod tests {
             0.00025,
             100000.0,
             0.25,
+            75.0,
             Some("pay123"),
             "completed",
         )
@@ -1622,6 +1675,7 @@ mod tests {
             0.000099,
             101000.0,
             0.10,
+            60.0,
             Some("pay456"),
             "completed",
         )

--- a/src/db.rs
+++ b/src/db.rs
@@ -61,6 +61,7 @@ pub struct PendingTradeRow {
     pub id: i64,
     pub new_expected_usd: f64,
     pub btc_price: f64,
+    pub new_backing_sats: Option<u64>,
     pub action: String,
 }
 
@@ -122,6 +123,7 @@ impl Database {
                 btc_price REAL NOT NULL,
                 fee_usd REAL NOT NULL DEFAULT 0.0,
                 new_expected_usd REAL NOT NULL DEFAULT 0.0,
+                new_backing_sats INTEGER,
                 payment_id TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
@@ -141,6 +143,10 @@ impl Database {
             "ALTER TABLE trades ADD COLUMN new_expected_usd REAL NOT NULL DEFAULT 0.0",
             [],
         );
+
+        // Exact allocation signed in TRADE_V1. NULL identifies trades written by older wallets,
+        // which still need the legacy price-derived recovery path.
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN new_backing_sats INTEGER", []);
 
         // Migration: Add stable_sats column to channels table if missing
         // stable_sats tracks the BTC backing the stable portion (excludes native BTC)
@@ -219,8 +225,8 @@ impl Database {
             [],
         );
 
-        // Migration: per-splice marker so ChannelReady's reconcile_outgoing skips a splice
-        // already reconciled by the SpliceNegotiated esplora deduction (prevents a double deduction).
+        // Durable reconciliation marker. Splices use it to prevent a second deduction at
+        // ChannelReady; outgoing Lightning payments use it to make PaymentSuccessful replay-safe.
         let _ = conn.execute(
             "ALTER TABLE payments ADD COLUMN stable_reconciled INTEGER NOT NULL DEFAULT 0",
             [],
@@ -534,32 +540,34 @@ impl Database {
         btc_price: f64,
         fee_usd: f64,
         new_expected_usd: f64,
+        new_backing_sats: Option<u64>,
         payment_id: Option<&str>,
         status: &str,
     ) -> SqliteResult<i64> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO trades (channel_id, action, amount_usd, amount_btc, btc_price, fee_usd,
-                                 new_expected_usd, payment_id, status)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                                 new_expected_usd, new_backing_sats, payment_id, status)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 channel_id, action, amount_usd, amount_btc, btc_price, fee_usd, new_expected_usd,
-                payment_id, status
+                new_backing_sats, payment_id, status
             ],
         )?;
         Ok(conn.last_insert_rowid())
     }
 
     /// Look up a still-pending trade by its payment_id, for restart recovery. Only returns rows
-    /// that stored new_expected_usd (> 0), i.e. recorded on the current schema.
+    /// that have either an exact allocation or a non-zero legacy target.
     pub fn get_pending_trade_by_payment_id(
         &self,
         payment_id: &str,
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, new_expected_usd, btc_price, action FROM trades
-             WHERE payment_id = ?1 AND status = 'pending' AND new_expected_usd > 0.0
+            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
+             WHERE payment_id = ?1 AND status = 'pending'
+               AND (new_backing_sats IS NOT NULL OR new_expected_usd > 0.0)
              ORDER BY id DESC LIMIT 1",
             params![payment_id],
             |row| {
@@ -567,7 +575,8 @@ impl Database {
                     id: row.get(0)?,
                     new_expected_usd: row.get(1)?,
                     btc_price: row.get(2)?,
-                    action: row.get(3)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
+                    action: row.get(4)?,
                 })
             },
         )
@@ -837,6 +846,121 @@ impl Database {
         )?;
         let exists = stmt.exists(params![payment_id])?;
         Ok(exists)
+    }
+
+    /// Atomically persist an outgoing payment's completed status and post-settlement channel state.
+    ///
+    /// `event_id` is the LDK `PaymentId` when available (falling back to its payment hash for old
+    /// events). `stable_reconciled` is the durable idempotency marker: a replay after commit returns
+    /// `Ok(false)` without applying the supplied state again. Any error rolls back the marker,
+    /// payment completion, and channel update together so the LDK event can be retried safely.
+    pub fn persist_outgoing_reconciliation(
+        &self,
+        event_id: &str,
+        payment_db_id: Option<i64>,
+        fee_msat: Option<u64>,
+        channel_id: &str,
+        user_channel_id: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        note: Option<&str>,
+        btc_price: Option<f64>,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result: SqliteResult<bool> = (|| {
+            let payment_row = if let Some(id) = payment_db_id {
+                conn.query_row(
+                    "SELECT id, stable_reconciled FROM payments WHERE id = ?1",
+                    params![id],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? != 0)),
+                )
+                .optional()?
+            } else {
+                conn.query_row(
+                    "SELECT id, stable_reconciled FROM payments
+                     WHERE payment_id = ?1 ORDER BY id DESC LIMIT 1",
+                    params![event_id],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? != 0)),
+                )
+                .optional()?
+            };
+
+            if matches!(payment_row, Some((_, true))) {
+                return Ok(false);
+            }
+
+            let updated = conn.execute(
+                "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
+                                     note = ?4, user_channel_id = ?5, native_sats = ?6,
+                                     closed_at = NULL, updated_at = strftime('%s', 'now')
+                 WHERE user_channel_id = ?5",
+                params![
+                    channel_id,
+                    expected_usd,
+                    backing_sats as i64,
+                    note,
+                    user_channel_id,
+                    native_sats as i64,
+                ],
+            )?;
+            if updated == 0 {
+                conn.execute(
+                    "INSERT INTO channels
+                        (channel_id, user_channel_id, expected_usd, stable_sats, native_sats, note)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(channel_id) DO UPDATE SET
+                        user_channel_id = ?2, expected_usd = ?3, stable_sats = ?4,
+                        native_sats = ?5, note = ?6, closed_at = NULL,
+                        updated_at = strftime('%s', 'now')",
+                    params![
+                        channel_id,
+                        user_channel_id,
+                        expected_usd,
+                        backing_sats as i64,
+                        native_sats as i64,
+                        note,
+                    ],
+                )?;
+            }
+
+            let fee_msat = fee_msat.map(|fee| fee as i64);
+            if let Some((id, _)) = payment_row {
+                conn.execute(
+                    "UPDATE payments SET payment_id = COALESCE(payment_id, ?1),
+                                         status = 'completed',
+                                         fee_msat = COALESCE(?2, fee_msat),
+                                         stable_reconciled = 1
+                     WHERE id = ?3",
+                    params![event_id, fee_msat, id],
+                )?;
+            } else {
+                conn.execute(
+                    "INSERT INTO payments
+                        (payment_id, payment_type, direction, amount_msat, btc_price, status,
+                         fee_msat, stable_reconciled)
+                     VALUES (?1, 'lightning', 'sent', 0, ?2, 'completed', ?3, 1)",
+                    params![event_id, btc_price, fee_msat.unwrap_or(0)],
+                )?;
+            }
+
+            Ok(true)
+        })();
+
+        match result {
+            Ok(applied) => match conn.execute_batch("COMMIT") {
+                Ok(()) => Ok(applied),
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
     }
 
     /// Record a payment
@@ -1537,6 +1661,127 @@ mod tests {
     }
 
     #[test]
+    fn outgoing_reconciliation_commits_once_across_event_replay() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 50.0, 50_000, 10_000, None)
+            .unwrap();
+        let payment_db_id = db
+            .record_payment(
+                Some("payment-1"),
+                "lightning",
+                "sent",
+                20_000_000,
+                Some(20.0),
+                Some(100_000.0),
+                None,
+                "pending",
+                None,
+                None,
+            )
+            .unwrap();
+
+        assert!(db
+            .persist_outgoing_reconciliation(
+                "payment-1",
+                Some(payment_db_id),
+                Some(12_000),
+                "channel-1",
+                "user-channel-1",
+                40.0,
+                40_000,
+                0,
+                None,
+                Some(100_000.0),
+            )
+            .unwrap());
+
+        // Simulate restart replay: the in-memory row id is gone and the caller proposes a
+        // different state. The durable marker must keep the first committed state unchanged.
+        assert!(!db
+            .persist_outgoing_reconciliation(
+                "payment-1",
+                None,
+                Some(12_000),
+                "channel-1",
+                "user-channel-1",
+                1.0,
+                1,
+                1,
+                None,
+                Some(100_000.0),
+            )
+            .unwrap());
+
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert!((channel.expected_usd - 40.0).abs() < 1e-9);
+        assert_eq!(channel.backing_sats, 40_000);
+        assert_eq!(channel.native_sats, 0);
+        let payments = db.get_recent_payments(1).unwrap();
+        assert_eq!(payments[0].status, "completed");
+        assert_eq!(payments[0].fee_msat, 12_000);
+    }
+
+    #[test]
+    fn outgoing_reconciliation_failure_rolls_back_marker_payment_and_channel() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 50.0, 50_000, 10_000, None)
+            .unwrap();
+        let payment_db_id = db
+            .record_payment(
+                Some("payment-rollback"),
+                "lightning",
+                "sent",
+                20_000_000,
+                Some(20.0),
+                Some(100_000.0),
+                None,
+                "pending",
+                None,
+                None,
+            )
+            .unwrap();
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER fail_outgoing_channel_save
+                 BEFORE UPDATE ON channels
+                 BEGIN SELECT RAISE(ABORT, 'forced channel save failure'); END;",
+            )
+            .unwrap();
+
+        assert!(db
+            .persist_outgoing_reconciliation(
+                "payment-rollback",
+                Some(payment_db_id),
+                Some(12_000),
+                "channel-1",
+                "user-channel-1",
+                40.0,
+                40_000,
+                0,
+                None,
+                Some(100_000.0),
+            )
+            .is_err());
+
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert!((channel.expected_usd - 50.0).abs() < 1e-9);
+        assert_eq!(channel.backing_sats, 50_000);
+        assert_eq!(channel.native_sats, 10_000);
+        let conn = db.conn.lock().unwrap();
+        let (status, reconciled): (String, i64) = conn
+            .query_row(
+                "SELECT status, stable_reconciled FROM payments WHERE id = ?1",
+                params![payment_db_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "pending");
+        assert_eq!(reconciled, 0);
+    }
+
+    #[test]
     fn test_save_channel_preserving_backing() {
         let db = Database::open_in_memory().unwrap();
         // No row yet — signals false so the caller can fall back to save_channel
@@ -1663,6 +1908,7 @@ mod tests {
             100000.0,
             0.25,
             75.0,
+            Some(75_000),
             Some("pay123"),
             "completed",
         )
@@ -1676,6 +1922,7 @@ mod tests {
             101000.0,
             0.10,
             60.0,
+            Some(59_405),
             Some("pay456"),
             "completed",
         )
@@ -1685,6 +1932,31 @@ mod tests {
         assert_eq!(trades.len(), 2);
         assert_eq!(trades[0].action, "sell"); // Most recent first
         assert_eq!(trades[1].action, "buy");
+    }
+
+    #[test]
+    fn pending_full_buy_recovers_exact_zero_allocation() {
+        let db = Database::open_in_memory().unwrap();
+        db.record_trade(
+            "ch1",
+            "buy",
+            25.0,
+            0.00025,
+            100_000.0,
+            0.25,
+            0.0,
+            Some(0),
+            Some("pending-full-buy"),
+            "pending",
+        )
+        .unwrap();
+
+        let pending = db
+            .get_pending_trade_by_payment_id("pending-full-buy")
+            .unwrap()
+            .expect("new exact-allocation trades must recover even when the target is zero");
+        assert_eq!(pending.new_expected_usd, 0.0);
+        assert_eq!(pending.new_backing_sats, Some(0));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,6 +23,15 @@ pub struct PaymentPersistence {
     pub clamped: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StabilityPaymentRollback {
+    pub user_channel_id: Option<String>,
+    pub backing_sats_before: Option<u64>,
+    pub backing_sats_after: Option<u64>,
+    /// True only when the channel still held this payment's optimistic allocation and was restored.
+    pub restored: bool,
+}
+
 /// Returns true if `err` is the distinct missing-channel-row condition from
 /// `record_payment_and_maybe_update_backing` — i.e. a backing update was
 /// requested but no `channels` row exists for the user_channel_id. Callers
@@ -207,6 +216,9 @@ impl Database {
                 btc_price REAL,
                 counterparty TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
+                user_channel_id TEXT,
+                backing_sats_before INTEGER,
+                backing_sats_after INTEGER,
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )",
             [],
@@ -223,6 +235,18 @@ impl Database {
             "ALTER TABLE payments ADD COLUMN fee_msat INTEGER NOT NULL DEFAULT 0",
             [],
         ); // Ignore error if column already exists
+
+        // Metadata needed to conditionally roll back an optimistic stability allocation when LDK
+        // later reports PaymentFailed. NULL values identify legacy payment rows.
+        let _ = conn.execute("ALTER TABLE payments ADD COLUMN user_channel_id TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE payments ADD COLUMN backing_sats_before INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE payments ADD COLUMN backing_sats_after INTEGER",
+            [],
+        );
 
         // Migration: Add on-chain fields to payments table
         let _ = conn.execute("ALTER TABLE payments ADD COLUMN txid TEXT", []);
@@ -1153,6 +1177,169 @@ impl Database {
         Ok(conn.last_insert_rowid())
     }
 
+    /// Persist a sent stability payment and its optimistic channel allocation in one transaction.
+    /// The before/after values make a later PaymentFailed rollback both durable across restart and
+    /// conditional, so it cannot overwrite a newer trade, sync, or reconciliation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_pending_stability_payment(
+        &self,
+        payment_id: &str,
+        amount_msat: u64,
+        amount_usd: Option<f64>,
+        btc_price: f64,
+        counterparty: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        expected_usd: f64,
+        backing_sats_before: u64,
+        backing_sats_after: u64,
+        native_sats: u64,
+        note: Option<&str>,
+    ) -> SqliteResult<i64> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result: SqliteResult<i64> = (|| {
+            let before = i64::try_from(backing_sats_before)
+                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX))?;
+            let after = i64::try_from(backing_sats_after)
+                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX))?;
+            let native = i64::try_from(native_sats)
+                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX))?;
+            let amount = i64::try_from(amount_msat)
+                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, i64::MAX))?;
+
+            conn.execute(
+                "INSERT INTO payments
+                    (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price,
+                     counterparty, status, user_channel_id, backing_sats_before,
+                     backing_sats_after)
+                 VALUES (?1, 'stability', 'sent', ?2, ?3, ?4, ?5, 'pending', ?6, ?7, ?8)",
+                params![
+                    payment_id,
+                    amount,
+                    amount_usd,
+                    btc_price,
+                    counterparty,
+                    user_channel_id,
+                    before,
+                    after,
+                ],
+            )?;
+            let payment_db_id = conn.last_insert_rowid();
+
+            let updated = conn.execute(
+                "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
+                                     note = ?4, user_channel_id = ?5, native_sats = ?6,
+                                     closed_at = NULL, updated_at = strftime('%s', 'now')
+                 WHERE user_channel_id = ?5",
+                params![channel_id, expected_usd, after, note, user_channel_id, native],
+            )?;
+            if updated == 0 {
+                conn.execute(
+                    "INSERT INTO channels
+                        (channel_id, user_channel_id, expected_usd, stable_sats, native_sats, note)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(channel_id) DO UPDATE SET
+                        user_channel_id = ?2, expected_usd = ?3, stable_sats = ?4,
+                        native_sats = ?5, note = ?6, closed_at = NULL,
+                        updated_at = strftime('%s', 'now')",
+                    params![channel_id, user_channel_id, expected_usd, after, native, note],
+                )?;
+            }
+
+            Ok(payment_db_id)
+        })();
+        match result {
+            Ok(id) => match conn.execute_batch("COMMIT") {
+                Ok(()) => Ok(id),
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    /// Mark a pending stability payment failed and restore its prior backing only if no newer
+    /// accounting transition has replaced the optimistic after-state.
+    pub fn fail_pending_stability_payment(
+        &self,
+        payment_id: &str,
+    ) -> SqliteResult<Option<StabilityPaymentRollback>> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result: SqliteResult<Option<StabilityPaymentRollback>> = (|| {
+            let row: Option<(i64, Option<String>, Option<i64>, Option<i64>)> = conn
+                .query_row(
+                    "SELECT id, user_channel_id, backing_sats_before, backing_sats_after
+                     FROM payments
+                     WHERE payment_id = ?1 AND payment_type = 'stability'
+                       AND direction = 'sent' AND status = 'pending'
+                     ORDER BY id DESC LIMIT 1",
+                    params![payment_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()?;
+            let Some((payment_db_id, user_channel_id, before_i64, after_i64)) = row else {
+                return Ok(None);
+            };
+
+            conn.execute(
+                "UPDATE payments SET status = 'failed' WHERE id = ?1 AND status = 'pending'",
+                params![payment_db_id],
+            )?;
+
+            let backing_sats_before = before_i64.and_then(|value| u64::try_from(value).ok());
+            let backing_sats_after = after_i64.and_then(|value| u64::try_from(value).ok());
+            let restored = match (
+                user_channel_id.as_deref(),
+                backing_sats_before,
+                backing_sats_after,
+            ) {
+                (Some(uid), Some(before), Some(after)) => {
+                    let before = i64::try_from(before).ok();
+                    let after = i64::try_from(after).ok();
+                    match (before, after) {
+                        (Some(before), Some(after)) => {
+                            conn.execute(
+                                "UPDATE channels SET stable_sats = ?1,
+                                                     updated_at = strftime('%s', 'now')
+                                 WHERE user_channel_id = ?2 AND stable_sats = ?3",
+                                params![before, uid, after],
+                            )? > 0
+                        }
+                        _ => false,
+                    }
+                }
+                _ => false,
+            };
+
+            Ok(Some(StabilityPaymentRollback {
+                user_channel_id,
+                backing_sats_before,
+                backing_sats_after,
+                restored,
+            }))
+        })();
+        match result {
+            Ok(rollback) => match conn.execute_batch("COMMIT") {
+                Ok(()) => Ok(rollback),
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(e)
+                }
+            },
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
     /// Insert a payment and optionally update channel backing sats in one SQLite transaction.
     ///
     /// The dedup check runs inside `BEGIN IMMEDIATE` so concurrent writers
@@ -2013,6 +2200,88 @@ mod tests {
                 .backing_sats,
             0
         );
+    }
+
+    #[test]
+    fn failed_stability_payment_restores_its_optimistic_backing() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 100.0, 120_000, 20_000, None)
+            .unwrap();
+        db.record_pending_stability_payment(
+            "stability-1",
+            20_000_000,
+            Some(20.0),
+            100_000.0,
+            "counterparty",
+            "channel-1",
+            "user-channel-1",
+            100.0,
+            120_000,
+            100_000,
+            20_000,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            db.load_channel("user-channel-1")
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            100_000
+        );
+
+        let rollback = db
+            .fail_pending_stability_payment("stability-1")
+            .unwrap()
+            .unwrap();
+        assert!(rollback.restored);
+        assert_eq!(rollback.backing_sats_before, Some(120_000));
+        assert_eq!(rollback.backing_sats_after, Some(100_000));
+        assert_eq!(
+            db.load_channel("user-channel-1")
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            120_000
+        );
+        assert_eq!(db.get_recent_payments(1).unwrap()[0].status, "failed");
+        assert!(db
+            .fail_pending_stability_payment("stability-1")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn late_stability_failure_does_not_overwrite_newer_allocation() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 100.0, 120_000, 20_000, None)
+            .unwrap();
+        db.record_pending_stability_payment(
+            "stability-1",
+            20_000_000,
+            Some(20.0),
+            100_000.0,
+            "counterparty",
+            "channel-1",
+            "user-channel-1",
+            100.0,
+            120_000,
+            100_000,
+            20_000,
+            None,
+        )
+        .unwrap();
+        db.save_channel("channel-1", "user-channel-1", 80.0, 80_000, 40_000, None)
+            .unwrap();
+
+        let rollback = db
+            .fail_pending_stability_payment("stability-1")
+            .unwrap()
+            .unwrap();
+        assert!(!rollback.restored);
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 80.0);
+        assert_eq!(channel.backing_sats, 80_000);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -164,6 +164,13 @@ impl Database {
             [],
         ); // Ignore error if column already exists
 
+        // Monotonic version for signed SYNC_V1 state. The LSP increments this before sending;
+        // the wallet persists the last accepted value with the allocation it protects.
+        let _ = conn.execute(
+            "ALTER TABLE channels ADD COLUMN sync_version INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+
         // Migration: Add closed_at column. NULL = active, unix timestamp = soft-closed.
         // We never hard-delete channel rows from reconcile / handle_channel_closed —
         // they're marked closed so closed-channel forensics survive transient gRPC blips.
@@ -400,6 +407,89 @@ impl Database {
             ],
         )?;
         Ok(updated > 0)
+    }
+
+    /// Atomically reserve the next outbound SYNC_V1 version for a channel.
+    pub fn next_sync_version(&self, user_channel_id: &str) -> SqliteResult<u64> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let updated = tx.execute(
+            "UPDATE channels
+             SET sync_version = sync_version + 1
+             WHERE user_channel_id = ?1 AND sync_version < 9223372036854775807",
+            params![user_channel_id],
+        )?;
+        if updated == 0 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
+        let version: i64 = tx.query_row(
+            "SELECT sync_version FROM channels WHERE user_channel_id = ?1",
+            params![user_channel_id],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        Ok(version as u64)
+    }
+
+    /// Apply a signed inbound SYNC_V1 allocation only when its version is newer.
+    /// The version and allocation share one SQLite statement, so a crash cannot
+    /// persist one without the other. Returns false for stale/replayed versions.
+    pub fn apply_sync_if_newer(
+        &self,
+        user_channel_id: &str,
+        sync_version: u64,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+    ) -> SqliteResult<bool> {
+        if sync_version == 0
+            || sync_version > i64::MAX as u64
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+            || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64
+        {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE channels
+             SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
+                 sync_version = ?4, updated_at = strftime('%s', 'now')
+             WHERE user_channel_id = ?5 AND sync_version < ?4",
+            params![
+                expected_usd,
+                backing_sats as i64,
+                native_sats as i64,
+                sync_version as i64,
+                user_channel_id,
+            ],
+        )?;
+        if updated == 0 {
+            let exists: bool = conn.query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM channels WHERE user_channel_id = ?1
+                 )",
+                params![user_channel_id],
+                |row| row.get(0),
+            )?;
+            if !exists {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+        }
+        Ok(updated == 1)
+    }
+
+    pub fn get_sync_version(&self, user_channel_id: &str) -> SqliteResult<Option<u64>> {
+        let conn = self.conn.lock().unwrap();
+        let version = conn
+            .query_row(
+                "SELECT sync_version FROM channels WHERE user_channel_id = ?1",
+                params![user_channel_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?;
+        Ok(version.map(|value| value.max(0) as u64))
     }
 
     /// Hard-delete a channel row. Reserved for explicit admin purge; reconcile
@@ -1527,6 +1617,53 @@ mod tests {
         assert_eq!(loaded.backing_sats, 100_000);
         assert_eq!(loaded.native_sats, 50_000);
         assert_eq!(loaded.note, Some("test note".to_string()));
+    }
+
+    #[test]
+    fn sync_versions_are_monotonic_and_persisted() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+
+        assert_eq!(db.next_sync_version("user-channel-1").unwrap(), 1);
+        assert_eq!(db.next_sync_version("user-channel-1").unwrap(), 2);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
+        assert!(db.next_sync_version("missing").is_err());
+    }
+
+    #[test]
+    fn inbound_sync_replay_cannot_overwrite_newer_state() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+
+        assert!(db
+            .apply_sync_if_newer("user-channel-1", 2, 20.0, 20_000, 4_000)
+            .unwrap());
+        assert!(!db
+            .apply_sync_if_newer("user-channel-1", 2, 12.0, 12_000, 1_000)
+            .unwrap());
+        assert!(!db
+            .apply_sync_if_newer("user-channel-1", 1, 11.0, 11_000, 2_000)
+            .unwrap());
+        assert!(!db
+            .apply_sync_if_newer("user-channel-1", 3, 30.0, u64::MAX, 0)
+            .unwrap());
+
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 20.0);
+        assert_eq!(channel.backing_sats, 20_000);
+        assert_eq!(channel.native_sats, 4_000);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
+    }
+
+    #[test]
+    fn inbound_sync_for_missing_channel_is_an_error() {
+        let db = Database::open_in_memory().unwrap();
+        assert!(matches!(
+            db.apply_sync_if_newer("missing", 1, 10.0, 10_000, 5_000),
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        ));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -203,6 +203,13 @@ impl Database {
             [],
         );
 
+        // Migration: per-splice marker so ChannelReady's reconcile_outgoing skips a splice
+        // already reconciled by the SpliceNegotiated esplora deduction (prevents a double deduction).
+        let _ = conn.execute(
+            "ALTER TABLE payments ADD COLUMN stable_reconciled INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+
         // Create index for faster payment queries
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_payments_created
@@ -996,6 +1003,30 @@ impl Database {
             [],
         )?;
         Ok(rows)
+    }
+
+    /// Mark a splice (by funding txid) as already stable-reconciled by the SpliceNegotiated
+    /// esplora deduction, so ChannelReady's reconcile_outgoing won't double-count it.
+    pub fn mark_splice_stable_reconciled(&self, txid: &str) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE payments SET stable_reconciled = 1
+             WHERE payment_type IN ('splice_in','splice_out') AND txid = ?1",
+            params![txid],
+        )?;
+        Ok(rows)
+    }
+
+    /// Whether the splice with this funding txid was already stable-reconciled.
+    pub fn is_splice_stable_reconciled(&self, txid: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM payments
+             WHERE payment_type IN ('splice_in','splice_out') AND txid = ?1 AND stable_reconciled = 1",
+            params![txid],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
     }
 
     /// Update confirmations and status for a payment by txid

--- a/src/db.rs
+++ b/src/db.rs
@@ -442,6 +442,28 @@ impl Database {
         backing_sats: u64,
         native_sats: u64,
     ) -> SqliteResult<bool> {
+        self.apply_sync_if_newer_and_complete_trade(
+            user_channel_id,
+            sync_version,
+            expected_usd,
+            backing_sats,
+            native_sats,
+            None,
+        )
+    }
+
+    /// Apply a signed sync and, when it acknowledges a wallet-authored trade, complete that trade
+    /// in the same transaction. This closes the crash window between accepting the allocation and
+    /// marking its fee payment as a trade rather than an ordinary outgoing payment.
+    pub fn apply_sync_if_newer_and_complete_trade(
+        &self,
+        user_channel_id: &str,
+        sync_version: u64,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        trade_id: Option<i64>,
+    ) -> SqliteResult<bool> {
         if sync_version == 0
             || sync_version > i64::MAX as u64
             || !expected_usd.is_finite()
@@ -451,8 +473,9 @@ impl Database {
         {
             return Ok(false);
         }
-        let conn = self.conn.lock().unwrap();
-        let updated = conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let updated = tx.execute(
             "UPDATE channels
              SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
                  sync_version = ?4, updated_at = strftime('%s', 'now')
@@ -466,7 +489,7 @@ impl Database {
             ],
         )?;
         if updated == 0 {
-            let exists: bool = conn.query_row(
+            let exists: bool = tx.query_row(
                 "SELECT EXISTS(
                     SELECT 1 FROM channels WHERE user_channel_id = ?1
                  )",
@@ -476,8 +499,20 @@ impl Database {
             if !exists {
                 return Err(rusqlite::Error::QueryReturnedNoRows);
             }
+            tx.commit()?;
+            return Ok(false);
         }
-        Ok(updated == 1)
+        if let Some(trade_id) = trade_id {
+            let completed = tx.execute(
+                "UPDATE trades SET status = 'completed' WHERE id = ?1 AND status = 'pending'",
+                params![trade_id],
+            )?;
+            if completed != 1 {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            }
+        }
+        tx.commit()?;
+        Ok(true)
     }
 
     pub fn get_sync_version(&self, user_channel_id: &str) -> SqliteResult<Option<u64>> {
@@ -671,6 +706,47 @@ impl Database {
             },
         )
         .optional()
+    }
+
+    /// Match a signed allocation acknowledgment to a trade authored by this wallet. The LSP can
+    /// deliver SYNC_V1 before or after LDK reports the trade-fee payment as successful, so the
+    /// allocation itself is the stable correlation key.
+    pub fn get_pending_trade_by_allocation(
+        &self,
+        new_expected_usd: f64,
+        new_backing_sats: u64,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
+             WHERE status = 'pending'
+               AND new_backing_sats = ?1
+               AND ABS(new_expected_usd - ?2) <= 0.000000001
+             ORDER BY id DESC LIMIT 1",
+            params![new_backing_sats, new_expected_usd],
+            |row| {
+                Ok(PendingTradeRow {
+                    id: row.get(0)?,
+                    new_expected_usd: row.get(1)?,
+                    btc_price: row.get(2)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
+                    action: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+    }
+
+    /// Whether this payment id belongs to any trade, including one already completed by an
+    /// earlier SYNC_V1. This prevents an out-of-order PaymentSuccessful event from being
+    /// reconciled as an ordinary wallet send.
+    pub fn is_trade_payment(&self, payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM trades WHERE payment_id = ?1)",
+            params![payment_id],
+            |row| row.get(0),
+        )
     }
 
     /// Update trade status
@@ -2259,6 +2335,83 @@ mod tests {
             .expect("new exact-allocation trades must recover even when the target is zero");
         assert_eq!(pending.new_expected_usd, 0.0);
         assert_eq!(pending.new_backing_sats, Some(0));
+    }
+
+    #[test]
+    fn pending_trade_matches_signed_allocation_and_payment_id_remains_classified() {
+        let db = Database::open_in_memory().unwrap();
+        let trade_id = db
+            .record_trade(
+                "ch1",
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.10,
+                60.0,
+                Some(60_000),
+                Some("trade-payment"),
+                "pending",
+            )
+            .unwrap();
+
+        let matched = db
+            .get_pending_trade_by_allocation(60.0, 60_000)
+            .unwrap()
+            .expect("exact wallet-authored allocation must match");
+        assert_eq!(matched.id, trade_id);
+        assert!(db
+            .get_pending_trade_by_allocation(60.01, 60_000)
+            .unwrap()
+            .is_none());
+        assert!(db.is_trade_payment("trade-payment").unwrap());
+
+        db.update_trade_status(trade_id, "completed").unwrap();
+        assert!(db.is_trade_payment("trade-payment").unwrap());
+        assert!(db
+            .get_pending_trade_by_allocation(60.0, 60_000)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn inbound_sync_atomically_completes_matching_trade() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let trade_id = db
+            .record_trade(
+                "user-channel-1",
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.10,
+                20.0,
+                Some(20_000),
+                Some("trade-payment"),
+                "pending",
+            )
+            .unwrap();
+
+        assert!(db
+            .apply_sync_if_newer_and_complete_trade(
+                "user-channel-1",
+                1,
+                20.0,
+                20_000,
+                4_000,
+                Some(trade_id),
+            )
+            .unwrap());
+        assert!(db
+            .get_pending_trade_by_payment_id("trade-payment")
+            .unwrap()
+            .is_none());
+        assert!(db.is_trade_payment("trade-payment").unwrap());
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 20.0);
+        assert_eq!(channel.backing_sats, 20_000);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,6 +23,20 @@ pub struct PaymentPersistence {
     pub clamped: bool,
 }
 
+/// Result of consuming a failed outbound stability settlement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StabilityRollback {
+    pub user_channel_id: String,
+    pub backing_sats_before: u64,
+    pub backing_sats_after: u64,
+    pub native_sats_before: u64,
+    pub expected_usd: f64,
+    pub last_stability_payment_before: i64,
+    /// False means the settlement was marked failed, but a newer allocation had already replaced
+    /// the optimistic state, so the channel row was intentionally left untouched.
+    pub applied: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StabilityPaymentRollback {
     pub user_channel_id: Option<String>,
@@ -330,6 +344,33 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN user_channel_id TEXT",
             [],
         ); // Ignore error if column already exists
+        // Outbound stability sends optimistically move backing to equilibrium. Persist the exact
+        // transition so a later asynchronous PaymentFailed can undo it without guessing or
+        // overwriting a newer trade/sync allocation.
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN backing_sats_before INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN backing_sats_after INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN native_sats_before INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN expected_usd REAL",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN last_stability_payment_before INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN outcome TEXT NOT NULL DEFAULT 'pending'",
+            [],
+        );
 
         // Forwarded-payment dedup: tracks fingerprints of forwards already audited (live or backfilled)
         conn.execute(
@@ -1773,6 +1814,130 @@ impl Database {
         Ok(())
     }
 
+    /// Record the reversible allocation transition for an outbound stability payment.
+    /// Returns false only if the payment id was already present.
+    pub fn record_stability_settlement_with_rollback(
+        &self,
+        payment_id: &str,
+        user_channel_id: &str,
+        backing_sats_before: u64,
+        backing_sats_after: u64,
+        native_sats_before: u64,
+        expected_usd: f64,
+        last_stability_payment_before: i64,
+    ) -> SqliteResult<bool> {
+        if backing_sats_before > i64::MAX as u64
+            || backing_sats_after > i64::MAX as u64
+            || native_sats_before > i64::MAX as u64
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+        {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO settlement_payments
+                (payment_id, kind, user_channel_id, backing_sats_before,
+                 backing_sats_after, native_sats_before, expected_usd,
+                 last_stability_payment_before)
+             VALUES (?1, 'stability', ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                payment_id,
+                user_channel_id,
+                backing_sats_before as i64,
+                backing_sats_after as i64,
+                native_sats_before as i64,
+                expected_usd,
+                last_stability_payment_before,
+            ],
+        )?;
+        Ok(inserted == 1)
+    }
+
+    /// Mark a settlement successful so a duplicate/conflicting failure event can never roll it
+    /// back. Returns true when this call consumed the pending outcome.
+    pub fn mark_settlement_succeeded(&self, payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE settlement_payments SET outcome = 'succeeded'
+             WHERE payment_id = ?1 AND outcome = 'pending'",
+            params![payment_id],
+        )?;
+        Ok(updated == 1)
+    }
+
+    /// Consume a failed outbound stability settlement and conditionally restore its allocation.
+    /// The channel update compares the optimistic backing, native sats, and expected USD snapshot:
+    /// if a newer trade, sync, or settlement changed the allocation, that newer state wins. The
+    /// outcome is still consumed so a replay cannot accidentally roll back a future allocation.
+    pub fn rollback_failed_stability_settlement(
+        &self,
+        payment_id: &str,
+    ) -> SqliteResult<Option<StabilityRollback>> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let row = tx
+            .query_row(
+                "SELECT user_channel_id, backing_sats_before, backing_sats_after,
+                        native_sats_before, expected_usd, last_stability_payment_before, outcome
+                 FROM settlement_payments
+                 WHERE payment_id = ?1 AND kind = 'stability'",
+                params![payment_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<i64>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
+                        row.get::<_, Option<f64>>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                        row.get::<_, String>(6)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((Some(user_channel_id), Some(before), Some(after), Some(native_before), Some(expected_usd), last_before, outcome)) = row else {
+            return Ok(None);
+        };
+        if outcome != "pending"
+            || before < 0
+            || after < 0
+            || native_before < 0
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+        {
+            return Ok(None);
+        }
+
+        let consumed = tx.execute(
+            "UPDATE settlement_payments SET outcome = 'failed'
+             WHERE payment_id = ?1 AND outcome = 'pending'",
+            params![payment_id],
+        )?;
+        if consumed != 1 {
+            tx.commit()?;
+            return Ok(None);
+        }
+        let applied = tx.execute(
+            "UPDATE channels
+             SET stable_sats = ?1, native_sats = ?2, updated_at = strftime('%s', 'now')
+             WHERE user_channel_id = ?3 AND stable_sats = ?4
+                   AND native_sats = ?2 AND expected_usd = ?5",
+            params![before, native_before, user_channel_id, after, expected_usd],
+        )? == 1;
+        tx.commit()?;
+
+        Ok(Some(StabilityRollback {
+            user_channel_id,
+            backing_sats_before: before as u64,
+            backing_sats_after: after as u64,
+            native_sats_before: native_before as u64,
+            expected_usd,
+            last_stability_payment_before: last_before.unwrap_or(0),
+            applied,
+        }))
+    }
+
     /// Record a forward's fingerprint. Returns true if newly inserted (not seen before).
     pub fn record_forwarded_seen(&self, fingerprint: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
@@ -1921,6 +2086,81 @@ mod tests {
         // plain record_settlement leaves user_channel_id as NULL (returns None)
         db.record_settlement("pmt2", "sync").unwrap();
         assert_eq!(db.get_settlement_channel("pmt2").unwrap(), None);
+    }
+
+    #[test]
+    fn failed_stability_settlement_rolls_back_only_its_optimistic_state() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user-channel", 50.0, 50_000, 50_000, None)
+            .unwrap();
+        assert!(db
+            .record_stability_settlement_with_rollback(
+                "payment", "user-channel", 50_000, 62_500, 50_000, 50.0, 17,
+            )
+            .unwrap());
+        db.save_channel("channel", "user-channel", 50.0, 62_500, 50_000, None)
+            .unwrap();
+
+        let rollback = db
+            .rollback_failed_stability_settlement("payment")
+            .unwrap()
+            .unwrap();
+        assert!(rollback.applied);
+        assert_eq!(rollback.backing_sats_before, 50_000);
+        assert_eq!(rollback.backing_sats_after, 62_500);
+        assert_eq!(rollback.last_stability_payment_before, 17);
+        let channel = db.load_channel("user-channel").unwrap().unwrap();
+        assert_eq!(channel.backing_sats, 50_000);
+        assert_eq!(channel.native_sats, 50_000);
+        assert!(db
+            .rollback_failed_stability_settlement("payment")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn failed_stability_settlement_does_not_overwrite_newer_allocation() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user-channel", 50.0, 50_000, 50_000, None)
+            .unwrap();
+        db.record_stability_settlement_with_rollback(
+            "payment", "user-channel", 50_000, 62_500, 50_000, 50.0, 0,
+        )
+        .unwrap();
+        db.save_channel("channel", "user-channel", 55.0, 70_000, 30_000, None)
+            .unwrap();
+
+        let rollback = db
+            .rollback_failed_stability_settlement("payment")
+            .unwrap()
+            .unwrap();
+        assert!(!rollback.applied);
+        let channel = db.load_channel("user-channel").unwrap().unwrap();
+        assert_eq!(channel.backing_sats, 70_000);
+        assert_eq!(channel.native_sats, 30_000);
+    }
+
+    #[test]
+    fn successful_stability_settlement_cannot_be_rolled_back() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user-channel", 50.0, 62_500, 50_000, None)
+            .unwrap();
+        db.record_stability_settlement_with_rollback(
+            "payment", "user-channel", 50_000, 62_500, 50_000, 50.0, 0,
+        )
+        .unwrap();
+        assert!(db.mark_settlement_succeeded("payment").unwrap());
+        assert!(db
+            .rollback_failed_stability_settlement("payment")
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            db.load_channel("user-channel")
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            62_500
+        );
     }
 
     #[test]

--- a/src/price_feeds.rs
+++ b/src/price_feeds.rs
@@ -4,6 +4,7 @@ use crate::constants::{
 use retry::{delay::Fixed, retry};
 use serde_json::Value;
 use std::error::Error;
+use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use ureq::Agent;
@@ -13,6 +14,7 @@ const MAX_PLAUSIBLE_BTC_USD_PRICE: f64 = 10_000_000.0;
 const MIN_AGREEING_PRICE_FEEDS: usize = 2;
 const MAX_FEED_DEVIATION_RATIO: f64 = 0.05;
 const MAX_MEDIAN_MOVE_RATIO: f64 = 0.10;
+const MAX_TRUSTED_PRICE_AGE_SECS: u64 = 60;
 
 lazy_static::lazy_static! {
     static ref PRICE_CACHE: Arc<Mutex<PriceCache>> = Arc::new(Mutex::new(PriceCache {
@@ -22,6 +24,7 @@ lazy_static::lazy_static! {
             .checked_sub(Duration::from_secs(10))
             .unwrap_or_else(Instant::now),
         updating: false,
+        quarantined: false,
     }));
 }
 
@@ -29,6 +32,81 @@ pub struct PriceCache {
     price: f64,
     last_update: Instant,
     updating: bool,
+    quarantined: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PriceRefreshErrorKind {
+    Transient,
+    LargeMove,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PriceRefreshError {
+    kind: PriceRefreshErrorKind,
+    message: String,
+}
+
+impl PriceRefreshError {
+    fn transient(message: impl Into<String>) -> Self {
+        Self {
+            kind: PriceRefreshErrorKind::Transient,
+            message: message.into(),
+        }
+    }
+
+    fn large_move(message: impl Into<String>) -> Self {
+        Self {
+            kind: PriceRefreshErrorKind::LargeMove,
+            message: message.into(),
+        }
+    }
+
+    fn quarantines_price(&self) -> bool {
+        self.kind == PriceRefreshErrorKind::LargeMove
+    }
+}
+
+impl fmt::Display for PriceRefreshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for PriceRefreshError {}
+
+impl PriceCache {
+    fn begin_refresh(&mut self) -> Result<(), String> {
+        if self.updating {
+            return Err("price refresh already in progress".to_string());
+        }
+
+        // A recent successful consensus remains valid while the next refresh is in flight.
+        // Invalidating it here made every five-second network fetch briefly expose price=0.
+        self.updating = true;
+        Ok(())
+    }
+
+    fn finish_refresh(&mut self, result: &Result<f64, PriceRefreshError>) {
+        self.updating = false;
+        match result {
+            Ok(price) => {
+                self.price = *price;
+                self.last_update = Instant::now();
+                self.quarantined = false;
+            }
+            Err(error) if error.quarantines_price() => {
+                // Multiple feeds agreeing on a >10% move is evidence that the old anchor may no
+                // longer be safe for accounting. Keep it only as raw display history until a new
+                // consensus is admitted after the anchor expires.
+                self.quarantined = true;
+            }
+            Err(_) => {
+                // A transport failure or temporary lack of consensus says nothing new about the
+                // last successful price. Its age limit will expire it naturally.
+            }
+        }
+    }
 }
 
 // Re-export from constants module
@@ -41,6 +119,14 @@ pub fn get_cached_price_no_fetch() -> f64 {
     cache.price
 }
 
+/// Return the cached value only while it is recent enough for accounting and protocol decisions.
+/// A stale value remains available through `get_cached_price_no_fetch` for display continuity.
+pub fn get_fresh_cached_price_no_fetch() -> f64 {
+    let cache = PRICE_CACHE.lock().unwrap();
+    accounting_price_reference(cache.price, cache.last_update.elapsed(), cache.quarantined)
+        .unwrap_or(0.0)
+}
+
 /// Set the cached price directly — for regtest/integration testing.
 /// Bypasses all network price fetching.
 pub fn set_cached_price(price: f64) {
@@ -48,9 +134,32 @@ pub fn set_cached_price(price: f64) {
     cache.price = price;
     cache.last_update = Instant::now();
     cache.updating = false;
+    cache.quarantined = false;
 }
 
-// Get cached price or fetch a new one if needed
+/// Force one network refresh. Unlike `get_cached_price`, this never returns an old value as a
+/// successful refresh, so background publishers only publish newly validated consensus. A recent
+/// successful price remains readable during the fetch and after transient failures; a confirmed
+/// large-move conflict quarantines it for accounting until a new consensus is accepted.
+pub fn refresh_cached_price() -> Result<f64, String> {
+    {
+        let mut cache = PRICE_CACHE.lock().unwrap();
+        cache.begin_refresh()?;
+    }
+
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(10))
+        .timeout(Duration::from_secs(15))
+        .build();
+    let result = get_latest_price_classified(&agent);
+
+    let mut cache = PRICE_CACHE.lock().unwrap();
+    cache.finish_refresh(&result);
+    result.map_err(|error| error.to_string())
+}
+
+// Get cached price or fetch a new one if needed. On refresh failure this compatibility API returns
+// the last known value; callers that require freshness must use `refresh_cached_price`.
 pub fn get_cached_price() -> f64 {
     let should_update = {
         let cache = PRICE_CACHE.lock().unwrap();
@@ -59,24 +168,8 @@ pub fn get_cached_price() -> f64 {
     };
 
     if should_update {
-        let mut cache = PRICE_CACHE.lock().unwrap();
-        cache.updating = true;
-        drop(cache);
-
-        let agent = ureq::AgentBuilder::new()
-            .timeout_connect(Duration::from_secs(10))
-            .timeout(Duration::from_secs(15))
-            .build();
-        if let Ok(new_price) = get_latest_price(&agent) {
-            let mut cache = PRICE_CACHE.lock().unwrap();
-            cache.price = new_price;
-            cache.last_update = Instant::now();
-            cache.updating = false;
+        if let Ok(new_price) = refresh_cached_price() {
             return new_price;
-        } else {
-            let mut cache = PRICE_CACHE.lock().unwrap();
-            cache.updating = false;
-            return cache.price;
         }
     }
 
@@ -134,12 +227,23 @@ fn relative_deviation(value: f64, reference: f64) -> f64 {
     (value - reference).abs() / reference
 }
 
+fn trusted_price_reference(price: f64, age: Duration) -> Option<f64> {
+    (is_plausible_price(price) && age <= Duration::from_secs(MAX_TRUSTED_PRICE_AGE_SECS))
+        .then_some(price)
+}
+
+fn accounting_price_reference(price: f64, age: Duration, quarantined: bool) -> Option<f64> {
+    (!quarantined)
+        .then(|| trusted_price_reference(price, age))
+        .flatten()
+}
+
 fn validate_price_consensus(
     prices: &[(String, f64)],
     last_trusted_price: Option<f64>,
-) -> Result<f64, String> {
+) -> Result<f64, PriceRefreshError> {
     let initial_median = calculate_median_price(prices)
-        .ok_or_else(|| "No plausible BTC/USD prices were returned".to_string())?;
+        .ok_or_else(|| PriceRefreshError::transient("No plausible BTC/USD prices were returned"))?;
     let agreeing_prices: Vec<(String, f64)> = prices
         .iter()
         .filter(|(_, price)| {
@@ -150,22 +254,23 @@ fn validate_price_consensus(
         .collect();
 
     if agreeing_prices.len() < MIN_AGREEING_PRICE_FEEDS {
-        return Err(format!(
+        return Err(PriceRefreshError::transient(format!(
             "Price consensus requires at least {MIN_AGREEING_PRICE_FEEDS} agreeing feeds; got {}",
             agreeing_prices.len()
-        ));
+        )));
     }
 
-    let median = calculate_median_price(&agreeing_prices)
-        .ok_or_else(|| "Agreeing feeds did not produce a valid median".to_string())?;
+    let median = calculate_median_price(&agreeing_prices).ok_or_else(|| {
+        PriceRefreshError::transient("Agreeing feeds did not produce a valid median")
+    })?;
     if let Some(last_price) = last_trusted_price.filter(|price| is_plausible_price(*price)) {
         let deviation = relative_deviation(median, last_price);
         if deviation > MAX_MEDIAN_MOVE_RATIO {
-            return Err(format!(
+            return Err(PriceRefreshError::large_move(format!(
                 "BTC/USD median moved {:.2}% from the last trusted price, above the {:.2}% limit",
                 deviation * 100.0,
                 MAX_MEDIAN_MOVE_RATIO * 100.0
-            ));
+            )));
         }
     }
 
@@ -249,25 +354,30 @@ pub fn fetch_prices(
     Ok(prices)
 }
 
-pub fn get_latest_price(agent: &Agent) -> Result<f64, Box<dyn Error>> {
+fn get_latest_price_classified(agent: &Agent) -> Result<f64, PriceRefreshError> {
     let price_feeds = set_price_feeds();
-    let prices = fetch_prices(agent, &price_feeds)?;
+    let prices = fetch_prices(agent, &price_feeds)
+        .map_err(|error| PriceRefreshError::transient(error.to_string()))?;
 
     for (feed_name, price) in &prices {
         println!("{:<25} ${:>1.2}", feed_name, price);
     }
 
-    let cached_price = get_cached_price_no_fetch();
-    let last_trusted_price = is_plausible_price(cached_price).then_some(cached_price);
-    let median_price = validate_price_consensus(&prices, last_trusted_price).map_err(
-        |message| -> Box<dyn Error> {
-            eprintln!("Rejected BTC/USD price update: {message}");
-            message.into()
-        },
-    )?;
+    let last_trusted_price = {
+        let cache = PRICE_CACHE.lock().unwrap();
+        trusted_price_reference(cache.price, cache.last_update.elapsed())
+    };
+    let median_price = validate_price_consensus(&prices, last_trusted_price).map_err(|error| {
+        eprintln!("Rejected BTC/USD price update: {error}");
+        error
+    })?;
 
     println!("\nMedian BTC/USD price:     ${:.2}\n", median_price);
     Ok(median_price)
+}
+
+pub fn get_latest_price(agent: &Agent) -> Result<f64, Box<dyn Error>> {
+    get_latest_price_classified(agent).map_err(|error| -> Box<dyn Error> { Box::new(error) })
 }
 
 /// Fetch daily OHLC data from Kraken
@@ -491,10 +601,104 @@ mod tests {
     #[test]
     fn test_price_consensus_rejects_large_move_from_last_trusted_price() {
         let prices = vec![("a".to_string(), 65_900.0), ("b".to_string(), 66_000.0)];
-        assert!(validate_price_consensus(&prices, Some(50_000.0)).is_err());
+        let error = validate_price_consensus(&prices, Some(50_000.0)).unwrap_err();
+        assert_eq!(error.kind, PriceRefreshErrorKind::LargeMove);
         assert_eq!(
             validate_price_consensus(&prices, Some(65_000.0)),
             Ok(65_950.0)
+        );
+    }
+
+    #[test]
+    fn large_move_anchor_expires_instead_of_wedging_forever() {
+        let prices = vec![("a".to_string(), 65_900.0), ("b".to_string(), 66_000.0)];
+        let recent =
+            trusted_price_reference(50_000.0, Duration::from_secs(MAX_TRUSTED_PRICE_AGE_SECS));
+        assert_eq!(recent, Some(50_000.0));
+        assert!(validate_price_consensus(&prices, recent).is_err());
+
+        let expired = trusted_price_reference(
+            50_000.0,
+            Duration::from_secs(MAX_TRUSTED_PRICE_AGE_SECS + 1),
+        );
+        assert_eq!(expired, None);
+        assert_eq!(validate_price_consensus(&prices, expired), Ok(65_950.0));
+    }
+
+    #[test]
+    fn refresh_in_progress_keeps_recent_consensus_available() {
+        let mut cache = PriceCache {
+            price: 65_000.0,
+            last_update: Instant::now(),
+            updating: false,
+            quarantined: false,
+        };
+
+        cache.begin_refresh().unwrap();
+
+        assert!(cache.updating);
+        assert_eq!(
+            accounting_price_reference(cache.price, cache.last_update.elapsed(), cache.quarantined,),
+            Some(65_000.0)
+        );
+    }
+
+    #[test]
+    fn transient_refresh_failure_keeps_recent_consensus_until_expiry() {
+        let mut cache = PriceCache {
+            price: 65_000.0,
+            last_update: Instant::now(),
+            updating: true,
+            quarantined: false,
+        };
+        let failure: Result<f64, PriceRefreshError> = Err(PriceRefreshError::transient(
+            "feeds temporarily unavailable",
+        ));
+
+        cache.finish_refresh(&failure);
+
+        assert!(!cache.updating);
+        assert!(!cache.quarantined);
+        assert_eq!(
+            accounting_price_reference(cache.price, cache.last_update.elapsed(), cache.quarantined,),
+            Some(65_000.0)
+        );
+        assert_eq!(
+            accounting_price_reference(
+                cache.price,
+                Duration::from_secs(MAX_TRUSTED_PRICE_AGE_SECS + 1),
+                cache.quarantined,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn large_move_failure_quarantines_old_consensus_until_success() {
+        let mut cache = PriceCache {
+            price: 50_000.0,
+            last_update: Instant::now(),
+            updating: true,
+            quarantined: false,
+        };
+        let rejection: Result<f64, PriceRefreshError> = Err(PriceRefreshError::large_move(
+            "validated move exceeds limit",
+        ));
+
+        cache.finish_refresh(&rejection);
+
+        assert!(cache.quarantined);
+        assert_eq!(
+            accounting_price_reference(cache.price, cache.last_update.elapsed(), cache.quarantined,),
+            None
+        );
+
+        cache.begin_refresh().unwrap();
+        cache.finish_refresh(&Ok(65_000.0));
+        assert!(!cache.quarantined);
+        assert_eq!(
+            accounting_price_reference(cache.price, cache.last_update.elapsed(), cache.quarantined,),
+            Some(65_000.0)
         );
     }
 

--- a/src/price_feeds.rs
+++ b/src/price_feeds.rs
@@ -8,6 +8,12 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use ureq::Agent;
 
+const MIN_PLAUSIBLE_BTC_USD_PRICE: f64 = 1_000.0;
+const MAX_PLAUSIBLE_BTC_USD_PRICE: f64 = 10_000_000.0;
+const MIN_AGREEING_PRICE_FEEDS: usize = 2;
+const MAX_FEED_DEVIATION_RATIO: f64 = 0.05;
+const MAX_MEDIAN_MOVE_RATIO: f64 = 0.10;
+
 lazy_static::lazy_static! {
     static ref PRICE_CACHE: Arc<Mutex<PriceCache>> = Arc::new(Mutex::new(PriceCache {
         price: 0.0,
@@ -90,6 +96,82 @@ pub fn bounded_agent() -> Agent {
         .build()
 }
 
+fn is_plausible_price(price: f64) -> bool {
+    price.is_finite()
+        && (MIN_PLAUSIBLE_BTC_USD_PRICE..=MAX_PLAUSIBLE_BTC_USD_PRICE).contains(&price)
+}
+
+fn parse_price_value(value: &Value) -> Option<f64> {
+    let price = value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|text| text.parse::<f64>().ok()))?;
+    is_plausible_price(price).then_some(price)
+}
+
+fn calculate_median_price(prices: &[(String, f64)]) -> Option<f64> {
+    let mut price_values: Vec<f64> = prices
+        .iter()
+        .map(|(_, price)| *price)
+        .filter(|price| is_plausible_price(*price))
+        .collect();
+    price_values.sort_by(f64::total_cmp);
+
+    let midpoint = price_values.len() / 2;
+    let median = if price_values.len().is_multiple_of(2) {
+        let lower = *price_values.get(midpoint.checked_sub(1)?)?;
+        let upper = *price_values.get(midpoint)?;
+        lower + (upper - lower) / 2.0
+    } else {
+        *price_values.get(midpoint)?
+    };
+    is_plausible_price(median).then_some(median)
+}
+
+fn relative_deviation(value: f64, reference: f64) -> f64 {
+    if !is_plausible_price(value) || !is_plausible_price(reference) {
+        return f64::INFINITY;
+    }
+    (value - reference).abs() / reference
+}
+
+fn validate_price_consensus(
+    prices: &[(String, f64)],
+    last_trusted_price: Option<f64>,
+) -> Result<f64, String> {
+    let initial_median = calculate_median_price(prices)
+        .ok_or_else(|| "No plausible BTC/USD prices were returned".to_string())?;
+    let agreeing_prices: Vec<(String, f64)> = prices
+        .iter()
+        .filter(|(_, price)| {
+            is_plausible_price(*price)
+                && relative_deviation(*price, initial_median) <= MAX_FEED_DEVIATION_RATIO
+        })
+        .cloned()
+        .collect();
+
+    if agreeing_prices.len() < MIN_AGREEING_PRICE_FEEDS {
+        return Err(format!(
+            "Price consensus requires at least {MIN_AGREEING_PRICE_FEEDS} agreeing feeds; got {}",
+            agreeing_prices.len()
+        ));
+    }
+
+    let median = calculate_median_price(&agreeing_prices)
+        .ok_or_else(|| "Agreeing feeds did not produce a valid median".to_string())?;
+    if let Some(last_price) = last_trusted_price.filter(|price| is_plausible_price(*price)) {
+        let deviation = relative_deviation(median, last_price);
+        if deviation > MAX_MEDIAN_MOVE_RATIO {
+            return Err(format!(
+                "BTC/USD median moved {:.2}% from the last trusted price, above the {:.2}% limit",
+                deviation * 100.0,
+                MAX_MEDIAN_MOVE_RATIO * 100.0
+            ));
+        }
+    }
+
+    Ok(median)
+}
+
 pub fn fetch_prices(
     agent: &Agent,
     price_feeds: &[PriceFeed],
@@ -150,20 +232,11 @@ pub fn fetch_prices(
             }
         }
 
-        if let Some(price) = data.as_f64() {
+        if let Some(price) = parse_price_value(data) {
             prices.push((price_feed.name.clone(), price));
-        } else if let Some(price_str) = data.as_str() {
-            if let Ok(price) = price_str.parse::<f64>() {
-                prices.push((price_feed.name.clone(), price));
-            } else {
-                eprintln!(
-                    "Invalid price format for {}: {}",
-                    price_feed.name, price_str
-                );
-            }
         } else {
             eprintln!(
-                "Price data not found or invalid format for {}",
+                "Price data for {} is missing, malformed, or outside the plausibility band",
                 price_feed.name
             );
         }
@@ -184,13 +257,14 @@ pub fn get_latest_price(agent: &Agent) -> Result<f64, Box<dyn Error>> {
         println!("{:<25} ${:>1.2}", feed_name, price);
     }
 
-    let mut price_values: Vec<f64> = prices.iter().map(|(_, price)| *price).collect();
-    price_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let median_price = if price_values.len().is_multiple_of(2) {
-        (price_values[price_values.len() / 2 - 1] + price_values[price_values.len() / 2]) / 2.0
-    } else {
-        price_values[price_values.len() / 2]
-    };
+    let cached_price = get_cached_price_no_fetch();
+    let last_trusted_price = is_plausible_price(cached_price).then_some(cached_price);
+    let median_price = validate_price_consensus(&prices, last_trusted_price).map_err(
+        |message| -> Box<dyn Error> {
+            eprintln!("Rejected BTC/USD price update: {message}");
+            message.into()
+        },
+    )?;
 
     println!("\nMedian BTC/USD price:     ${:.2}\n", median_price);
     Ok(median_price)
@@ -353,6 +427,75 @@ mod tests {
             .replace("{currency_lc}", "usd")
             .replace("{currency}", "USD");
         assert_eq!(url, "https://example.com/usd/USD");
+    }
+
+    #[test]
+    fn test_price_parser_rejects_non_finite_and_non_positive_values() {
+        for value in [
+            Value::String("NaN".to_string()),
+            Value::String("inf".to_string()),
+            Value::String("-inf".to_string()),
+            Value::String("0".to_string()),
+            Value::String("-1".to_string()),
+            Value::String("999.99".to_string()),
+            Value::String("10000000.01".to_string()),
+            Value::Null,
+        ] {
+            assert_eq!(parse_price_value(&value), None);
+        }
+
+        assert_eq!(
+            parse_price_value(&Value::String("50000.5".to_string())),
+            Some(50000.5)
+        );
+    }
+
+    #[test]
+    fn test_median_filters_invalid_prices_without_panicking() {
+        let prices = vec![
+            ("nan".to_string(), f64::NAN),
+            ("infinity".to_string(), f64::INFINITY),
+            ("zero".to_string(), 0.0),
+            ("negative".to_string(), -1.0),
+            ("low".to_string(), 40_000.0),
+            ("high".to_string(), 60_000.0),
+        ];
+        assert_eq!(calculate_median_price(&prices), Some(50_000.0));
+
+        let invalid = vec![("nan".to_string(), f64::NAN)];
+        assert_eq!(calculate_median_price(&invalid), None);
+    }
+
+    #[test]
+    fn test_price_consensus_requires_two_agreeing_feeds() {
+        let single = vec![("only".to_string(), 60_000.0)];
+        assert!(validate_price_consensus(&single, None).is_err());
+
+        let split = vec![
+            ("low".to_string(), 40_000.0),
+            ("high".to_string(), 80_000.0),
+        ];
+        assert!(validate_price_consensus(&split, None).is_err());
+    }
+
+    #[test]
+    fn test_price_consensus_ignores_outlier() {
+        let prices = vec![
+            ("a".to_string(), 65_900.0),
+            ("b".to_string(), 66_000.0),
+            ("outlier".to_string(), 1_000_000.0),
+        ];
+        assert_eq!(validate_price_consensus(&prices, None), Ok(65_950.0));
+    }
+
+    #[test]
+    fn test_price_consensus_rejects_large_move_from_last_trusted_price() {
+        let prices = vec![("a".to_string(), 65_900.0), ("b".to_string(), 66_000.0)];
+        assert!(validate_price_consensus(&prices, Some(50_000.0)).is_err());
+        assert_eq!(
+            validate_price_consensus(&prices, Some(65_000.0)),
+            Ok(65_950.0)
+        );
     }
 
     // Integration test (requires network)

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -125,22 +125,46 @@ pub fn reconcile_forwarded(
 ///
 /// Returns `Some(usd_deducted)` if stable was reduced, `None` if fully covered by native.
 pub fn deduct_outgoing(sc: &mut StableChannel, amount_sats: u64, price: f64) -> Option<f64> {
-    if sc.expected_usd.0 <= 0.01 || price <= 0.0 {
+    let receiver_sats_before = sc.stable_receiver_btc.sats;
+    let backing_sats_before = sc.backing_sats;
+    deduct_outgoing_from_snapshot(
+        sc,
+        receiver_sats_before,
+        backing_sats_before,
+        amount_sats,
+        price,
+    )
+}
+
+/// Deduct a known outgoing amount using the allocation immediately before the spend.
+/// This remains correct when the live channel balance has already advanced to its post-splice
+/// state by the time the asynchronous funding-output lookup completes.
+pub fn deduct_outgoing_from_snapshot(
+    sc: &mut StableChannel,
+    receiver_sats_before: u64,
+    backing_sats_before: u64,
+    amount_sats: u64,
+    price: f64,
+) -> Option<f64> {
+    if !price.is_finite() || price <= 0.0 {
         return None;
     }
 
-    let native_sats = sc.native_channel_btc.sats;
+    let native_sats = receiver_sats_before.saturating_sub(backing_sats_before);
     if amount_sats <= native_sats {
         return None; // Fully covered by native BTC
     }
 
     let overflow_sats = amount_sats - native_sats;
-    let usd_to_deduct = overflow_sats as f64 / SATS_IN_BTC as f64 * price;
+    let usd_to_deduct = (overflow_sats as f64 / SATS_IN_BTC as f64 * price)
+        .min(sc.expected_usd.0.max(0.0));
     let new_expected = (sc.expected_usd.0 - usd_to_deduct).max(0.0);
 
     sc.expected_usd = USD::from_f64(new_expected);
-    let btc_amount = new_expected / price;
-    sc.backing_sats = (btc_amount * 100_000_000.0) as u64;
+    sc.backing_sats = backing_sats_before.saturating_sub(overflow_sats);
+    if new_expected == 0.0 {
+        sc.backing_sats = 0;
+    }
     sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
     recompute_native(sc);
 
@@ -343,6 +367,7 @@ pub fn update_balances<'update_balance_lifetime>(
 
         // Native BTC is the portion not backing the stable position
         let native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
+        sc.native_sats = native_sats;
         sc.native_channel_btc = Bitcoin::from_sats(native_sats);
 
         audit_event(
@@ -795,6 +820,39 @@ mod tests {
         assert!((sc.expected_usd.0 - 92.0).abs() < 1e-9);
         assert_eq!(sc.backing_sats, 90_000);
         assert_eq!(sc.native_sats, 0);
+    }
+
+    #[test]
+    fn splice_out_snapshot_is_stable_after_live_balance_advances() {
+        // Production regression: ChannelReady exposed the post-splice 1,742 sats before the
+        // funding-output lookup returned. The deduction must still use the pre-splice allocation.
+        let price = 65_872.5;
+        let mut sc = test_sc(31.4424, price, 1_742);
+        sc.backing_sats = 47_615;
+        sc.native_sats = 0;
+
+        let deducted =
+            deduct_outgoing_from_snapshot(&mut sc, 92_022, 47_615, 90_280, price).unwrap();
+
+        assert!((deducted - 30.217691925).abs() < 1e-9);
+        assert!((sc.expected_usd.0 - 1.224708075).abs() < 1e-9);
+        assert_eq!(sc.backing_sats, 1_742);
+        assert_eq!(sc.native_sats, 0);
+        assert_eq!(sc.native_channel_btc.sats, 0);
+    }
+
+    #[test]
+    fn splice_out_releases_remaining_backing_when_expected_usd_reaches_zero() {
+        let mut sc = test_sc(0.005, 65_000.0, 250);
+        sc.backing_sats = 500;
+
+        let deducted =
+            deduct_outgoing_from_snapshot(&mut sc, 500, 500, 250, 65_000.0).unwrap();
+
+        assert!((deducted - 0.005).abs() < f64::EPSILON);
+        assert_eq!(sc.expected_usd.0, 0.0);
+        assert_eq!(sc.backing_sats, 0);
+        assert_eq!(sc.native_sats, 250);
     }
 
     // ================================================================

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -55,6 +55,70 @@ pub fn reconcile_outgoing(sc: &mut StableChannel, price: f64) -> Option<f64> {
     Some(usd_to_deduct)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OverbackedRepair {
+    pub backing_sats_before: u64,
+    pub backing_sats_after: u64,
+    pub expected_usd_before: f64,
+    pub expected_usd_after: f64,
+    pub usd_deducted: f64,
+}
+
+/// Repair a persisted allocation whose stable backing exceeds the wallet's live channel balance.
+/// This is the durable-startup counterpart of outgoing-payment reconciliation: native sats are
+/// exhausted first, then the missing stable sats reduce the USD claim at the current trusted price.
+pub fn repair_overbacked_allocation(
+    sc: &mut StableChannel,
+    price: f64,
+) -> Option<OverbackedRepair> {
+    let live_receiver_sats = sc.stable_receiver_btc.sats;
+    if sc.backing_sats <= live_receiver_sats || !price.is_finite() || price <= 0.0 {
+        return None;
+    }
+
+    let backing_sats_before = sc.backing_sats;
+    let expected_usd_before = sc.expected_usd.0.max(0.0);
+    let missing_backing_sats = backing_sats_before - live_receiver_sats;
+    let usd_deducted =
+        (missing_backing_sats as f64 / SATS_IN_BTC as f64 * price).min(expected_usd_before);
+    let expected_usd_after = (expected_usd_before - usd_deducted).max(0.0);
+
+    sc.expected_usd = USD::from_f64(expected_usd_after);
+    sc.backing_sats = if expected_usd_after < 0.01 {
+        0
+    } else {
+        live_receiver_sats
+    };
+    sc.native_sats = live_receiver_sats.saturating_sub(sc.backing_sats);
+    recompute_native(sc);
+    sc.last_stability_payment = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+
+    let repair = OverbackedRepair {
+        backing_sats_before,
+        backing_sats_after: sc.backing_sats,
+        expected_usd_before,
+        expected_usd_after,
+        usd_deducted,
+    };
+    audit_event(
+        "OVERBACKED_ALLOCATION_REPAIRED",
+        json!({
+            "user_channel_id": format!("{}", sc.user_channel_id),
+            "live_receiver_sats": live_receiver_sats,
+            "backing_sats_before": repair.backing_sats_before,
+            "backing_sats_after": repair.backing_sats_after,
+            "expected_usd_before": repair.expected_usd_before,
+            "expected_usd_after": repair.expected_usd_after,
+            "usd_deducted": repair.usd_deducted,
+            "btc_price": price,
+        }),
+    );
+    Some(repair)
+}
+
 /// Reconcile an outgoing forwarded payment on the LSP side.
 ///
 /// The LSP knows the total sats forwarded and the user's current balance.
@@ -405,6 +469,8 @@ pub struct StabilityPaymentInfo {
     pub amount_msat: u64,
     pub counterparty: String,
     pub btc_price: f64,
+    pub backing_sats_before: u64,
+    pub backing_sats_after: u64,
 }
 
 /// Check and enforce stability for a channel.
@@ -474,16 +540,7 @@ pub fn check_stability(
         current_price,
         sc.stable_receiver_btc.sats,
     );
-    if sc.backing_sats > sc.stable_receiver_btc.sats {
-        audit_event(
-            "STABILITY_SKIP",
-            json!({
-                "user_channel_id": format!("{}", sc.user_channel_id),
-                "reason": "backing exceeds live balance; awaiting spend reconciliation",
-                "backing_sats": sc.backing_sats,
-                "live_receiver_sats": sc.stable_receiver_btc.sats,
-            }),
-        );
+    if repair_overbacked_allocation(sc, current_price).is_some() {
         return None;
     }
     sc.native_sats = sc
@@ -613,6 +670,7 @@ pub fn check_stability(
             // This accounts the payment against the stable pool, not native BTC.
             // Don't recompute native_sats here — receiver balance hasn't updated yet
             // (HTLC still in flight). Native will be recomputed on next balance refresh.
+            let previous_backing = sc.backing_sats;
             let new_backing = (target_usd / sc.latest_price * 100_000_000.0) as u64;
             sc.backing_sats = new_backing;
 
@@ -633,6 +691,8 @@ pub fn check_stability(
                 amount_msat: amt,
                 counterparty: counterparty_str,
                 btc_price: sc.latest_price,
+                backing_sats_before: previous_backing,
+                backing_sats_after: new_backing,
             })
         }
         Err(e) => {
@@ -824,6 +884,32 @@ mod tests {
         let mut sc = test_sc(500.0, 100_000.0, 300_000);
         sc.backing_sats = 0;
         assert!(reconcile_outgoing(&mut sc, 100_000.0).is_none());
+    }
+
+    #[test]
+    fn overbacked_allocation_is_repaired_from_live_balance() {
+        let mut sc = test_sc(100.0, 100_000.0, 80_000);
+        sc.backing_sats = 100_000;
+        sc.native_sats = 0;
+
+        let repair = repair_overbacked_allocation(&mut sc, 100_000.0).unwrap();
+
+        assert_eq!(repair.backing_sats_before, 100_000);
+        assert_eq!(repair.backing_sats_after, 80_000);
+        assert!((repair.usd_deducted - 20.0).abs() < 1e-6);
+        assert!((sc.expected_usd.0 - 80.0).abs() < 1e-6);
+        assert_eq!(sc.backing_sats, 80_000);
+        assert_eq!(sc.native_sats, 0);
+    }
+
+    #[test]
+    fn overbacked_repair_waits_for_a_valid_price() {
+        let mut sc = test_sc(100.0, 100_000.0, 80_000);
+        sc.backing_sats = 100_000;
+
+        assert!(repair_overbacked_allocation(&mut sc, 0.0).is_none());
+        assert_eq!(sc.expected_usd.0, 100.0);
+        assert_eq!(sc.backing_sats, 100_000);
     }
 
     #[test]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -3,7 +3,7 @@ use crate::constants::{
     MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_PAYMENT_COOLDOWN_SECS, STABILITY_THRESHOLD_PERCENT,
     STABILITY_THRESHOLD_USD,
 };
-use crate::price_feeds::get_cached_price;
+use crate::price_feeds::{get_cached_price, get_cached_price_no_fetch};
 use crate::types::{Bitcoin, StableChannel, USD};
 use ldk_node::Node;
 use serde_json::json;
@@ -204,12 +204,10 @@ pub fn update_balances<'update_balance_lifetime>(
     node: &Node,
     sc: &'update_balance_lifetime mut StableChannel,
 ) -> (bool, &'update_balance_lifetime mut StableChannel) {
-    let cached = get_cached_price();
+    // Cache-only so no caller (incl. the UI thread) blocks on the network; the background loop owns refreshes.
+    let cached = get_cached_price_no_fetch();
     if cached > 0.0 {
         sc.latest_price = cached;
-    } else if sc.latest_price == 0.0 {
-        let agent = Agent::new();
-        sc.latest_price = get_current_price(&agent);
     }
 
     // --- Update On-chain ---
@@ -311,7 +309,7 @@ pub fn check_stability(
     let current_price = if price > 0.0 {
         price
     } else {
-        let cached_price = get_cached_price();
+        let cached_price = get_cached_price_no_fetch();
         if cached_price > 0.0 {
             cached_price
         } else {

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -291,11 +291,16 @@ pub fn get_current_price(agent: &Agent) -> f64 {
 /// The sats effectively backing the stable position. If `backing_sats` was left unset (0) while a
 /// peg is active, derive it from the target so the stable value is the peg — never the full channel
 /// balance (which would count native BTC and fire a spurious PAY that drains it to the LSP).
-fn effective_backing_sats(backing_sats: u64, expected_usd: f64, price: f64) -> u64 {
+fn effective_backing_sats(
+    backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+    receiver_sats: u64,
+) -> u64 {
     if backing_sats > 0 || expected_usd < 0.01 || price <= 0.0 {
         backing_sats
     } else {
-        (expected_usd / price * 100_000_000.0) as u64
+        ((expected_usd / price * 100_000_000.0) as u64).min(receiver_sats)
     }
 }
 
@@ -352,7 +357,7 @@ pub fn update_balances<'update_balance_lifetime>(
         let unspendable_punishment_sats = channel.unspendable_punishment_reserve.unwrap_or(0);
         let our_balance_sats =
             (channel.outbound_capacity_msat / 1000) + unspendable_punishment_sats;
-        let their_balance_sats = channel.channel_value_sats - our_balance_sats;
+        let their_balance_sats = channel.channel_value_sats.saturating_sub(our_balance_sats);
 
         if sc.is_stable_receiver {
             sc.stable_receiver_btc = Bitcoin::from_sats(our_balance_sats);
@@ -414,22 +419,17 @@ pub fn check_stability(
     sc: &mut StableChannel,
     price: f64,
 ) -> Option<StabilityPaymentInfo> {
-    let current_price = if price > 0.0 {
-        price
-    } else {
-        let cached_price = get_cached_price_no_fetch();
-        if cached_price > 0.0 {
-            cached_price
-        } else {
-            audit_event(
-                "STABILITY_SKIP",
-                json!({
-                    "reason": "no valid price available"
-                }),
-            );
-            return None;
-        }
-    };
+    if !price.is_finite() || price <= 0.0 {
+        audit_event(
+            "STABILITY_SKIP",
+            json!({
+                "reason": "caller supplied no valid current price",
+                "price": price,
+            }),
+        );
+        return None;
+    }
+    let current_price = price;
 
     sc.latest_price = current_price;
     let (success, _) = update_balances(node, sc);
@@ -468,7 +468,29 @@ pub fn check_stability(
     // Repair an unset backing (0 with a live peg + price) by deriving it from the target, so the
     // stable portion is valued at the peg — NOT the full channel balance, which would count native
     // BTC and trigger a spurious PAY that drains it to the LSP.
-    sc.backing_sats = effective_backing_sats(sc.backing_sats, target_usd, current_price);
+    sc.backing_sats = effective_backing_sats(
+        sc.backing_sats,
+        target_usd,
+        current_price,
+        sc.stable_receiver_btc.sats,
+    );
+    if sc.backing_sats > sc.stable_receiver_btc.sats {
+        audit_event(
+            "STABILITY_SKIP",
+            json!({
+                "user_channel_id": format!("{}", sc.user_channel_id),
+                "reason": "backing exceeds live balance; awaiting spend reconciliation",
+                "backing_sats": sc.backing_sats,
+                "live_receiver_sats": sc.stable_receiver_btc.sats,
+            }),
+        );
+        return None;
+    }
+    sc.native_sats = sc
+        .stable_receiver_btc
+        .sats
+        .saturating_sub(sc.backing_sats);
+    recompute_native(sc);
 
     // Value of the stable portion only (excludes native BTC).
     let stable_usd_value = if sc.backing_sats > 0 {
@@ -642,12 +664,23 @@ mod tests {
     fn effective_backing_recomputes_when_unset() {
         // Unset backing (0) with a live peg + price → derived from the peg, not left at 0
         // (so the stable value can't balloon to the full channel balance and fire a bad PAY).
-        assert_eq!(effective_backing_sats(0, 100.0, 50_000.0), 200_000);
+        assert_eq!(
+            effective_backing_sats(0, 100.0, 50_000.0, 300_000),
+            200_000
+        );
         // Already-set backing is returned unchanged.
-        assert_eq!(effective_backing_sats(123_456, 100.0, 50_000.0), 123_456);
+        assert_eq!(
+            effective_backing_sats(123_456, 100.0, 50_000.0, 300_000),
+            123_456
+        );
+        // A legacy peg cannot repair to more backing than the wallet actually owns.
+        assert_eq!(
+            effective_backing_sats(0, 100.0, 100_000.0, 95_000),
+            95_000
+        );
         // No price / no peg → nothing to derive from; left as-is.
-        assert_eq!(effective_backing_sats(0, 100.0, 0.0), 0);
-        assert_eq!(effective_backing_sats(0, 0.0, 50_000.0), 0);
+        assert_eq!(effective_backing_sats(0, 100.0, 0.0, 300_000), 0);
+        assert_eq!(effective_backing_sats(0, 0.0, 50_000.0, 300_000), 0);
     }
 
     #[test]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -191,6 +191,45 @@ pub fn normalize_backing_sats(
     }
 }
 
+/// Derive the stable backing allocation for a trade at the signed quote price.
+///
+/// The result is clamped to the receiver's post-settlement balance. Sub-cent native residue is
+/// absorbed into the stable side so a full BTC-to-USD trade has no floating native remainder.
+pub fn trade_backing_sats(
+    receiver_sats: u64,
+    new_expected_usd: f64,
+    quote_price: f64,
+) -> u64 {
+    if receiver_sats == 0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd <= 0.0
+        || !quote_price.is_finite()
+        || quote_price <= 0.0
+    {
+        return 0;
+    }
+
+    let derived_backing = (new_expected_usd / quote_price * SATS_IN_BTC as f64) as u64;
+    normalize_backing_sats(
+        receiver_sats,
+        derived_backing.min(receiver_sats),
+        new_expected_usd,
+        quote_price,
+    )
+}
+
+/// Apply a previously agreed trade allocation without repricing it.
+///
+/// `backing_sats` is part of the signed trade intent. A peer may validate that intent against its
+/// own price and live LDK balance first, but once accepted it must not derive a different allocation
+/// from a later price snapshot.
+pub fn apply_trade_allocation(sc: &mut StableChannel, new_expected_usd: f64, backing_sats: u64) {
+    sc.expected_usd = USD::from_f64(new_expected_usd);
+    sc.backing_sats = backing_sats;
+    sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
+    recompute_native(sc);
+}
+
 /// Apply a trade — set new expected_usd and recalculate backing_sats + native_sats.
 ///
 /// Used after buy/sell trades and when the LSP processes a trade message.
@@ -200,20 +239,12 @@ pub fn normalize_backing_sats(
 pub fn apply_trade(sc: &mut StableChannel, new_expected_usd: f64, price: f64) {
     sc.expected_usd = USD::from_f64(new_expected_usd);
     if price > 0.0 {
-        let btc_amount = new_expected_usd / price;
-        let derived_backing = (btc_amount * 100_000_000.0) as u64;
         let receiver_sats = sc.stable_receiver_btc.sats;
-        let clamped_backing = if receiver_sats > 0 {
-            derived_backing.min(receiver_sats)
+        sc.backing_sats = if receiver_sats > 0 {
+            trade_backing_sats(receiver_sats, new_expected_usd, price)
         } else {
-            derived_backing
+            (new_expected_usd / price * SATS_IN_BTC as f64) as u64
         };
-        sc.backing_sats = normalize_backing_sats(
-            receiver_sats,
-            clamped_backing,
-            new_expected_usd,
-            price,
-        );
     }
     // native_sats is everything NOT backing the stable position
     sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
@@ -961,6 +992,32 @@ mod tests {
         apply_trade(&mut sc, 100.0, 100_000.0);
 
         assert_eq!(sc.backing_sats, 95_000);
+        assert_eq!(sc.native_sats, 0);
+    }
+
+    #[test]
+    fn signed_trade_allocation_is_not_repriced_by_the_applying_peer() {
+        let receiver_sats = 50_000;
+        let quote_price = 100_000.0;
+        let backing_sats = trade_backing_sats(receiver_sats, 49.95, quote_price);
+        assert_eq!(backing_sats, 49_950);
+
+        let mut sc = test_sc(0.0, 100_500.0, receiver_sats);
+        apply_trade_allocation(&mut sc, 49.95, backing_sats);
+
+        assert_eq!(sc.expected_usd.0, 49.95);
+        assert_eq!(sc.backing_sats, 49_950);
+        assert_eq!(sc.native_sats, 50);
+    }
+
+    #[test]
+    fn signed_full_peg_allocation_absorbs_sub_cent_residue() {
+        let backing_sats = trade_backing_sats(57_444, 38.055025828575, 66_250.21);
+        assert_eq!(backing_sats, 57_444);
+
+        let mut sc = test_sc(0.0, 66_400.0, 57_444);
+        apply_trade_allocation(&mut sc, 38.055025828575, backing_sats);
+        assert_eq!(sc.backing_sats, 57_444);
         assert_eq!(sc.native_sats, 0);
     }
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -19,7 +19,7 @@ use ureq::Agent;
 /// When the user sends a payment, their channel balance decreases.
 /// If `backing_sats > actual_receiver_sats`, the payment ate into
 /// the stable portion. This function deducts the overflow from
-/// `expected_usd` and recalculates `backing_sats`.
+/// `expected_usd` and from the persisted sat allocation.
 ///
 /// Returns `Some(usd_deducted)` if stable was reduced, `None` otherwise.
 pub fn reconcile_outgoing(sc: &mut StableChannel, price: f64) -> Option<f64> {
@@ -38,9 +38,12 @@ pub fn reconcile_outgoing(sc: &mut StableChannel, price: f64) -> Option<f64> {
     let new_expected = (old_expected - usd_to_deduct).max(0.0);
 
     sc.expected_usd = USD::from_f64(new_expected);
-    let btc_amount = new_expected / price;
-    sc.backing_sats = (btc_amount * 100_000_000.0) as u64;
-    sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
+    // Native sats have already been exhausted when live balance drops below backing. Every
+    // remaining sat therefore stays in the stable allocation. Deriving backing from
+    // new_expected/current_price would silently reclassify sats whenever price moved since the
+    // last trade or stability settlement.
+    sc.backing_sats = user_sats;
+    sc.native_sats = 0;
     recompute_native(sc);
 
     // Set cooldown so stability check doesn't immediately re-fire
@@ -85,13 +88,12 @@ pub fn reconcile_forwarded(
     let new_expected = (old_expected - usd_to_deduct).max(0.0);
 
     sc.expected_usd = USD::from_f64(new_expected);
-    if price > 0.0 {
-        let btc_amount = new_expected / price;
-        sc.backing_sats = (btc_amount * 100_000_000.0) as u64;
-    }
     // After forwarding: user's actual remaining balance is user_sats - total_forwarded_sats
     let remaining_user_sats = user_sats.saturating_sub(total_forwarded_sats);
-    sc.native_sats = remaining_user_sats.saturating_sub(sc.backing_sats);
+    // An overflow means native was fully consumed, so all remaining sats are stable. Preserve
+    // that exact allocation instead of deriving a new one from a potentially newer BTC price.
+    sc.backing_sats = remaining_user_sats;
+    sc.native_sats = 0;
     recompute_native(sc);
 
     // Set cooldown so stability check doesn't immediately re-fire on a price micro-tick
@@ -162,6 +164,33 @@ pub fn reconcile_incoming(sc: &mut StableChannel) {
     recompute_native(sc);
 }
 
+/// Stable/native allocation residue smaller than one cent is not useful to the user and cannot be
+/// entered precisely in the two-decimal trade UI. Absorb it into the stable side so a full
+/// BTC-to-USD trade produces an exact all-stable allocation.
+pub fn normalize_backing_sats(
+    receiver_sats: u64,
+    backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+) -> u64 {
+    if receiver_sats == 0
+        || backing_sats > receiver_sats
+        || expected_usd <= 0.0
+        || !price.is_finite()
+        || price <= 0.0
+    {
+        return backing_sats;
+    }
+
+    let native_sats = receiver_sats - backing_sats;
+    let native_usd = native_sats as f64 / SATS_IN_BTC as f64 * price;
+    if native_usd < 0.01 {
+        receiver_sats
+    } else {
+        backing_sats
+    }
+}
+
 /// Apply a trade — set new expected_usd and recalculate backing_sats + native_sats.
 ///
 /// Used after buy/sell trades and when the LSP processes a trade message.
@@ -172,7 +201,19 @@ pub fn apply_trade(sc: &mut StableChannel, new_expected_usd: f64, price: f64) {
     sc.expected_usd = USD::from_f64(new_expected_usd);
     if price > 0.0 {
         let btc_amount = new_expected_usd / price;
-        sc.backing_sats = (btc_amount * 100_000_000.0) as u64;
+        let derived_backing = (btc_amount * 100_000_000.0) as u64;
+        let receiver_sats = sc.stable_receiver_btc.sats;
+        let clamped_backing = if receiver_sats > 0 {
+            derived_backing.min(receiver_sats)
+        } else {
+            derived_backing
+        };
+        sc.backing_sats = normalize_backing_sats(
+            receiver_sats,
+            clamped_backing,
+            new_expected_usd,
+            price,
+        );
     }
     // native_sats is everything NOT backing the stable position
     sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
@@ -190,6 +231,17 @@ pub fn get_current_price(agent: &Agent) -> f64 {
     }
 
     crate::price_feeds::get_latest_price(agent).unwrap_or(0.0)
+}
+
+/// The sats effectively backing the stable position. If `backing_sats` was left unset (0) while a
+/// peg is active, derive it from the target so the stable value is the peg — never the full channel
+/// balance (which would count native BTC and fire a spurious PAY that drains it to the LSP).
+fn effective_backing_sats(backing_sats: u64, expected_usd: f64, price: f64) -> u64 {
+    if backing_sats > 0 || expected_usd < 0.01 || price <= 0.0 {
+        backing_sats
+    } else {
+        (expected_usd / price * 100_000_000.0) as u64
+    }
 }
 
 pub fn channel_exists(node: &Node, user_channel_id: u128) -> bool {
@@ -357,15 +409,18 @@ pub fn check_stability(
     // The target is expected_usd
     let target_usd = sc.expected_usd.0;
 
-    // Use backing_sats to calculate the current value of the stable portion only
-    // This excludes the native BTC position from stability calculations
+    // Repair an unset backing (0 with a live peg + price) by deriving it from the target, so the
+    // stable portion is valued at the peg — NOT the full channel balance, which would count native
+    // BTC and trigger a spurious PAY that drains it to the LSP.
+    sc.backing_sats = effective_backing_sats(sc.backing_sats, target_usd, current_price);
+
+    // Value of the stable portion only (excludes native BTC).
     let stable_usd_value = if sc.backing_sats > 0 {
-        // backing_sats tracks the BTC backing the stable portion
         (sc.backing_sats as f64 / 100_000_000.0) * current_price
     } else {
-        // Fallback for channels without backing_sats set yet - use total balance
-        // but only if expected_usd is set (means user has a stable position)
-        sc.stable_receiver_usd.0
+        // Backing still unset (degenerate: no price / sub-cent peg) — value at the peg, never the
+        // full channel balance.
+        target_usd
     };
 
     // Calculate deviation: how much the stable portion has drifted from target
@@ -528,6 +583,18 @@ mod tests {
     }
 
     #[test]
+    fn effective_backing_recomputes_when_unset() {
+        // Unset backing (0) with a live peg + price → derived from the peg, not left at 0
+        // (so the stable value can't balloon to the full channel balance and fire a bad PAY).
+        assert_eq!(effective_backing_sats(0, 100.0, 50_000.0), 200_000);
+        // Already-set backing is returned unchanged.
+        assert_eq!(effective_backing_sats(123_456, 100.0, 50_000.0), 123_456);
+        // No price / no peg → nothing to derive from; left as-is.
+        assert_eq!(effective_backing_sats(0, 100.0, 0.0), 0);
+        assert_eq!(effective_backing_sats(0, 0.0, 50_000.0), 0);
+    }
+
+    #[test]
     fn test_usd_from_bitcoin_conversion() {
         let btc = Bitcoin::from_sats(100_000_000); // 1 BTC
         let price = 50_000.0;
@@ -632,9 +699,8 @@ mod tests {
             d
         );
         assert!((sc.expected_usd.0 - 900.0).abs() < 0.01);
-        // backing_sats should match new expected_usd
-        let expected_backing = (900.0 / 100_000.0 * 100_000_000.0) as u64;
-        assert_eq!(sc.backing_sats, expected_backing);
+        // All remaining sats stay in the stable allocation exactly.
+        assert_eq!(sc.backing_sats, 900_000);
     }
 
     #[test]
@@ -687,6 +753,19 @@ mod tests {
         assert!((d2 - 200.0).abs() < 0.01);
     }
 
+    #[test]
+    fn outgoing_after_price_move_preserves_remaining_stable_sats() {
+        // Allocated at $100k: $100 is 100k stable sats. Price falls to $80k before a 10k-sat
+        // stable overflow is reconciled. The quote changes the USD deduction, not the allocation.
+        let mut sc = test_sc(100.0, 100_000.0, 90_000);
+        let deducted = reconcile_outgoing(&mut sc, 80_000.0).unwrap();
+
+        assert!((deducted - 8.0).abs() < 1e-9);
+        assert!((sc.expected_usd.0 - 92.0).abs() < 1e-9);
+        assert_eq!(sc.backing_sats, 90_000);
+        assert_eq!(sc.native_sats, 0);
+    }
+
     // ================================================================
     // reconcile_forwarded (LSP side)
     // ================================================================
@@ -720,6 +799,19 @@ mod tests {
         let deducted = reconcile_forwarded(&mut sc, 500_000, 100_000, 100_000.0).unwrap();
         assert!((deducted - 100.0).abs() < 0.01);
         assert!((sc.expected_usd.0 - 400.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn forwarded_after_price_move_preserves_remaining_stable_sats() {
+        // 100k stable + 50k native were allocated at $100k. At an $80k execution quote, a 60k
+        // payment consumes all native and 10k stable, leaving exactly 90k stable sats.
+        let mut sc = test_sc(100.0, 100_000.0, 150_000);
+        let deducted = reconcile_forwarded(&mut sc, 150_000, 60_000, 80_000.0).unwrap();
+
+        assert!((deducted - 8.0).abs() < 1e-9);
+        assert!((sc.expected_usd.0 - 92.0).abs() < 1e-9);
+        assert_eq!(sc.backing_sats, 90_000);
+        assert_eq!(sc.native_sats, 0);
     }
 
     #[test]
@@ -841,6 +933,35 @@ mod tests {
         apply_trade(&mut sc, 1000.0, 100_000.0);
         assert_eq!(sc.expected_usd.0, 1000.0);
         assert_eq!(sc.backing_sats, 1_000_000);
+    }
+
+    #[test]
+    fn trade_full_balance_absorbs_sub_cent_native_dust() {
+        let mut sc = test_sc(0.0, 66_250.21, 57_444);
+        apply_trade(&mut sc, 38.055025828575, 66_250.21);
+
+        assert_eq!(sc.backing_sats, 57_444);
+        assert_eq!(sc.native_sats, 0);
+        assert_eq!(sc.native_channel_btc.sats, 0);
+    }
+
+    #[test]
+    fn trade_keeps_meaningful_native_allocation() {
+        let mut sc = test_sc(0.0, 100_000.0, 100_000);
+        apply_trade(&mut sc, 99.0, 100_000.0);
+
+        assert_eq!(sc.backing_sats, 99_000);
+        assert_eq!(sc.native_sats, 1_000);
+        assert_eq!(sc.native_channel_btc.sats, 1_000);
+    }
+
+    #[test]
+    fn trade_backing_never_exceeds_live_balance() {
+        let mut sc = test_sc(0.0, 100_000.0, 95_000);
+        apply_trade(&mut sc, 100.0, 100_000.0);
+
+        assert_eq!(sc.backing_sats, 95_000);
+        assert_eq!(sc.native_sats, 0);
     }
 
     // ================================================================

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -3,7 +3,7 @@ use crate::constants::{
     MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_PAYMENT_COOLDOWN_SECS, STABILITY_THRESHOLD_PERCENT,
     STABILITY_THRESHOLD_USD,
 };
-use crate::price_feeds::{get_cached_price, get_cached_price_no_fetch};
+use crate::price_feeds::{get_cached_price, get_fresh_cached_price_no_fetch};
 use crate::types::{Bitcoin, StableChannel, USD};
 use ldk_node::Node;
 use serde_json::json;
@@ -117,6 +117,57 @@ pub fn repair_overbacked_allocation(
         }),
     );
     Some(repair)
+}
+
+/// Return whether an outbound Lightning payment is still unresolved.
+///
+/// LDK temporarily removes an in-flight HTLC from `outbound_capacity_msat`. Treating that lower
+/// capacity as a settled spend would permanently reduce the stable claim if the payment later
+/// fails. On-chain payments are excluded because they remain pending until confirmation without
+/// affecting a channel's Lightning capacity.
+fn is_pending_outbound_lightning(
+    direction: ldk_node::payment::PaymentDirection,
+    status: ldk_node::payment::PaymentStatus,
+    is_onchain: bool,
+) -> bool {
+    direction == ldk_node::payment::PaymentDirection::Outbound
+        && status == ldk_node::payment::PaymentStatus::Pending
+        && !is_onchain
+}
+
+fn has_pending_outbound_lightning_payment(node: &Node) -> bool {
+    node.list_payments().iter().any(|payment| {
+        is_pending_outbound_lightning(
+            payment.direction,
+            payment.status,
+            matches!(payment.kind, ldk_node::payment::PaymentKind::Onchain { .. }),
+        )
+    })
+}
+
+/// Repair an over-backed allocation only when the observed capacity cannot be explained by an
+/// unresolved outbound HTLC.
+pub fn repair_overbacked_allocation_if_safe(
+    node: &Node,
+    sc: &mut StableChannel,
+    price: f64,
+) -> Option<OverbackedRepair> {
+    if sc.backing_sats > sc.stable_receiver_btc.sats
+        && has_pending_outbound_lightning_payment(node)
+    {
+        audit_event(
+            "OVERBACKED_REPAIR_SKIPPED_PENDING_HTLC",
+            json!({
+                "user_channel_id": format!("{}", sc.user_channel_id),
+                "live_receiver_sats": sc.stable_receiver_btc.sats,
+                "backing_sats": sc.backing_sats,
+                "reason": "outbound Lightning payment is still pending",
+            }),
+        );
+        return None;
+    }
+
+    repair_overbacked_allocation(sc, price)
 }
 
 /// Reconcile an outgoing forwarded payment on the LSP side.
@@ -381,7 +432,7 @@ pub fn update_balances<'update_balance_lifetime>(
     sc: &'update_balance_lifetime mut StableChannel,
 ) -> (bool, &'update_balance_lifetime mut StableChannel) {
     // Cache-only so no caller (incl. the UI thread) blocks on the network; the background loop owns refreshes.
-    let cached = get_cached_price_no_fetch();
+    let cached = get_fresh_cached_price_no_fetch();
     if cached > 0.0 {
         sc.latest_price = cached;
     }
@@ -540,7 +591,15 @@ pub fn check_stability(
         current_price,
         sc.stable_receiver_btc.sats,
     );
-    if repair_overbacked_allocation(sc, current_price).is_some() {
+    if sc.backing_sats > sc.stable_receiver_btc.sats
+        && has_pending_outbound_lightning_payment(node)
+    {
+        // Emit the common safety audit and stop the whole stability decision. Continuing with the
+        // temporarily reduced capacity could initiate another payment from a false drift signal.
+        let _ = repair_overbacked_allocation_if_safe(node, sc, current_price);
+        return None;
+    }
+    if repair_overbacked_allocation_if_safe(node, sc, current_price).is_some() {
         return None;
     }
     sc.native_sats = sc
@@ -712,6 +771,32 @@ pub fn check_stability(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_pending_outbound_lightning_blocks_capacity_repair() {
+        use ldk_node::payment::{PaymentDirection, PaymentStatus};
+
+        assert!(is_pending_outbound_lightning(
+            PaymentDirection::Outbound,
+            PaymentStatus::Pending,
+            false,
+        ));
+        assert!(!is_pending_outbound_lightning(
+            PaymentDirection::Outbound,
+            PaymentStatus::Succeeded,
+            false,
+        ));
+        assert!(!is_pending_outbound_lightning(
+            PaymentDirection::Inbound,
+            PaymentStatus::Pending,
+            false,
+        ));
+        assert!(!is_pending_outbound_lightning(
+            PaymentDirection::Outbound,
+            PaymentStatus::Pending,
+            true,
+        ));
+    }
 
     #[test]
     fn test_get_current_price_returns_non_negative() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -195,11 +195,11 @@ pub struct StableChannel {
     /// Native BTC exposure (the portion of the channel that floats with BTC price)
     #[serde(default)]
     pub native_channel_btc: Bitcoin,
-    /// Sats backing the stable portion (derived: receiver_sats - native_sats)
+    /// Sats allocated to the stable portion. Changes on trades, stability settlements, or
+    /// reconciliation; a price quote alone never moves sats between allocations.
     #[serde(default)]
     pub backing_sats: u64,
-    /// Sats NOT backing the stable position (only changes on trades).
-    /// backing_sats is derived as receiver_sats - native_sats on every stability check.
+    /// Sats allocated to native BTC after the latest settled accounting update.
     #[serde(default)]
     pub native_sats: u64,
     /// Unix timestamp (seconds) of the last stability payment sent on this channel

--- a/src/user.rs
+++ b/src/user.rs
@@ -11,7 +11,7 @@ use egui::{Color32, CursorIcon, OpenUrl, RichText, Sense, TextureOptions};
 use image::{GrayImage, Luma};
 use ldk_node::lightning::ln::channelmanager::PaymentId;
 use ldk_node::payment::{PaymentDirection, PaymentKind};
-use qrcode::{Color, QrCode};
+use qrcode::QrCode;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs::File;
@@ -749,14 +749,13 @@ impl UserApp {
                     .timeout_connect(Duration::from_secs(5))
                     .timeout(Duration::from_secs(10))
                     .build();
-                let price = match stable_channels::price_feeds::get_latest_price(&price_agent)
-                {
-                    Ok(p) if p > 0.0 => p,
-                    _ => stable_channels::price_feeds::get_cached_price(),
-                };
+                let price = stable_channels::price_feeds::get_latest_price(&price_agent)
+                    .ok()
+                    .filter(|price| *price > 0.0);
 
-                // Only proceed if we have a valid price
-                if price > 0.0 {
+                // Automatic stability payments require a freshly validated consensus price.
+                // The last trusted cached price remains available to the UI during an outage.
+                if let Some(price) = price {
                     // Publish so the UI thread's non-blocking get_cached_price_no_fetch reads stay fresh.
                     stable_channels::price_feeds::set_cached_price(price);
                     let mut payment_sent = false;
@@ -944,50 +943,22 @@ impl UserApp {
                         "type": "variable_amount"
                     }),
                 );
-                let code = QrCode::new(&self.invoice_result).unwrap();
-                let bits = code.to_colors();
-                let width = code.width();
-                let scale = 4;
-                let border = scale * 2; // 2 modules of border
-                let img_size = (width * scale) as u32;
-                let bordered_size = img_size + (border * 2) as u32;
-
-                // Create image with border (white background)
-                let mut imgbuf = GrayImage::from_pixel(bordered_size, bordered_size, Luma([255]));
-
-                // Draw QR code in the center
-                for y in 0..width {
-                    for x in 0..width {
-                        let color = if bits[y * width + x] == Color::Dark {
-                            0
-                        } else {
-                            255
-                        };
-                        for dy in 0..scale {
-                            for dx in 0..scale {
-                                imgbuf.put_pixel(
-                                    (x * scale + dx) as u32 + border as u32,
-                                    (y * scale + dy) as u32 + border as u32,
-                                    Luma([color]),
-                                );
-                            }
-                        }
-                    }
+                self.qr_texture = Self::generate_qr_texture(&self.invoice_result, ctx, "qr_code");
+                if self.qr_texture.is_some() {
+                    self.status_message =
+                        "Invoice generated. Pay it to create a JIT channel.".to_string();
+                } else {
+                    audit_event(
+                        "QR_GENERATION_FAILED",
+                        json!({
+                            "context": "jit_onboarding",
+                            "payload_len": self.invoice_result.len()
+                        }),
+                    );
+                    self.status_message =
+                        "Invoice generated, but its QR code could not be rendered.".to_string();
+                    self.show_toast("QR code unavailable", "!");
                 }
-                let (w, h) = (imgbuf.width() as usize, imgbuf.height() as usize);
-                let mut rgba = Vec::with_capacity(w * h * 4);
-                for p in imgbuf.pixels() {
-                    let lum = p[0];
-                    rgba.extend_from_slice(&[lum, lum, lum, 255]);
-                }
-                let tex = ctx.load_texture(
-                    "qr_code",
-                    egui::ColorImage::from_rgba_unmultiplied([w, h], &rgba),
-                    TextureOptions::LINEAR,
-                );
-                self.qr_texture = Some(tex);
-                self.status_message =
-                    "Invoice generated. Pay it to create a JIT channel.".to_string();
                 self.waiting_for_payment = true;
             }
             Err(e) => {
@@ -1079,49 +1050,24 @@ impl UserApp {
                     }),
                 );
 
-                // Generate QR code
-                let code = QrCode::new(&self.lightning_receive_invoice).unwrap();
-                let bits = code.to_colors();
-                let width = code.width();
-                let scale = 4;
-                let border = scale * 2;
-                let img_size = (width * scale) as u32;
-                let bordered_size = img_size + (border * 2) as u32;
-
-                let mut imgbuf = GrayImage::from_pixel(bordered_size, bordered_size, Luma([255]));
-
-                for y in 0..width {
-                    for x in 0..width {
-                        let color = if bits[y * width + x] == Color::Dark {
-                            0
-                        } else {
-                            255
-                        };
-                        for dy in 0..scale {
-                            for dx in 0..scale {
-                                imgbuf.put_pixel(
-                                    (x * scale + dx) as u32 + border as u32,
-                                    (y * scale + dy) as u32 + border as u32,
-                                    Luma([color]),
-                                );
-                            }
-                        }
-                    }
-                }
-
-                let (w, h) = (imgbuf.width() as usize, imgbuf.height() as usize);
-                let mut rgba = Vec::with_capacity(w * h * 4);
-                for p in imgbuf.pixels() {
-                    let lum = p[0];
-                    rgba.extend_from_slice(&[lum, lum, lum, 255]);
-                }
-
-                let tex = ctx.load_texture(
+                self.lightning_receive_qr = Self::generate_qr_texture(
+                    &self.lightning_receive_invoice,
+                    ctx,
                     "lightning_receive_qr",
-                    egui::ColorImage::from_rgba_unmultiplied([w, h], &rgba),
-                    TextureOptions::LINEAR,
                 );
-                self.lightning_receive_qr = Some(tex);
+                if self.lightning_receive_qr.is_some() {
+                    self.lightning_receive_error.clear();
+                } else {
+                    self.lightning_receive_error =
+                        "Invoice ready, but its QR code could not be rendered.".to_string();
+                    audit_event(
+                        "QR_GENERATION_FAILED",
+                        json!({
+                            "context": "lightning_receive",
+                            "payload_len": self.lightning_receive_invoice.len()
+                        }),
+                    );
+                }
                 self.show_lightning_receive = true;
             }
             Err(e) => {
@@ -1164,43 +1110,24 @@ impl UserApp {
         match result {
             Ok(invoice) => {
                 self.lightning_receive_invoice = invoice.to_string();
-                let code = QrCode::new(&self.lightning_receive_invoice).unwrap();
-                let bits = code.to_colors();
-                let width = code.width();
-                let scale = 4;
-                let border = scale * 2;
-                let bordered_size = (width * scale) as u32 + (border * 2) as u32;
-                let mut imgbuf = GrayImage::from_pixel(bordered_size, bordered_size, Luma([255u8]));
-                for y in 0..width {
-                    for x in 0..width {
-                        let color = if bits[y * width + x] == Color::Dark {
-                            0
-                        } else {
-                            255
-                        };
-                        for dy in 0..scale {
-                            for dx in 0..scale {
-                                imgbuf.put_pixel(
-                                    (x * scale + dx) as u32 + border as u32,
-                                    (y * scale + dy) as u32 + border as u32,
-                                    Luma([color]),
-                                );
-                            }
-                        }
-                    }
-                }
-                let (w, h) = (imgbuf.width() as usize, imgbuf.height() as usize);
-                let mut rgba = Vec::with_capacity(w * h * 4);
-                for p in imgbuf.pixels() {
-                    let lum = p[0];
-                    rgba.extend_from_slice(&[lum, lum, lum, 255]);
-                }
-                let tex = ctx.load_texture(
+                self.lightning_receive_qr = Self::generate_qr_texture(
+                    &self.lightning_receive_invoice,
+                    ctx,
                     "lightning_receive_qr",
-                    egui::ColorImage::from_rgba_unmultiplied([w, h], &rgba),
-                    TextureOptions::LINEAR,
                 );
-                self.lightning_receive_qr = Some(tex);
+                if self.lightning_receive_qr.is_some() {
+                    self.lightning_receive_error.clear();
+                } else {
+                    self.lightning_receive_error =
+                        "Invoice ready, but its QR code could not be rendered.".to_string();
+                    audit_event(
+                        "QR_GENERATION_FAILED",
+                        json!({
+                            "context": "jit_receive",
+                            "payload_len": self.lightning_receive_invoice.len()
+                        }),
+                    );
+                }
                 self.show_lightning_receive = true;
             }
             Err(e) => {
@@ -1250,20 +1177,7 @@ impl UserApp {
             return false;
         }
 
-        // Auto-fix double-paste
-        let input = {
-            let len = input.len();
-            if len > 60 && len.is_multiple_of(2) {
-                let (first, second) = input.split_at(len / 2);
-                if first == second {
-                    first.to_string()
-                } else {
-                    input
-                }
-            } else {
-                input
-            }
-        };
+        let input = collapse_double_paste(input);
 
         let lower = input.to_lowercase();
 
@@ -1284,32 +1198,27 @@ impl UserApp {
                             "No Lightning channel open. Fund your wallet first.".to_string();
                         return false;
                     }
-                    let result = if invoice.amount_milli_satoshis().is_none() {
-                        // Variable-amount invoice — use amount from input
-                        match self.send_amount.trim().parse::<f64>() {
-                            Ok(btc) if btc > 0.0 => {
-                                let msat = (btc * 100_000_000_000.0) as u64;
-                                self.node
-                                    .bolt11_payment()
-                                    .send_using_amount(&invoice, msat, None)
-                            }
-                            _ => {
+                    let invoice_amount_msat = invoice.amount_milli_satoshis();
+                    let amount_msat = if let Some(amount_msat) = invoice_amount_msat {
+                        amount_msat
+                    } else {
+                        match btc_amount_to_msat(&self.send_amount) {
+                            Some(amount_msat) => amount_msat,
+                            None => {
                                 self.send_error = "Enter an amount in BTC".to_string();
                                 return false;
                             }
                         }
-                    } else {
+                    };
+                    let result = if invoice_amount_msat.is_some() {
                         self.node.bolt11_payment().send(&invoice, None)
+                    } else {
+                        self.node
+                            .bolt11_payment()
+                            .send_using_amount(&invoice, amount_msat, None)
                     };
                     match result {
                         Ok(payment_id) => {
-                            // Determine amount_msat for the pending record
-                            let amount_msat = if let Some(amt) = invoice.amount_milli_satoshis() {
-                                amt
-                            } else {
-                                (self.send_amount.trim().parse::<f64>().unwrap_or(0.0)
-                                    * 100_000_000_000.0) as u64
-                            };
                             let (amount_usd, btc_price_opt) = {
                                 let sc = self.stable_channel.lock().unwrap();
                                 let price = sc.latest_price;
@@ -3508,9 +3417,16 @@ impl UserApp {
 
     /// Format a price with comma separators and 2 decimal places (e.g., 100000.50 -> "$100,000.50")
     fn format_price(price: f64) -> String {
-        let price_int = price as i64;
-        let decimal_part = ((price - price_int as f64) * 100.0).round() as i64;
-        let formatted = price_int
+        if !price.is_finite() {
+            return "$0.00".to_string();
+        }
+
+        let total_cents = (price * 100.0).round() as i64;
+        let sign = if total_cents < 0 { "-" } else { "" };
+        let absolute_cents = total_cents.unsigned_abs();
+        let dollars = absolute_cents / 100;
+        let cents = absolute_cents % 100;
+        let formatted = dollars
             .to_string()
             .as_bytes()
             .rchunks(3)
@@ -3518,7 +3434,7 @@ impl UserApp {
             .map(|chunk| std::str::from_utf8(chunk).unwrap())
             .collect::<Vec<_>>()
             .join(",");
-        format!("${}.{:02}", formatted, decimal_part.abs())
+        format!("{sign}${formatted}.{cents:02}")
     }
 
     fn format_chart_price(price: f64) -> String {
@@ -7820,6 +7736,13 @@ impl UserApp {
                         let img = egui::Image::from_texture(qr).max_size(egui::vec2(180.0, 180.0));
                         ui.add(img);
                     }
+                    if !self.lightning_receive_error.is_empty() {
+                        ui.label(
+                            RichText::new(&self.lightning_receive_error)
+                                .size(12.0)
+                                .color(theme::DANGER_HOVER),
+                        );
+                    }
                     ui.add_space(6.0);
                     ui.label(
                         RichText::new(
@@ -9722,10 +9645,36 @@ fn channel_balance_split(
     (stable_sats, native_sats, native_usd)
 }
 
+fn collapse_double_paste(input: String) -> String {
+    let len = input.len();
+    let midpoint = len / 2;
+    if len > 60 && len.is_multiple_of(2) && input.is_char_boundary(midpoint) {
+        let (first, second) = input.split_at(midpoint);
+        if first == second {
+            return first.to_string();
+        }
+    }
+    input
+}
+
+fn btc_amount_to_msat(input: &str) -> Option<u64> {
+    let btc = input.trim().parse::<f64>().ok()?;
+    if !btc.is_finite() || btc <= 0.0 || btc > 21_000_000.0 {
+        return None;
+    }
+
+    let amount_msat = (btc * SATS_IN_BTC as f64 * 1000.0).round();
+    if !amount_msat.is_finite() || amount_msat < 1.0 || amount_msat > u64::MAX as f64 {
+        return None;
+    }
+    Some(amount_msat as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        channel_balance_split, floor_usd_cents, parse_trade_usd_cents, sats_for_usd_cents,
+        btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
+        parse_trade_usd_cents, sats_for_usd_cents, UserApp,
     };
 
     #[test]
@@ -9805,5 +9754,45 @@ mod tests {
         assert_eq!(stable, 57_444);
         assert_eq!(native, 0);
         assert_eq!(usd, 0.0);
+    }
+
+    #[test]
+    fn double_paste_is_collapsed() {
+        let invoice = "lnbc".repeat(20);
+        assert_eq!(
+            collapse_double_paste(format!("{invoice}{invoice}")),
+            invoice
+        );
+    }
+
+    #[test]
+    fn double_paste_check_handles_utf8_midpoint() {
+        let input = format!("{}\u{20ac}{}", "a".repeat(30), "a".repeat(31));
+        assert_eq!(input.len(), 64);
+        assert!(!input.is_char_boundary(input.len() / 2));
+        assert_eq!(collapse_double_paste(input.clone()), input);
+    }
+
+    #[test]
+    fn oversized_qr_payload_is_rejected_without_panicking() {
+        let ctx = eframe::egui::Context::default();
+        assert!(UserApp::generate_qr_texture(&"x".repeat(10_000), &ctx, "test_qr").is_none());
+    }
+
+    #[test]
+    fn variable_invoice_amount_uses_btc_units_once() {
+        assert_eq!(btc_amount_to_msat("0.0001"), Some(10_000_000));
+        assert_eq!(btc_amount_to_msat("1"), Some(100_000_000_000));
+        assert_eq!(btc_amount_to_msat("NaN"), None);
+        assert_eq!(btc_amount_to_msat("inf"), None);
+        assert_eq!(btc_amount_to_msat("0"), None);
+    }
+
+    #[test]
+    fn price_formatting_carries_rounded_cents() {
+        assert_eq!(UserApp::format_price(99.999), "$100.00");
+        assert_eq!(UserApp::format_price(1_234.5), "$1,234.50");
+        assert_eq!(UserApp::format_price(-0.005), "-$0.01");
+        assert_eq!(UserApp::format_price(f64::NAN), "$0.00");
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -161,6 +161,7 @@ pub struct PendingTrade {
 struct PendingTradePayment {
     new_expected_usd: f64,
     price: f64,
+    backing_sats: Option<u64>,
     trade_db_id: i64,
     action: String,
 }
@@ -1880,32 +1881,67 @@ impl UserApp {
 
     /// Send a trade message to the LSP with the new stabilized USD amount.
     /// The fee is sent as the keysend payment amount.
-    /// Returns the PaymentId on success so the caller can track it.
+    /// Returns the PaymentId and signed backing allocation on success so the caller can track it.
     fn send_trade(
         &mut self,
         new_expected_usd: f64,
         fee_usd: f64,
         trade_action: &str,
         trade_price: f64,
-    ) -> Option<PaymentId> {
-        // Grab channel identifiers and counterparty from StableChannel. The fee and the local
-        // settlement use the quote the user reviewed on the confirmation screen.
-        let (channel_id_str, user_channel_id_str, counterparty, old_expected_usd) = {
-            let sc = self.stable_channel.lock().unwrap();
+    ) -> Option<(PaymentId, u64)> {
+        // The fee is a direct keysend amount. Calculate its whole-sat channel impact before
+        // signing the allocation so both peers derive against the same post-settlement balance.
+        let fee_sats = if trade_price > 0.0 && fee_usd > 0.0 {
+            (fee_usd / trade_price * SATS_IN_BTC as f64) as u64
+        } else {
+            0
+        };
+        let fee_msats = fee_sats.saturating_mul(1000);
+        let amt_msat = fee_msats.max(1);
+
+        // Refresh from this wallet's LDK node, then sign one exact allocation at the quote the
+        // user reviewed. The LSP independently validates this against its LDK view and price.
+        let (
+            channel_id_str,
+            user_channel_id_str,
+            counterparty,
+            old_expected_usd,
+            post_fee_receiver_sats,
+            backing_sats,
+        ) = {
+            let mut sc = self.stable_channel.lock().unwrap();
+            stable::update_balances(&self.node, &mut sc);
+            let post_fee_receiver_sats = sc.stable_receiver_btc.sats.saturating_sub(fee_sats);
+            let backing_sats = stable::trade_backing_sats(
+                post_fee_receiver_sats,
+                new_expected_usd,
+                trade_price,
+            );
             (
                 sc.channel_id.to_string(),
                 format!("{}", sc.user_channel_id),
                 sc.counterparty,
                 sc.expected_usd.0,
+                post_fee_receiver_sats,
+                backing_sats,
             )
         };
 
-        // Build payload with channel_id (shared between both nodes) for LSP lookup
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // All allocation inputs are signed. A different price observed later cannot alter this
+        // already-reviewed trade.
         let payload = json!({
             "type": TRADE_MESSAGE_TYPE,
             "channel_id": channel_id_str,
             "user_channel_id": user_channel_id_str,
             "expected_usd": new_expected_usd,
+            "quote_price": trade_price,
+            "backing_sats": backing_sats,
+            "ts": ts,
         });
 
         // Serialize payload and sign it with the node's key
@@ -1926,16 +1962,6 @@ impl UserApp {
             type_num: STABLE_CHANNEL_TLV_TYPE,
             value: signed_str.as_bytes().to_vec(),
         };
-
-        // Calculate fee in msats (sent to LSP as keysend amount)
-        let fee_msats = if trade_price > 0.0 && fee_usd > 0.0 {
-            let fee_btc = fee_usd / trade_price;
-            let fee_sats = (fee_btc * 100_000_000.0) as u64;
-            fee_sats * 1000 // convert to msats
-        } else {
-            1 // minimum 1 msat if no fee
-        };
-        let amt_msat: u64 = fee_msats.max(1);
 
         match self.node.spontaneous_payment().send_with_custom_tlvs(
             amt_msat,
@@ -1959,12 +1985,15 @@ impl UserApp {
                         "new_expected_usd": new_expected_usd,
                         "fee_usd": fee_usd,
                         "fee_msats": amt_msat,
-                        "btc_price": trade_price,
+                        "quote_price": trade_price,
+                        "post_fee_receiver_sats": post_fee_receiver_sats,
+                        "backing_sats": backing_sats,
+                        "ts": ts,
                         "status": "pending",
                     }),
                 );
 
-                Some(payment_id)
+                Some((payment_id, backing_sats))
             }
             Err(e) => {
                 self.status_message = format!("Failed to send order: {}", e);
@@ -2145,8 +2174,10 @@ impl UserApp {
         action: &str,
         amount_usd: f64,
         amount_btc: f64,
+        btc_price: f64,
         fee_usd: f64,
         new_expected_usd: f64,
+        new_backing_sats: Option<u64>,
         payment_id: Option<&str>,
         status: &str,
     ) -> i64 {
@@ -2160,9 +2191,10 @@ impl UserApp {
             action,
             amount_usd,
             amount_btc,
-            self.btc_price,
+            btc_price,
             fee_usd,
             new_expected_usd,
+            new_backing_sats,
             payment_id,
             status,
         ) {
@@ -2419,11 +2451,25 @@ impl UserApp {
                             if let Some(expected_usd) =
                                 payload.get("expected_usd").and_then(|v| v.as_f64())
                             {
+                                if expected_usd < 0.0 || !expected_usd.is_finite() {
+                                    continue;
+                                }
+                                let backing_sats =
+                                    payload.get("backing_sats").and_then(|v| v.as_u64());
                                 let mut sc = self.stable_channel.lock().unwrap();
                                 stable::update_balances(&self.node, &mut sc);
                                 let price = sc.latest_price;
                                 let old_expected = sc.expected_usd.0;
-                                stable::apply_trade(&mut sc, expected_usd, price);
+                                let live_receiver_sats = sc.stable_receiver_btc.sats;
+                                if let Some(backing_sats) = backing_sats {
+                                    stable::apply_trade_allocation(
+                                        &mut sc,
+                                        expected_usd,
+                                        backing_sats,
+                                    );
+                                } else {
+                                    stable::apply_trade(&mut sc, expected_usd, price);
+                                }
                                 drop(sc);
                                 self.save_channel_settings();
 
@@ -2432,6 +2478,8 @@ impl UserApp {
                                     json!({
                                         "old_expected_usd": old_expected,
                                         "new_expected_usd": expected_usd,
+                                        "backing_sats": backing_sats,
+                                        "live_receiver_sats": live_receiver_sats,
                                         "btc_price": price,
                                         "payment_hash": &payment_hash_str,
                                     }),
@@ -2627,6 +2675,7 @@ impl UserApp {
                                 pending_trade = Some(PendingTradePayment {
                                     new_expected_usd: row.new_expected_usd,
                                     price: row.btc_price,
+                                    backing_sats: row.new_backing_sats,
                                     trade_db_id: row.id,
                                     action: row.action,
                                 });
@@ -2641,7 +2690,15 @@ impl UserApp {
                             // The trade fee has left the channel. Apply against the post-fee live
                             // balance so native_sats cannot retain the pre-settlement amount.
                             stable::update_balances(&self.node, &mut sc);
-                            stable::apply_trade(&mut sc, trade.new_expected_usd, trade.price);
+                            if let Some(backing_sats) = trade.backing_sats {
+                                stable::apply_trade_allocation(
+                                    &mut sc,
+                                    trade.new_expected_usd,
+                                    backing_sats,
+                                );
+                            } else {
+                                stable::apply_trade(&mut sc, trade.new_expected_usd, trade.price);
+                            }
                         }
                         self.save_channel_settings();
                         let _ = self.db.update_trade_status(trade.trade_db_id, "completed");
@@ -2652,6 +2709,7 @@ impl UserApp {
                                 "payment_hash": payment_hash_str,
                                 "action": trade.action,
                                 "new_expected_usd": trade.new_expected_usd,
+                                "backing_sats": trade.backing_sats,
                                 "fee_paid_msat": fee_paid_msat,
                             }),
                         );
@@ -2673,107 +2731,204 @@ impl UserApp {
                             sc.latest_price
                         };
 
-                        // Stability payments are already balanced by check_stability; only genuine
-                        // user sends reconcile against the stable position here.
-                        let needs_reconcile =
-                            !self.db.is_stability_payment(&payment_hash_str).unwrap_or(false);
+                        // LDK's PaymentId is the key persisted when a send starts. It equals the
+                        // payment hash for BOLT11/keysend today, but not for every payment kind.
+                        let event_id = payment_id
+                            .map(|pid| format!("{pid}"))
+                            .unwrap_or_else(|| payment_hash_str.clone());
 
-                        if needs_reconcile && price <= 0.0 {
-                            // No price yet — we can't size the peg overflow. Withhold the ack so LDK
-                            // re-delivers and we reconcile once the price feed returns; the background
-                            // loop keeps refreshing it, so redelivery makes progress. Nothing has been
-                            // deducted or removed from the pending map, so the retry is clean.
-                            ack = false;
-                            audit_event(
-                                "OUTGOING_RECONCILE_DEFERRED_NO_PRICE",
-                                json!({ "payment_hash": payment_hash_str }),
-                            );
-                        } else {
-                            let pending =
-                                payment_id.and_then(|pid| self.pending_payments.remove(&pid));
-                            let payment_sent_message = pending
-                                .as_ref()
-                                .map(|p| {
-                                    p.amount_usd
-                                        .map(|usd| {
-                                            format!("Payment sent: {}", Self::format_price(usd))
-                                        })
-                                        .unwrap_or_else(|| {
-                                            format!(
-                                                "Payment sent: {}",
-                                                Self::format_msats_as_btc(p.amount_msat)
-                                            )
-                                        })
-                                })
-                                .unwrap_or_else(|| "Payment sent".to_string());
+                        // A DB lookup error is not evidence that this is a user payment. Deferring
+                        // avoids incorrectly reconciling a stability payment during a DB outage.
+                        match self.db.is_stability_payment(&event_id) {
+                            Err(e) => {
+                                ack = false;
+                                audit_event(
+                                    "OUTGOING_PAYMENT_CLASSIFICATION_FAILED",
+                                    json!({
+                                        "payment_hash": payment_hash_str,
+                                        "payment_id": event_id,
+                                        "error": e.to_string(),
+                                    }),
+                                );
+                                self.status_message =
+                                    "Payment confirmed but accounting could not be saved; retrying"
+                                        .to_string();
+                            }
+                            Ok(is_stability_payment) => {
+                                let needs_reconcile = !is_stability_payment;
 
-                            audit_event(
-                                "PAYMENT_SUCCESSFUL",
-                                json!({
-                                    "payment_hash": payment_hash_str,
-                                    "fee_paid_msat": fee_paid_msat,
-                                }),
-                            );
-
-                            if needs_reconcile {
-                                let mut sc = self.stable_channel.lock().unwrap();
-                                let old_expected = sc.expected_usd.0;
-                                if let Some(usd_deducted) =
-                                    stable::reconcile_outgoing(&mut sc, price)
-                                {
+                                if needs_reconcile && price <= 0.0 {
+                                    // No price yet — we can't size the peg overflow. Withhold the ack
+                                    // so LDK re-delivers after the background price refresh. No state
+                                    // was deducted or removed from the pending map, so retry is clean.
+                                    ack = false;
                                     audit_event(
-                                        "OUTGOING_STABLE_DEDUCTED",
+                                        "OUTGOING_RECONCILE_DEFERRED_NO_PRICE",
                                         json!({
                                             "payment_hash": payment_hash_str,
-                                            "usd_deducted": usd_deducted,
-                                            "old_expected_usd": old_expected,
-                                            "new_expected_usd": sc.expected_usd.0,
-                                            "btc_price": price,
+                                            "payment_id": event_id,
                                         }),
                                     );
-                                }
-                            }
+                                } else {
+                                    let pending = payment_id
+                                        .and_then(|pid| self.pending_payments.get(&pid).cloned());
+                                    let payment_sent_message = pending
+                                        .as_ref()
+                                        .map(|p| {
+                                            p.amount_usd
+                                                .map(|usd| {
+                                                    format!(
+                                                        "Payment sent: {}",
+                                                        Self::format_price(usd)
+                                                    )
+                                                })
+                                                .unwrap_or_else(|| {
+                                                    format!(
+                                                        "Payment sent: {}",
+                                                        Self::format_msats_as_btc(p.amount_msat)
+                                                    )
+                                                })
+                                        })
+                                        .unwrap_or_else(|| "Payment sent".to_string());
 
-                            if let Some(p) = pending {
-                                // Update existing pending record to completed + fee
-                                let _ = self.db.update_payment_status(
-                                    p.payment_db_id,
-                                    "completed",
-                                    fee_paid_msat,
-                                );
-                            } else {
-                                // Try to confirm a pending stability payment by payment_hash
-                                let updated = self
-                                    .db
-                                    .update_payment_status_by_pid(
-                                        &payment_hash_str,
-                                        "completed",
-                                        fee_paid_msat,
-                                    )
-                                    .unwrap_or(0);
-                                if updated == 0
-                                    && !self.db.payment_exists(&payment_hash_str).unwrap_or(false)
-                                {
-                                    // Completely unknown payment — record as completed
-                                    let _ = self.db.record_payment(
-                                        Some(&payment_hash_str),
-                                        "lightning",
-                                        "sent",
-                                        0,
-                                        None,
-                                        if price > 0.0 { Some(price) } else { None },
-                                        None,
-                                        "completed",
-                                        None,
-                                        None,
+                                    audit_event(
+                                        "PAYMENT_SUCCESSFUL",
+                                        json!({
+                                            "payment_hash": payment_hash_str,
+                                            "payment_id": event_id,
+                                            "fee_paid_msat": fee_paid_msat,
+                                        }),
                                     );
+
+                                    if needs_reconcile {
+                                        // Hold the channel lock through the short SQLite transaction.
+                                        // On failure restore the pre-reconcile snapshot and leave the
+                                        // event unacked. A durable marker handles post-COMMIT replay.
+                                        let persisted = {
+                                            let mut sc = self.stable_channel.lock().unwrap();
+                                            let before_reconcile = sc.clone();
+                                            let old_expected_usd = sc.expected_usd.0;
+                                            let usd_deducted =
+                                                stable::reconcile_outgoing(&mut sc, price);
+
+                                            // Native-only sends do not change the peg, but their
+                                            // settled native allocation must still be persisted.
+                                            sc.native_sats = sc
+                                                .stable_receiver_btc
+                                                .sats
+                                                .saturating_sub(sc.backing_sats);
+                                            stable::recompute_native(&mut sc);
+
+                                            let result = self.db.persist_outgoing_reconciliation(
+                                                &event_id,
+                                                pending.as_ref().map(|p| p.payment_db_id),
+                                                fee_paid_msat,
+                                                &sc.channel_id.to_string(),
+                                                &format!("{}", sc.user_channel_id),
+                                                sc.expected_usd.0,
+                                                sc.backing_sats,
+                                                sc.native_sats,
+                                                sc.note.as_deref(),
+                                                if price > 0.0 { Some(price) } else { None },
+                                            );
+
+                                            match result {
+                                                Ok(true) => Ok((
+                                                    true,
+                                                    usd_deducted,
+                                                    old_expected_usd,
+                                                    sc.expected_usd.0,
+                                                )),
+                                                Ok(false) => {
+                                                    *sc = before_reconcile;
+                                                    Ok((
+                                                        false,
+                                                        None,
+                                                        old_expected_usd,
+                                                        old_expected_usd,
+                                                    ))
+                                                }
+                                                Err(e) => {
+                                                    *sc = before_reconcile;
+                                                    Err(e)
+                                                }
+                                            }
+                                        };
+
+                                        match persisted {
+                                            Ok((
+                                                applied,
+                                                usd_deducted,
+                                                old_expected_usd,
+                                                new_expected_usd,
+                                            )) => {
+                                                if let Some(pid) = payment_id {
+                                                    self.pending_payments.remove(&pid);
+                                                }
+                                                if let Some(usd_deducted) = usd_deducted {
+                                                    audit_event(
+                                                        "OUTGOING_STABLE_DEDUCTED",
+                                                        json!({
+                                                            "payment_hash": payment_hash_str,
+                                                            "payment_id": event_id,
+                                                            "usd_deducted": usd_deducted,
+                                                            "old_expected_usd": old_expected_usd,
+                                                            "new_expected_usd": new_expected_usd,
+                                                            "btc_price": price,
+                                                        }),
+                                                    );
+                                                }
+                                                audit_event(
+                                                    if applied {
+                                                        "OUTGOING_RECONCILE_COMMITTED"
+                                                    } else {
+                                                        "OUTGOING_RECONCILE_REPLAY"
+                                                    },
+                                                    json!({
+                                                        "payment_hash": payment_hash_str,
+                                                        "payment_id": event_id,
+                                                    }),
+                                                );
+                                            }
+                                            Err(e) => {
+                                                ack = false;
+                                                audit_event(
+                                                    "OUTGOING_RECONCILE_PERSIST_FAILED",
+                                                    json!({
+                                                        "payment_hash": payment_hash_str,
+                                                        "payment_id": event_id,
+                                                        "error": e.to_string(),
+                                                    }),
+                                                );
+                                                self.status_message = "Payment confirmed but accounting could not be saved; retrying".to_string();
+                                            }
+                                        }
+                                    } else if let Some(p) = pending {
+                                        // Stability payments were accounted when sent. Only complete
+                                        // their history row here.
+                                        let _ = self.db.update_payment_status(
+                                            p.payment_db_id,
+                                            "completed",
+                                            fee_paid_msat,
+                                        );
+                                        if let Some(pid) = payment_id {
+                                            self.pending_payments.remove(&pid);
+                                        }
+                                    } else {
+                                        let _ = self.db.update_payment_status_by_pid(
+                                            &event_id,
+                                            "completed",
+                                            fee_paid_msat,
+                                        );
+                                    }
+
+                                    if ack {
+                                        self.update_balances();
+                                        self.status_message = payment_sent_message.clone();
+                                        self.show_toast(&payment_sent_message, "-");
+                                    }
                                 }
                             }
-
-                            self.save_channel_settings();
-                            self.update_balances();
-                            self.status_message = payment_sent_message.clone();
-                            self.show_toast(&payment_sent_message, "-");
                         }
                     }
                 }
@@ -8928,14 +9083,18 @@ impl UserApp {
         } else {
             0.0
         };
-        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "buy", btc_price) {
+        if let Some((payment_id, backing_sats)) =
+            self.send_trade(new_expected_usd, fee_usd, "buy", btc_price)
+        {
             let payment_id_str = format!("{payment_id}");
             let trade_db_id = self.record_trade(
                 "buy",
                 amount_usd,
                 btc_amount,
+                btc_price,
                 fee_usd,
                 new_expected_usd,
+                Some(backing_sats),
                 Some(&payment_id_str),
                 "pending",
             );
@@ -8944,6 +9103,7 @@ impl UserApp {
                 PendingTradePayment {
                     new_expected_usd,
                     price: btc_price,
+                    backing_sats: Some(backing_sats),
                     trade_db_id,
                     action: "buy".to_string(),
                 },
@@ -8988,14 +9148,18 @@ impl UserApp {
         let new_expected_usd = current_expected_usd + net_amount;
 
         let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
-        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "sell", btc_price) {
+        if let Some((payment_id, backing_sats)) =
+            self.send_trade(new_expected_usd, fee_usd, "sell", btc_price)
+        {
             let payment_id_str = format!("{payment_id}");
             let trade_db_id = self.record_trade(
                 "sell",
                 amount_usd,
                 btc_amount,
+                btc_price,
                 fee_usd,
                 new_expected_usd,
+                Some(backing_sats),
                 Some(&payment_id_str),
                 "pending",
             );
@@ -9004,6 +9168,7 @@ impl UserApp {
                 PendingTradePayment {
                     new_expected_usd,
                     price: btc_price,
+                    backing_sats: Some(backing_sats),
                     trade_db_id,
                     action: "sell".to_string(),
                 },

--- a/src/user.rs
+++ b/src/user.rs
@@ -162,7 +162,6 @@ pub struct PendingTrade {
 #[derive(Clone, Debug)]
 struct PendingTradePayment {
     new_expected_usd: f64,
-    price: f64,
     backing_sats: Option<u64>,
     trade_db_id: i64,
     action: String,
@@ -910,86 +909,75 @@ impl UserApp {
                     if payment_sent {
                         std::thread::sleep(Duration::from_secs(2));
                     }
+                }
 
-                    // Detect new onchain deposits
-                    {
-                        let current_onchain = node_arc.list_balances().total_onchain_balance_sats;
-                        let is_splicing = splice_flag.load(std::sync::atomic::Ordering::Relaxed);
-                        if current_onchain > prev_onchain_sats && !is_splicing {
-                            let deposit_sats = current_onchain - prev_onchain_sats;
-                            let amount_usd = if price > 0.0 {
-                                Some(deposit_sats as f64 / 100_000_000.0 * price)
-                            } else {
-                                None
-                            };
-                            // Try to find the txid from LDK's payment list
-                            let deposit_txid: Option<String> =
-                                node_arc.list_payments().iter().rev().find_map(|p| {
-                                    if p.direction == PaymentDirection::Inbound {
-                                        if let PaymentKind::Onchain { ref txid, .. } = p.kind {
-                                            return Some(txid.to_string());
-                                        }
+                // Housekeeping must continue during a price-feed outage. Only the optional USD
+                // metadata depends on price; balance observations and splice completion do not.
+                {
+                    let current_onchain = node_arc.list_balances().total_onchain_balance_sats;
+                    let is_splicing = splice_flag.load(std::sync::atomic::Ordering::Relaxed);
+                    if current_onchain > prev_onchain_sats && !is_splicing {
+                        let deposit_sats = current_onchain - prev_onchain_sats;
+                        let amount_usd =
+                            price.map(|value| deposit_sats as f64 / 100_000_000.0 * value);
+                        // Try to find the txid from LDK's payment list
+                        let deposit_txid: Option<String> =
+                            node_arc.list_payments().iter().rev().find_map(|p| {
+                                if p.direction == PaymentDirection::Inbound {
+                                    if let PaymentKind::Onchain { ref txid, .. } = p.kind {
+                                        return Some(txid.to_string());
                                     }
-                                    None
-                                });
-                            let _ = db.record_payment(
-                                None,
-                                "onchain",
-                                "received",
-                                deposit_sats * 1000,
-                                amount_usd,
-                                if price > 0.0 { Some(price) } else { None },
-                                None,
-                                "completed",
-                                deposit_txid.as_deref(),
-                                None,
-                            );
-                            audit_event(
-                                "ONCHAIN_DEPOSIT_DETECTED",
-                                json!({
-                                    "amount_sats": deposit_sats,
-                                    "prev_onchain": prev_onchain_sats,
-                                    "new_onchain": current_onchain,
-                                }),
-                            );
-                        }
-                        prev_onchain_sats = current_onchain;
-                    }
-
-                    // Auto-splice: if onchain balance exists and channel is ready,
-                    // splice it into the channel automatically.
-                    // The splice_flag stays true until the onchain balance drops
-                    // (confirming the splice tx landed), preventing duplicate splices.
-                    if splice_flag.load(std::sync::atomic::Ordering::Relaxed) {
-                        // Check if the onchain balance dropped since we started the splice
-                        let prev = splice_onchain_start.load(std::sync::atomic::Ordering::Relaxed);
-                        let current = node_arc.list_balances().total_onchain_balance_sats;
-                        if prev > 0 && current < prev {
-                            splice_flag.store(false, std::sync::atomic::Ordering::Relaxed);
-                            splice_onchain_start.store(0, std::sync::atomic::Ordering::Relaxed);
-                            if let Ok(mut pending) = pending_splice.lock() {
-                                if pending
-                                    .as_ref()
-                                    .map(|splice| splice.direction == "in")
-                                    .unwrap_or(false)
-                                {
-                                    *pending = None;
                                 }
-                            }
-                            audit_event(
-                                "AUTO_SPLICE_CONFIRMED",
-                                json!({
-                                    "prev_onchain": prev,
-                                    "new_onchain": current,
-                                }),
-                            );
-                        }
+                                None
+                            });
+                        let _ = db.record_payment(
+                            None,
+                            "onchain",
+                            "received",
+                            deposit_sats * 1000,
+                            amount_usd,
+                            price,
+                            None,
+                            "completed",
+                            deposit_txid.as_deref(),
+                            None,
+                        );
+                        audit_event(
+                            "ONCHAIN_DEPOSIT_DETECTED",
+                            json!({
+                                "amount_sats": deposit_sats,
+                                "prev_onchain": prev_onchain_sats,
+                                "new_onchain": current_onchain,
+                            }),
+                        );
                     }
+                    prev_onchain_sats = current_onchain;
+                }
 
-                    // Auto-splice trigger removed for iOS parity (2026-05-19): onchain →
-                    // channel splice is now user-initiated via the Swap button in the home
-                    // tab. The clear-flag-on-balance-drop path above remains so user-initiated
-                    // splices still get their in-progress flag cleared when confirmed.
+                // The splice flag stays set until BDK observes the on-chain spend.
+                if splice_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                    let prev = splice_onchain_start.load(std::sync::atomic::Ordering::Relaxed);
+                    let current = node_arc.list_balances().total_onchain_balance_sats;
+                    if prev > 0 && current < prev {
+                        splice_flag.store(false, std::sync::atomic::Ordering::Relaxed);
+                        splice_onchain_start.store(0, std::sync::atomic::Ordering::Relaxed);
+                        if let Ok(mut pending) = pending_splice.lock() {
+                            if pending
+                                .as_ref()
+                                .map(|splice| splice.direction == "in")
+                                .unwrap_or(false)
+                            {
+                                *pending = None;
+                            }
+                        }
+                        audit_event(
+                            "AUTO_SPLICE_CONFIRMED",
+                            json!({
+                                "prev_onchain": prev,
+                                "new_onchain": current,
+                            }),
+                        );
+                    }
                 }
 
                 std::thread::sleep(Duration::from_secs(BALANCE_UPDATE_INTERVAL_SECS));
@@ -1388,9 +1376,9 @@ impl UserApp {
             }
             match Offer::from_str(&input) {
                 Ok(offer) => {
-                    let amount_msat = match self.send_amount.trim().parse::<f64>() {
-                        Ok(btc) if btc > 0.0 => (btc * 100_000_000_000.0) as u64,
-                        _ => {
+                    let amount_msat = match btc_amount_to_msat(&self.send_amount) {
+                        Some(amount_msat) => amount_msat,
+                        None => {
                             self.send_error = "Enter an amount in BTC".to_string();
                             return false;
                         }
@@ -2273,6 +2261,187 @@ impl UserApp {
         }
     }
 
+    fn handle_normal_payment_success(
+        &mut self,
+        payment_id: Option<PaymentId>,
+        payment_hash: &str,
+        fee_paid_msat: Option<u64>,
+        ack: &mut bool,
+    ) {
+        {
+            let mut sc = self.stable_channel.lock().unwrap();
+            update_balances(&self.node, &mut sc);
+        }
+        let price = self.stable_channel.lock().unwrap().latest_price;
+        let event_id = payment_id
+            .map(|pid| format!("{pid}"))
+            .unwrap_or_else(|| payment_hash.to_string());
+
+        match self.db.is_stability_payment(&event_id) {
+            Err(e) => {
+                *ack = false;
+                audit_event(
+                    "OUTGOING_PAYMENT_CLASSIFICATION_FAILED",
+                    json!({
+                        "payment_hash": payment_hash,
+                        "payment_id": event_id,
+                        "error": e.to_string(),
+                    }),
+                );
+                self.status_message =
+                    "Payment confirmed but accounting could not be saved; retrying".to_string();
+            }
+            Ok(is_stability_payment) => {
+                let needs_reconcile = !is_stability_payment;
+                if needs_reconcile && price <= 0.0 {
+                    *ack = false;
+                    audit_event(
+                        "OUTGOING_RECONCILE_DEFERRED_NO_PRICE",
+                        json!({
+                            "payment_hash": payment_hash,
+                            "payment_id": event_id,
+                        }),
+                    );
+                    return;
+                }
+
+                let pending =
+                    payment_id.and_then(|pid| self.pending_payments.get(&pid).cloned());
+                let payment_sent_message = pending
+                    .as_ref()
+                    .map(|p| {
+                        p.amount_usd
+                            .map(|usd| format!("Payment sent: {}", Self::format_price(usd)))
+                            .unwrap_or_else(|| {
+                                format!(
+                                    "Payment sent: {}",
+                                    Self::format_msats_as_btc(p.amount_msat)
+                                )
+                            })
+                    })
+                    .unwrap_or_else(|| "Payment sent".to_string());
+                audit_event(
+                    "PAYMENT_SUCCESSFUL",
+                    json!({
+                        "payment_hash": payment_hash,
+                        "payment_id": event_id,
+                        "fee_paid_msat": fee_paid_msat,
+                    }),
+                );
+
+                if needs_reconcile {
+                    let persisted = {
+                        let mut sc = self.stable_channel.lock().unwrap();
+                        let before_reconcile = sc.clone();
+                        let old_expected_usd = sc.expected_usd.0;
+                        let usd_deducted = stable::reconcile_outgoing(&mut sc, price);
+                        sc.native_sats = sc
+                            .stable_receiver_btc
+                            .sats
+                            .saturating_sub(sc.backing_sats);
+                        stable::recompute_native(&mut sc);
+
+                        let result = self.db.persist_outgoing_reconciliation(
+                            &event_id,
+                            pending.as_ref().map(|p| p.payment_db_id),
+                            fee_paid_msat,
+                            &sc.channel_id.to_string(),
+                            &format!("{}", sc.user_channel_id),
+                            sc.expected_usd.0,
+                            sc.backing_sats,
+                            sc.native_sats,
+                            sc.note.as_deref(),
+                            Some(price),
+                        );
+                        match result {
+                            Ok(true) => Ok((
+                                true,
+                                usd_deducted,
+                                old_expected_usd,
+                                sc.expected_usd.0,
+                            )),
+                            Ok(false) => {
+                                *sc = before_reconcile;
+                                Ok((false, None, old_expected_usd, old_expected_usd))
+                            }
+                            Err(e) => {
+                                *sc = before_reconcile;
+                                Err(e)
+                            }
+                        }
+                    };
+
+                    match persisted {
+                        Ok((applied, usd_deducted, old_expected_usd, new_expected_usd)) => {
+                            if let Some(pid) = payment_id {
+                                self.pending_payments.remove(&pid);
+                            }
+                            if let Some(usd_deducted) = usd_deducted {
+                                audit_event(
+                                    "OUTGOING_STABLE_DEDUCTED",
+                                    json!({
+                                        "payment_hash": payment_hash,
+                                        "payment_id": event_id,
+                                        "usd_deducted": usd_deducted,
+                                        "old_expected_usd": old_expected_usd,
+                                        "new_expected_usd": new_expected_usd,
+                                        "btc_price": price,
+                                    }),
+                                );
+                            }
+                            audit_event(
+                                if applied {
+                                    "OUTGOING_RECONCILE_COMMITTED"
+                                } else {
+                                    "OUTGOING_RECONCILE_REPLAY"
+                                },
+                                json!({
+                                    "payment_hash": payment_hash,
+                                    "payment_id": event_id,
+                                }),
+                            );
+                        }
+                        Err(e) => {
+                            *ack = false;
+                            audit_event(
+                                "OUTGOING_RECONCILE_PERSIST_FAILED",
+                                json!({
+                                    "payment_hash": payment_hash,
+                                    "payment_id": event_id,
+                                    "error": e.to_string(),
+                                }),
+                            );
+                            self.status_message =
+                                "Payment confirmed but accounting could not be saved; retrying"
+                                    .to_string();
+                        }
+                    }
+                } else if let Some(pending) = pending {
+                    let _ = self.db.update_payment_status(
+                        pending.payment_db_id,
+                        "completed",
+                        fee_paid_msat,
+                    );
+                    if let Some(pid) = payment_id {
+                        self.pending_payments.remove(&pid);
+                    }
+                } else {
+                    let _ = self.db.update_payment_status_by_pid(
+                        &event_id,
+                        "completed",
+                        fee_paid_msat,
+                    );
+                }
+
+                if *ack {
+                    self.update_balances();
+                    self.status_message = payment_sent_message.clone();
+                    self.show_toast(&payment_sent_message, "-");
+                }
+            }
+        }
+    }
+
     fn process_events(&mut self) {
         while let Some(event) = self.node.next_event() {
             let mut ack = true;
@@ -2407,9 +2576,24 @@ impl UserApp {
                                         "SPLICE_OUT_RECONCILE_DEFERRED",
                                         json!({ "txid": txid_str.clone() }),
                                     );
+                                    // Do not acknowledge ChannelReady until the exact funding-output
+                                    // value and the accounting update are durable. LDK will replay the
+                                    // event after a crash instead of leaving a completed-but-unreconciled
+                                    // splice row with no startup work item.
+                                    ack = false;
                                 }
                                 SpliceReconcileAction::ReconcileNow => {
                                     let price = sc.latest_price;
+                                    if !price.is_finite() || price <= 0.0 {
+                                        audit_event(
+                                            "SPLICE_OUT_RECONCILE_DEFERRED_NO_PRICE",
+                                            json!({
+                                                "txid": txid_str.clone(),
+                                                "source": "channel_ready_fallback",
+                                            }),
+                                        );
+                                        break;
+                                    }
                                     let mut reconciled = sc.clone();
                                     let usd_deducted =
                                         stable::reconcile_outgoing(&mut reconciled, price);
@@ -2622,14 +2806,53 @@ impl UserApp {
                             let price = sc.latest_price;
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
+                            let pending_trade = match self.db.get_pending_trade_by_allocation(
+                                sync.expected_usd,
+                                sync.backing_sats,
+                            ) {
+                                Ok(trade) => trade,
+                                Err(e) => {
+                                    audit_event(
+                                        "DB_READ_FAILED",
+                                        json!({
+                                            "op": "get_pending_trade_by_allocation",
+                                            "payment_hash": &payment_hash_str,
+                                            "error": e.to_string(),
+                                        }),
+                                    );
+                                    ack = false;
+                                    break 'sync true;
+                                }
+                            };
+                            if let Err(reason) = validate_incoming_sync_allocation(
+                                &sync,
+                                live_receiver_sats,
+                                price,
+                                pending_trade.is_some(),
+                            ) {
+                                audit_event(
+                                    "SYNC_V1_ALLOCATION_REJECTED",
+                                    json!({
+                                        "payment_hash": &payment_hash_str,
+                                        "reason": reason,
+                                        "expected_usd": sync.expected_usd,
+                                        "backing_sats": sync.backing_sats,
+                                        "live_receiver_sats": live_receiver_sats,
+                                        "btc_price": price,
+                                        "sync_version": sync.sync_version,
+                                    }),
+                                );
+                                break 'sync true;
+                            }
                             let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
                             let user_channel_id = format!("{}", sc.user_channel_id);
-                            match self.db.apply_sync_if_newer(
+                            match self.db.apply_sync_if_newer_and_complete_trade(
                                 &user_channel_id,
                                 sync.sync_version,
                                 sync.expected_usd,
                                 sync.backing_sats,
                                 native_sats,
+                                pending_trade.as_ref().map(|trade| trade.id),
                             ) {
                                 Ok(true) => {
                                     stable::apply_trade_allocation(
@@ -2649,6 +2872,30 @@ impl UserApp {
                                             "payment_hash": &payment_hash_str,
                                         }),
                                     );
+                                    drop(sc);
+                                    if let Some(trade) = pending_trade {
+                                        self.pending_trade_payments
+                                            .retain(|_, pending| pending.trade_db_id != trade.id);
+                                        audit_event(
+                                            "TRADE_ACCEPTED_BY_LSP",
+                                            json!({
+                                                "trade_id": trade.id,
+                                                "action": trade.action,
+                                                "expected_usd": sync.expected_usd,
+                                                "backing_sats": sync.backing_sats,
+                                                "sync_version": sync.sync_version,
+                                            }),
+                                        );
+                                        let verb = if trade.action == "buy" {
+                                            "USD → BTC"
+                                        } else {
+                                            "BTC → USD"
+                                        };
+                                        self.show_toast(
+                                            &format!("{} order confirmed", verb),
+                                            "OK",
+                                        );
+                                    }
                                 }
                                 Ok(false) => {
                                     audit_event(
@@ -2848,11 +3095,10 @@ impl UserApp {
                 } => {
                     let payment_hash_str = format!("{payment_hash}");
 
-                    // Check if this is a pending trade payment. The in-memory map is empty after a
-                    // restart, so fall back to the persisted pending trade row — otherwise a trade
-                    // that settles across a restart would never apply_trade (peg left wrong).
-                    let mut pending_trade =
-                        payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
+                    // Payment success proves that the fee reached the LSP, not that it accepted the
+                    // signed allocation. Keep the trade pending until its signed SYNC_V1 arrives.
+                    let mut pending_trade = payment_id
+                        .and_then(|pid| self.pending_trade_payments.get(&pid).cloned());
                     if pending_trade.is_none() {
                         if let Some(pid) = payment_id {
                             if let Some(row) = self
@@ -2863,7 +3109,6 @@ impl UserApp {
                             {
                                 pending_trade = Some(PendingTradePayment {
                                     new_expected_usd: row.new_expected_usd,
-                                    price: row.btc_price,
                                     backing_sats: row.new_backing_sats,
                                     trade_db_id: row.id,
                                     action: row.action,
@@ -2873,252 +3118,61 @@ impl UserApp {
                     }
 
                     if let Some(trade) = pending_trade {
-                        // Trade payment confirmed — now apply the trade
-                        {
-                            let mut sc = self.stable_channel.lock().unwrap();
-                            // The trade fee has left the channel. Apply against the post-fee live
-                            // balance so native_sats cannot retain the pre-settlement amount.
-                            stable::update_balances(&self.node, &mut sc);
-                            if let Some(backing_sats) = trade.backing_sats {
-                                stable::apply_trade_allocation(
-                                    &mut sc,
-                                    trade.new_expected_usd,
-                                    backing_sats,
-                                );
-                            } else {
-                                stable::apply_trade(&mut sc, trade.new_expected_usd, trade.price);
-                            }
-                        }
-                        self.save_channel_settings();
-                        let _ = self.db.update_trade_status(trade.trade_db_id, "completed");
-
                         audit_event(
-                            "TRADE_CONFIRMED",
+                            "TRADE_FEE_CONFIRMED_AWAITING_SYNC",
                             json!({
                                 "payment_hash": payment_hash_str,
+                                "trade_id": trade.trade_db_id,
                                 "action": trade.action,
                                 "new_expected_usd": trade.new_expected_usd,
                                 "backing_sats": trade.backing_sats,
                                 "fee_paid_msat": fee_paid_msat,
                             }),
                         );
-
                         self.update_balances();
-                        let verb =
-                            if trade.action == "buy" { "USD → BTC" } else { "BTC → USD" };
-                        self.show_toast(&format!("{} order confirmed", verb), "OK");
-                    } else {
-                        // Normal (non-trade) outgoing payment
-                        // Refresh channel balances from LDK
-                        {
-                            let mut sc = self.stable_channel.lock().unwrap();
-                            update_balances(&self.node, &mut sc);
-                        }
-
-                        let price = {
-                            let sc = self.stable_channel.lock().unwrap();
-                            sc.latest_price
-                        };
-
-                        // LDK's PaymentId is the key persisted when a send starts. It equals the
-                        // payment hash for BOLT11/keysend today, but not for every payment kind.
-                        let event_id = payment_id
-                            .map(|pid| format!("{pid}"))
-                            .unwrap_or_else(|| payment_hash_str.clone());
-
-                        // A DB lookup error is not evidence that this is a user payment. Deferring
-                        // avoids incorrectly reconciling a stability payment during a DB outage.
-                        match self.db.is_stability_payment(&event_id) {
+                        self.status_message =
+                            "Trade fee confirmed; waiting for LSP acceptance".to_string();
+                    } else if let Some(pid) = payment_id {
+                        match self.db.is_trade_payment(&format!("{pid}")) {
                             Err(e) => {
                                 ack = false;
                                 audit_event(
-                                    "OUTGOING_PAYMENT_CLASSIFICATION_FAILED",
+                                    "TRADE_PAYMENT_CLASSIFICATION_FAILED",
                                     json!({
                                         "payment_hash": payment_hash_str,
-                                        "payment_id": event_id,
+                                        "payment_id": format!("{pid}"),
                                         "error": e.to_string(),
                                     }),
                                 );
-                                self.status_message =
-                                    "Payment confirmed but accounting could not be saved; retrying"
-                                        .to_string();
                             }
-                            Ok(is_stability_payment) => {
-                                let needs_reconcile = !is_stability_payment;
-
-                                if needs_reconcile && price <= 0.0 {
-                                    // No price yet — we can't size the peg overflow. Withhold the ack
-                                    // so LDK re-delivers after the background price refresh. No state
-                                    // was deducted or removed from the pending map, so retry is clean.
-                                    ack = false;
-                                    audit_event(
-                                        "OUTGOING_RECONCILE_DEFERRED_NO_PRICE",
-                                        json!({
-                                            "payment_hash": payment_hash_str,
-                                            "payment_id": event_id,
-                                        }),
-                                    );
-                                } else {
-                                    let pending = payment_id
-                                        .and_then(|pid| self.pending_payments.get(&pid).cloned());
-                                    let payment_sent_message = pending
-                                        .as_ref()
-                                        .map(|p| {
-                                            p.amount_usd
-                                                .map(|usd| {
-                                                    format!(
-                                                        "Payment sent: {}",
-                                                        Self::format_price(usd)
-                                                    )
-                                                })
-                                                .unwrap_or_else(|| {
-                                                    format!(
-                                                        "Payment sent: {}",
-                                                        Self::format_msats_as_btc(p.amount_msat)
-                                                    )
-                                                })
-                                        })
-                                        .unwrap_or_else(|| "Payment sent".to_string());
-
-                                    audit_event(
-                                        "PAYMENT_SUCCESSFUL",
-                                        json!({
-                                            "payment_hash": payment_hash_str,
-                                            "payment_id": event_id,
-                                            "fee_paid_msat": fee_paid_msat,
-                                        }),
-                                    );
-
-                                    if needs_reconcile {
-                                        // Hold the channel lock through the short SQLite transaction.
-                                        // On failure restore the pre-reconcile snapshot and leave the
-                                        // event unacked. A durable marker handles post-COMMIT replay.
-                                        let persisted = {
-                                            let mut sc = self.stable_channel.lock().unwrap();
-                                            let before_reconcile = sc.clone();
-                                            let old_expected_usd = sc.expected_usd.0;
-                                            let usd_deducted =
-                                                stable::reconcile_outgoing(&mut sc, price);
-
-                                            // Native-only sends do not change the peg, but their
-                                            // settled native allocation must still be persisted.
-                                            sc.native_sats = sc
-                                                .stable_receiver_btc
-                                                .sats
-                                                .saturating_sub(sc.backing_sats);
-                                            stable::recompute_native(&mut sc);
-
-                                            let result = self.db.persist_outgoing_reconciliation(
-                                                &event_id,
-                                                pending.as_ref().map(|p| p.payment_db_id),
-                                                fee_paid_msat,
-                                                &sc.channel_id.to_string(),
-                                                &format!("{}", sc.user_channel_id),
-                                                sc.expected_usd.0,
-                                                sc.backing_sats,
-                                                sc.native_sats,
-                                                sc.note.as_deref(),
-                                                if price > 0.0 { Some(price) } else { None },
-                                            );
-
-                                            match result {
-                                                Ok(true) => Ok((
-                                                    true,
-                                                    usd_deducted,
-                                                    old_expected_usd,
-                                                    sc.expected_usd.0,
-                                                )),
-                                                Ok(false) => {
-                                                    *sc = before_reconcile;
-                                                    Ok((
-                                                        false,
-                                                        None,
-                                                        old_expected_usd,
-                                                        old_expected_usd,
-                                                    ))
-                                                }
-                                                Err(e) => {
-                                                    *sc = before_reconcile;
-                                                    Err(e)
-                                                }
-                                            }
-                                        };
-
-                                        match persisted {
-                                            Ok((
-                                                applied,
-                                                usd_deducted,
-                                                old_expected_usd,
-                                                new_expected_usd,
-                                            )) => {
-                                                if let Some(pid) = payment_id {
-                                                    self.pending_payments.remove(&pid);
-                                                }
-                                                if let Some(usd_deducted) = usd_deducted {
-                                                    audit_event(
-                                                        "OUTGOING_STABLE_DEDUCTED",
-                                                        json!({
-                                                            "payment_hash": payment_hash_str,
-                                                            "payment_id": event_id,
-                                                            "usd_deducted": usd_deducted,
-                                                            "old_expected_usd": old_expected_usd,
-                                                            "new_expected_usd": new_expected_usd,
-                                                            "btc_price": price,
-                                                        }),
-                                                    );
-                                                }
-                                                audit_event(
-                                                    if applied {
-                                                        "OUTGOING_RECONCILE_COMMITTED"
-                                                    } else {
-                                                        "OUTGOING_RECONCILE_REPLAY"
-                                                    },
-                                                    json!({
-                                                        "payment_hash": payment_hash_str,
-                                                        "payment_id": event_id,
-                                                    }),
-                                                );
-                                            }
-                                            Err(e) => {
-                                                ack = false;
-                                                audit_event(
-                                                    "OUTGOING_RECONCILE_PERSIST_FAILED",
-                                                    json!({
-                                                        "payment_hash": payment_hash_str,
-                                                        "payment_id": event_id,
-                                                        "error": e.to_string(),
-                                                    }),
-                                                );
-                                                self.status_message = "Payment confirmed but accounting could not be saved; retrying".to_string();
-                                            }
-                                        }
-                                    } else if let Some(p) = pending {
-                                        // Stability payments were accounted when sent. Only complete
-                                        // their history row here.
-                                        let _ = self.db.update_payment_status(
-                                            p.payment_db_id,
-                                            "completed",
-                                            fee_paid_msat,
-                                        );
-                                        if let Some(pid) = payment_id {
-                                            self.pending_payments.remove(&pid);
-                                        }
-                                    } else {
-                                        let _ = self.db.update_payment_status_by_pid(
-                                            &event_id,
-                                            "completed",
-                                            fee_paid_msat,
-                                        );
-                                    }
-
-                                    if ack {
-                                        self.update_balances();
-                                        self.status_message = payment_sent_message.clone();
-                                        self.show_toast(&payment_sent_message, "-");
-                                    }
-                                }
+                            Ok(true) => {
+                                // SYNC_V1 can arrive first and atomically complete the trade. Do not
+                                // run ordinary outgoing reconciliation when LDK later reports its fee.
+                                audit_event(
+                                    "TRADE_FEE_CONFIRMED_AFTER_SYNC",
+                                    json!({
+                                        "payment_hash": payment_hash_str,
+                                        "payment_id": format!("{pid}"),
+                                        "fee_paid_msat": fee_paid_msat,
+                                    }),
+                                );
+                            }
+                            Ok(false) => {
+                                self.handle_normal_payment_success(
+                                    payment_id,
+                                    &payment_hash_str,
+                                    fee_paid_msat,
+                                    &mut ack,
+                                );
                             }
                         }
+                    } else {
+                        self.handle_normal_payment_success(
+                            payment_id,
+                            &payment_hash_str,
+                            fee_paid_msat,
+                            &mut ack,
+                        );
                     }
                 }
 
@@ -3128,8 +3182,34 @@ impl UserApp {
                     reason,
                 } => {
                     // Check if this is a pending trade payment
-                    let pending_trade =
+                    let mut pending_trade =
                         payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
+                    if pending_trade.is_none() {
+                        if let Some(pid) = payment_id {
+                            match self.db.get_pending_trade_by_payment_id(&format!("{pid}")) {
+                                Ok(Some(row)) => {
+                                    pending_trade = Some(PendingTradePayment {
+                                        new_expected_usd: row.new_expected_usd,
+                                        backing_sats: row.new_backing_sats,
+                                        trade_db_id: row.id,
+                                        action: row.action,
+                                    });
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    ack = false;
+                                    audit_event(
+                                        "TRADE_PAYMENT_CLASSIFICATION_FAILED",
+                                        json!({
+                                            "payment_id": format!("{pid}"),
+                                            "context": "payment_failed",
+                                            "error": e.to_string(),
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
 
                     if let Some(trade) = pending_trade {
                         // Trade payment failed — mark as failed, don't apply trade
@@ -3149,7 +3229,7 @@ impl UserApp {
                             if trade.action == "buy" { "USD → BTC" } else { "BTC → USD" };
                         self.status_message = format!("{} order failed: {:?}", verb, reason);
                         self.show_toast(&format!("{} order failed", verb), "X");
-                    } else {
+                    } else if ack {
                         // Check if this is a pending outgoing payment
                         let pending = payment_id.and_then(|pid| self.pending_payments.remove(&pid));
                         if let Some(p) = pending {
@@ -3375,11 +3455,19 @@ impl UserApp {
                 if let Some(new_value) = pending.resolved_new_value {
                     (new_value, false)
                 } else {
-                    let recv = pending.rx.as_ref().expect("unresolved lookup has receiver");
-                    let new_value = match recv.try_recv() {
-                        Ok(value) => value,
-                        Err(std::sync::mpsc::TryRecvError::Empty) => return,
-                        Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
+                    let new_value = match pending.rx.as_ref() {
+                        Some(recv) => match recv.try_recv() {
+                            Ok(value) => value,
+                            Err(std::sync::mpsc::TryRecvError::Empty) => return,
+                            Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
+                        },
+                        None => {
+                            audit_event(
+                                "SPLICE_OUT_LOOKUP_STATE_INVALID",
+                                json!({ "txid": pending.txid.clone() }),
+                            );
+                            None
+                        }
                     };
                     pending.resolved_new_value = Some(new_value);
                     pending.rx = None;
@@ -3442,6 +3530,18 @@ impl UserApp {
         let mut sc = self.stable_channel.lock().unwrap();
         update_balances(&self.node, &mut sc);
         let price = sc.latest_price;
+        if !price.is_finite() || price <= 0.0 {
+            drop(sc);
+            pending.retry_after = Some(
+                std::time::Instant::now() + Duration::from_secs(BALANCE_UPDATE_INTERVAL_SECS),
+            );
+            self.pending_splice_deduction = Some(pending);
+            audit_event(
+                "SPLICE_OUT_RECONCILE_DEFERRED_NO_PRICE",
+                json!({ "source": "funding_lookup" }),
+            );
+            return;
+        }
         let mut reconciled = sc.clone();
         let (usd_deducted, source) = if let Some(splice_out_sats) = exact_splice_out_sats {
             (
@@ -9426,7 +9526,6 @@ impl UserApp {
                 payment_id,
                 PendingTradePayment {
                     new_expected_usd,
-                    price: btc_price,
                     backing_sats: Some(backing_sats),
                     trade_db_id,
                     action: "buy".to_string(),
@@ -9491,7 +9590,6 @@ impl UserApp {
                 payment_id,
                 PendingTradePayment {
                     new_expected_usd,
-                    price: btc_price,
                     backing_sats: Some(backing_sats),
                     trade_db_id,
                     action: "sell".to_string(),
@@ -10248,6 +10346,46 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     })
 }
 
+fn validate_incoming_sync_allocation(
+    sync: &IncomingSync,
+    live_receiver_sats: u64,
+    current_price: f64,
+    matches_pending_trade: bool,
+) -> Result<(), &'static str> {
+    if sync.backing_sats > live_receiver_sats {
+        return Err("backing exceeds live receiver balance");
+    }
+    if sync.expected_usd < 0.01 {
+        return if sync.backing_sats == 0 {
+            Ok(())
+        } else {
+            Err("zero peg has nonzero backing")
+        };
+    }
+    if sync.backing_sats == 0 {
+        return Err("nonzero peg has no backing");
+    }
+
+    // A pending trade was priced, bounded, and signed by this wallet before it was sent. Other
+    // syncs are recovery/reconciliation messages, so independently reject allocations whose
+    // implied booking price is implausibly far from the wallet's current trusted price.
+    if matches_pending_trade {
+        return Ok(());
+    }
+    if !current_price.is_finite() || current_price <= 0.0 {
+        return Err("no trusted wallet price available");
+    }
+    let implied_booking_price =
+        sync.expected_usd / sync.backing_sats as f64 * SATS_IN_BTC as f64;
+    if !implied_booking_price.is_finite()
+        || implied_booking_price < current_price / 10.0
+        || implied_booking_price > current_price * 10.0
+    {
+        return Err("allocation implies an implausible booking price");
+    }
+    Ok(())
+}
+
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
     let mut options = OpenOptions::new();
     options.write(true).create(true).truncate(true);
@@ -10289,8 +10427,9 @@ mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
         parse_incoming_sync, parse_trade_usd_cents, restrict_secret_file_permissions,
-        sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action, write_secret_file,
-        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
+        sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
+        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
+        SpliceReconcileAction, UserApp,
     };
 
     #[test]
@@ -10370,6 +10509,61 @@ mod tests {
         assert_eq!(stable, 57_444);
         assert_eq!(native, 0);
         assert_eq!(usd, 0.0);
+    }
+
+    #[test]
+    fn incoming_sync_allocation_is_bounded_by_wallet_state() {
+        let sync = IncomingSync {
+            channel_id: "00".repeat(32),
+            expected_usd: 60.0,
+            backing_sats: 60_000,
+            sync_version: 1,
+        };
+        assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_ok());
+
+        let overdrawn = IncomingSync {
+            backing_sats: 100_001,
+            ..sync.clone()
+        };
+        assert!(validate_incoming_sync_allocation(
+            &overdrawn,
+            100_000,
+            100_000.0,
+            true
+        )
+        .is_err());
+
+        let implausible = IncomingSync {
+            expected_usd: 10_000.0,
+            ..sync.clone()
+        };
+        assert!(validate_incoming_sync_allocation(
+            &implausible,
+            100_000,
+            100_000.0,
+            false
+        )
+        .is_err());
+        assert!(validate_incoming_sync_allocation(
+            &implausible,
+            100_000,
+            100_000.0,
+            true
+        )
+        .is_ok());
+
+        let inconsistent_zero = IncomingSync {
+            expected_usd: 0.0,
+            backing_sats: 1,
+            ..sync
+        };
+        assert!(validate_incoming_sync_allocation(
+            &inconsistent_zero,
+            100_000,
+            100_000.0,
+            true
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/user.rs
+++ b/src/user.rs
@@ -150,6 +150,7 @@ pub struct PendingTrade {
     pub btc_price: f64,
     pub fee_usd: f64,
     pub btc_amount: f64,
+    pub btc_sats: u64,
     pub net_amount_usd: f64,
 }
 
@@ -1885,15 +1886,16 @@ impl UserApp {
         new_expected_usd: f64,
         fee_usd: f64,
         trade_action: &str,
+        trade_price: f64,
     ) -> Option<PaymentId> {
-        // Grab channel identifiers, counterparty, price from StableChannel
-        let (channel_id_str, user_channel_id_str, counterparty, price, old_expected_usd) = {
+        // Grab channel identifiers and counterparty from StableChannel. The fee and the local
+        // settlement use the quote the user reviewed on the confirmation screen.
+        let (channel_id_str, user_channel_id_str, counterparty, old_expected_usd) = {
             let sc = self.stable_channel.lock().unwrap();
             (
                 sc.channel_id.to_string(),
                 format!("{}", sc.user_channel_id),
                 sc.counterparty,
-                sc.latest_price,
                 sc.expected_usd.0,
             )
         };
@@ -1926,8 +1928,8 @@ impl UserApp {
         };
 
         // Calculate fee in msats (sent to LSP as keysend amount)
-        let fee_msats = if price > 0.0 && fee_usd > 0.0 {
-            let fee_btc = fee_usd / price;
+        let fee_msats = if trade_price > 0.0 && fee_usd > 0.0 {
+            let fee_btc = fee_usd / trade_price;
             let fee_sats = (fee_btc * 100_000_000.0) as u64;
             fee_sats * 1000 // convert to msats
         } else {
@@ -1957,6 +1959,7 @@ impl UserApp {
                         "new_expected_usd": new_expected_usd,
                         "fee_usd": fee_usd,
                         "fee_msats": amt_msat,
+                        "btc_price": trade_price,
                         "status": "pending",
                     }),
                 );
@@ -2143,6 +2146,7 @@ impl UserApp {
         amount_usd: f64,
         amount_btc: f64,
         fee_usd: f64,
+        new_expected_usd: f64,
         payment_id: Option<&str>,
         status: &str,
     ) -> i64 {
@@ -2158,6 +2162,7 @@ impl UserApp {
             amount_btc,
             self.btc_price,
             fee_usd,
+            new_expected_usd,
             payment_id,
             status,
         ) {
@@ -2415,6 +2420,7 @@ impl UserApp {
                                 payload.get("expected_usd").and_then(|v| v.as_f64())
                             {
                                 let mut sc = self.stable_channel.lock().unwrap();
+                                stable::update_balances(&self.node, &mut sc);
                                 let price = sc.latest_price;
                                 let old_expected = sc.expected_usd.0;
                                 stable::apply_trade(&mut sc, expected_usd, price);
@@ -2605,14 +2611,36 @@ impl UserApp {
                 } => {
                     let payment_hash_str = format!("{payment_hash}");
 
-                    // Check if this is a pending trade payment
-                    let pending_trade =
+                    // Check if this is a pending trade payment. The in-memory map is empty after a
+                    // restart, so fall back to the persisted pending trade row — otherwise a trade
+                    // that settles across a restart would never apply_trade (peg left wrong).
+                    let mut pending_trade =
                         payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
+                    if pending_trade.is_none() {
+                        if let Some(pid) = payment_id {
+                            if let Some(row) = self
+                                .db
+                                .get_pending_trade_by_payment_id(&format!("{pid}"))
+                                .ok()
+                                .flatten()
+                            {
+                                pending_trade = Some(PendingTradePayment {
+                                    new_expected_usd: row.new_expected_usd,
+                                    price: row.btc_price,
+                                    trade_db_id: row.id,
+                                    action: row.action,
+                                });
+                            }
+                        }
+                    }
 
                     if let Some(trade) = pending_trade {
                         // Trade payment confirmed — now apply the trade
                         {
                             let mut sc = self.stable_channel.lock().unwrap();
+                            // The trade fee has left the channel. Apply against the post-fee live
+                            // balance so native_sats cannot retain the pre-settlement amount.
+                            stable::update_balances(&self.node, &mut sc);
                             stable::apply_trade(&mut sc, trade.new_expected_usd, trade.price);
                         }
                         self.save_channel_settings();
@@ -2634,21 +2662,6 @@ impl UserApp {
                         self.show_toast(&format!("{} order confirmed", verb), "OK");
                     } else {
                         // Normal (non-trade) outgoing payment
-                        let pending = payment_id.and_then(|pid| self.pending_payments.remove(&pid));
-                        let payment_sent_message = pending
-                            .as_ref()
-                            .map(|p| {
-                                p.amount_usd
-                                    .map(|usd| format!("Payment sent: {}", Self::format_price(usd)))
-                                    .unwrap_or_else(|| {
-                                        format!(
-                                            "Payment sent: {}",
-                                            Self::format_msats_as_btc(p.amount_msat)
-                                        )
-                                    })
-                            })
-                            .unwrap_or_else(|| "Payment sent".to_string());
-
                         // Refresh channel balances from LDK
                         {
                             let mut sc = self.stable_channel.lock().unwrap();
@@ -2660,72 +2673,108 @@ impl UserApp {
                             sc.latest_price
                         };
 
-                        audit_event(
-                            "PAYMENT_SUCCESSFUL",
-                            json!({
-                                "payment_hash": payment_hash_str,
-                                "fee_paid_msat": fee_paid_msat,
-                            }),
-                        );
+                        // Stability payments are already balanced by check_stability; only genuine
+                        // user sends reconcile against the stable position here.
+                        let needs_reconcile =
+                            !self.db.is_stability_payment(&payment_hash_str).unwrap_or(false);
 
-                        // Reconcile stable balance
-                        {
-                            let mut sc = self.stable_channel.lock().unwrap();
-                            let old_expected = sc.expected_usd.0;
-                            if let Some(usd_deducted) = stable::reconcile_outgoing(&mut sc, price) {
-                                audit_event(
-                                    "OUTGOING_STABLE_DEDUCTED",
-                                    json!({
-                                        "payment_hash": payment_hash_str,
-                                        "usd_deducted": usd_deducted,
-                                        "old_expected_usd": old_expected,
-                                        "new_expected_usd": sc.expected_usd.0,
-                                        "btc_price": price,
-                                    }),
-                                );
-                            }
-                        }
-
-                        if let Some(p) = pending {
-                            // Update existing pending record to completed + fee
-                            let _ = self.db.update_payment_status(
-                                p.payment_db_id,
-                                "completed",
-                                fee_paid_msat,
+                        if needs_reconcile && price <= 0.0 {
+                            // No price yet — we can't size the peg overflow. Withhold the ack so LDK
+                            // re-delivers and we reconcile once the price feed returns; the background
+                            // loop keeps refreshing it, so redelivery makes progress. Nothing has been
+                            // deducted or removed from the pending map, so the retry is clean.
+                            ack = false;
+                            audit_event(
+                                "OUTGOING_RECONCILE_DEFERRED_NO_PRICE",
+                                json!({ "payment_hash": payment_hash_str }),
                             );
                         } else {
-                            // Try to confirm a pending stability payment by payment_hash
-                            let updated = self
-                                .db
-                                .update_payment_status_by_pid(
-                                    &payment_hash_str,
+                            let pending =
+                                payment_id.and_then(|pid| self.pending_payments.remove(&pid));
+                            let payment_sent_message = pending
+                                .as_ref()
+                                .map(|p| {
+                                    p.amount_usd
+                                        .map(|usd| {
+                                            format!("Payment sent: {}", Self::format_price(usd))
+                                        })
+                                        .unwrap_or_else(|| {
+                                            format!(
+                                                "Payment sent: {}",
+                                                Self::format_msats_as_btc(p.amount_msat)
+                                            )
+                                        })
+                                })
+                                .unwrap_or_else(|| "Payment sent".to_string());
+
+                            audit_event(
+                                "PAYMENT_SUCCESSFUL",
+                                json!({
+                                    "payment_hash": payment_hash_str,
+                                    "fee_paid_msat": fee_paid_msat,
+                                }),
+                            );
+
+                            if needs_reconcile {
+                                let mut sc = self.stable_channel.lock().unwrap();
+                                let old_expected = sc.expected_usd.0;
+                                if let Some(usd_deducted) =
+                                    stable::reconcile_outgoing(&mut sc, price)
+                                {
+                                    audit_event(
+                                        "OUTGOING_STABLE_DEDUCTED",
+                                        json!({
+                                            "payment_hash": payment_hash_str,
+                                            "usd_deducted": usd_deducted,
+                                            "old_expected_usd": old_expected,
+                                            "new_expected_usd": sc.expected_usd.0,
+                                            "btc_price": price,
+                                        }),
+                                    );
+                                }
+                            }
+
+                            if let Some(p) = pending {
+                                // Update existing pending record to completed + fee
+                                let _ = self.db.update_payment_status(
+                                    p.payment_db_id,
                                     "completed",
                                     fee_paid_msat,
-                                )
-                                .unwrap_or(0);
-                            if updated == 0
-                                && !self.db.payment_exists(&payment_hash_str).unwrap_or(false)
-                            {
-                                // Completely unknown payment — record as completed
-                                let _ = self.db.record_payment(
-                                    Some(&payment_hash_str),
-                                    "lightning",
-                                    "sent",
-                                    0,
-                                    None,
-                                    if price > 0.0 { Some(price) } else { None },
-                                    None,
-                                    "completed",
-                                    None,
-                                    None,
                                 );
+                            } else {
+                                // Try to confirm a pending stability payment by payment_hash
+                                let updated = self
+                                    .db
+                                    .update_payment_status_by_pid(
+                                        &payment_hash_str,
+                                        "completed",
+                                        fee_paid_msat,
+                                    )
+                                    .unwrap_or(0);
+                                if updated == 0
+                                    && !self.db.payment_exists(&payment_hash_str).unwrap_or(false)
+                                {
+                                    // Completely unknown payment — record as completed
+                                    let _ = self.db.record_payment(
+                                        Some(&payment_hash_str),
+                                        "lightning",
+                                        "sent",
+                                        0,
+                                        None,
+                                        if price > 0.0 { Some(price) } else { None },
+                                        None,
+                                        "completed",
+                                        None,
+                                        None,
+                                    );
+                                }
                             }
-                        }
 
-                        self.save_channel_settings();
-                        self.update_balances();
-                        self.status_message = payment_sent_message.clone();
-                        self.show_toast(&payment_sent_message, "-");
+                            self.save_channel_settings();
+                            self.update_balances();
+                            self.status_message = payment_sent_message.clone();
+                            self.show_toast(&payment_sent_message, "-");
+                        }
                     }
                 }
 
@@ -4462,16 +4511,21 @@ impl UserApp {
             let spendable_onchain_sats = balances.spendable_onchain_balance_sats;
 
             // Get balance info
-            let (btc_price, last_update, expected_usd) = {
+            let (btc_price, last_update, expected_usd, backing_sats) = {
                 let sc = self.stable_channel.lock().unwrap();
-                (sc.latest_price, sc.timestamp, sc.expected_usd.0)
+                (
+                    sc.latest_price,
+                    sc.timestamp,
+                    sc.expected_usd.0,
+                    sc.backing_sats,
+                )
             };
 
-            // If no active channel, stability is gone - show $0 stabilized
-            // Claimable lightning balances are NOT added to total because they overlap
-            // with pending_sweep or onchain once the sweep tx is broadcast/confirmed.
+            // The green bucket is the user's fixed USD claim. Collateral's live market value can
+            // temporarily drift while a stability payment is pending, but that must not make the
+            // displayed peg move with BTC. The top total remains the real-time sat valuation.
             let stabilized_usd = if has_active_channel {
-                expected_usd
+                expected_usd.max(0.0)
             } else {
                 0.0
             };
@@ -4500,6 +4554,12 @@ impl UserApp {
             };
             let total_btc = total_sats as f64 / 100_000_000.0;
             let total_usd = total_btc * btc_price;
+            let (stable_sats, native_sats, native_usd) = channel_balance_split(
+                balances.total_lightning_balance_sats,
+                backing_sats,
+                expected_usd,
+                btc_price,
+            );
 
             // Header row: "Total Balance" (click to toggle USD↔BTC) + refresh button
             ui.horizontal(|ui| {
@@ -4649,11 +4709,6 @@ impl UserApp {
             let btc_color = Color32::from_rgb(255, 149, 0);
 
             if has_active_channel && total_usd > 0.01 {
-                let (_, native_usd) = channel_native_split(
-                    balances.total_lightning_balance_sats,
-                    stabilized_usd,
-                    btc_price,
-                );
                 let bar_total_usd = stabilized_usd + native_usd;
                 let synth_ratio = if bar_total_usd > 0.0 {
                     (stabilized_usd / bar_total_usd).clamp(0.0, 1.0) as f32
@@ -4881,11 +4936,7 @@ impl UserApp {
                                 );
                             });
                             let stable_text = if self.bar_chart_show_btc {
-                                let synth_btc = if btc_price > 0.0 {
-                                    stabilized_usd / btc_price
-                                } else {
-                                    0.0
-                                };
+                                let synth_btc = stable_sats as f64 / 100_000_000.0;
                                 format!("{} BTC", Self::format_btc_spaced(synth_btc))
                             } else {
                                 Self::format_price(stabilized_usd)
@@ -4902,11 +4953,7 @@ impl UserApp {
                                 ui.label(RichText::new("BTC").size(13.0).color(btc_color).strong());
                             });
                             let native_text = if self.bar_chart_show_btc {
-                                let native_btc = if btc_price > 0.0 {
-                                    native_usd / btc_price
-                                } else {
-                                    0.0
-                                };
+                                let native_btc = native_sats as f64 / 100_000_000.0;
                                 format!("{} BTC", Self::format_btc_spaced(native_btc))
                             } else {
                                 Self::format_price(native_usd)
@@ -7942,10 +7989,11 @@ impl UserApp {
         ui.add_space(5.0);
 
         // Show available USD balance (the stabilized amount)
-        let available_usd = {
+        let available_usd_cents = {
             let sc = self.stable_channel.lock().unwrap();
-            sc.expected_usd.0
+            floor_usd_cents(sc.expected_usd.0)
         };
+        let available_usd = available_usd_cents as f64 / 100.0;
         ui.label(
             RichText::new(format!("Available: {}", Self::format_price(available_usd)))
                 .size(14.0)
@@ -7977,8 +8025,9 @@ impl UserApp {
                 });
 
             // BTC equivalent below input
-            if let Ok(amount) = self.trade_amount_input.trim().parse::<f64>() {
-                if amount > 0.0 {
+            if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
+                if amount_cents > 0 {
+                    let amount = amount_cents as f64 / 100.0;
                     let btc_price = get_cached_price_no_fetch();
                     if btc_price > 0.0 {
                         let btc = amount / btc_price;
@@ -8005,12 +8054,8 @@ impl UserApp {
         ui.add_space(20.0);
 
         // Next button — enabled when amount is a positive number
-        let has_amount = self
-            .trade_amount_input
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .map(|v| v > 0.0)
+        let has_amount = parse_trade_usd_cents(&self.trade_amount_input)
+            .map(|v| v > 0)
             .unwrap_or(false);
         let btn_color = if has_amount {
             theme::PRIMARY
@@ -8036,9 +8081,10 @@ impl UserApp {
         });
 
         if should_process {
-            if let Ok(amount) = self.trade_amount_input.parse::<f64>() {
+            if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
+                let amount = amount_cents as f64 / 100.0;
                 // Validate user has enough USD
-                if amount > available_usd {
+                if amount_cents > available_usd_cents {
                     self.trade_error = format!(
                         "Insufficient balance. You have {} available.",
                         Self::format_price(available_usd)
@@ -8046,9 +8092,14 @@ impl UserApp {
                 } else {
                     // Calculate trade details (use non-blocking cached price)
                     let btc_price = get_cached_price_no_fetch();
+                    if btc_price < 1.0 || !btc_price.is_finite() {
+                        self.trade_error = "Invalid price".to_string();
+                        return;
+                    }
                     let fee_usd = Self::stable_trade_fee(amount);
                     let net_amount = amount - fee_usd;
                     let btc_amount = net_amount / btc_price;
+                    let btc_sats = (btc_amount * SATS_IN_BTC as f64).floor() as u64;
 
                     self.pending_trade = Some(PendingTrade {
                         action: TradeAction::BuyBtc,
@@ -8056,6 +8107,7 @@ impl UserApp {
                         btc_price,
                         fee_usd,
                         btc_amount,
+                        btc_sats,
                         net_amount_usd: net_amount,
                     });
                     self.show_confirm_trade = true;
@@ -8223,7 +8275,7 @@ impl UserApp {
             }
         });
         if should_confirm {
-            self.execute_buy(amount_usd);
+            self.execute_buy(amount_usd, btc_price);
             if self.trade_error.is_empty() {
                 self.trade_success = Some(TradeAction::BuyBtc);
                 self.pending_trade = None;
@@ -8282,18 +8334,24 @@ impl UserApp {
         );
         ui.add_space(5.0);
 
-        // Show available BTC balance (in USD terms) = total - stabilized
+        // Show the native allocation valued in USD. A price quote changes its value, not which
+        // sats belong to it.
         let btc_price = get_cached_price_no_fetch();
-        let available_btc_usd = {
+        let native_sats = {
             let sc = self.stable_channel.lock().unwrap();
-            let total_usd = if sc.is_stable_receiver {
-                sc.stable_receiver_usd.0
-            } else {
-                sc.stable_provider_usd.0
-            };
-            // BTC portion is total minus the stabilized USD amount
-            (total_usd - sc.expected_usd.0).max(0.0)
+            let (_, native_sats, _) = channel_balance_split(
+                sc.stable_receiver_btc.sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+                btc_price,
+            );
+            native_sats
         };
+        // A hard spending limit must never be formatted upward. Otherwise an exact displayed
+        // maximum can exceed the underlying sats by a fraction of a cent.
+        let available_btc_usd_cents =
+            floor_usd_cents(native_sats as f64 / SATS_IN_BTC as f64 * btc_price);
+        let available_btc_usd = available_btc_usd_cents as f64 / 100.0;
         ui.label(
             RichText::new(format!(
                 "Available: {}",
@@ -8328,9 +8386,9 @@ impl UserApp {
                 });
 
             // BTC equivalent below input
-            if let Ok(amount) = self.trade_amount_input.trim().parse::<f64>() {
-                if amount > 0.0 && btc_price > 0.0 {
-                    let btc = amount / btc_price;
+            if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
+                if amount_cents > 0 && btc_price > 0.0 {
+                    let btc = amount_cents as f64 / 100.0 / btc_price;
                     ui.add_space(4.0);
                     ui.label(
                         RichText::new(format!("\u{2248} {:.8} BTC", btc))
@@ -8353,12 +8411,8 @@ impl UserApp {
         ui.add_space(20.0);
 
         // Next button — enabled when amount is a positive number
-        let has_amount = self
-            .trade_amount_input
-            .trim()
-            .parse::<f64>()
-            .ok()
-            .map(|v| v > 0.0)
+        let has_amount = parse_trade_usd_cents(&self.trade_amount_input)
+            .map(|v| v > 0)
             .unwrap_or(false);
         let btn_color = if has_amount {
             theme::PRIMARY
@@ -8384,18 +8438,26 @@ impl UserApp {
         });
 
         if should_process {
-            if let Ok(amount) = self.trade_amount_input.parse::<f64>() {
+            if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
+                let amount = amount_cents as f64 / 100.0;
                 // Validate user has enough BTC to sell
-                if amount > available_btc_usd {
+                if amount_cents > available_btc_usd_cents {
                     self.trade_error = format!(
                         "Insufficient BTC. You have {} available.",
                         Self::format_price(available_btc_usd)
                     );
+                } else if btc_price < 1.0 || !btc_price.is_finite() {
+                    self.trade_error = "Invalid price".to_string();
                 } else {
                     // Calculate trade details
                     let fee_usd = Self::stable_trade_fee(amount);
                     let net_amount = amount - fee_usd;
-                    let btc_amount = amount / btc_price; // BTC being sold
+                    let btc_sats = sats_for_usd_cents(amount_cents, btc_price).unwrap_or(0);
+                    if btc_sats == 0 || btc_sats > native_sats {
+                        self.trade_error = "Amount exceeds the available BTC sats".to_string();
+                        return;
+                    }
+                    let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
 
                     self.pending_trade = Some(PendingTrade {
                         action: TradeAction::SellBtc,
@@ -8403,6 +8465,7 @@ impl UserApp {
                         btc_price,
                         fee_usd,
                         btc_amount,
+                        btc_sats,
                         net_amount_usd: net_amount,
                     });
                     self.show_confirm_trade = true;
@@ -8455,6 +8518,7 @@ impl UserApp {
         let btc_price = trade.btc_price;
         let fee_usd = trade.fee_usd;
         let btc_amount = trade.btc_amount;
+        let btc_sats = trade.btc_sats;
         let net_amount = trade.net_amount_usd;
 
         // Header
@@ -8570,7 +8634,7 @@ impl UserApp {
             }
         });
         if should_confirm {
-            self.execute_sell(amount_usd);
+            self.execute_sell(amount_usd, btc_price, btc_sats);
             if self.trade_error.is_empty() {
                 self.trade_success = Some(TradeAction::SellBtc);
                 self.pending_trade = None;
@@ -8831,25 +8895,30 @@ impl UserApp {
         });
     }
 
-    fn execute_buy(&mut self, amount_usd: f64) {
+    fn execute_buy(&mut self, amount_usd: f64, btc_price: f64) {
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
-        let (current_expected_usd, btc_price) = {
+        let current_expected_usd = {
             let sc = self.stable_channel.lock().unwrap();
-            (sc.expected_usd.0, sc.latest_price)
+            sc.expected_usd.0
         };
 
-        if btc_price < 1.0 {
+        if btc_price < 1.0 || !btc_price.is_finite() {
             self.trade_error = "Invalid price".to_string();
             return;
         }
 
         // Buying BTC means reducing the stabilized USD amount
         // Subtract full amount (fee comes out of the trade)
-        let new_expected_usd = (current_expected_usd - amount_usd).max(0.0);
+        let remaining_usd = (current_expected_usd - amount_usd).max(0.0);
+        let new_expected_usd = if remaining_usd < 0.01 {
+            0.0
+        } else {
+            remaining_usd
+        };
 
-        if amount_usd > current_expected_usd {
+        if floor_usd_cents(amount_usd) > floor_usd_cents(current_expected_usd) {
             self.trade_error = "Amount exceeds available USD".to_string();
             return;
         }
@@ -8859,13 +8928,14 @@ impl UserApp {
         } else {
             0.0
         };
-        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "buy") {
+        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "buy", btc_price) {
             let payment_id_str = format!("{payment_id}");
             let trade_db_id = self.record_trade(
                 "buy",
                 amount_usd,
                 btc_amount,
                 fee_usd,
+                new_expected_usd,
                 Some(&payment_id_str),
                 "pending",
             );
@@ -8886,32 +8956,30 @@ impl UserApp {
         self.trade_error.clear();
     }
 
-    fn execute_sell(&mut self, amount_usd: f64) {
+    fn execute_sell(&mut self, amount_usd: f64, btc_price: f64, btc_sats: u64) {
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
-        let (current_expected_usd, total_usd, btc_price) = {
+        let (current_expected_usd, native_sats) = {
             let sc = self.stable_channel.lock().unwrap();
-            let total = if sc.is_stable_receiver {
-                sc.stable_receiver_usd.0
-            } else {
-                sc.stable_provider_usd.0
-            };
-            (sc.expected_usd.0, total, sc.latest_price)
+            let (_, native_sats, _) = channel_balance_split(
+                sc.stable_receiver_btc.sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+                btc_price,
+            );
+            (sc.expected_usd.0, native_sats)
         };
 
-        if btc_price < 1.0 {
+        if btc_price < 1.0 || !btc_price.is_finite() {
             self.trade_error = "Invalid price".to_string();
             return;
         }
 
-        // Can't sell more BTC than you have
-        let available_btc_usd = (total_usd - current_expected_usd).max(0.0);
-        if amount_usd > available_btc_usd {
-            self.trade_error = format!(
-                "Amount exceeds BTC holdings (${:.2} available)",
-                available_btc_usd
-            );
+        // Revalidate the accepted sat amount, not its moving USD value. Price movement between
+        // the amount and confirmation screens does not change how many native sats are owned.
+        if btc_sats == 0 || btc_sats > native_sats {
+            self.trade_error = format!("BTC balance changed ({} sats available)", native_sats);
             return;
         }
 
@@ -8919,14 +8987,15 @@ impl UserApp {
         // Add net amount (after fee) to stable
         let new_expected_usd = current_expected_usd + net_amount;
 
-        let btc_amount = net_amount / btc_price;
-        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "sell") {
+        let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
+        if let Some(payment_id) = self.send_trade(new_expected_usd, fee_usd, "sell", btc_price) {
             let payment_id_str = format!("{payment_id}");
             let trade_db_id = self.record_trade(
                 "sell",
                 amount_usd,
                 btc_amount,
                 fee_usd,
+                new_expected_usd,
                 Some(&payment_id_str),
                 "pending",
             );
@@ -9402,53 +9471,174 @@ pub fn run() {
     }
 }
 
-/// Mobile-parity channel split: native = channel sats above the peg target (saturating, never negative), valued at price. Mirrors iOS HomeView.
-fn channel_native_split(lightning_sats: u64, target_usd: f64, price: f64) -> (u64, f64) {
-    if price <= 0.0 {
-        return (0, 0.0);
+/// Parse a user-entered USD trade amount into its exact cent representation. Trades are quoted
+/// and validated in cents, so values with more than two decimal places are intentionally rejected.
+fn parse_trade_usd_cents(input: &str) -> Option<u64> {
+    let cleaned: String = input
+        .trim()
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '$' && *c != ',' && *c != '_')
+        .collect();
+    if cleaned.is_empty() {
+        return None;
     }
-    let stable_sats = (target_usd / price * 100_000_000.0) as u64;
+
+    let mut parts = cleaned.split('.');
+    let whole = parts.next()?;
+    let fraction = parts.next().unwrap_or("");
+    if parts.next().is_some()
+        || fraction.len() > 2
+        || (!whole.is_empty() && !whole.bytes().all(|b| b.is_ascii_digit()))
+        || (!fraction.is_empty() && !fraction.bytes().all(|b| b.is_ascii_digit()))
+        || (whole.is_empty() && fraction.is_empty())
+    {
+        return None;
+    }
+
+    let whole_cents = if whole.is_empty() {
+        0
+    } else {
+        whole.parse::<u64>().ok()?.checked_mul(100)?
+    };
+    let fraction_cents = match fraction.len() {
+        0 => 0,
+        1 => fraction.parse::<u64>().ok()?.checked_mul(10)?,
+        2 => fraction.parse::<u64>().ok()?,
+        _ => return None,
+    };
+    whole_cents.checked_add(fraction_cents)
+}
+
+/// Return only whole spendable cents. A hard maximum must be rounded down, never up like a
+/// presentation-only currency value.
+fn floor_usd_cents(usd: f64) -> u64 {
+    if !usd.is_finite() || usd <= 0.0 {
+        return 0;
+    }
+    let cents = usd * 100.0;
+    if cents >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        (cents + 1e-9).floor() as u64
+    }
+}
+
+/// Sats required to cover an exact cent-denominated USD amount at a fixed quote. Round up so the
+/// order can never claim more USD than the selected sats are worth.
+fn sats_for_usd_cents(cents: u64, price: f64) -> Option<u64> {
+    if cents == 0 || !price.is_finite() || price <= 0.0 {
+        return None;
+    }
+    let sats = cents as f64 / 100.0 / price * SATS_IN_BTC as f64;
+    if !sats.is_finite() || sats > u64::MAX as f64 {
+        None
+    } else {
+        Some(sats.ceil() as u64)
+    }
+}
+
+/// Split the live channel using its persisted sat allocation. Price values the native bucket but
+/// never moves sats between buckets; stable + native therefore always equals the live balance.
+fn channel_balance_split(
+    lightning_sats: u64,
+    backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+) -> (u64, u64, f64) {
+    let normalized_backing =
+        stable::normalize_backing_sats(lightning_sats, backing_sats, expected_usd, price);
+    let stable_sats = normalized_backing.min(lightning_sats);
     let native_sats = lightning_sats.saturating_sub(stable_sats);
-    let native_usd = native_sats as f64 / 100_000_000.0 * price;
-    (native_sats, native_usd)
+    let native_usd = if price > 0.0 {
+        native_sats as f64 / 100_000_000.0 * price
+    } else {
+        0.0
+    };
+    (stable_sats, native_sats, native_usd)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::channel_native_split;
+    use super::{
+        channel_balance_split, floor_usd_cents, parse_trade_usd_cents, sats_for_usd_cents,
+    };
 
     #[test]
-    fn native_split_under_peg_is_zero() {
-        let (sats, usd) = channel_native_split(95_000, 100.0, 100_000.0);
-        assert_eq!(sats, 0);
-        assert!((usd - 0.0).abs() < 1e-9);
+    fn trade_usd_input_is_exactly_cent_denominated() {
+        assert_eq!(parse_trade_usd_cents("10.61"), Some(1_061));
+        assert_eq!(parse_trade_usd_cents("$1,000.5"), Some(100_050));
+        assert_eq!(parse_trade_usd_cents(".09"), Some(9));
+        assert_eq!(parse_trade_usd_cents("10.611"), None);
+        assert_eq!(parse_trade_usd_cents("-1.00"), None);
     }
 
     #[test]
-    fn native_split_over_peg() {
-        let (sats, usd) = channel_native_split(150_000, 100.0, 100_000.0);
-        assert_eq!(sats, 50_000);
+    fn spendable_usd_limit_is_floored_not_rounded() {
+        assert_eq!(floor_usd_cents(10.6099), 1_060);
+        assert_eq!(floor_usd_cents(10.61), 1_061);
+        assert_eq!(floor_usd_cents(f64::NAN), 0);
+    }
+
+    #[test]
+    fn displayed_native_limit_always_fits_available_sats() {
+        let native_sats = 15_978;
+        let price = 66_395.1;
+        let available_usd = native_sats as f64 / 100_000_000.0 * price;
+        let available_cents = floor_usd_cents(available_usd);
+        let required_sats = sats_for_usd_cents(available_cents, price).unwrap();
+
+        assert_eq!(available_cents, 1_060);
+        assert!(required_sats <= native_sats);
+    }
+
+    #[test]
+    fn balance_split_uses_backing_not_current_price() {
+        let at_trade_price = channel_balance_split(150_000, 100_000, 100.0, 100_000.0);
+        let after_price_move = channel_balance_split(150_000, 100_000, 100.0, 120_000.0);
+        assert_eq!(at_trade_price.0, 100_000);
+        assert_eq!(at_trade_price.1, 50_000);
+        assert_eq!(after_price_move.0, 100_000);
+        assert_eq!(after_price_move.1, 50_000);
+        assert!(after_price_move.2 > at_trade_price.2);
+    }
+
+    #[test]
+    fn balance_split_over_peg() {
+        let (stable, native, usd) = channel_balance_split(150_000, 100_000, 100.0, 100_000.0);
+        assert_eq!(stable, 100_000);
+        assert_eq!(native, 50_000);
         assert!((usd - 50.0).abs() < 1e-6);
     }
 
     #[test]
-    fn native_split_exactly_pegged() {
-        let (sats, usd) = channel_native_split(100_000, 100.0, 100_000.0);
-        assert_eq!(sats, 0);
+    fn balance_split_exactly_pegged() {
+        let (stable, native, usd) = channel_balance_split(100_000, 100_000, 100.0, 100_000.0);
+        assert_eq!(stable, 100_000);
+        assert_eq!(native, 0);
         assert!((usd - 0.0).abs() < 1e-9);
     }
 
     #[test]
-    fn native_split_zero_price() {
-        let (sats, usd) = channel_native_split(150_000, 100.0, 0.0);
-        assert_eq!(sats, 0);
+    fn balance_split_zero_price_preserves_sats() {
+        let (stable, native, usd) = channel_balance_split(150_000, 100_000, 100.0, 0.0);
+        assert_eq!(stable, 100_000);
+        assert_eq!(native, 50_000);
         assert_eq!(usd, 0.0);
     }
 
     #[test]
-    fn native_split_zero_lightning() {
-        let (sats, usd) = channel_native_split(0, 100.0, 100_000.0);
-        assert_eq!(sats, 0);
+    fn balance_split_backing_above_live_clamps_to_live() {
+        let (stable, native, usd) = channel_balance_split(95_000, 100_000, 100.0, 100_000.0);
+        assert_eq!(stable, 95_000);
+        assert_eq!(native, 0);
+        assert_eq!(usd, 0.0);
+    }
+
+    #[test]
+    fn balance_split_absorbs_sub_cent_trade_dust() {
+        let (stable, native, usd) = channel_balance_split(57_444, 57_441, 38.055, 66_250.21);
+        assert_eq!(stable, 57_444);
+        assert_eq!(native, 0);
         assert_eq!(usd, 0.0);
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -206,6 +206,14 @@ impl Toast {
     }
 }
 
+/// A splice-out deduction awaiting its off-thread esplora funding-output lookup.
+struct PendingSpliceDeduction {
+    old_value_sats: u64,
+    txid: String,
+    vout: u32,
+    rx: std::sync::mpsc::Receiver<Option<u64>>,
+}
+
 pub struct UserApp {
     pub node: Arc<Node>,
     pub status_message: String,
@@ -314,6 +322,10 @@ pub struct UserApp {
 
     // Non-blocking daily price update
     daily_prices_receiver: Option<std::sync::mpsc::Receiver<bool>>,
+    // Startup historical/intraday Kraken backfill — off-thread so it never blocks the first frame.
+    historical_backfill_receiver: Option<std::sync::mpsc::Receiver<bool>>,
+    // In-flight splice-out esplora lookup; the deduction is applied when it lands.
+    pending_splice_deduction: Option<PendingSpliceDeduction>,
 
     // Bar chart display toggle: false = default (Stable=USD, BTC=BTC), true = swapped
     bar_chart_show_btc: bool,
@@ -644,6 +656,8 @@ impl UserApp {
             pending_trade_payments: HashMap::new(),
             pending_payments: HashMap::new(),
             daily_prices_receiver: None,
+            historical_backfill_receiver: None,
+            pending_splice_deduction: None,
             bar_chart_show_btc: false,
             bar_chart_anim: 0.0,
             bar_slider_drag_offset: 0.0,
@@ -663,13 +677,12 @@ impl UserApp {
             trade_success: None,
         };
 
-        // Seed historical price data if needed
-        app.seed_historical_prices();
+        // Backfill historical + intraday prices from Kraken on a background thread so a
+        // slow/hung feed can't block startup before the first frame.
+        app.start_historical_backfill();
 
-        // Backfill intraday data from Kraken for the 1D chart
-        app.backfill_intraday_prices();
-
-        // Load initial chart data
+        // Load whatever is already in the DB immediately (non-blocking); the chart
+        // refreshes when the backfill thread completes.
         app.load_chart_data();
 
         {
@@ -742,6 +755,8 @@ impl UserApp {
 
                 // Only proceed if we have a valid price
                 if price > 0.0 {
+                    // Publish so the UI thread's non-blocking get_cached_price_no_fetch reads stay fresh.
+                    stable_channels::price_feeds::set_cached_price(price);
                     let mut payment_sent = false;
 
                     // Brief lock to update values
@@ -2207,6 +2222,13 @@ impl UserApp {
                             .complete_latest_splice(Some(txid_str.as_str()))
                             .map(|rows| rows > 0)
                             .unwrap_or(false);
+                    // If SpliceNegotiated's esplora deduction already reconciled this splice,
+                    // ChannelReady must not reconcile again (persisted, so it survives a restart).
+                    let splice_already_reconciled = txid_str != "unknown"
+                        && self
+                            .db
+                            .is_splice_stable_reconciled(&txid_str)
+                            .unwrap_or(false);
                     let is_splice;
                     {
                         let mut sc = self.stable_channel.lock().unwrap();
@@ -2237,16 +2259,28 @@ impl UserApp {
                         // After splice confirms, reconcile: if splice-out exceeded
                         // native BTC, the overflow eats into the stable position.
                         if is_splice {
-                            let price = sc.latest_price;
-                            if let Some(usd_deducted) = stable::reconcile_outgoing(&mut sc, price) {
+                            if splice_already_reconciled {
+                                // SpliceNegotiated already deducted this splice-out precisely
+                                // (esplora); skip reconcile_outgoing so the pre-existing under-peg
+                                // gap isn't deducted a second time.
                                 audit_event(
-                                    "SPLICE_OUT_STABLE_DEDUCTED",
-                                    json!({
-                                        "usd_deducted": usd_deducted,
-                                        "new_expected_usd": sc.expected_usd.0,
-                                        "btc_price": price,
-                                    }),
+                                    "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
+                                    json!({ "txid": txid_str.clone() }),
                                 );
+                            } else {
+                                let price = sc.latest_price;
+                                if let Some(usd_deducted) =
+                                    stable::reconcile_outgoing(&mut sc, price)
+                                {
+                                    audit_event(
+                                        "SPLICE_OUT_STABLE_DEDUCTED",
+                                        json!({
+                                            "usd_deducted": usd_deducted,
+                                            "new_expected_usd": sc.expected_usd.0,
+                                            "btc_price": price,
+                                        }),
+                                    );
+                                }
                             }
                             // Splice complete: clear the auto-splice flag (bg-thread
                             // clear only handles splice-in via balance drop;
@@ -2850,52 +2884,20 @@ impl UserApp {
                         .map(|c| c.channel_value_sats);
 
                     if let Some(old_value) = old_channel_value_sats {
-                        match Self::lookup_funding_output_sats_esplora(&txid_str, vout) {
-                            Some(new_value) => {
-                                audit_event(
-                                    "SPLICE_PENDING_LOOKUP",
-                                    json!({
-                                        "old_channel_sats": old_value,
-                                        "new_channel_sats": new_value,
-                                        "delta_sats": (new_value as i64) - (old_value as i64),
-                                    }),
-                                );
-
-                                if new_value < old_value {
-                                    let splice_out_sats = old_value - new_value;
-                                    let mut sc = self.stable_channel.lock().unwrap();
-                                    let price = sc.latest_price;
-                                    if let Some(usd_deducted) =
-                                        stable::deduct_outgoing(&mut sc, splice_out_sats, price)
-                                    {
-                                        audit_event(
-                                            "SPLICE_OUT_STABLE_DEDUCTED",
-                                            json!({
-                                                "splice_out_sats": splice_out_sats,
-                                                "usd_deducted": usd_deducted,
-                                                "new_expected_usd": sc.expected_usd.0,
-                                                "btc_price": price,
-                                            }),
-                                        );
-                                    }
-                                    drop(sc);
-                                    self.save_channel_settings();
-                                }
-                            }
-                            None => {
-                                println!(
-                                    "[SplicePending] Could not look up funding output {}:{}",
-                                    txid_str, vout
-                                );
-                                audit_event(
-                                    "SPLICE_PENDING_LOOKUP_FAILED",
-                                    json!({
-                                        "txid": txid_str,
-                                        "vout": vout,
-                                    }),
-                                );
-                            }
-                        }
+                        // Run the esplora lookup off the UI thread; the deduction is applied in
+                        // poll_pending_splice_deduction() when the result lands (never blocks).
+                        let (tx, rx) = std::sync::mpsc::channel();
+                        let txid_for_lookup = txid_str.clone();
+                        std::thread::spawn(move || {
+                            let _ = tx
+                                .send(Self::lookup_funding_output_sats_esplora(&txid_for_lookup, vout));
+                        });
+                        self.pending_splice_deduction = Some(PendingSpliceDeduction {
+                            old_value_sats: old_value,
+                            txid: txid_str.clone(),
+                            vout,
+                            rx,
+                        });
                     }
 
                     self.status_message = format!("Splice pending - tx: {}", new_funding_txo.txid);
@@ -2941,6 +2943,68 @@ impl UserApp {
                 // LDK returns the same queue-front event until it is acknowledged.
                 // Exit this processing pass so a transient DB failure cannot spin forever.
                 break;
+            }
+        }
+    }
+
+    /// Apply a deferred splice-out deduction once its background esplora lookup lands.
+    /// Non-blocking: returns immediately while the lookup is still in flight.
+    fn poll_pending_splice_deduction(&mut self) {
+        let recv = match self.pending_splice_deduction.as_ref() {
+            Some(p) => p.rx.try_recv(),
+            None => return,
+        };
+        let new_value_opt = match recv {
+            Ok(v) => v,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return, // still looking up
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => None, // lookup thread died
+        };
+        let pending = self.pending_splice_deduction.take().unwrap();
+        match new_value_opt {
+            Some(new_value) => {
+                audit_event(
+                    "SPLICE_PENDING_LOOKUP",
+                    json!({
+                        "old_channel_sats": pending.old_value_sats,
+                        "new_channel_sats": new_value,
+                        "delta_sats": (new_value as i64) - (pending.old_value_sats as i64),
+                    }),
+                );
+                if new_value < pending.old_value_sats {
+                    let splice_out_sats = pending.old_value_sats - new_value;
+                    let mut sc = self.stable_channel.lock().unwrap();
+                    let price = sc.latest_price;
+                    if let Some(usd_deducted) =
+                        stable::deduct_outgoing(&mut sc, splice_out_sats, price)
+                    {
+                        audit_event(
+                            "SPLICE_OUT_STABLE_DEDUCTED",
+                            json!({
+                                "splice_out_sats": splice_out_sats,
+                                "usd_deducted": usd_deducted,
+                                "new_expected_usd": sc.expected_usd.0,
+                                "btc_price": price,
+                            }),
+                        );
+                    }
+                    drop(sc);
+                    self.save_channel_settings();
+                }
+                // This splice was reconciled here authoritatively; block a second deduction at ChannelReady.
+                let _ = self.db.mark_splice_stable_reconciled(&pending.txid);
+            }
+            None => {
+                println!(
+                    "[SplicePending] Could not look up funding output {}:{}",
+                    pending.txid, pending.vout
+                );
+                audit_event(
+                    "SPLICE_PENDING_LOOKUP_FAILED",
+                    json!({
+                        "txid": pending.txid,
+                        "vout": pending.vout,
+                    }),
+                );
             }
         }
     }
@@ -3267,141 +3331,70 @@ impl UserApp {
     }
 
     /// Seed historical price data into the database if not already present
-    fn seed_historical_prices(&mut self) {
-        // Check if we already have historical data going back to 2013
-        let needs_seed = match self.db.get_oldest_daily_price_date() {
-            Ok(Some(oldest)) => {
-                // Re-seed if oldest data is not from 2013
-                !oldest.starts_with("2013")
-            }
-            Ok(None) => true, // No data at all
-            Err(_) => true,   // Error, try to seed
-        };
-
-        if !needs_seed {
-            if let Ok(count) = self.db.get_daily_price_count() {
-                println!(
-                    "[Chart] Historical prices already seeded ({} records back to 2013)",
-                    count
-                );
-            }
-            // Still check if we need to fetch recent Kraken data
-            self.maybe_fetch_recent_data();
+    /// Kick off the 2013-present seed + recent Kraken daily/intraday backfill on a
+    /// background thread, so a slow/hung feed can never block startup or the UI thread.
+    /// The chart refreshes when it completes (polled in `update`).
+    fn start_historical_backfill(&mut self) {
+        if self.historical_backfill_receiver.is_some() {
             return;
         }
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.historical_backfill_receiver = Some(rx);
+        let db = self.db.clone();
 
-        println!("[Chart] Seeding historical price data (2013-present)...");
-        let seed_data = get_seed_prices();
-        let data: Vec<(String, f64, f64, f64, f64, Option<f64>)> = seed_data
-            .into_iter()
-            .map(|(date, o, h, l, c, v)| (date.to_string(), o, h, l, c, v))
-            .collect();
+        std::thread::spawn(move || {
+            let agent = stable_channels::price_feeds::bounded_agent();
 
-        match self.db.bulk_insert_daily_prices(&data) {
-            Ok(count) => println!("[Chart] Seeded {} historical price records", count),
-            Err(e) => eprintln!("[Chart] Failed to seed historical prices: {}", e),
-        }
-
-        // Immediately fetch recent Kraken data to fill in gaps
-        self.fetch_kraken_daily_data();
-    }
-
-    /// Check if we need to fetch recent Kraken data and do so if needed
-    fn maybe_fetch_recent_data(&mut self) {
-        // Check if latest data is older than 3 days
-        let needs_update = match self.db.get_latest_daily_price_date() {
-            Ok(Some(latest)) => {
-                let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-                if let (Ok(latest_date), Ok(today_date)) = (
-                    chrono::NaiveDate::parse_from_str(&latest, "%Y-%m-%d"),
-                    chrono::NaiveDate::parse_from_str(&today, "%Y-%m-%d"),
-                ) {
-                    let days_old = (today_date - latest_date).num_days();
-                    println!("[Chart] Latest data is {} days old ({})", days_old, latest);
-                    days_old > 3
-                } else {
-                    true
-                }
-            }
-            _ => true,
-        };
-
-        if needs_update {
-            println!("[Chart] Data is stale, fetching from Kraken...");
-            self.fetch_kraken_daily_data();
-        }
-    }
-
-    /// Fetch daily OHLC data from Kraken API (up to 720 days)
-    fn fetch_kraken_daily_data(&mut self) {
-        println!("[Chart] Fetching Kraken OHLC data...");
-        let agent = stable_channels::price_feeds::bounded_agent();
-
-        // Fetch without 'since' to get the most recent 720 days
-        match stable_channels::price_feeds::fetch_kraken_ohlc(&agent, None) {
-            Ok(prices) => {
-                let count = prices.len();
-                for (date, open, high, low, close, volume) in prices {
-                    let _ = self.db.record_daily_price(
-                        &date,
-                        open,
-                        high,
-                        low,
-                        close,
-                        volume,
-                        Some("kraken"),
-                    );
-                }
-                println!("[Chart] Fetched {} daily prices from Kraken", count);
-            }
-            Err(e) => {
-                eprintln!("[Chart] Failed to fetch Kraken OHLC data: {}", e);
-            }
-        }
-    }
-
-    /// Backfill intraday price data from Kraken (15-min candles) if we have gaps
-    fn backfill_intraday_prices(&self) {
-        // Check how many points we have in the last 24 hours
-        let existing = self.db.get_price_history(24).unwrap_or_default();
-        if existing.len() >= 80 {
-            println!(
-                "[Chart] Intraday data sufficient ({} points), skipping backfill",
-                existing.len()
-            );
-            return;
-        }
-
-        println!(
-            "[Chart] Backfilling intraday prices from Kraken (have {} points)...",
-            existing.len()
-        );
-        let agent = stable_channels::price_feeds::bounded_agent();
-        match stable_channels::price_feeds::fetch_kraken_intraday(&agent) {
-            Ok(prices) => {
-                // Build a set of existing timestamps (rounded to nearest minute) to avoid dupes
-                let existing_ts: std::collections::HashSet<i64> = existing
-                    .iter()
-                    .map(|p| p.timestamp / 60 * 60) // round to minute
+            // Seed the full 2013-present daily history once (local insert) if missing.
+            let needs_seed = match db.get_oldest_daily_price_date() {
+                Ok(Some(oldest)) => !oldest.starts_with("2013"),
+                _ => true,
+            };
+            if needs_seed {
+                let data: Vec<(String, f64, f64, f64, f64, Option<f64>)> = get_seed_prices()
+                    .into_iter()
+                    .map(|(date, o, h, l, c, v)| (date.to_string(), o, h, l, c, v))
                     .collect();
-
-                let mut inserted = 0;
-                for (ts, price) in &prices {
-                    let rounded = ts / 60 * 60;
-                    if !existing_ts.contains(&rounded) {
-                        let _ = self.db.record_price_at(*price, *ts, Some("kraken"));
-                        inserted += 1;
-                    }
+                if let Err(e) = db.bulk_insert_daily_prices(&data) {
+                    eprintln!("[Chart] Failed to seed historical prices: {}", e);
                 }
-                println!(
-                    "[Chart] Backfilled {} intraday price points from Kraken",
-                    inserted
-                );
             }
-            Err(e) => {
-                eprintln!("[Chart] Failed to backfill intraday prices: {}", e);
+
+            // Refresh recent daily OHLC from Kraken when seeding or when data is stale.
+            let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+            let daily_stale =
+                db.get_latest_daily_price_date().ok().flatten().as_deref() != Some(today.as_str());
+            if needs_seed || daily_stale {
+                match stable_channels::price_feeds::fetch_kraken_ohlc(&agent, None) {
+                    Ok(prices) => {
+                        for (date, open, high, low, close, volume) in prices {
+                            let _ = db
+                                .record_daily_price(&date, open, high, low, close, volume, Some("kraken"));
+                        }
+                    }
+                    Err(e) => eprintln!("[Chart] Failed to fetch Kraken OHLC data: {}", e),
+                }
             }
-        }
+
+            // Backfill intraday (15-min) points for the 1D chart if sparse.
+            let existing = db.get_price_history(24).unwrap_or_default();
+            if existing.len() < 80 {
+                match stable_channels::price_feeds::fetch_kraken_intraday(&agent) {
+                    Ok(prices) => {
+                        let existing_ts: std::collections::HashSet<i64> =
+                            existing.iter().map(|p| p.timestamp / 60 * 60).collect();
+                        for (ts, price) in &prices {
+                            if !existing_ts.contains(&(ts / 60 * 60)) {
+                                let _ = db.record_price_at(*price, *ts, Some("kraken"));
+                            }
+                        }
+                    }
+                    Err(e) => eprintln!("[Chart] Failed to backfill intraday prices: {}", e),
+                }
+            }
+
+            let _ = tx.send(true);
+        });
     }
 
     /// Load chart data based on current period selection
@@ -9104,6 +9097,23 @@ impl App for UserApp {
                 Err(std::sync::mpsc::TryRecvError::Empty) => {} // Still fetching
             }
         }
+
+        // Poll background historical/intraday backfill; refresh the chart when it lands.
+        if let Some(ref rx) = self.historical_backfill_receiver {
+            match rx.try_recv() {
+                Ok(_) => {
+                    self.load_chart_data();
+                    self.historical_backfill_receiver = None;
+                }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.historical_backfill_receiver = None;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+            }
+        }
+
+        // Apply a deferred splice-out deduction once its esplora lookup completes.
+        self.poll_pending_splice_deduction();
 
         self.show_onboarding = false;
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -176,9 +176,9 @@ struct PendingPayment {
     amount_usd: Option<f64>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct IncomingSync {
-    user_channel_id: u128,
+    channel_id: String,
     expected_usd: f64,
     backing_sats: u64,
     sync_version: u64,
@@ -232,6 +232,8 @@ pub struct PendingSplice {
     pub direction: String, // "in" or "out"
     pub amount_sats: u64,
     pub address: Option<String>, // For splice_out
+    pub onchain_sats_at_start: u64,
+    pub channel_value_sats_at_start: u64,
 }
 
 #[derive(Clone)]
@@ -264,9 +266,38 @@ impl Toast {
 /// A splice-out deduction awaiting its off-thread esplora funding-output lookup.
 struct PendingSpliceDeduction {
     old_value_sats: u64,
+    receiver_sats_at_start: u64,
+    backing_sats_at_start: u64,
     txid: String,
     vout: u32,
-    rx: std::sync::mpsc::Receiver<Option<u64>>,
+    channel_ready_seen: bool,
+    rx: Option<std::sync::mpsc::Receiver<Option<u64>>>,
+    resolved_new_value: Option<Option<u64>>,
+    retry_after: Option<std::time::Instant>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpliceReconcileAction {
+    AlreadyReconciled,
+    NoOutgoingDeduction,
+    DeferToFundingLookup,
+    ReconcileNow,
+}
+
+fn splice_reconcile_action(
+    direction: Option<&str>,
+    already_reconciled: bool,
+    funding_lookup_pending: bool,
+) -> SpliceReconcileAction {
+    if already_reconciled {
+        SpliceReconcileAction::AlreadyReconciled
+    } else if direction == Some("in") {
+        SpliceReconcileAction::NoOutgoingDeduction
+    } else if funding_lookup_pending {
+        SpliceReconcileAction::DeferToFundingLookup
+    } else {
+        SpliceReconcileAction::ReconcileNow
+    }
 }
 
 pub struct UserApp {
@@ -796,6 +827,7 @@ impl UserApp {
         let db = self.db.clone();
         let splice_flag = Arc::clone(&self.auto_splice_in_progress);
         let splice_onchain_start = Arc::clone(&self.auto_splice_onchain_at_start);
+        let pending_splice = Arc::clone(&self.pending_splice);
 
         std::thread::spawn(move || {
             fn current_unix_time() -> i64 {
@@ -935,6 +967,15 @@ impl UserApp {
                         if prev > 0 && current < prev {
                             splice_flag.store(false, std::sync::atomic::Ordering::Relaxed);
                             splice_onchain_start.store(0, std::sync::atomic::Ordering::Relaxed);
+                            if let Ok(mut pending) = pending_splice.lock() {
+                                if pending
+                                    .as_ref()
+                                    .map(|splice| splice.direction == "in")
+                                    .unwrap_or(false)
+                                {
+                                    *pending = None;
+                                }
+                            }
                             audit_event(
                                 "AUTO_SPLICE_CONFIRMED",
                                 json!({
@@ -1462,8 +1503,10 @@ impl UserApp {
                                     // Block auto-splice while this splice is in flight
                                     self.auto_splice_in_progress
                                         .store(true, std::sync::atomic::Ordering::Relaxed);
+                                    let onchain_sats_at_start =
+                                        self.node.list_balances().total_onchain_balance_sats;
                                     self.auto_splice_onchain_at_start.store(
-                                        self.node.list_balances().total_onchain_balance_sats,
+                                        onchain_sats_at_start,
                                         std::sync::atomic::Ordering::Relaxed,
                                     );
 
@@ -1471,6 +1514,8 @@ impl UserApp {
                                         direction: "out".to_string(),
                                         amount_sats,
                                         address: Some(input.clone()),
+                                        onchain_sats_at_start,
+                                        channel_value_sats_at_start: ch.channel_value_sats,
                                     });
                                     // Record pending withdrawal in payment history immediately
                                     let amount_msat = amount_sats * 1000;
@@ -1621,10 +1666,29 @@ impl UserApp {
         }
 
         let balances = self.node.list_balances();
+        let current_channel_value_sats = self
+            .node
+            .list_channels()
+            .iter()
+            .find(|channel| channel.is_channel_ready)
+            .map(|channel| channel.channel_value_sats)
+            .unwrap_or(0);
+        let pending_splice = self
+            .pending_splice
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone());
+        let splice_overlap_sats = splice_in_overlap_sats(
+            pending_splice.as_ref(),
+            current_channel_value_sats,
+            balances.total_onchain_balance_sats,
+        );
 
         // Detect incoming payment: total sats went up → trigger balance flash
-        let total_sats_now =
-            balances.total_lightning_balance_sats + balances.total_onchain_balance_sats;
+        let total_sats_now = balances
+            .total_lightning_balance_sats
+            .saturating_add(balances.total_onchain_balance_sats)
+            .saturating_sub(splice_overlap_sats);
         if self.last_known_total_sats > 0 && total_sats_now > self.last_known_total_sats {
             self.payment_flash_at = Some(std::time::Instant::now());
         }
@@ -1636,8 +1700,8 @@ impl UserApp {
         self.lightning_balance_usd = self.lightning_balance_btc * self.btc_price;
         self.onchain_balance_usd = self.onchain_balance_btc * self.btc_price;
 
-        self.total_balance_btc = self.lightning_balance_btc + self.onchain_balance_btc;
-        self.total_balance_usd = self.lightning_balance_usd + self.onchain_balance_usd;
+        self.total_balance_btc = total_sats_now as f64 / 100_000_000.0;
+        self.total_balance_usd = self.total_balance_btc * self.btc_price;
 
         // Clear syncing state once we have valid price AND stable_channel has been updated
         if self.is_syncing && current_price > 0.0 {
@@ -1758,6 +1822,8 @@ impl UserApp {
                     direction: "in".to_string(),
                     amount_sats: splice_amount,
                     address: None,
+                    onchain_sats_at_start: balances.total_onchain_balance_sats,
+                    channel_value_sats_at_start: ch.channel_value_sats,
                 });
                 let _ = self.db.record_payment(
                     None,
@@ -2242,6 +2308,26 @@ impl UserApp {
                             .db
                             .is_splice_stable_reconciled(&txid_str)
                             .unwrap_or(false);
+                    let pending_splice_direction =
+                        self.pending_splice.lock().ok().and_then(|guard| {
+                            guard.as_ref().map(|splice| splice.direction.clone())
+                        });
+                    let splice_direction = pending_splice_direction.clone().or_else(|| {
+                        (txid_str != "unknown")
+                            .then(|| self.db.get_splice_direction(&txid_str).ok().flatten())
+                            .flatten()
+                    });
+                    let keep_splice_in_pending = splice_direction.as_deref() == Some("in");
+                    let funding_lookup_pending = self
+                        .pending_splice_deduction
+                        .as_ref()
+                        .map(|pending| pending.txid == txid_str)
+                        .unwrap_or(false);
+                    let reconcile_action = splice_reconcile_action(
+                        splice_direction.as_deref(),
+                        splice_already_reconciled,
+                        funding_lookup_pending,
+                    );
                     let is_splice;
                     {
                         let mut sc = self.stable_channel.lock().unwrap();
@@ -2266,51 +2352,136 @@ impl UserApp {
                                     .unwrap_or(false);
                             }
                         }
-                        is_splice = ours && (completed_splice || channel_id_changed);
+                        is_splice = ours
+                            && (completed_splice
+                                || channel_id_changed
+                                || splice_direction.is_some());
                         update_balances(&self.node, &mut sc);
 
                         // After splice confirms, reconcile: if splice-out exceeded
                         // native BTC, the overflow eats into the stable position.
                         if is_splice {
-                            if splice_already_reconciled {
-                                // SpliceNegotiated already deducted this splice-out precisely
-                                // (esplora); skip reconcile_outgoing so the pre-existing under-peg
-                                // gap isn't deducted a second time.
-                                audit_event(
-                                    "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
-                                    json!({ "txid": txid_str.clone() }),
-                                );
-                            } else {
-                                let price = sc.latest_price;
-                                if let Some(usd_deducted) =
-                                    stable::reconcile_outgoing(&mut sc, price)
-                                {
+                            match reconcile_action {
+                                SpliceReconcileAction::AlreadyReconciled => {
                                     audit_event(
-                                        "SPLICE_OUT_STABLE_DEDUCTED",
-                                        json!({
-                                            "usd_deducted": usd_deducted,
-                                            "new_expected_usd": sc.expected_usd.0,
-                                            "btc_price": price,
-                                        }),
+                                        "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
+                                        json!({ "txid": txid_str.clone() }),
                                     );
                                 }
+                                SpliceReconcileAction::NoOutgoingDeduction => {
+                                    match self.db.persist_splice_reconciliation(
+                                        &txid_str,
+                                        &sc.channel_id.to_string(),
+                                        &format!("{}", sc.user_channel_id),
+                                        sc.expected_usd.0,
+                                        sc.backing_sats,
+                                        sc.native_sats,
+                                        sc.note.as_deref(),
+                                    ) {
+                                        Ok(_) => audit_event(
+                                            "SPLICE_IN_RECONCILED",
+                                            json!({ "txid": txid_str.clone() }),
+                                        ),
+                                        Err(e) => {
+                                            ack = false;
+                                            audit_event(
+                                                "DB_WRITE_FAILED",
+                                                json!({
+                                                    "op": "persist_splice_reconciliation",
+                                                    "txid": txid_str.clone(),
+                                                    "error": e.to_string(),
+                                                }),
+                                            );
+                                        }
+                                    }
+                                }
+                                SpliceReconcileAction::DeferToFundingLookup => {
+                                    if let Some(pending) = self
+                                        .pending_splice_deduction
+                                        .as_mut()
+                                        .filter(|pending| pending.txid == txid_str)
+                                    {
+                                        pending.channel_ready_seen = true;
+                                    }
+                                    audit_event(
+                                        "SPLICE_OUT_RECONCILE_DEFERRED",
+                                        json!({ "txid": txid_str.clone() }),
+                                    );
+                                }
+                                SpliceReconcileAction::ReconcileNow => {
+                                    let price = sc.latest_price;
+                                    let mut reconciled = sc.clone();
+                                    let usd_deducted =
+                                        stable::reconcile_outgoing(&mut reconciled, price);
+                                    match self.db.persist_splice_reconciliation(
+                                        &txid_str,
+                                        &reconciled.channel_id.to_string(),
+                                        &format!("{}", reconciled.user_channel_id),
+                                        reconciled.expected_usd.0,
+                                        reconciled.backing_sats,
+                                        reconciled.native_sats,
+                                        reconciled.note.as_deref(),
+                                    ) {
+                                        Ok(true) => {
+                                            *sc = reconciled;
+                                            if let Some(usd_deducted) = usd_deducted {
+                                                audit_event(
+                                                    "SPLICE_OUT_STABLE_DEDUCTED",
+                                                    json!({
+                                                        "usd_deducted": usd_deducted,
+                                                        "new_expected_usd": sc.expected_usd.0,
+                                                        "btc_price": price,
+                                                        "source": "channel_ready_fallback",
+                                                    }),
+                                                );
+                                            }
+                                        }
+                                        Ok(false) => audit_event(
+                                            "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
+                                            json!({ "txid": txid_str.clone() }),
+                                        ),
+                                        Err(e) => {
+                                            ack = false;
+                                            audit_event(
+                                                "DB_WRITE_FAILED",
+                                                json!({
+                                                    "op": "persist_splice_reconciliation",
+                                                    "txid": txid_str.clone(),
+                                                    "error": e.to_string(),
+                                                }),
+                                            );
+                                        }
+                                    }
+                                }
                             }
-                            // Splice complete: clear the auto-splice flag (bg-thread
-                            // clear only handles splice-in via balance drop;
-                            // splice-out needs this explicit clear).
-                            self.auto_splice_in_progress
-                                .store(false, std::sync::atomic::Ordering::Relaxed);
-                            self.auto_splice_onchain_at_start
-                                .store(0, std::sync::atomic::Ordering::Relaxed);
+                            // A zero-conf splice-in becomes channel-ready before BDK removes the
+                            // spent input. Keep its accounting marker until the on-chain balance
+                            // drops. Splice-out can be cleared immediately here.
+                            if ack && !keep_splice_in_pending {
+                                self.auto_splice_in_progress
+                                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                                self.auto_splice_onchain_at_start
+                                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                                *self.pending_splice.lock().unwrap() = None;
+                            }
                         }
                     }
-                    self.save_channel_settings();
-                    self.update_balances(); // Update UI immediately
+                    if ack {
+                        if !is_splice
+                            || reconcile_action != SpliceReconcileAction::DeferToFundingLookup
+                        {
+                            self.save_channel_settings();
+                        }
+                        self.update_balances(); // Update UI immediately
+                    }
 
                     // Splice rows were already completed above (exact txid match,
                     // or the legacy latest-row fallback). Everything else with a
                     // known funding txid is a regular channel open.
-                    if !completed_splice && txid_str != "unknown" {
+                    if !completed_splice
+                        && splice_direction.is_none()
+                        && txid_str != "unknown"
+                    {
                         let _ = self
                             .db
                             .update_payment_confirmations(&txid_str, 1, "completed");
@@ -2433,13 +2604,14 @@ impl UserApp {
                             };
 
                             let mut sc = self.stable_channel.lock().unwrap();
-                            if sync.user_channel_id != sc.user_channel_id {
+                            let wallet_channel_id = sc.channel_id.to_string();
+                            if sync.channel_id != wallet_channel_id {
                                 audit_event(
                                     "SYNC_V1_CHANNEL_MISMATCH",
                                     json!({
                                         "payment_hash": &payment_hash_str,
-                                        "payload_user_channel_id": format!("{}", sync.user_channel_id),
-                                        "wallet_user_channel_id": format!("{}", sc.user_channel_id),
+                                        "payload_channel_id": sync.channel_id.clone(),
+                                        "wallet_channel_id": wallet_channel_id,
                                         "sync_version": sync.sync_version,
                                     }),
                                 );
@@ -2451,7 +2623,7 @@ impl UserApp {
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
                             let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
-                            let user_channel_id = format!("{}", sync.user_channel_id);
+                            let user_channel_id = format!("{}", sc.user_channel_id);
                             match self.db.apply_sync_if_newer(
                                 &user_channel_id,
                                 sync.sync_version,
@@ -3065,8 +3237,12 @@ impl UserApp {
 
                     // Record/update splice payment
                     let txid_str = new_funding_txo.txid.to_string();
-                    if let Some(splice) = self.pending_splice.lock().unwrap().take() {
-                        if splice.direction == "in" {
+                    let pending_direction =
+                        self.pending_splice.lock().ok().and_then(|guard| {
+                            guard.as_ref().map(|splice| splice.direction.clone())
+                        });
+                    if let Some(direction) = pending_direction.as_deref() {
+                        if direction == "in" {
                             // Auto-splice (splice_in) was already recorded in background thread
                             // — just update it with the txid now that we know it
                             let _ = self.db.set_pending_splice_txid(&txid_str);
@@ -3091,6 +3267,8 @@ impl UserApp {
                         }
                     }
 
+                    let live_splice_out = pending_direction.as_deref() == Some("out");
+
                     // Deduct stable balance if splice-out exceeded native BTC.
                     // Uses the same capacity-delta approach as the LSP (via bitcoind)
                     // so both sides compute identical expected_usd.
@@ -3104,21 +3282,34 @@ impl UserApp {
                         .find(|c| c.user_channel_id.0 == user_channel_id.0)
                         .map(|c| c.channel_value_sats);
 
-                    if let Some(old_value) = old_channel_value_sats {
-                        // Run the esplora lookup off the UI thread; the deduction is applied in
-                        // poll_pending_splice_deduction() when the result lands (never blocks).
-                        let (tx, rx) = std::sync::mpsc::channel();
-                        let txid_for_lookup = txid_str.clone();
-                        std::thread::spawn(move || {
-                            let _ = tx
-                                .send(Self::lookup_funding_output_sats_esplora(&txid_for_lookup, vout));
-                        });
-                        self.pending_splice_deduction = Some(PendingSpliceDeduction {
-                            old_value_sats: old_value,
-                            txid: txid_str.clone(),
-                            vout,
-                            rx,
-                        });
+                    if live_splice_out {
+                        if let Some(old_value) = old_channel_value_sats {
+                            let (receiver_sats_at_start, backing_sats_at_start) = {
+                                let sc = self.stable_channel.lock().unwrap();
+                                (sc.stable_receiver_btc.sats, sc.backing_sats)
+                            };
+                            // Run the esplora lookup off the UI thread; the deduction is applied in
+                            // poll_pending_splice_deduction() when the result lands (never blocks).
+                            let (tx, rx) = std::sync::mpsc::channel();
+                            let txid_for_lookup = txid_str.clone();
+                            std::thread::spawn(move || {
+                                let _ = tx.send(Self::lookup_funding_output_sats_esplora(
+                                    &txid_for_lookup,
+                                    vout,
+                                ));
+                            });
+                            self.pending_splice_deduction = Some(PendingSpliceDeduction {
+                                old_value_sats: old_value,
+                                receiver_sats_at_start,
+                                backing_sats_at_start,
+                                txid: txid_str.clone(),
+                                vout,
+                                channel_ready_seen: false,
+                                rx: Some(rx),
+                                resolved_new_value: None,
+                                retry_after: None,
+                            });
+                        }
                     }
 
                     self.status_message = format!("Splice pending - tx: {}", new_funding_txo.txid);
@@ -3171,61 +3362,146 @@ impl UserApp {
     /// Apply a deferred splice-out deduction once its background esplora lookup lands.
     /// Non-blocking: returns immediately while the lookup is still in flight.
     fn poll_pending_splice_deduction(&mut self) {
-        let recv = match self.pending_splice_deduction.as_ref() {
-            Some(p) => p.rx.try_recv(),
+        let (new_value_opt, newly_resolved) = match self.pending_splice_deduction.as_mut() {
+            Some(pending) => {
+                if pending
+                    .retry_after
+                    .is_some_and(|retry_after| std::time::Instant::now() < retry_after)
+                {
+                    return;
+                }
+                pending.retry_after = None;
+
+                if let Some(new_value) = pending.resolved_new_value {
+                    (new_value, false)
+                } else {
+                    let recv = pending.rx.as_ref().expect("unresolved lookup has receiver");
+                    let new_value = match recv.try_recv() {
+                        Ok(value) => value,
+                        Err(std::sync::mpsc::TryRecvError::Empty) => return,
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
+                    };
+                    pending.resolved_new_value = Some(new_value);
+                    pending.rx = None;
+                    (new_value, true)
+                }
+            }
             None => return,
         };
-        let new_value_opt = match recv {
-            Ok(v) => v,
-            Err(std::sync::mpsc::TryRecvError::Empty) => return, // still looking up
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => None, // lookup thread died
-        };
-        let pending = self.pending_splice_deduction.take().unwrap();
-        match new_value_opt {
+        let mut pending = self.pending_splice_deduction.take().unwrap();
+        if self
+            .db
+            .is_splice_stable_reconciled(&pending.txid)
+            .unwrap_or(false)
+        {
+            audit_event(
+                "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
+                json!({ "txid": pending.txid.clone(), "source": "funding_lookup" }),
+            );
+            return;
+        }
+
+        let exact_splice_out_sats = match new_value_opt {
             Some(new_value) => {
-                audit_event(
-                    "SPLICE_PENDING_LOOKUP",
-                    json!({
-                        "old_channel_sats": pending.old_value_sats,
-                        "new_channel_sats": new_value,
-                        "delta_sats": (new_value as i64) - (pending.old_value_sats as i64),
-                    }),
-                );
-                if new_value < pending.old_value_sats {
-                    let splice_out_sats = pending.old_value_sats - new_value;
-                    let mut sc = self.stable_channel.lock().unwrap();
-                    let price = sc.latest_price;
-                    if let Some(usd_deducted) =
-                        stable::deduct_outgoing(&mut sc, splice_out_sats, price)
-                    {
-                        audit_event(
-                            "SPLICE_OUT_STABLE_DEDUCTED",
-                            json!({
-                                "splice_out_sats": splice_out_sats,
-                                "usd_deducted": usd_deducted,
-                                "new_expected_usd": sc.expected_usd.0,
-                                "btc_price": price,
-                            }),
-                        );
-                    }
-                    drop(sc);
-                    self.save_channel_settings();
+                if newly_resolved {
+                    audit_event(
+                        "SPLICE_PENDING_LOOKUP",
+                        json!({
+                            "old_channel_sats": pending.old_value_sats,
+                            "new_channel_sats": new_value,
+                            "delta_sats": (new_value as i64) - (pending.old_value_sats as i64),
+                        }),
+                    );
                 }
-                // This splice was reconciled here authoritatively; block a second deduction at ChannelReady.
-                let _ = self.db.mark_splice_stable_reconciled(&pending.txid);
+                (new_value < pending.old_value_sats).then_some(pending.old_value_sats - new_value)
             }
             None => {
-                println!(
-                    "[SplicePending] Could not look up funding output {}:{}",
-                    pending.txid, pending.vout
-                );
+                if newly_resolved {
+                    println!(
+                        "[SplicePending] Could not look up funding output {}:{}",
+                        pending.txid, pending.vout
+                    );
+                    audit_event(
+                        "SPLICE_PENDING_LOOKUP_FAILED",
+                        json!({
+                            "txid": pending.txid.clone(),
+                            "vout": pending.vout,
+                        }),
+                    );
+                }
+                None
+            }
+        };
+
+        // If ChannelReady has not arrived yet, a failed or inconsistent lookup can simply leave
+        // reconciliation to that event's balance-based fallback.
+        if exact_splice_out_sats.is_none() && !pending.channel_ready_seen {
+            return;
+        }
+
+        let mut sc = self.stable_channel.lock().unwrap();
+        update_balances(&self.node, &mut sc);
+        let price = sc.latest_price;
+        let mut reconciled = sc.clone();
+        let (usd_deducted, source) = if let Some(splice_out_sats) = exact_splice_out_sats {
+            (
+                stable::deduct_outgoing_from_snapshot(
+                    &mut reconciled,
+                    pending.receiver_sats_at_start,
+                    pending.backing_sats_at_start,
+                    splice_out_sats,
+                    price,
+                ),
+                "funding_lookup",
+            )
+        } else {
+            (
+                stable::reconcile_outgoing(&mut reconciled, price),
+                "channel_ready_lookup_fallback",
+            )
+        };
+
+        match self.db.persist_splice_reconciliation(
+            &pending.txid,
+            &reconciled.channel_id.to_string(),
+            &format!("{}", reconciled.user_channel_id),
+            reconciled.expected_usd.0,
+            reconciled.backing_sats,
+            reconciled.native_sats,
+            reconciled.note.as_deref(),
+        ) {
+            Ok(true) => {
+                *sc = reconciled;
                 audit_event(
-                    "SPLICE_PENDING_LOOKUP_FAILED",
+                    "SPLICE_OUT_STABLE_RECONCILED",
                     json!({
-                        "txid": pending.txid,
-                        "vout": pending.vout,
+                        "txid": pending.txid.clone(),
+                        "splice_out_sats": exact_splice_out_sats,
+                        "usd_deducted": usd_deducted,
+                        "new_expected_usd": sc.expected_usd.0,
+                        "new_backing_sats": sc.backing_sats,
+                        "btc_price": price,
+                        "source": source,
                     }),
                 );
+            }
+            Ok(false) => audit_event(
+                "SPLICE_RECONCILE_SKIPPED_ALREADY_DEDUCTED",
+                json!({ "txid": pending.txid.clone(), "source": source }),
+            ),
+            Err(e) => {
+                audit_event(
+                    "DB_WRITE_FAILED",
+                    json!({
+                        "op": "persist_splice_reconciliation",
+                        "txid": pending.txid.clone(),
+                        "error": e.to_string(),
+                        "will_retry": true,
+                    }),
+                );
+                drop(sc);
+                pending.retry_after = Some(std::time::Instant::now() + Duration::from_secs(1));
+                self.pending_splice_deduction = Some(pending);
             }
         }
     }
@@ -4658,7 +4934,12 @@ impl UserApp {
     fn show_home_tab(&mut self, ui: &mut egui::Ui) {
         egui::ScrollArea::vertical().show(ui, |ui| {
             // Check if we have an active, ready channel (not just pending)
-            let has_active_channel = self.node.list_channels().iter().any(|c| c.is_channel_ready);
+            let channels = self.node.list_channels();
+            let active_channel = channels.iter().find(|channel| channel.is_channel_ready);
+            let has_active_channel = active_channel.is_some();
+            let current_channel_value_sats = active_channel
+                .map(|channel| channel.channel_value_sats)
+                .unwrap_or(0);
 
             // Get fresh balances
             let balances = self.node.list_balances();
@@ -4709,25 +4990,27 @@ impl UserApp {
                 0.0
             };
             // Total balance calculation:
-            // - Splice-in pending: lightning already reflects the post-splice
-            //   capacity but onchain hasn't dropped yet — adding both would
-            //   double-count the splice amount until BDK sees the spent UTXO.
-            //   Show lightning only during this window. Matches iOS
-            //   `if isSweeping { return lightningBalanceSats }` at
-            //   AppState.swift:95.
-            // - Active channel (no pending splice-in): lightning + onchain.
+            // - Before splice-in promotion, Lightning and on-chain are independent.
+            // - After promotion but before BDK removes the spent input, subtract the
+            //   recorded pre-splice on-chain balance exactly once.
+            // - Outside that overlap window, add Lightning and on-chain normally.
             // - No channel: pending_sweep + onchain (lightning_balances
             //   overlaps with pending_sweep/onchain after close).
-            let pending_splice_in = self
+            let pending_splice = self
                 .pending_splice
                 .lock()
                 .ok()
-                .and_then(|guard| guard.as_ref().map(|s| s.direction == "in"))
-                .unwrap_or(false);
-            let total_sats = if pending_splice_in {
-                balances.total_lightning_balance_sats
-            } else if has_active_channel {
-                balances.total_lightning_balance_sats + total_onchain_sats
+                .and_then(|guard| guard.clone());
+            let splice_overlap_sats = splice_in_overlap_sats(
+                pending_splice.as_ref(),
+                current_channel_value_sats,
+                total_onchain_sats,
+            );
+            let total_sats = if has_active_channel {
+                balances
+                    .total_lightning_balance_sats
+                    .saturating_add(total_onchain_sats)
+                    .saturating_sub(splice_overlap_sats)
             } else {
                 pending_sweep_sats + total_onchain_sats
             };
@@ -5157,14 +5440,16 @@ impl UserApp {
             // confirmed funds, unconfirmed deposits, and pending channel-close
             // sweeps. Folds in what used to be a separate "Bitcoin (pending)"
             // section. Matches iOS savingsSection 4-state layout.
-            let has_any_onchain_activity = total_onchain_sats > 0 || pending_sweep_sats > 0;
+            let splicing = self
+                .auto_splice_in_progress
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let accounted_onchain_sats = total_onchain_sats.saturating_sub(splice_overlap_sats);
+            let has_any_onchain_activity =
+                accounted_onchain_sats > 0 || pending_sweep_sats > 0 || splicing;
             if has_any_onchain_activity {
                 let has_ready_channel =
                     self.node.list_channels().iter().any(|c| c.is_channel_ready);
-                let splicing = self
-                    .auto_splice_in_progress
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                let total_visible_sats = total_onchain_sats + pending_sweep_sats;
+                let total_visible_sats = accounted_onchain_sats + pending_sweep_sats;
                 let total_visible_btc = total_visible_sats as f64 / 100_000_000.0;
 
                 ui.add_space(8.0);
@@ -9843,6 +10128,26 @@ fn channel_balance_split(
     (stable_sats, native_sats, native_usd)
 }
 
+/// During a zero-conf splice-in, LDK can expose the increased channel value before its on-chain
+/// wallet has removed the spent input. Subtract only that known overlap, and only after channel
+/// promotion; before promotion both balances are still independent and must both be counted.
+fn splice_in_overlap_sats(
+    pending: Option<&PendingSplice>,
+    current_channel_value_sats: u64,
+    current_onchain_sats: u64,
+) -> u64 {
+    let Some(pending) = pending.filter(|pending| pending.direction == "in") else {
+        return 0;
+    };
+    if current_channel_value_sats > pending.channel_value_sats_at_start
+        && current_onchain_sats >= pending.onchain_sats_at_start
+    {
+        pending.onchain_sats_at_start
+    } else {
+        0
+    }
+}
+
 fn collapse_double_paste(input: String) -> String {
     let len = input.len();
     let midpoint = len / 2;
@@ -9919,11 +10224,11 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     if payload.get("type").and_then(|value| value.as_str()) != Some(SYNC_MESSAGE_TYPE) {
         return None;
     }
-    let user_channel_id = payload
-        .get("user_channel_id")?
-        .as_str()?
-        .parse::<u128>()
-        .ok()?;
+    let channel_id = payload.get("channel_id")?.as_str()?;
+    if channel_id.len() != 64 || !channel_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let channel_id = channel_id.to_ascii_lowercase();
     let expected_usd = payload.get("expected_usd")?.as_f64()?;
     let backing_sats = payload.get("backing_sats")?.as_u64()?;
     let sync_version = payload.get("sync_version")?.as_u64()?;
@@ -9936,7 +10241,7 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
         return None;
     }
     Some(IncomingSync {
-        user_channel_id,
+        channel_id,
         expected_usd,
         backing_sats,
         sync_version,
@@ -9984,7 +10289,8 @@ mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
         parse_incoming_sync, parse_trade_usd_cents, restrict_secret_file_permissions,
-        sats_for_usd_cents, write_secret_file, IncomingSync, UserApp,
+        sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action, write_secret_file,
+        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
     };
 
     #[test]
@@ -10067,6 +10373,61 @@ mod tests {
     }
 
     #[test]
+    fn splice_in_overlap_is_counted_exactly_once_after_channel_promotion() {
+        let pending = PendingSplice {
+            direction: "in".to_string(),
+            amount_sats: 60_598,
+            address: None,
+            onchain_sats_at_start: 60_598,
+            channel_value_sats_at_start: 102_345,
+        };
+
+        // Negotiation has started, but the channel still has its old value.
+        assert_eq!(splice_in_overlap_sats(Some(&pending), 102_345, 60_598), 0);
+
+        // LDK promoted the splice while BDK still reports the spent on-chain input.
+        let overlap = splice_in_overlap_sats(Some(&pending), 162_719, 60_598);
+        assert_eq!(overlap, 60_598);
+        assert_eq!(62_400u64 + 60_598 - overlap, 62_400);
+        assert_eq!(60_598u64.saturating_sub(overlap), 0);
+
+        // Once BDK observes the spend, there is no overlap left to subtract.
+        assert_eq!(splice_in_overlap_sats(Some(&pending), 162_719, 0), 0);
+    }
+
+    #[test]
+    fn splice_out_never_suppresses_onchain_balance() {
+        let pending = PendingSplice {
+            direction: "out".to_string(),
+            amount_sats: 20_000,
+            address: Some("tb1qexample".to_string()),
+            onchain_sats_at_start: 10_000,
+            channel_value_sats_at_start: 100_000,
+        };
+        assert_eq!(splice_in_overlap_sats(Some(&pending), 80_000, 30_000), 0);
+    }
+
+    #[test]
+    fn splice_reconciliation_has_one_authoritative_path() {
+        assert_eq!(
+            splice_reconcile_action(Some("out"), false, true),
+            SpliceReconcileAction::DeferToFundingLookup
+        );
+        assert_eq!(
+            splice_reconcile_action(Some("out"), false, false),
+            SpliceReconcileAction::ReconcileNow
+        );
+        assert_eq!(
+            splice_reconcile_action(Some("in"), false, true),
+            SpliceReconcileAction::NoOutgoingDeduction
+        );
+        assert_eq!(
+            splice_reconcile_action(Some("out"), true, true),
+            SpliceReconcileAction::AlreadyReconciled
+        );
+    }
+
+    #[test]
     fn double_paste_is_collapsed() {
         let invoice = "lnbc".repeat(20);
         assert_eq!(
@@ -10107,10 +10468,12 @@ mod tests {
     }
 
     #[test]
-    fn sync_payload_requires_channel_and_monotonic_version() {
+    fn sync_payload_requires_shared_channel_and_monotonic_version() {
+        let channel_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let payload = serde_json::json!({
             "type": "SYNC_V1",
-            "user_channel_id": "7",
+            "channel_id": channel_id,
+            "user_channel_id": "different-node-local-id-is-ignored",
             "expected_usd": 25.0,
             "backing_sats": 31_250,
             "sync_version": 4,
@@ -10118,7 +10481,7 @@ mod tests {
         assert_eq!(
             parse_incoming_sync(&payload),
             Some(IncomingSync {
-                user_channel_id: 7,
+                channel_id: channel_id.to_string(),
                 expected_usd: 25.0,
                 backing_sats: 31_250,
                 sync_version: 4,
@@ -10138,12 +10501,21 @@ mod tests {
 
         let oversized_balance = serde_json::json!({
             "type": "SYNC_V1",
-            "user_channel_id": "7",
+            "channel_id": channel_id,
             "expected_usd": 25.0,
             "backing_sats": u64::MAX,
             "sync_version": 5,
         });
         assert_eq!(parse_incoming_sync(&oversized_balance), None);
+
+        let malformed_channel = serde_json::json!({
+            "type": "SYNC_V1",
+            "channel_id": "not-a-channel",
+            "expected_usd": 25.0,
+            "backing_sats": 31_250,
+            "sync_version": 5,
+        });
+        assert_eq!(parse_incoming_sync(&malformed_channel), None);
     }
 
     #[cfg(unix)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -14,9 +14,11 @@ use ldk_node::payment::{PaymentDirection, PaymentKind};
 use qrcode::QrCode;
 use serde_json::json;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read as IoRead, Write};
-use std::path::Path;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -174,6 +176,57 @@ struct PendingPayment {
     amount_usd: Option<f64>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct IncomingSync {
+    user_channel_id: u128,
+    expected_usd: f64,
+    backing_sats: u64,
+    sync_version: u64,
+}
+
+struct BackupSnapshotDir {
+    path: PathBuf,
+}
+
+impl BackupSnapshotDir {
+    fn create() -> Result<Self, String> {
+        let parent = std::env::temp_dir();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        for attempt in 0..100u32 {
+            let path = parent.join(format!(
+                "stable-channels-backup-{}-{}-{}",
+                std::process::id(),
+                timestamp,
+                attempt
+            ));
+            let mut builder = std::fs::DirBuilder::new();
+            #[cfg(unix)]
+            builder.mode(0o700);
+            match builder.create(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(format!("Failed to create private backup workspace: {}", e)),
+            }
+        }
+
+        Err("Failed to allocate a private backup workspace".to_string())
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for BackupSnapshotDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PendingSplice {
     pub direction: String, // "in" or "out"
@@ -324,6 +377,8 @@ pub struct UserApp {
 
     // Non-blocking daily price update
     daily_prices_receiver: Option<std::sync::mpsc::Receiver<bool>>,
+    // ZIP creation runs off-thread; completion is polled from the UI loop.
+    backup_receiver: Option<std::sync::mpsc::Receiver<Result<String, String>>>,
     // Startup historical/intraday Kraken backfill — off-thread so it never blocks the first frame.
     historical_backfill_receiver: Option<std::sync::mpsc::Receiver<bool>>,
     // In-flight splice-out esplora lookup; the deduction is applied when it lands.
@@ -465,6 +520,17 @@ impl UserApp {
         // Determine mnemonic for wallet
         let seed_phrase_path = data_dir.join("seed_phrase");
         let keys_seed_path = data_dir.join("keys_seed");
+        for secret_path in [&seed_phrase_path, &keys_seed_path] {
+            if secret_path.exists() {
+                restrict_secret_file_permissions(secret_path).map_err(|e| {
+                    format!(
+                        "Failed to secure wallet secret {}: {}",
+                        secret_path.display(),
+                        e
+                    )
+                })?;
+            }
+        }
         let mut mnemonic_words: Option<String> = None;
         let mut node_entropy: Option<ldk_node::entropy::NodeEntropy> = None;
 
@@ -492,7 +558,7 @@ impl UserApp {
             }
             let mnemonic = ldk_node::entropy::generate_entropy_mnemonic(None);
             let words = mnemonic.to_string();
-            std::fs::write(&seed_phrase_path, &words).expect("Failed to save seed phrase");
+            write_secret_file(&seed_phrase_path, &words).expect("Failed to save seed phrase");
             let entropy = ldk_node::entropy::NodeEntropy::from_bip39_mnemonic(mnemonic, None);
             node_entropy = Some(entropy);
             mnemonic_words = Some(words);
@@ -658,6 +724,7 @@ impl UserApp {
             pending_trade_payments: HashMap::new(),
             pending_payments: HashMap::new(),
             daily_prices_receiver: None,
+            backup_receiver: None,
             historical_backfill_receiver: None,
             pending_splice_deduction: None,
             bar_chart_show_btc: false,
@@ -2357,44 +2424,85 @@ impl UserApp {
                                 );
                                 continue;
                             }
-                            if let Some(expected_usd) =
-                                payload.get("expected_usd").and_then(|v| v.as_f64())
-                            {
-                                if expected_usd < 0.0 || !expected_usd.is_finite() {
-                                    continue;
-                                }
-                                let backing_sats =
-                                    payload.get("backing_sats").and_then(|v| v.as_u64());
-                                let mut sc = self.stable_channel.lock().unwrap();
-                                stable::update_balances(&self.node, &mut sc);
-                                let price = sc.latest_price;
-                                let old_expected = sc.expected_usd.0;
-                                let live_receiver_sats = sc.stable_receiver_btc.sats;
-                                if let Some(backing_sats) = backing_sats {
-                                    stable::apply_trade_allocation(
-                                        &mut sc,
-                                        expected_usd,
-                                        backing_sats,
-                                    );
-                                } else {
-                                    stable::apply_trade(&mut sc, expected_usd, price);
-                                }
-                                drop(sc);
-                                self.save_channel_settings();
-
+                            let Some(sync) = parse_incoming_sync(&payload) else {
                                 audit_event(
-                                    "SYNC_V1_APPLIED",
+                                    "SYNC_V1_PAYLOAD_INVALID",
+                                    json!({ "payment_hash": &payment_hash_str }),
+                                );
+                                break 'sync true;
+                            };
+
+                            let mut sc = self.stable_channel.lock().unwrap();
+                            if sync.user_channel_id != sc.user_channel_id {
+                                audit_event(
+                                    "SYNC_V1_CHANNEL_MISMATCH",
                                     json!({
-                                        "old_expected_usd": old_expected,
-                                        "new_expected_usd": expected_usd,
-                                        "backing_sats": backing_sats,
-                                        "live_receiver_sats": live_receiver_sats,
-                                        "btc_price": price,
                                         "payment_hash": &payment_hash_str,
+                                        "payload_user_channel_id": format!("{}", sync.user_channel_id),
+                                        "wallet_user_channel_id": format!("{}", sc.user_channel_id),
+                                        "sync_version": sync.sync_version,
                                     }),
                                 );
                                 break 'sync true;
                             }
+
+                            stable::update_balances(&self.node, &mut sc);
+                            let price = sc.latest_price;
+                            let old_expected = sc.expected_usd.0;
+                            let live_receiver_sats = sc.stable_receiver_btc.sats;
+                            let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
+                            let user_channel_id = format!("{}", sync.user_channel_id);
+                            match self.db.apply_sync_if_newer(
+                                &user_channel_id,
+                                sync.sync_version,
+                                sync.expected_usd,
+                                sync.backing_sats,
+                                native_sats,
+                            ) {
+                                Ok(true) => {
+                                    stable::apply_trade_allocation(
+                                        &mut sc,
+                                        sync.expected_usd,
+                                        sync.backing_sats,
+                                    );
+                                    audit_event(
+                                        "SYNC_V1_APPLIED",
+                                        json!({
+                                            "old_expected_usd": old_expected,
+                                            "new_expected_usd": sync.expected_usd,
+                                            "backing_sats": sync.backing_sats,
+                                            "sync_version": sync.sync_version,
+                                            "live_receiver_sats": live_receiver_sats,
+                                            "btc_price": price,
+                                            "payment_hash": &payment_hash_str,
+                                        }),
+                                    );
+                                }
+                                Ok(false) => {
+                                    audit_event(
+                                        "SYNC_V1_REPLAY_REJECTED",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "user_channel_id": user_channel_id,
+                                            "sync_version": sync.sync_version,
+                                        }),
+                                    );
+                                }
+                                Err(e) => {
+                                    audit_event(
+                                        "DB_WRITE_FAILED",
+                                        json!({
+                                            "op": "apply_sync_if_newer",
+                                            "payment_hash": &payment_hash_str,
+                                            "user_channel_id": user_channel_id,
+                                            "sync_version": sync.sync_version,
+                                            "error": e.to_string(),
+                                        }),
+                                    );
+                                    ack = false;
+                                }
+                            }
+                            break 'sync true;
                         }
                         false
                     };
@@ -6185,14 +6293,21 @@ impl UserApp {
                 ui.label(RichText::new("Save a full backup of your wallet data.").size(12.0).color(theme::MUTED));
                 ui.add_space(6.0);
                 ui.horizontal(|ui| {
-                    let backup_btn = egui::Button::new(RichText::new("Download Backup").size(12.0).color(Color32::WHITE))
-                        .fill(blue)
-                        .corner_radius(theme::RADIUS_PILL);
-                    if ui.add(backup_btn).clicked() {
-                        match self.create_backup() {
-                            Ok(_) => self.show_toast("Backup saved!", "OK"),
-                            Err(e) => { self.show_toast("Backup failed", "!"); self.status_message = format!("Backup failed: {}", e); }
-                        }
+                    let backup_in_progress = self.backup_receiver.is_some();
+                    let backup_label = if backup_in_progress {
+                        "Creating Backup..."
+                    } else {
+                        "Download Backup"
+                    };
+                    let backup_btn = egui::Button::new(
+                        RichText::new(backup_label)
+                            .size(12.0)
+                            .color(Color32::WHITE),
+                    )
+                    .fill(blue)
+                    .corner_radius(theme::RADIUS_PILL);
+                    if ui.add_enabled(!backup_in_progress, backup_btn).clicked() {
+                        self.start_backup();
                     }
                 });
                 ui.add_space(4.0);
@@ -8937,7 +9052,8 @@ impl UserApp {
                     ] {
                         std::fs::remove_file(data_dir.join(name)).ok();
                     }
-                    if let Err(e) = std::fs::write(data_dir.join("seed_phrase"), &mnemonic_str) {
+                    if let Err(e) = write_secret_file(&data_dir.join("seed_phrase"), &mnemonic_str)
+                    {
                         self.restore_error = format!("Failed to save seed: {}", e);
                         return;
                     }
@@ -9134,32 +9250,81 @@ impl UserApp {
             });
     }
 
-    /// Create a backup zip of the data directory and save to Downloads
-    fn create_backup(&mut self) -> Result<String, String> {
+    fn start_backup(&mut self) {
+        if self.backup_receiver.is_some() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.backup_receiver = Some(rx);
+        std::thread::spawn(move || {
+            let _ = tx.send(Self::create_backup());
+        });
+    }
+
+    /// Create a backup zip of the data directory and save to Downloads.
+    /// This performs blocking I/O and must only be called from a worker thread.
+    fn create_backup() -> Result<String, String> {
         let data_dir = get_user_data_dir();
 
-        // Get downloads directory
         let downloads_dir =
             dirs::download_dir().ok_or_else(|| "Could not find Downloads folder".to_string())?;
 
-        // Create timestamped filename
-        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        Self::create_backup_archive(&data_dir, &downloads_dir)
+    }
+
+    fn create_backup_archive(data_dir: &Path, output_dir: &Path) -> Result<String, String> {
+        std::fs::create_dir_all(output_dir)
+            .map_err(|e| format!("Failed to create backup directory: {}", e))?;
+        let snapshot_dir = BackupSnapshotDir::create()?;
+
+        // Build under a non-zip name and publish only after every snapshot verifies.
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S_%3f");
         let backup_filename = format!("stable_channels_backup_{}.zip", timestamp);
-        let backup_path = downloads_dir.join(&backup_filename);
+        let backup_path = output_dir.join(&backup_filename);
+        let partial_path = output_dir.join(format!(
+            ".{}.{}.partial",
+            backup_filename,
+            std::process::id()
+        ));
 
-        // Create the zip file
-        let file = File::create(&backup_path)
-            .map_err(|e| format!("Failed to create backup file: {}", e))?;
-        let mut zip = zip::ZipWriter::new(file);
+        let archive_result = (|| -> Result<(), String> {
+            let mut file_options = OpenOptions::new();
+            file_options.write(true).create_new(true);
+            #[cfg(unix)]
+            file_options.mode(0o600);
+            let file = file_options
+                .open(&partial_path)
+                .map_err(|e| format!("Failed to create backup file: {}", e))?;
+            let mut zip = zip::ZipWriter::new(file);
 
-        let options =
-            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            let options = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
 
-        // Walk through data directory and add files
-        Self::add_dir_to_zip(&mut zip, &data_dir, &data_dir, &options)?;
+            // SQLite databases are snapshotted into a private temporary directory.
+            // Their live WAL/journal files must never be copied independently.
+            let mut snapshot_index = 0u64;
+            Self::add_dir_to_zip(
+                &mut zip,
+                data_dir,
+                data_dir,
+                snapshot_dir.path(),
+                &mut snapshot_index,
+                &options,
+            )?;
 
-        zip.finish()
-            .map_err(|e| format!("Failed to finalize zip: {}", e))?;
+            zip.finish()
+                .map_err(|e| format!("Failed to finalize zip: {}", e))?;
+            Ok(())
+        })();
+
+        if let Err(e) = archive_result {
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(e);
+        }
+        if let Err(e) = std::fs::rename(&partial_path, &backup_path) {
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(format!("Failed to publish backup file: {}", e));
+        }
 
         Ok(backup_path.to_string_lossy().to_string())
     }
@@ -9168,6 +9333,8 @@ impl UserApp {
         zip: &mut zip::ZipWriter<File>,
         dir: &Path,
         base: &Path,
+        snapshot_dir: &Path,
+        snapshot_index: &mut u64,
         options: &zip::write::FileOptions,
     ) -> Result<(), String> {
         if !dir.exists() {
@@ -9191,19 +9358,29 @@ impl UserApp {
                 zip.add_directory(&name, *options)
                     .map_err(|e| format!("Failed to add directory: {}", e))?;
                 // Recursively add contents
-                Self::add_dir_to_zip(zip, &path, base, options)?;
+                Self::add_dir_to_zip(zip, &path, base, snapshot_dir, snapshot_index, options)?;
+            } else if is_sqlite_sidecar(&path) {
+                continue;
             } else {
+                let snapshot_path;
+                let archive_source = if is_sqlite_database(&path) {
+                    snapshot_path =
+                        snapshot_dir.join(format!("database-snapshot-{}.sqlite", *snapshot_index));
+                    *snapshot_index += 1;
+                    snapshot_sqlite_database(&path, &snapshot_path)?;
+                    snapshot_path.as_path()
+                } else {
+                    path.as_path()
+                };
+
                 // Add file
                 zip.start_file(&name, *options)
                     .map_err(|e| format!("Failed to start file: {}", e))?;
 
-                let mut file =
-                    File::open(&path).map_err(|e| format!("Failed to open file: {}", e))?;
-                let mut buffer = Vec::new();
-                file.read_to_end(&mut buffer)
-                    .map_err(|e| format!("Failed to read file: {}", e))?;
-                zip.write_all(&buffer)
-                    .map_err(|e| format!("Failed to write file: {}", e))?;
+                let mut file = File::open(archive_source)
+                    .map_err(|e| format!("Failed to open {} for backup: {}", path.display(), e))?;
+                std::io::copy(&mut file, zip)
+                    .map_err(|e| format!("Failed to archive {}: {}", path.display(), e))?;
             }
         }
 
@@ -9221,6 +9398,27 @@ impl App for UserApp {
         ctx.set_visuals(visuals);
 
         self.process_events();
+
+        // Poll backup worker without blocking rendering.
+        if let Some(rx) = self.backup_receiver.take() {
+            match rx.try_recv() {
+                Ok(Ok(path)) => {
+                    self.status_message = format!("Backup saved to {}", path);
+                    self.show_toast("Backup saved!", "OK");
+                }
+                Ok(Err(e)) => {
+                    self.status_message = format!("Backup failed: {}", e);
+                    self.show_toast("Backup failed", "!");
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {
+                    self.backup_receiver = Some(rx);
+                }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.status_message = "Backup worker stopped unexpectedly".to_string();
+                    self.show_toast("Backup failed", "!");
+                }
+            }
+        }
 
         // Poll background fee rate fetch
         if let Some(ref rx) = self.fee_rate_receiver {
@@ -9657,6 +9855,117 @@ fn collapse_double_paste(input: String) -> String {
     input
 }
 
+fn is_sqlite_database(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "db" | "sqlite" | "sqlite3"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn is_sqlite_sidecar(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            let name = name.to_ascii_lowercase();
+            name.ends_with("-wal") || name.ends_with("-shm") || name.ends_with("-journal")
+        })
+        .unwrap_or(false)
+}
+
+fn snapshot_sqlite_database(source: &Path, destination: &Path) -> Result<(), String> {
+    let source_conn =
+        rusqlite::Connection::open_with_flags(source, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE)
+            .map_err(|e| format!("Failed to open SQLite database {}: {}", source.display(), e))?;
+    source_conn
+        .busy_timeout(Duration::from_secs(15))
+        .map_err(|e| format!("Failed to configure SQLite backup timeout: {}", e))?;
+
+    let destination_string = destination.to_string_lossy().into_owned();
+    source_conn
+        .execute("VACUUM INTO ?1", rusqlite::params![destination_string])
+        .map_err(|e| {
+            format!(
+                "Failed to create consistent snapshot of {}: {}",
+                source.display(),
+                e
+            )
+        })?;
+
+    let snapshot_conn = rusqlite::Connection::open_with_flags(
+        destination,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .map_err(|e| format!("Failed to open SQLite snapshot for verification: {}", e))?;
+    let integrity: String = snapshot_conn
+        .query_row("PRAGMA quick_check(1)", [], |row| row.get(0))
+        .map_err(|e| format!("Failed to verify SQLite snapshot: {}", e))?;
+    if integrity != "ok" {
+        return Err(format!(
+            "SQLite snapshot of {} failed integrity check: {}",
+            source.display(),
+            integrity
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
+    if payload.get("type").and_then(|value| value.as_str()) != Some(SYNC_MESSAGE_TYPE) {
+        return None;
+    }
+    let user_channel_id = payload
+        .get("user_channel_id")?
+        .as_str()?
+        .parse::<u128>()
+        .ok()?;
+    let expected_usd = payload.get("expected_usd")?.as_f64()?;
+    let backing_sats = payload.get("backing_sats")?.as_u64()?;
+    let sync_version = payload.get("sync_version")?.as_u64()?;
+    if !expected_usd.is_finite()
+        || expected_usd < 0.0
+        || sync_version == 0
+        || sync_version > i64::MAX as u64
+        || backing_sats > i64::MAX as u64
+    {
+        return None;
+    }
+    Some(IncomingSync {
+        user_channel_id,
+        expected_usd,
+        backing_sats,
+        sync_version,
+    })
+}
+
+fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(path)?;
+    #[cfg(unix)]
+    file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    file.write_all(contents.as_bytes())?;
+    file.sync_all()
+}
+
+fn restrict_secret_file_permissions(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
 fn btc_amount_to_msat(input: &str) -> Option<u64> {
     let btc = input.trim().parse::<f64>().ok()?;
     if !btc.is_finite() || btc <= 0.0 || btc > 21_000_000.0 {
@@ -9674,7 +9983,8 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        parse_trade_usd_cents, sats_for_usd_cents, UserApp,
+        parse_incoming_sync, parse_trade_usd_cents, restrict_secret_file_permissions,
+        sats_for_usd_cents, write_secret_file, IncomingSync, UserApp,
     };
 
     #[test]
@@ -9794,5 +10104,141 @@ mod tests {
         assert_eq!(UserApp::format_price(1_234.5), "$1,234.50");
         assert_eq!(UserApp::format_price(-0.005), "-$0.01");
         assert_eq!(UserApp::format_price(f64::NAN), "$0.00");
+    }
+
+    #[test]
+    fn sync_payload_requires_channel_and_monotonic_version() {
+        let payload = serde_json::json!({
+            "type": "SYNC_V1",
+            "user_channel_id": "7",
+            "expected_usd": 25.0,
+            "backing_sats": 31_250,
+            "sync_version": 4,
+        });
+        assert_eq!(
+            parse_incoming_sync(&payload),
+            Some(IncomingSync {
+                user_channel_id: 7,
+                expected_usd: 25.0,
+                backing_sats: 31_250,
+                sync_version: 4,
+            })
+        );
+
+        let mut missing_version = payload.clone();
+        missing_version
+            .as_object_mut()
+            .unwrap()
+            .remove("sync_version");
+        assert_eq!(parse_incoming_sync(&missing_version), None);
+
+        let mut zero_version = payload;
+        zero_version["sync_version"] = serde_json::json!(0);
+        assert_eq!(parse_incoming_sync(&zero_version), None);
+
+        let oversized_balance = serde_json::json!({
+            "type": "SYNC_V1",
+            "user_channel_id": "7",
+            "expected_usd": 25.0,
+            "backing_sats": u64::MAX,
+            "sync_version": 5,
+        });
+        assert_eq!(parse_incoming_sync(&oversized_balance), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn seed_file_is_written_and_repaired_as_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seed_phrase");
+        write_secret_file(&path, "test seed").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        restrict_secret_file_permissions(&path).unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn backup_archive_can_be_created_off_thread() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        std::fs::write(source.path().join("wallet.dat"), b"wallet state").unwrap();
+
+        let source_path = source.path().to_path_buf();
+        let output_path = output.path().to_path_buf();
+        let archive =
+            std::thread::spawn(move || UserApp::create_backup_archive(&source_path, &output_path))
+                .join()
+                .unwrap()
+                .unwrap();
+        assert!(std::path::Path::new(&archive).exists());
+    }
+
+    #[test]
+    fn backup_snapshots_live_sqlite_and_excludes_sidecars() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let database_path = source.path().join("ldk_node_data.sqlite");
+        let mut connection = rusqlite::Connection::open(&database_path).unwrap();
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .unwrap();
+        connection
+            .execute("CREATE TABLE wallet_state (value INTEGER NOT NULL)", [])
+            .unwrap();
+        connection
+            .execute("INSERT INTO wallet_state VALUES (1)", [])
+            .unwrap();
+
+        let transaction = connection.transaction().unwrap();
+        transaction
+            .execute("INSERT INTO wallet_state VALUES (2)", [])
+            .unwrap();
+        std::fs::write(source.path().join("orphan.db-journal"), b"stale journal").unwrap();
+
+        let source_path = source.path().to_path_buf();
+        let output_path = output.path().to_path_buf();
+        let backup_worker =
+            std::thread::spawn(move || UserApp::create_backup_archive(&source_path, &output_path));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        drop(transaction);
+
+        let archive_path = backup_worker.join().unwrap().unwrap();
+        let archive_file = std::fs::File::open(archive_path).unwrap();
+        let mut archive = zip::ZipArchive::new(archive_file).unwrap();
+        assert!(archive.by_name("ldk_node_data.sqlite-wal").is_err());
+        assert!(archive.by_name("ldk_node_data.sqlite-shm").is_err());
+        assert!(archive.by_name("orphan.db-journal").is_err());
+
+        let extracted_path = output.path().join("snapshot.sqlite");
+        {
+            let mut archived_database = archive.by_name("ldk_node_data.sqlite").unwrap();
+            let mut extracted = std::fs::File::create(&extracted_path).unwrap();
+            std::io::copy(&mut archived_database, &mut extracted).unwrap();
+        }
+        let snapshot = rusqlite::Connection::open(extracted_path).unwrap();
+        let row_count: i64 = snapshot
+            .query_row("SELECT COUNT(*) FROM wallet_state", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(row_count, 1, "uncommitted writes must not enter a backup");
+    }
+
+    #[test]
+    fn failed_database_snapshot_leaves_no_backup_file() {
+        let source = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        std::fs::write(source.path().join("corrupt.db"), b"not sqlite").unwrap();
+
+        assert!(UserApp::create_backup_archive(source.path(), output.path()).is_err());
+        assert_eq!(std::fs::read_dir(output.path()).unwrap().count(), 0);
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -786,25 +786,6 @@ impl UserApp {
 
         {
             let mut sc = app.stable_channel.lock().unwrap();
-            if let Some(payment_info) = stable::check_stability(&app.node, &mut sc, btc_price) {
-                // Record sent stability payment as pending (confirmed on PaymentSuccessful)
-                let amount_usd = (payment_info.amount_msat as f64 / 1000.0 / 100_000_000.0)
-                    * payment_info.btc_price;
-                let _ = app.db.record_payment(
-                    Some(&payment_info.payment_id),
-                    "stability",
-                    "sent",
-                    payment_info.amount_msat,
-                    Some(amount_usd),
-                    Some(payment_info.btc_price),
-                    Some(&payment_info.counterparty),
-                    "pending",
-                    None,
-                    None,
-                );
-                // Persist updated backing_sats
-                app.save_channel_settings();
-            }
             update_balances(&app.node, &mut sc);
         }
 
@@ -861,40 +842,63 @@ impl UserApp {
                     // Brief lock to update values
                     if let Ok(mut sc) = sc_arc.lock() {
                         if !node_arc.list_channels().is_empty() {
-                            if let Some(payment_info) =
-                                stable_channels::stable::check_stability(&node_arc, &mut sc, price)
+                            stable_channels::stable::update_balances(&node_arc, &mut sc);
+                            if stable_channels::stable::repair_overbacked_allocation(
+                                &mut sc, price,
+                            )
+                            .is_some()
                             {
+                                if let Err(e) = db.save_channel(
+                                    &sc.channel_id.to_string(),
+                                    &format!("{}", sc.user_channel_id),
+                                    sc.expected_usd.0,
+                                    sc.backing_sats,
+                                    sc.native_sats,
+                                    sc.note.as_deref(),
+                                ) {
+                                    audit_event(
+                                        "OVERBACKED_REPAIR_PERSIST_FAILED",
+                                        json!({
+                                            "user_channel_id": format!("{}", sc.user_channel_id),
+                                            "error": e.to_string(),
+                                        }),
+                                    );
+                                }
+                            }
+
+                            if let Some(payment_info) = stable_channels::stable::check_stability(
+                                &node_arc, &mut sc, price,
+                            ) {
                                 // Record sent stability payment as pending (confirmed on PaymentSuccessful)
                                 let amount_usd =
                                     (payment_info.amount_msat as f64 / 1000.0 / 100_000_000.0)
                                         * payment_info.btc_price;
-                                let _ = db.record_payment(
-                                    Some(&payment_info.payment_id),
-                                    "stability",
-                                    "sent",
+                                if let Err(e) = db.record_pending_stability_payment(
+                                    &payment_info.payment_id,
                                     payment_info.amount_msat,
                                     Some(amount_usd),
-                                    Some(payment_info.btc_price),
-                                    Some(&payment_info.counterparty),
-                                    "pending",
-                                    None,
-                                    None,
-                                );
-                                payment_sent = true;
-
-                                // Persist updated backing_sats to DB
-                                let ch_id = sc.channel_id.to_string();
-                                let uch_id = format!("{}", sc.user_channel_id);
-                                if sc.expected_usd.0 > 0.0 {
-                                    let _ = db.save_channel(
-                                        &ch_id,
-                                        &uch_id,
-                                        sc.expected_usd.0,
-                                        sc.backing_sats,
-                                        sc.native_sats,
-                                        sc.note.as_deref(),
+                                    payment_info.btc_price,
+                                    &payment_info.counterparty,
+                                    &sc.channel_id.to_string(),
+                                    &format!("{}", sc.user_channel_id),
+                                    sc.expected_usd.0,
+                                    payment_info.backing_sats_before,
+                                    payment_info.backing_sats_after,
+                                    sc.native_sats,
+                                    sc.note.as_deref(),
+                                ) {
+                                    audit_event(
+                                        "STABILITY_PAYMENT_PERSIST_FAILED",
+                                        json!({
+                                            "payment_id": payment_info.payment_id,
+                                            "user_channel_id": format!("{}", sc.user_channel_id),
+                                            "backing_sats_before": payment_info.backing_sats_before,
+                                            "backing_sats_after": payment_info.backing_sats_after,
+                                            "error": e.to_string(),
+                                        }),
                                     );
                                 }
+                                payment_sent = true;
                             }
                             stable_channels::stable::update_balances(&node_arc, &mut sc);
                         }
@@ -2117,12 +2121,46 @@ impl UserApp {
 
         // Try to load from database by user_channel_id (stable across splices)
         if let Ok(Some(record)) = self.db.load_channel(&user_channel_id_str) {
-            let mut sc = self.stable_channel.lock().unwrap();
-            sc.expected_usd = USD::from_f64(record.expected_usd);
-            sc.backing_sats = record.backing_sats;
-            sc.native_sats = record.native_sats;
-            if record.note.is_some() {
-                sc.note = record.note;
+            let repaired_snapshot = {
+                let mut sc = self.stable_channel.lock().unwrap();
+                sc.expected_usd = USD::from_f64(record.expected_usd);
+                sc.backing_sats = record.backing_sats;
+                sc.native_sats = record.native_sats;
+                if record.note.is_some() {
+                    sc.note = record.note;
+                }
+                stable::update_balances(&self.node, &mut sc);
+                let price = sc.latest_price;
+                stable::repair_overbacked_allocation(&mut sc, price).map(|_| {
+                    (
+                        sc.channel_id.to_string(),
+                        format!("{}", sc.user_channel_id),
+                        sc.expected_usd.0,
+                        sc.backing_sats,
+                        sc.native_sats,
+                        sc.note.clone(),
+                    )
+                })
+            };
+            if let Some((channel_id, user_channel_id, expected, backing, native, note)) =
+                repaired_snapshot
+            {
+                if let Err(e) = self.db.save_channel(
+                    &channel_id,
+                    &user_channel_id,
+                    expected,
+                    backing,
+                    native,
+                    note.as_deref(),
+                ) {
+                    audit_event(
+                        "OVERBACKED_REPAIR_PERSIST_FAILED",
+                        json!({
+                            "user_channel_id": user_channel_id,
+                            "error": e.to_string(),
+                        }),
+                    );
+                }
             }
             return;
         }
@@ -3181,73 +3219,147 @@ impl UserApp {
                     payment_hash,
                     reason,
                 } => {
-                    // Check if this is a pending trade payment
-                    let mut pending_trade =
-                        payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
-                    if pending_trade.is_none() {
-                        if let Some(pid) = payment_id {
-                            match self.db.get_pending_trade_by_payment_id(&format!("{pid}")) {
-                                Ok(Some(row)) => {
-                                    pending_trade = Some(PendingTradePayment {
-                                        new_expected_usd: row.new_expected_usd,
-                                        backing_sats: row.new_backing_sats,
-                                        trade_db_id: row.id,
-                                        action: row.action,
-                                    });
+                    let mut handled_stability_failure = false;
+                    if let Some(pid) = payment_id {
+                        match self
+                            .db
+                            .fail_pending_stability_payment(&format!("{pid}"))
+                        {
+                            Ok(Some(rollback)) => {
+                                handled_stability_failure = true;
+                                let mut memory_restored = false;
+                                if rollback.restored {
+                                    if let (Some(uid), Some(before), Some(after)) = (
+                                        rollback.user_channel_id.as_deref(),
+                                        rollback.backing_sats_before,
+                                        rollback.backing_sats_after,
+                                    ) {
+                                        let mut sc = self.stable_channel.lock().unwrap();
+                                        if format!("{}", sc.user_channel_id) == uid
+                                            && sc.backing_sats == after
+                                        {
+                                            sc.backing_sats = before;
+                                            sc.native_sats = sc
+                                                .stable_receiver_btc
+                                                .sats
+                                                .saturating_sub(before);
+                                            stable::recompute_native(&mut sc);
+                                            sc.last_stability_payment = 0;
+                                            sc.payment_made = false;
+                                            memory_restored = true;
+                                        }
+                                    }
                                 }
-                                Ok(None) => {}
-                                Err(e) => {
-                                    ack = false;
-                                    audit_event(
-                                        "TRADE_PAYMENT_CLASSIFICATION_FAILED",
-                                        json!({
-                                            "payment_id": format!("{pid}"),
-                                            "context": "payment_failed",
-                                            "error": e.to_string(),
-                                        }),
-                                    );
-                                }
+
+                                audit_event(
+                                    "STABILITY_PAYMENT_FAILED_RECONCILED",
+                                    json!({
+                                        "payment_id": format!("{pid}"),
+                                        "payment_hash": payment_hash.map(|h| format!("{h}")),
+                                        "reason": format!("{:?}", reason),
+                                        "user_channel_id": rollback.user_channel_id,
+                                        "backing_sats_before": rollback.backing_sats_before,
+                                        "backing_sats_after": rollback.backing_sats_after,
+                                        "database_restored": rollback.restored,
+                                        "memory_restored": memory_restored,
+                                    }),
+                                );
+                                self.status_message = if rollback.restored {
+                                    "Stability payment failed; allocation restored".to_string()
+                                } else {
+                                    "Stability payment failed; newer allocation preserved"
+                                        .to_string()
+                                };
+                                self.show_toast("Stability payment failed", "X");
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                handled_stability_failure = true;
+                                ack = false;
+                                audit_event(
+                                    "STABILITY_PAYMENT_FAILURE_PERSIST_FAILED",
+                                    json!({
+                                        "payment_id": format!("{pid}"),
+                                        "error": e.to_string(),
+                                    }),
+                                );
                             }
                         }
                     }
 
-                    if let Some(trade) = pending_trade {
-                        // Trade payment failed — mark as failed, don't apply trade
-                        let _ = self.db.update_trade_status(trade.trade_db_id, "failed");
-
-                        audit_event(
-                            "TRADE_FAILED",
-                            json!({
-                                "payment_hash": payment_hash.map(|h| format!("{h}")),
-                                "action": trade.action,
-                                "new_expected_usd": trade.new_expected_usd,
-                                "reason": format!("{:?}", reason),
-                            }),
-                        );
-
-                        let verb =
-                            if trade.action == "buy" { "USD → BTC" } else { "BTC → USD" };
-                        self.status_message = format!("{} order failed: {:?}", verb, reason);
-                        self.show_toast(&format!("{} order failed", verb), "X");
-                    } else if ack {
-                        // Check if this is a pending outgoing payment
-                        let pending = payment_id.and_then(|pid| self.pending_payments.remove(&pid));
-                        if let Some(p) = pending {
-                            let _ = self
-                                .db
-                                .update_payment_status(p.payment_db_id, "failed", None);
+                    if !handled_stability_failure {
+                        // Check if this is a pending trade payment
+                        let mut pending_trade =
+                            payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
+                        if pending_trade.is_none() {
+                            if let Some(pid) = payment_id {
+                                match self.db.get_pending_trade_by_payment_id(&format!("{pid}")) {
+                                    Ok(Some(row)) => {
+                                        pending_trade = Some(PendingTradePayment {
+                                            new_expected_usd: row.new_expected_usd,
+                                            backing_sats: row.new_backing_sats,
+                                            trade_db_id: row.id,
+                                            action: row.action,
+                                        });
+                                    }
+                                    Ok(None) => {}
+                                    Err(e) => {
+                                        ack = false;
+                                        audit_event(
+                                            "TRADE_PAYMENT_CLASSIFICATION_FAILED",
+                                            json!({
+                                                "payment_id": format!("{pid}"),
+                                                "context": "payment_failed",
+                                                "error": e.to_string(),
+                                            }),
+                                        );
+                                    }
+                                }
+                            }
                         }
 
-                        audit_event(
-                            "PAYMENT_FAILED",
-                            json!({
-                                "payment_hash": payment_hash.map(|h| format!("{h}")),
-                                "reason": format!("{:?}", reason),
-                            }),
-                        );
+                        if let Some(trade) = pending_trade {
+                            // Trade payment failed — mark as failed, don't apply trade
+                            let _ = self.db.update_trade_status(trade.trade_db_id, "failed");
 
-                        self.status_message = format!("Payment failed: {:?}", reason);
-                        self.show_toast("Payment failed", "X");
+                            audit_event(
+                                "TRADE_FAILED",
+                                json!({
+                                    "payment_hash": payment_hash.map(|h| format!("{h}")),
+                                    "action": trade.action,
+                                    "new_expected_usd": trade.new_expected_usd,
+                                    "reason": format!("{:?}", reason),
+                                }),
+                            );
+
+                            let verb = if trade.action == "buy" {
+                                "USD → BTC"
+                            } else {
+                                "BTC → USD"
+                            };
+                            self.status_message = format!("{} order failed: {:?}", verb, reason);
+                            self.show_toast(&format!("{} order failed", verb), "X");
+                        } else if ack {
+                            // Check if this is a pending outgoing payment
+                            let pending =
+                                payment_id.and_then(|pid| self.pending_payments.remove(&pid));
+                            if let Some(p) = pending {
+                                let _ = self
+                                    .db
+                                    .update_payment_status(p.payment_db_id, "failed", None);
+                            }
+
+                            audit_event(
+                                "PAYMENT_FAILED",
+                                json!({
+                                    "payment_hash": payment_hash.map(|h| format!("{h}")),
+                                    "reason": format!("{:?}", reason),
+                                }),
+                            );
+
+                            self.status_message = format!("Payment failed: {:?}", reason);
+                            self.show_toast("Payment failed", "X");
+                        }
                     }
                 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -822,29 +822,24 @@ impl UserApp {
             let mut prev_onchain_sats: u64 = node_arc.list_balances().total_onchain_balance_sats;
 
             loop {
-                // Fetch price (network call) OUTSIDE of lock
-                // Bounded timeouts so a geo-blocked/hanging price feed can't freeze this loop.
-                let price_agent = ureq::AgentBuilder::new()
-                    .timeout_connect(Duration::from_secs(5))
-                    .timeout(Duration::from_secs(10))
-                    .build();
-                let price = stable_channels::price_feeds::get_latest_price(&price_agent)
+                // Refresh the shared price state outside the channel lock. This preserves the
+                // last display value through transient failures while honoring accounting
+                // quarantine for validated large-move conflicts.
+                let price = stable_channels::price_feeds::refresh_cached_price()
                     .ok()
                     .filter(|price| *price > 0.0);
 
                 // Automatic stability payments require a freshly validated consensus price.
                 // The last trusted cached price remains available to the UI during an outage.
                 if let Some(price) = price {
-                    // Publish so the UI thread's non-blocking get_cached_price_no_fetch reads stay fresh.
-                    stable_channels::price_feeds::set_cached_price(price);
                     let mut payment_sent = false;
 
                     // Brief lock to update values
                     if let Ok(mut sc) = sc_arc.lock() {
                         if !node_arc.list_channels().is_empty() {
                             stable_channels::stable::update_balances(&node_arc, &mut sc);
-                            if stable_channels::stable::repair_overbacked_allocation(
-                                &mut sc, price,
+                            if stable_channels::stable::repair_overbacked_allocation_if_safe(
+                                &node_arc, &mut sc, price,
                             )
                             .is_some()
                             {
@@ -2131,7 +2126,7 @@ impl UserApp {
                 }
                 stable::update_balances(&self.node, &mut sc);
                 let price = sc.latest_price;
-                stable::repair_overbacked_allocation(&mut sc, price).map(|_| {
+                stable::repair_overbacked_allocation_if_safe(&self.node, &mut sc, price).map(|_| {
                     (
                         sc.channel_id.to_string(),
                         format!("{}", sc.user_channel_id),
@@ -5265,11 +5260,7 @@ impl UserApp {
                         // Force a fresh price fetch in the background, then
                         // refresh balances from LDK + recompute USD values.
                         std::thread::spawn(|| {
-                            let agent = ureq::AgentBuilder::new()
-                                .timeout_connect(Duration::from_secs(5))
-                                .timeout(Duration::from_secs(10))
-                                .build();
-                            let _ = stable_channels::price_feeds::get_latest_price(&agent);
+                            let _ = stable_channels::price_feeds::refresh_cached_price();
                         });
                         self.update_balances();
                         self.show_toast("Refreshing…", "~");

--- a/src/user.rs
+++ b/src/user.rs
@@ -27,7 +27,7 @@ use stable_channels::audit::*;
 use stable_channels::constants::*;
 use stable_channels::db::{self, DailyPriceRecord, Database, PaymentRecord, TradeRecord};
 use stable_channels::historical_prices::get_seed_prices;
-use stable_channels::price_feeds::get_cached_price_no_fetch;
+use stable_channels::price_feeds::{get_cached_price_no_fetch, get_fresh_cached_price_no_fetch};
 use stable_channels::stable;
 use stable_channels::stable::update_balances;
 use stable_channels::types::*;
@@ -2305,7 +2305,11 @@ impl UserApp {
             let mut sc = self.stable_channel.lock().unwrap();
             update_balances(&self.node, &mut sc);
         }
-        let price = self.stable_channel.lock().unwrap().latest_price;
+        // Accounting must not use `latest_price`: during quarantine or staleness it retains the
+        // last positive value, which would price this deduction at a pre-move quote. The fresh
+        // getter returns 0.0 in those states, routing into the deferral below until a new
+        // consensus is admitted.
+        let price = get_fresh_cached_price_no_fetch();
         let event_id = payment_id
             .map(|pid| format!("{pid}"))
             .unwrap_or_else(|| payment_hash.to_string());
@@ -2616,8 +2620,13 @@ impl UserApp {
                                     ack = false;
                                 }
                                 SpliceReconcileAction::ReconcileNow => {
-                                    let price = sc.latest_price;
+                                    // Same constraint as outgoing reconciliation: a quarantined or
+                                    // stale price must defer the deduction, not price it.
+                                    let price = get_fresh_cached_price_no_fetch();
                                     if !price.is_finite() || price <= 0.0 {
+                                        // Breaking out before the loop-tail ack check leaves the
+                                        // event unacknowledged, so LDK redelivers ChannelReady and
+                                        // this deduction retries once a fresh price is admitted.
                                         audit_event(
                                             "SPLICE_OUT_RECONCILE_DEFERRED_NO_PRICE",
                                             json!({


### PR DESCRIPTION
## Summary

  Fixes wallet and LSP bookkeeping so stable USD, native BTC, fees, payments, and splices consistently add up.

  ## Key changes

  - Reworked balance accounting: pegged USD stays fixed at the accepted trade value, native BTC is the remaining live allocation, and full-peg trades no longer leave sub-cent BTC residue.
  - Added signed trade allocations and versioned `SYNC_V1` messages so the wallet and LSP agree on the exact USD and sat allocation without repricing during transmission.
  - Made payment, trade, forwarding, and splice reconciliation atomic, persistent, and idempotent across retries and restarts.
  - Corrected LSP channel balance calculations to exclude commitment fees and use actual peer capacities.
  - Fixed splice-in double counting and splice-out double deduction.
  - Added replay protection, channel binding, allocation validation, and startup synchronization retries.
  - Hardened price validation, amount conversion, maximum-spend calculations, QR generation, and UTF-8 input handling.
  - Moved blocking price, fee, splice, and backup work off the UI thread.
  - Improved SQLite backup consistency and restricted seed-file permissions.