### PR TITLE
build(android): Target Android 16 (API 36) & Compliance Fixes

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -12,12 +12,12 @@ if (file("../google-services.json").exists() || file("google-services.json").exi
 
 android {
     namespace = "com.stablechannels.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.stablechannels.app"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 3
         versionName = "0.9.2"
     }

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -122,7 +122,15 @@ class StabilityProcessingService : Service() {
             .setSmallIcon(R.mipmap.ic_launcher)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
-        startForeground(StableChannelsApp.STABILITY_NOTIFICATION_ID, notification)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            startForeground(
+                StableChannelsApp.STABILITY_NOTIFICATION_ID,
+                notification,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            startForeground(StableChannelsApp.STABILITY_NOTIFICATION_ID, notification)
+        }
 
         isRunning = true
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false


### PR DESCRIPTION
## Summary
This PR prepares the Android application for Android 16 and Google Play's API requirements (deadline Aug 31, 2026).

## Changes
- **build.gradle.kts**: Bumped `compileSdk` and `targetSdk` to API 36.
- **StabilityProcessingService.kt**: Passed `FOREGROUND_SERVICE_TYPE_DATA_SYNC` when launching the foreground service to comply with Android 14+ background service requirements.
