### PR TITLE
feat(iOS): custom lsp

### DIFF
--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		05856856E6E8EF9E688EFA20 /* PriceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0446A88D1E083A380EDC5436 /* PriceService.swift */; };
 		06C3B1697681F176DD44C146 /* StableChannelsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B785A33E02FD999CB62019AD /* StableChannelsApp.swift */; };
 		0CB88B7AD5C868A8BAB15AB7 /* ExportImportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */; };
+		1039784966D1ED4635CA96E6 /* LSPConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379669F5815ECD9926C3A5D2 /* LSPConfig.swift */; };
 		10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F8D724F5E6F0624E67D488 /* SeedWordGridView.swift */; };
 		1A54F909B027D90A0AADD1AF /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95055FDBC76859CB74803660 /* HomeView.swift */; };
 		1A972F89DB503A5171D1525C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFF3730F0DCCB9662892DE /* KeychainService.swift */; };
@@ -103,6 +104,7 @@
 		6CC27037A08B1EC6BC4E3B4F /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCB92A88D9FEEAE6BF49737 /* NotificationService.swift */; };
 		6FC18A5668E49E3CD5E990A8 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB261201C1C656BAAED5283 /* SettingsView.swift */; };
 		7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F22F6639A59D4B86A959586 /* Constants.swift */; };
+		7015C73934B1CDBCEF48751A /* LSPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D4B3FBC893E4863B95AB9 /* LSPService.swift */; };
 		76D934F4495402F7B4944BE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8811E90D4B2B5C5C51093A95 /* Assets.xcassets */; };
 		8173B7F0205744685F9E67E6 /* NodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB0D1D623E0794FC1ED6ED /* NodeService.swift */; };
 		88769D82377C43BCF549A52C /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A9339F75D1A3A7B5313C7 /* HistoryView.swift */; };
@@ -113,6 +115,7 @@
 		96B467E3F04FC01EB23B8413 /* FundWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840E14EF06B6DF0135F2BE70 /* FundWalletView.swift */; };
 		96F38A820CB6644940199C95 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 79D34B41CFF9ABC3C914B624 /* KeychainAccess */; };
 		9EBF713364DF88022CB4F1D0 /* RestoreSeedSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */; };
+		A576FC086B9C883563FBE05A /* LSPSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134775C01F3C51CA39B262FC /* LSPSettingsView.swift */; };
 		A9F8B3821ACA38AD4DF869BD /* CloudBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */; };
 		B4C85619D6A5506E1BD9FC11 /* SellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955C6E8D6DB076A3B20A6F46 /* SellView.swift */; };
 		B58FDE639A431D2000E0F86D /* StableChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD82B198645873A6F492F2 /* StableChannel.swift */; };
@@ -162,7 +165,9 @@
 /* Begin PBXFileReference section */
 		0446A88D1E083A380EDC5436 /* PriceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceService.swift; sourceTree = "<group>"; };
 		07579A3C5174C8FED2BFCFBF /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
+		134775C01F3C51CA39B262FC /* LSPSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LSPSettingsView.swift; sourceTree = "<group>"; };
 		24158DEF5FC6BF7AE004C56B /* StableChannels.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StableChannels.entitlements; sourceTree = "<group>"; };
+		379669F5815ECD9926C3A5D2 /* LSPConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LSPConfig.swift; sourceTree = "<group>"; };
 		3940DC5406ABC63AA090441A /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
 		3B46630309755AE15EF291D4 /* HistoricalPrices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoricalPrices.swift; sourceTree = "<group>"; };
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
@@ -243,6 +248,7 @@
 		5194C003A28A4B2941C7AC40 /* CloudBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudBackupService.swift; sourceTree = "<group>"; };
 		55E70A76A6F35E1A6677742F /* RestoreSeedSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreSeedSheet.swift; sourceTree = "<group>"; };
 		5AFFF3730F0DCCB9662892DE /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		5E0D4B3FBC893E4863B95AB9 /* LSPService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LSPService.swift; sourceTree = "<group>"; };
 		61BB0D1D623E0794FC1ED6ED /* NodeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeService.swift; sourceTree = "<group>"; };
 		623F41D841B312F0C9AE01E6 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		6666E1947A119ECA89E2F4C2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -319,6 +325,7 @@
 			isa = PBXGroup;
 			children = (
 				ABD66CEF54B4AD55A14B6FE1 /* BackupModels.swift */,
