### PR TITLE
feat(iOS): automated 90-day price history pruning

### DIFF
--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -220,6 +220,13 @@ final class DatabaseService {
         if !paymentsColNames.contains("resolution_id") {
             try rawSQL.execute("ALTER TABLE payments ADD COLUMN resolution_id INTEGER")
         }
+
+        try pruneHistoricalData()
+    }
+
+    private func pruneHistoricalData() throws {
+        let cutoffSeconds = 90 * 86400
+        try rawSQL.execute("DELETE FROM price_history WHERE timestamp < strftime('%s', 'now') - \(cutoffSeconds)")
     }
 
     // MARK: - Transaction & SPV Header Delegations

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -567,4 +567,30 @@ final class DatabaseServiceTests: XCTestCase {
         // must not return nil.
         XCTAssertNotNil(second)
     }
+
+    // MARK: - Price History Pruning Tests
+
+    func testPruneHistoricalDataPurgesStalePriceHistory() throws {
+        let now = Int64(Date().timeIntervalSince1970)
+        let freshTimestamp = now - 3600 // 1 hour ago
+        let staleTimestamp = now - 10_000_000 // > 90 days ago (90 days = 7,776,000 sec)
+
+        // Insert fresh and stale price history records
+        try service.rawSQL.execute(
+            "INSERT INTO price_history (price, source, timestamp) VALUES (?, ?, ?)",
+            params: [.real(60_000), .text("test_fresh"), .integer(freshTimestamp)]
+        )
+        try service.rawSQL.execute(
+            "INSERT INTO price_history (price, source, timestamp) VALUES (?, ?, ?)",
+            params: [.real(50_000), .text("test_stale"), .integer(staleTimestamp)]
+        )
+
+        // Re-init DatabaseService to trigger pruneHistoricalData()
+        service = nil
+        let newService = try DatabaseService(dataDir: dataDir)
+
+        let history = try newService.priceRepo.getPriceHistory(hours: 24 * 365) // Query 1 year
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history.first?.price, 60_000)
+    }
 }


### PR DESCRIPTION
## Summary

Adds automated 90-day price history pruning in `DatabaseService` to automatically purge stale spot price records and prevent mobile database storage bloat over time.

---

## Problem

**Unbounded Database Storage**: The `price_history` table continuously accumulates BTC spot price records over time without automatic pruning, increasing SQLite database file size on mobile devices over months of usage.

---

## Solution

1. **Automated 90-Day Price History Pruning**:
   - Added `pruneHistoricalData()` in `DatabaseService` executing `DELETE FROM price_history WHERE timestamp < strftime('%s', 'now') - 7776000` to automatically purge price history entries older than 90 days during database initialization.
2. **Unit Testing**:
   - Added `testPruneHistoricalDataPurgesStalePriceHistory` in `DatabaseServiceTests.swift` validating that price history entries older than 90 days are purged while fresh entries survive.

---

## Key Changes

1. **`DatabaseService.swift`**:
   - Added `pruneHistoricalData()` called in `initSchema()` to purge `price_history` entries older than 90 days (`90 * 86400` seconds).

2. **`DatabaseServiceTests.swift`**:
   - `testPruneHistoricalDataPurgesStalePriceHistory`: Verifies price history entries older than 90 days are purged while fresh entries survive.

---

## Related
- Closes #212