+				379669F5815ECD9926C3A5D2 /* LSPConfig.swift */,
 				499F1E563009F03E00936944 /* PaymentProgress.swift */,
 				6DDD82B198645873A6F492F2 /* StableChannel.swift */,
 				45B3E864653E657FB0FCA3D2 /* Trade.swift */,
@@ -463,6 +470,7 @@
 				492B54AB300CC81D003EC383 /* EsploraError.swift */,
 				49DAFB392FDB5FEB003BE0EB /* FeeRateService.swift */,
 				5AFFF3730F0DCCB9662892DE /* KeychainService.swift */,
+				5E0D4B3FBC893E4863B95AB9 /* LSPService.swift */,
 				61BB0D1D623E0794FC1ED6ED /* NodeService.swift */,
 				499DBE6D2FD2DACF003E89F9 /* OnchainTxidResolver.swift */,
 				0446A88D1E083A380EDC5436 /* PriceService.swift */,
@@ -502,6 +510,7 @@
 				49F0B0D72FC0EF3A003A3B89 /* BackupSettingsView.swift */,
 				49F0B0D82FC0EF3A003A3B89 /* ChannelSettingsView.swift */,
 				BDDC110C0BEE6FCEFE32C0AE /* ExportImportSheet.swift */,
+				134775C01F3C51CA39B262FC /* LSPSettingsView.swift */,
 				49AD1B502FEE812E0015A7D9 /* NativeTimerAlert.swift */,
 				49F0B0DA2FC0EF3A003A3B89 /* NodeSettingsView.swift */,
 				49F0B0DB2FC0EF3A003A3B89 /* NotificationsSettingsView.swift */,
@@ -829,6 +838,9 @@
 				10B6FDC89D0F405959F39079 /* SeedWordGridView.swift in Sources */,
 				495CB3FF3017724E00560837 /* ReconnectionManager.swift in Sources */,
 				495CB4003017724E00560837 /* ProcessedTxStore.swift in Sources */,
+				1039784966D1ED4635CA96E6 /* LSPConfig.swift in Sources */,
+				A576FC086B9C883563FBE05A /* LSPSettingsView.swift in Sources */,
+				7015C73934B1CDBCEF48751A /* LSPService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -2602,6 +2602,14 @@ class AppState {
                 stableChannel.nativeSats = record.nativeSats
                 stableChannel.note = record.note
 
+                // Restore authoritative counterparty: prefer active channel's counterpartyNodeId, fallback to active
+                // LSP pubkey
+                if let activeChannel = nodeService.channels.first(where: { $0.isChannelReady }) {
+                    stableChannel.counterparty = activeChannel.counterpartyNodeId
+                } else {
+                    stableChannel.counterparty = lspService.activeLSP.pubkey
+                }
+
                 // Restore cached balances so UI shows immediately
                 if record.receiverSats > 0 {
                     stableChannel.stableReceiverBTC = Bitcoin(sats: record.receiverSats)

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -76,6 +76,7 @@ class AppState {
     /// Views observe this to reload payment data at the right time.
     var confirmationUpdateEpoch: Int = 0
     let mempoolWebSocketService: MempoolWebSocketProtocol = MempoolWebSocketService()
+    let lspService = LSPService()
 
     // MARK: - State
 
@@ -100,6 +101,9 @@ class AppState {
     }()
 
     var hasReadyChannel: Bool = false
+
+    /// The active LSP configuration managed by `LSPService`.
+    var activeLSP: LSPConfig { lspService.activeLSP }
 
     var totalBalanceSats: UInt64 {
         if isChannelClosing {
@@ -323,7 +327,8 @@ class AppState {
             try await nodeService.start(
                 network: .bitcoin,
                 esploraURL: chainURL,
-                mnemonic: words
+                mnemonic: words,
+                lspConfig: activeLSP
             )
 
             let nodeId = nodeService.nodeId
@@ -554,7 +559,8 @@ class AppState {
                 try await nodeService.start(
                     network: .bitcoin,
                     esploraURL: chainURL,
-                    mnemonic: "" // Uses existing seed from data dir
+                    mnemonic: "", // Uses existing seed from data dir
+                    lspConfig: activeLSP
                 )
                 // Store node_id in shared UserDefaults for NSE and push registration
                 let nodeId = nodeService.nodeId
@@ -598,7 +604,8 @@ class AppState {
                 try await nodeService.start(
                     network: .bitcoin,
                     esploraURL: chainURL,
-                    mnemonic: ""
+                    mnemonic: "",
+                    lspConfig: activeLSP
                 )
                 let nodeId = nodeService.nodeId
                 if !nodeId.isEmpty {
@@ -802,7 +809,8 @@ class AppState {
             try await nodeService.start(
                 network: .bitcoin,
                 esploraURL: chainURL,
-                mnemonic: ""
+                mnemonic: "",
+                lspConfig: activeLSP
             )
             refreshBalances()
             blockHeightService.start()
@@ -1060,8 +1068,8 @@ class AppState {
         // Reconnect to LSP so pending payment can be received
         do {
             try nodeService.node?.connect(
-                nodeId: Constants.defaultLSPPubkey,
-                address: Constants.defaultLSPAddress,
+                nodeId: activeLSP.pubkey,
+                address: activeLSP.address,
                 persist: true
             )
 
@@ -1107,8 +1115,8 @@ class AppState {
             guard let self, self.nodeService.isRunning else { return }
             // Re-connect to LSP to ensure we can receive the pending payment
             try? self.nodeService.node?.connect(
-                nodeId: Constants.defaultLSPPubkey,
-                address: Constants.defaultLSPAddress,
+                nodeId: self.activeLSP.pubkey,
+                address: self.activeLSP.address,
                 persist: true
             )
             self.refreshBalances()
@@ -2027,8 +2035,8 @@ class AppState {
         // can block for seconds — long enough for the iOS watchdog to kill the app.
         // Dispatch off the main actor so the UI stays responsive. .utility priority because
         // this is opportunistic plumbing — no user is actively waiting on it.
-        let lspPubkey = Constants.defaultLSPPubkey
-        let lspAddress = Constants.defaultLSPAddress
+        let lspPubkey = activeLSP.pubkey
+        let lspAddress = activeLSP.address
         Task.detached(priority: .utility) {
             try? node.connect(nodeId: lspPubkey, address: lspAddress, persist: true)
         }
@@ -2395,8 +2403,8 @@ class AppState {
                 // Reserve some sats for fees
                 let channelSats = spendable - 5_000
                 try await nodeService.connectAndOpenChannel(
-                    pubkey: Constants.defaultLSPPubkey,
-                    address: Constants.defaultLSPAddress,
+                    pubkey: activeLSP.pubkey,
+                    address: activeLSP.address,
                     amountSats: channelSats
                 )
                 await MainActor.run {
@@ -2681,5 +2689,20 @@ class AppState {
         } catch {
             print("[Chart] Failed to seed historical prices: \(error)")
         }
+    }
+
+    // MARK: - LSP Configuration
+
+    /// Switch to a new LSP configuration via LSPService.
+    @MainActor
+    func switchLSP(to newConfig: LSPConfig) async -> Bool {
+        await lspService.switchLSP(
+            to: newConfig,
+            nodeService: nodeService,
+            chainURL: chainURL,
+            onSuccess: { [weak self] in
+                self?.refreshBalances()
+            }
+        )
     }
 }

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -2701,7 +2701,11 @@ class AppState {
             nodeService: nodeService,
             chainURL: chainURL,
             onSuccess: { [weak self] in
-                self?.refreshBalances()
+                guard let self else { return }
+                if self.stableChannel.channelId.isEmpty {
+                    self.stableChannel.counterparty = newConfig.pubkey
+                }
+                self.refreshBalances()
             }
         )
     }

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -2602,12 +2602,12 @@ class AppState {
                 stableChannel.nativeSats = record.nativeSats
                 stableChannel.note = record.note
 
-                // Restore authoritative counterparty: prefer active channel's counterpartyNodeId, fallback to active
-                // LSP pubkey
-                if let activeChannel = nodeService.channels.first(where: { $0.isChannelReady }) {
-                    stableChannel.counterparty = activeChannel.counterpartyNodeId
-                } else {
-                    stableChannel.counterparty = lspService.activeLSP.pubkey
+                // Restore the counterparty from the same channel identity used to load this record.
+                // Readiness is intentionally irrelevant: pending channels still have an authoritative peer.
+                if let matchingChannel = nodeService.channels.first(where: {
+                    $0.userChannelId == record.userChannelId
+                }) {
+                    stableChannel.counterparty = matchingChannel.counterpartyNodeId
                 }
 
                 // Restore cached balances so UI shows immediately

--- a/ios/StableChannels/StableChannels/Domain/LSPConfig.swift
+++ b/ios/StableChannels/StableChannels/Domain/LSPConfig.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct LSPConfig: Codable, Equatable {
+    let alias: String
+    let pubkey: String
+    let address: String
+    let token: String?
+
+    static let `default` = LSPConfig(
+        alias: "stablechannels.com",
+        pubkey: Constants.defaultLSPPubkey,
+        address: Constants.defaultLSPAddress,
+        token: nil
+    )
+
+    // MARK: - Persistence
+
+    private static let userDefaultsKey = "active_lsp_config"
+
+    static func load() -> LSPConfig {
+        let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        guard let data = shared?.data(forKey: userDefaultsKey),
+              let config = try? JSONDecoder().decode(LSPConfig.self, from: data)
+        else {
+            return .default
+        }
+        return config
+    }
+
+    func save() {
+        let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        if let data = try? JSONEncoder().encode(self) {
+            shared?.set(data, forKey: Self.userDefaultsKey)
+        }
+    }
+
+    static func resetToDefault() {
+        let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        shared?.removeObject(forKey: userDefaultsKey)
+    }
+
+    // MARK: - Validation
+
+    static func isValidPubkey(_ key: String) -> Bool {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 66 else { return false }
+        guard trimmed.hasPrefix("02") || trimmed.hasPrefix("03") else { return false }
+        return trimmed.allSatisfy(\.isHexDigit)
+    }
+
+    static func isValidAddress(_ addr: String) -> Bool {
+        let trimmed = addr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2,
+              !parts[0].isEmpty,
+              UInt16(parts[1]) != nil
+        else {
+            return false
+        }
+        return true
+    }
+
+    var isDefault: Bool {
+        self == LSPConfig.default
+    }
+}

--- a/ios/StableChannels/StableChannels/Domain/LSPConfig.swift
+++ b/ios/StableChannels/StableChannels/Domain/LSPConfig.swift
@@ -29,7 +29,9 @@ struct LSPConfig: Codable, Equatable {
 
     func save() {
         let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        if let data = try? JSONEncoder().encode(self) {
+        if isDefault {
+            shared?.removeObject(forKey: Self.userDefaultsKey)
+        } else if let data = try? JSONEncoder().encode(self) {
             shared?.set(data, forKey: Self.userDefaultsKey)
         }
     }

--- a/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
@@ -47,7 +47,7 @@ struct LSPSettingsView: View {
             ))
         }
         .alert(
-            String(localized: "alert_reset_lsp_title", defaultValue: "Reset to Default"),
+            String(localized: "alert_reset_lsp_title", defaultValue: "Reset LSP"),
             isPresented: $showResetAlert
         ) {
             Button(String(localized: "alert_cancel", defaultValue: "Cancel"), role: .cancel) {}
@@ -281,7 +281,7 @@ struct LSPSettingsView: View {
             } label: {
                 HStack {
                     Image(systemName: "arrow.counterclockwise")
-                    Text(String(localized: "button_reset_lsp", defaultValue: "Reset to Default LSP"))
+                    Text(String(localized: "button_reset_lsp", defaultValue: "Reset LSP"))
                 }
             }
             .disabled(appState.activeLSP.isDefault || isRestarting)

--- a/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
@@ -1,0 +1,404 @@
+import SwiftUI
+
+struct LSPSettingsView: View {
+    @Environment(AppState.self) private var appState
+
+    @State private var alias = ""
+    @State private var pubkey = ""
+    @State private var address = ""
+    @State private var token = ""
+
+    @State private var showResetAlert = false
+    @State private var showConnectAlert = false
+    @State private var validationError: String?
+    @State private var isRestarting = false
+    @State private var showSuccess = false
+
+    private var hasActiveChannel: Bool {
+        !appState.nodeService.channels.isEmpty
+    }
+
+    var body: some View {
+        List {
+            activeLSPSection
+
+            if hasActiveChannel {
+                channelLockedSection
+            } else {
+                customLSPFormSection
+                resetSection
+            }
+        }
+        .navigationTitle(String(localized: "title_lsp", defaultValue: "Lightning Service Provider"))
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { loadCurrentConfig() }
+        .alert(
+            String(localized: "alert_connect_lsp_title", defaultValue: "Connect to LSP"),
+            isPresented: $showConnectAlert
+        ) {
+            Button(String(localized: "alert_cancel", defaultValue: "Cancel"), role: .cancel) {}
+            Button(String(localized: "alert_connect", defaultValue: "Connect")) {
+                applyCustomLSP()
+            }
+        } message: {
+            Text(String(
+                localized: "alert_connect_lsp_message",
+                defaultValue: "This will restart your node to connect to the new LSP. No funds will be lost."
+            ))
+        }
+        .alert(
+            String(localized: "alert_reset_lsp_title", defaultValue: "Reset to Default"),
+            isPresented: $showResetAlert
+        ) {
+            Button(String(localized: "alert_cancel", defaultValue: "Cancel"), role: .cancel) {}
+            Button(String(localized: "alert_reset", defaultValue: "Reset"), role: .destructive) {
+                resetToDefault()
+            }
+        } message: {
+            Text(String(
+                localized: "alert_reset_lsp_message",
+                defaultValue: "This will reconnect to the default Stable Channels LSP and restart your node."
+            ))
+        }
+    }
+
+    // MARK: - Active LSP
+
+    private var activeLSPSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    ZStack {
+                        Circle()
+                            .fill(connectionColor.opacity(0.15))
+                            .frame(width: 36, height: 36)
+                        Image(systemName: "server.rack")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(connectionColor)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(appState.activeLSP.alias)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(connectionColor)
+                                .frame(width: 6, height: 6)
+                            Text(connectionLabel)
+                                .font(.caption2)
+                                .foregroundStyle(connectionColor)
+                        }
+                    }
+                    Spacer()
+                    if appState.activeLSP.isDefault {
+                        Text(String(localized: "badge_default", defaultValue: "Default"))
+                            .font(.caption2)
+                            .fontWeight(.medium)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(Color.green.opacity(0.12))
+                            .foregroundStyle(.green)
+                            .clipShape(Capsule())
+                    } else {
+                        Text(String(localized: "badge_custom", defaultValue: "Custom"))
+                            .font(.caption2)
+                            .fontWeight(.medium)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(Color.cyan.opacity(0.12))
+                            .foregroundStyle(.cyan)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                Divider()
+
+                configRow(
+                    label: String(localized: "label_pubkey", defaultValue: "Pubkey"),
+                    value: String(appState.activeLSP.pubkey.prefix(12)) + "..." +
+                        String(appState.activeLSP.pubkey.suffix(8))
+                )
+                configRow(
+                    label: String(localized: "label_address", defaultValue: "Address"),
+                    value: appState.activeLSP.address
+                )
+            }
+            .padding(.vertical, 4)
+        } header: {
+            Text(String(localized: "section_active_lsp", defaultValue: "Active LSP"))
+        }
+    }
+
+    // MARK: - Channel Locked
+
+    private var channelLockedSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(
+                        localized: "lsp_locked_title",
+                        defaultValue: "LSP configuration locked"
+                    ))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    Text(String(
+                        localized: "lsp_locked_body",
+                        defaultValue: "Close your active channel to switch LSP."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+        } footer: {
+            Text(String(
+                localized: "lsp_locked_footer",
+                defaultValue: "The Lightning Service Provider cannot be changed while a channel is open. The counterparty node is part of the channel's funding transaction."
+            ))
+        }
+    }
+
+    // MARK: - Custom LSP Form
+
+    private var customLSPFormSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "label_display_name", defaultValue: "Display Name"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField(
+                    String(localized: "placeholder_alias", defaultValue: "My LSP"),
+                    text: $alias
+                )
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+            }
+            .padding(.vertical, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "label_node_pubkey", defaultValue: "Node Pubkey"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField(
+                    String(localized: "placeholder_pubkey", defaultValue: "02... or 03..."),
+                    text: $pubkey
+                )
+                .font(.system(.caption, design: .monospaced))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            }
+            .padding(.vertical, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "label_host_port", defaultValue: "Host:Port"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField(
+                    String(localized: "placeholder_address", defaultValue: "example.com:9735"),
+                    text: $address
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+            }
+            .padding(.vertical, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "label_lsps2_token", defaultValue: "LSPS2 Token (optional)"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField(
+                    String(localized: "placeholder_token", defaultValue: "Leave empty if not required"),
+                    text: $token
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            }
+            .padding(.vertical, 2)
+
+            if let error = validationError {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            if showSuccess {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                    Text(String(localized: "lsp_switch_success", defaultValue: "Node restarted with new LSP"))
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+                .transition(.scale.combined(with: .opacity))
+            }
+
+            Button {
+                validateAndConnect()
+            } label: {
+                HStack {
+                    Spacer()
+                    if isRestarting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Label(
+                            String(localized: "button_connect_lsp", defaultValue: "Connect"),
+                            systemImage: "bolt.fill"
+                        )
+                        .fontWeight(.semibold)
+                    }
+                    Spacer()
+                }
+            }
+            .disabled(isRestarting)
+            .padding(.vertical, 4)
+        } header: {
+            Text(String(localized: "section_custom_lsp", defaultValue: "Connect to a Custom LSP"))
+        } footer: {
+            Text(String(
+                localized: "info_custom_lsp",
+                defaultValue: "Enter the details of any LSPS2-compatible Lightning Service Provider. Your node will restart to apply the new configuration."
+            ))
+        }
+    }
+
+    // MARK: - Reset
+
+    private var resetSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showResetAlert = true
+            } label: {
+                HStack {
+                    Image(systemName: "arrow.counterclockwise")
+                    Text(String(localized: "button_reset_lsp", defaultValue: "Reset to Default LSP"))
+                }
+            }
+            .disabled(appState.activeLSP.isDefault || isRestarting)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var connectionColor: Color {
+        guard appState.nodeService.isRunning else { return .red }
+        let isConnected = appState.nodeService.channels.contains {
+            $0.counterpartyNodeId == appState.activeLSP.pubkey
+        }
+        // If the node is running we consider it "connected" to the LSP for
+        // visual purposes. Peer-level connectivity is managed by LDK internally.
+        return isConnected || appState.nodeService.isRunning ? .green : .orange
+    }
+
+    private var connectionLabel: String {
+        guard appState.nodeService.isRunning else {
+            return String(localized: "status_offline", defaultValue: "Offline")
+        }
+        return String(localized: "status_connected", defaultValue: "Connected")
+    }
+
+    private func configRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func loadCurrentConfig() {
+        let config = appState.activeLSP
+        alias = config.alias
+        pubkey = config.pubkey
+        address = config.address
+        token = config.token ?? ""
+    }
+
+    private func validateAndConnect() {
+        validationError = nil
+
+        let trimmedAlias = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPubkey = pubkey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedAlias.isEmpty else {
+            validationError = String(localized: "error_alias_empty", defaultValue: "Display name is required.")
+            return
+        }
+        guard LSPConfig.isValidPubkey(trimmedPubkey) else {
+            validationError = String(
+                localized: "error_pubkey_invalid",
+                defaultValue: "Pubkey must be a 66-character hex string starting with 02 or 03."
+            )
+            return
+        }
+        guard LSPConfig.isValidAddress(trimmedAddress) else {
+            validationError = String(
+                localized: "error_address_invalid",
+                defaultValue: "Address must be in host:port format (e.g. example.com:9735)."
+            )
+            return
+        }
+
+        showConnectAlert = true
+    }
+
+    private func applyCustomLSP() {
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let config = LSPConfig(
+            alias: alias.trimmingCharacters(in: .whitespacesAndNewlines),
+            pubkey: pubkey.trimmingCharacters(in: .whitespacesAndNewlines),
+            address: address.trimmingCharacters(in: .whitespacesAndNewlines),
+            token: trimmedToken.isEmpty ? nil : trimmedToken
+        )
+
+        isRestarting = true
+        validationError = nil
+
+        Task { @MainActor in
+            let success = await appState.switchLSP(to: config)
+            isRestarting = false
+            if success {
+                withAnimation { showSuccess = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    withAnimation { showSuccess = false }
+                }
+            } else {
+                validationError = String(
+                    localized: "error_lsp_restart_failed",
+                    defaultValue: "Failed to connect. The node has been restored to the previous LSP."
+                )
+            }
+        }
+    }
+
+    private func resetToDefault() {
+        isRestarting = true
+        validationError = nil
+
+        Task { @MainActor in
+            let success = await appState.switchLSP(to: .default)
+            isRestarting = false
+            loadCurrentConfig()
+            if !success {
+                validationError = String(
+                    localized: "error_lsp_reset_failed",
+                    defaultValue: "Failed to reset. Please try again."
+                )
+            }
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/LSPSettingsView.swift
@@ -267,7 +267,7 @@ struct LSPSettingsView: View {
         } footer: {
             Text(String(
                 localized: "info_custom_lsp",
-                defaultValue: "Enter the details of any LSPS2-compatible Lightning Service Provider. Your node will restart to apply the new configuration."
+                defaultValue: "Enter the details of a compatible Lightning Service Provider. Your node will restart to apply the new configuration."
             ))
         }
     }

--- a/ios/StableChannels/StableChannels/Features/Settings/SettingsView.swift
+++ b/ios/StableChannels/StableChannels/Features/Settings/SettingsView.swift
@@ -109,6 +109,15 @@ struct SettingsView: View {
                             text: String(localized: "link_push_connectivity", defaultValue: "Push Connectivity")
                         )
                     }
+                    NavigationLink {
+                        LSPSettingsView()
+                    } label: {
+                        rowLabel(
+                            icon: "server.rack",
+                            color: .cyan,
+                            text: String(localized: "link_lsp", defaultValue: "Lightning Service Provider")
+                        )
+                    }
                 } header: {
                     Text(String(localized: "section_node_network", defaultValue: "Node & Network"))
                         .font(.headline)

--- a/ios/StableChannels/StableChannels/Services/LSPService.swift
+++ b/ios/StableChannels/StableChannels/Services/LSPService.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class LSPService {
+    private(set) var activeLSP: LSPConfig
+
+    init(initialConfig: LSPConfig = .load()) {
+        self.activeLSP = initialConfig
+    }
+
+    func switchLSP(
+        to newConfig: LSPConfig,
+        nodeService: NodeServiceProtocol,
+        chainURL: String,
+        onSuccess: @MainActor () -> Void = {}
+    ) async -> Bool {
+        guard !nodeService.channels.contains(where: { $0.isChannelReady || $0.isUsable }) else {
+            return false
+        }
+
+        let oldConfig = activeLSP
+        activeLSP = newConfig
+        newConfig.save()
+
+        nodeService.stop()
+        NodeDirLock.shared.release()
+
+        do {
+            try await nodeService.start(
+                network: .bitcoin,
+                esploraURL: chainURL,
+                mnemonic: "",
+                lspConfig: newConfig
+            )
+            onSuccess()
+            return true
+        } catch {
+            print("[LSPService] Failed to start node with new LSP config: \(error.localizedDescription)")
+            activeLSP = oldConfig
+            oldConfig.save()
+
+            nodeService.stop()
+            NodeDirLock.shared.release()
+
+            try? await nodeService.start(
+                network: .bitcoin,
+                esploraURL: chainURL,
+                mnemonic: "",
+                lspConfig: oldConfig
+            )
+            return false
+        }
+    }
+}

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -86,7 +86,8 @@ protocol NodeServiceProtocol {
     var nodeId: String { get }
     var channels: [ChannelDetails] { get }
     var savedMnemonic: String? { get }
-    func start(network: Network, esploraURL: String, mnemonic: String) async throws
+    func start(network: Network, esploraURL: String, mnemonic: String, lspConfig: LSPConfig) async throws
+    func stop()
 }
 
 @Observable
@@ -120,7 +121,7 @@ class NodeService: NodeServiceProtocol {
 
     // MARK: - Lifecycle
 
-    func start(network: Network, esploraURL: String, mnemonic: String) async throws {
+    func start(network: Network, esploraURL: String, mnemonic: String, lspConfig: LSPConfig = .default) async throws {
         guard !isRunning else { throw NodeServiceError.alreadyRunning }
         isStarting = true
         defer { isStarting = false }
@@ -147,11 +148,11 @@ class NodeService: NodeServiceProtocol {
         var config = defaultConfig()
         config.storageDirPath = dataDir
         config.network = network
-        config.trustedPeers0conf = [Constants.defaultLSPPubkey]
+        config.trustedPeers0conf = [lspConfig.pubkey]
 
         // Anchor channels: trust LSP so no reserve held for their channel
         config.anchorChannelsConfig = AnchorChannelsConfig(
-            trustedPeersNoReserve: [Constants.defaultLSPPubkey],
+            trustedPeersNoReserve: [lspConfig.pubkey],
             perChannelReserveSats: 25_000
         )
 
@@ -189,9 +190,9 @@ class NodeService: NodeServiceProtocol {
 
         // LSPS2 liquidity source — enables JIT channel opening on first receive
         builder.setLiquiditySourceLsps2(
-            nodeId: Constants.defaultLSPPubkey,
-            address: Constants.defaultLSPAddress,
-            token: nil
+            nodeId: lspConfig.pubkey,
+            address: lspConfig.address,
+            token: lspConfig.token
         )
 
         let seedPhrasePath = Constants.userDataDir.appendingPathComponent("seed_phrase")
@@ -236,8 +237,8 @@ class NodeService: NodeServiceProtocol {
 
         // Connect to LSP
         try? ldkNode.connect(
-            nodeId: Constants.defaultLSPPubkey,
-            address: Constants.defaultLSPAddress,
+            nodeId: lspConfig.pubkey,
+            address: lspConfig.address,
             persist: true
         )
 

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -235,12 +235,21 @@ class NodeService: NodeServiceProtocol {
         self.isRunning = true
         self.nodeId = ldkNode.nodeId()
 
-        // Connect to LSP
-        try? ldkNode.connect(
-            nodeId: lspConfig.pubkey,
-            address: lspConfig.address,
-            persist: true
-        )
+        // Connect to LSP — propagate error if custom LSP fails so switchLSP rolls back
+        do {
+            try ldkNode.connect(
+                nodeId: lspConfig.pubkey,
+                address: lspConfig.address,
+                persist: true
+            )
+        } catch {
+            print(
+                "[NodeService] Warning: Could not connect to LSP (\(lspConfig.address)): \(error.localizedDescription)"
+            )
+            if !lspConfig.isDefault {
+                throw error
+            }
+        }
 
         refreshChannels()
         startEventLoop()

--- a/ios/StableChannels/StableChannels/Services/StabilityService.swift
+++ b/ios/StableChannels/StableChannels/Services/StabilityService.swift
@@ -201,8 +201,9 @@ enum StabilityService {
             sc.userChannelId = channel.userChannelId
             sc.channelId = channel.channelId
         }
-        // Always keep channelId current (it changes on splice)
+        // Always keep channelId & counterparty current
         sc.channelId = channel.channelId
+        sc.counterparty = channel.counterpartyNodeId
 
         // Skip balance update if channel is not ready yet — during ChannelPending,
         // outbound_capacity_msat is 0, which produces a misleading near-zero balance.


### PR DESCRIPTION
## Summary

Adds custom LSP (Lightning Service Provider) configuration support for iOS. Users can configure and connect to any LSPS2-compatible LSP, with format validation, channel-active safety gating, dynamic counterparty pubkey synchronization, and automatic fault-recovery rollback if a new LSP fails to start or connect.

---

## Architecture Sequence Diagram


<img width="8192" height="5174" alt="image" src="https://github.com/user-attachments/assets/fbc7c33c-923d-4361-b862-bda32cfb4790" />


---

## Key Changes

1. **`LSPConfig.swift`** — Domain model for LSP configurations:
   - Stores `pubkey`, `address` (`host:port`), `token`, and `alias`.
   - Persists securely in `UserDefaults` (app group suite) so background extensions can read it.
   - Includes format validators (`isValidPubkey`, `isValidAddress`) and `save()` method that cleans up keys when resetting to default.

2. **`LSPService.swift`** — Single Responsibility service managing LSP lifecycle:
   - Encapsulates `activeLSP` state and `switchLSP(to:)`.
   - Executes safe in-process node restarts: `nodeService.stop()` -> `NodeDirLock.release()` -> `nodeService.start(...)`.
   - Automatic rollback: If starting or connecting to a custom LSP throws an error, it immediately restores the previous `LSPConfig`, re-saves it, and restarts the node safely.

3. **`LSPSettingsView.swift`** — Channel-aware SwiftUI settings interface:
   - Displays active LSP details (alias, connection status, truncated pubkey, address).
   - Form inputs with real-time validation error alerts.
   - Gated UI: When `appState.nodeService.channels` is non-empty, the configuration form is disabled with a locked channel warning.
   - Action buttons for "Connect" and "Reset LSP".

4. **`NodeService.swift`** — Dynamic LSP initialization & error propagation:
   - Updated `NodeServiceProtocol` and `start()` to accept `LSPConfig`.
   - Propagates LSP connection errors for custom LSPs so unreachable hosts or bad pubkeys trigger the `switchLSP` rollback path rather than failing silently.

5. **`AppState.swift`** — Environment orchestration:
   - Holds `let lspService = LSPService()` and delegates `activeLSP` and `switchLSP`.
   - Synchronizes `stableChannel.counterparty = newConfig.pubkey` on switch when no channel is open so subsequent trades and channel funding target the active LSP.

---
| Settings Hub | LSP Settings |
| :---: | :---: |
| <img width="400" alt="Settings Hub" src="https://github.com/user-attachments/assets/ff67dc10-ea34-4fa8-b670-c0da9a57952c" /> | <img width="400" alt="LSP Settings" src="https://github.com/user-attachments/assets/0285686a-ab15-4174-8a78-bac5759da0fd" /> |


---
## Related
- Closes #206 