### PR TITLE
feat(iOS): database indexes and migrations

### DIFF
--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -189,7 +189,15 @@ final class DatabaseService {
             "CREATE INDEX IF NOT EXISTS idx_daily_prices_date ON daily_prices(date DESC)",
             "CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_onchain_receive_txids_status ON onchain_receive_txids(status)",
-            "CREATE INDEX IF NOT EXISTS idx_block_headers_hash ON block_headers(hash)"
+            "CREATE INDEX IF NOT EXISTS idx_block_headers_hash ON block_headers(hash)",
+            "CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)",
+            "CREATE INDEX IF NOT EXISTS idx_payments_txid ON payments(txid) WHERE txid IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_pending_ops_funding_txid ON pending_operations(funding_outpoint_txid) WHERE funding_outpoint_txid IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_payments_resolution_id ON payments(resolution_id) WHERE resolution_id IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_payments_type_status ON payments(payment_type, status)",
+            "CREATE INDEX IF NOT EXISTS idx_trades_channel_id ON trades(channel_id)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique ON payments(payment_id) WHERE payment_id IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_payments_confirmation_scan ON payments(txid, payment_type, status, confirmations) WHERE txid IS NOT NULL"
         ]
 
         for sql in statements {

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -245,16 +245,16 @@ final class DatabaseService {
         ).isEmpty
         if !hasUniquePaymentIndex {
             try rawSQL.execute("""
-                DELETE FROM payments
-                WHERE payment_id IS NOT NULL AND payment_id != ''
-                  AND id NOT IN (SELECT MIN(id) FROM payments
-                                 WHERE payment_id IS NOT NULL AND payment_id != ''
-                                 GROUP BY payment_id)
-                """)
+            DELETE FROM payments
+            WHERE payment_id IS NOT NULL AND payment_id != ''
+              AND id NOT IN (SELECT MIN(id) FROM payments
+                             WHERE payment_id IS NOT NULL AND payment_id != ''
+                             GROUP BY payment_id)
+            """)
             try rawSQL.execute("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique
-                ON payments(payment_id) WHERE payment_id IS NOT NULL AND payment_id != ''
-                """)
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique
+            ON payments(payment_id) WHERE payment_id IS NOT NULL AND payment_id != ''
+            """)
         }
 
         try pruneHistoricalData()

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -191,12 +191,9 @@ final class DatabaseService {
             "CREATE INDEX IF NOT EXISTS idx_onchain_receive_txids_status ON onchain_receive_txids(status)",
             "CREATE INDEX IF NOT EXISTS idx_block_headers_hash ON block_headers(hash)",
             "CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)",
-            "CREATE INDEX IF NOT EXISTS idx_payments_txid ON payments(txid) WHERE txid IS NOT NULL",
             "CREATE INDEX IF NOT EXISTS idx_pending_ops_funding_txid ON pending_operations(funding_outpoint_txid) WHERE funding_outpoint_txid IS NOT NULL",
-            "CREATE INDEX IF NOT EXISTS idx_payments_resolution_id ON payments(resolution_id) WHERE resolution_id IS NOT NULL",
             "CREATE INDEX IF NOT EXISTS idx_payments_type_status ON payments(payment_type, status)",
             "CREATE INDEX IF NOT EXISTS idx_trades_channel_id ON trades(channel_id)",
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique ON payments(payment_id) WHERE payment_id IS NOT NULL",
             "CREATE INDEX IF NOT EXISTS idx_payments_confirmation_scan ON payments(txid, payment_type, status, confirmations) WHERE txid IS NOT NULL"
         ]
 
@@ -227,6 +224,37 @@ final class DatabaseService {
         // Migrate: add resolution_id to payments if missing (onchain deposit <-> resolver link)
         if !paymentsColNames.contains("resolution_id") {
             try rawSQL.execute("ALTER TABLE payments ADD COLUMN resolution_id INTEGER")
+        }
+
+        // Must come after the resolution_id ALTER above — on legacy DBs the column
+        // doesn't exist yet when the main statements array runs, and indexing a
+        // missing column would abort init.
+        try rawSQL.execute(
+            "CREATE INDEX IF NOT EXISTS idx_payments_resolution_id ON payments(resolution_id) WHERE resolution_id IS NOT NULL"
+        )
+
+        // Unique payment_id index: the engine-level backstop for PaymentRepository's
+        // check-then-insert dedup. Existing installs may hold duplicate rows from the
+        // pre-NodeDirLock multi-writer era, and building the index over them would
+        // fail and abort init — so dedup must run first, keeping the first-recorded
+        // row per payment_id (the outcome check-then-insert always intended).
+        // Empty-string payment_ids are excluded from the index just like NULLs,
+        // matching the `!pid.isEmpty` guard on the app's dedup check.
+        let hasUniquePaymentIndex = try !rawSQL.query(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_payments_payment_id_unique'"
+        ).isEmpty
+        if !hasUniquePaymentIndex {
+            try rawSQL.execute("""
+                DELETE FROM payments
+                WHERE payment_id IS NOT NULL AND payment_id != ''
+                  AND id NOT IN (SELECT MIN(id) FROM payments
+                                 WHERE payment_id IS NOT NULL AND payment_id != ''
+                                 GROUP BY payment_id)
+                """)
+            try rawSQL.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique
+                ON payments(payment_id) WHERE payment_id IS NOT NULL AND payment_id != ''
+                """)
         }
 
         try pruneHistoricalData()

--- a/ios/StableChannels/StableChannels/Services/Repositories/Models.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/Models.swift
@@ -133,6 +133,30 @@ final class RawSQL {
         }
     }
 
+    /// Executes a statement and returns how many rows it changed, atomically with
+    /// the statement itself (sqlite3_changes is per-connection, so reading it in a
+    /// separate call could observe another statement's count).
+    func executeReturningChanges(_ sql: String, params: [SQLValue] = []) throws -> Int {
+        try queue.sync {
+            guard let db = getDB() else {
+                throw DatabaseError.executeFailed("Database handle is nil")
+            }
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw DatabaseError.prepareFailed(String(cString: sqlite3_errmsg(db)))
+            }
+            defer { sqlite3_finalize(stmt) }
+
+            bindParams(stmt, params: params)
+
+            let result = sqlite3_step(stmt)
+            guard result == SQLITE_DONE || result == SQLITE_ROW else {
+                throw DatabaseError.executeFailed(String(cString: sqlite3_errmsg(db)))
+            }
+            return Int(sqlite3_changes(db))
+        }
+    }
+
     func query(_ sql: String, params: [SQLValue] = []) throws -> [[Any?]] {
         try queue.sync {
             guard let db = getDB() else {

--- a/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
@@ -50,11 +50,14 @@ final class PaymentRepository {
             }
         }
 
+        // OR IGNORE: this path is not transactional, so the existence check above
+        // can race the NSE. The unique payment_id index turns the losing insert
+        // into a no-op instead of a duplicate row (or, without it, an error).
         let sql = """
-            INSERT INTO payments (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, txid, address)
+            INSERT OR IGNORE INTO payments (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, txid, address)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
-        try rawSQL.execute(sql, params: [
+        let inserted = try rawSQL.executeReturningChanges(sql, params: [
             paymentId.map { .text($0) } ?? .null,
             .text(paymentType), .text(direction), .integer(Int64(amountMsat)),
             amountUSD.map { .real($0) } ?? .null,
@@ -64,7 +67,7 @@ final class PaymentRepository {
             txid.map { .text($0) } ?? .null,
             address.map { .text($0) } ?? .null
         ])
-        return true
+        return inserted > 0
     }
 
     func updatePaymentStatus(paymentId: String, status: String, feeMsat: UInt64? = nil) throws {

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -1,3 +1,4 @@
+import SQLite3
 import XCTest
 @testable import StableChannels
 
@@ -612,6 +613,82 @@ final class DatabaseServiceTests: XCTestCase {
             1,
             "Expected payment status index idx_payments_status to exist"
         )
+    }
+
+    func testUpgradeFromLegacyDBWithDuplicatePaymentIdsSucceeds() throws {
+        // Build a pre-unique-index DB by hand: old payments schema containing
+        // duplicate payment_id rows (the pre-NodeDirLock multi-writer shape) plus
+        // legitimate empty-string payment_ids. Init must dedup then index, not throw.
+        let legacyDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_legacy_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: legacyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: legacyDir) }
+
+        var legacyDB: OpaquePointer?
+        let path = legacyDir.appendingPathComponent(DatabaseService.dbFilename).path
+        XCTAssertEqual(sqlite3_open(path, &legacyDB), SQLITE_OK)
+        let legacySQL = """
+        CREATE TABLE payments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            payment_id TEXT,
+            payment_type TEXT NOT NULL DEFAULT 'manual',
+            direction TEXT NOT NULL,
+            amount_msat INTEGER NOT NULL,
+            amount_usd REAL,
+            btc_price REAL,
+            counterparty TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            fee_msat INTEGER NOT NULL DEFAULT 0,
+            txid TEXT,
+            address TEXT,
+            confirmations INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+        INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('dup_pay', 'received', 1000, 'pending');
+        INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('dup_pay', 'received', 1000, 'completed');
+        INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('', 'received', 1, 'completed');
+        INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('', 'received', 2, 'completed');
+        """
+        XCTAssertEqual(sqlite3_exec(legacyDB, legacySQL, nil, nil, nil), SQLITE_OK)
+        sqlite3_close(legacyDB)
+
+        let upgraded = try DatabaseService(dataDir: legacyDir)
+
+        // First-recorded row per payment_id survives.
+        let dupRows = try upgraded.rawSQL.query(
+            "SELECT status FROM payments WHERE payment_id = 'dup_pay'"
+        )
+        XCTAssertEqual(dupRows.count, 1)
+        XCTAssertEqual(dupRows.first?.first as? String, "pending")
+
+        // Empty-string payment_ids are outside the index predicate and untouched.
+        let emptyCount = try upgraded.rawSQL.query(
+            "SELECT COUNT(*) FROM payments WHERE payment_id = ''"
+        )
+        XCTAssertEqual(emptyCount.first?.first as? Int64, 2)
+
+        // The unique index exists and enforces from now on.
+        let indexRows = try upgraded.rawSQL.query(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_payments_payment_id_unique'"
+        )
+        XCTAssertEqual(indexRows.count, 1)
+    }
+
+    func testRecordPaymentIgnoresConcurrentDuplicate() throws {
+        // Simulate losing the check-then-insert race: a row with the same
+        // payment_id already exists when recordPayment's INSERT runs.
+        XCTAssertTrue(try service.paymentRepo.recordPayment(
+            paymentId: "race_pay", paymentType: "lightning", direction: "received",
+            amountMsat: 5000, amountUSD: nil, btcPrice: nil, counterparty: nil, status: "completed"
+        ))
+        XCTAssertFalse(try service.paymentRepo.recordPayment(
+            paymentId: "race_pay", paymentType: "lightning", direction: "received",
+            amountMsat: 5000, amountUSD: nil, btcPrice: nil, counterparty: nil, status: "completed"
+        ))
+        let count = try service.rawSQL.query(
+            "SELECT COUNT(*) FROM payments WHERE payment_id = 'race_pay'"
+        )
+        XCTAssertEqual(count.first?.first as? Int64, 1)
     }
 
     func testUniquePaymentIdIndexEnforcesDeduplication() throws {

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -593,4 +593,37 @@ final class DatabaseServiceTests: XCTestCase {
         XCTAssertEqual(history.count, 1)
         XCTAssertEqual(history.first?.price, 60_000)
     }
+
+    // MARK: - Query Indexes & Deduplication Tests
+
+    func testCustomQueryIndexesAndUniquePaymentIdCreated() throws {
+        let indexRows = try service.rawSQL
+            .query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_payments_payment_id_unique';")
+        XCTAssertEqual(
+            indexRows.count,
+            1,
+            "Expected unique payment index idx_payments_payment_id_unique to exist"
+        )
+
+        let statusIndexRows = try service.rawSQL
+            .query("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_payments_status';")
+        XCTAssertEqual(
+            statusIndexRows.count,
+            1,
+            "Expected payment status index idx_payments_status to exist"
+        )
+    }
+
+    func testUniquePaymentIdIndexEnforcesDeduplication() throws {
+        try service.rawSQL.execute(
+            "INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('unique_pay_1', 'sent', 100000, 'completed')"
+        )
+
+        // Second insert with exact same payment_id should throw a unique constraint error
+        XCTAssertThrowsError(
+            try service.rawSQL.execute(
+                "INSERT INTO payments (payment_id, direction, amount_msat, status) VALUES ('unique_pay_1', 'sent', 100000, 'completed')"
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Introduces targeted SQLite query performance indexes and hardware-level unique payment deduplication in `DatabaseService`.

---

## Problem

1. **Full Table Scan Latency**: Frequent status queries, confirmation scans, and outpoint lookups (`payments.status`, `payments.txid`, `pending_operations.funding_outpoint_txid`, `trades.channel_id`) perform full table scans as database row counts grow.
2. **Concurrent Payment Deduplication Risk**: Software-level deduplication alone in `PaymentRepository` leaves a small window for duplicate payment inserts if concurrent writes occur outside transaction boundaries.

---

## Solution

1. **Hardware-Level Payment Deduplication**:
   - Added partial unique index `CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_payment_id_unique ON payments(payment_id) WHERE payment_id IS NOT NULL` to enforce strict deduplication at the SQLite engine level.
2. **Targeted Query Performance Indexes**:
   - Added `idx_payments_status ON payments(status)`
   - Added `idx_payments_txid ON payments(txid) WHERE txid IS NOT NULL`
   - Added `idx_pending_ops_funding_txid ON pending_operations(funding_outpoint_txid) WHERE funding_outpoint_txid IS NOT NULL`
   - Added `idx_payments_resolution_id ON payments(resolution_id) WHERE resolution_id IS NOT NULL`
   - Added `idx_payments_type_status ON payments(payment_type, status)`
   - Added `idx_trades_channel_id ON trades(channel_id)`
   - Added `idx_payments_confirmation_scan ON payments(txid, payment_type, status, confirmations) WHERE txid IS NOT NULL`
3. **Idempotent Index Creation**:
   - Integrated all index creations into `createTablesAndIndexes()` and `applyMigrations()` using `IF NOT EXISTS` so new installations and existing databases acquire the indexes idempotently.
4. **Constraint & Index Unit Testing**:
   - Added `testCustomQueryIndexesAndUniquePaymentIdCreated`: Verifies that custom query and unique payment indexes are created upon database initialization.
   - Added `testUniquePaymentIdIndexEnforcesDeduplication`: Verifies that attempting to insert a duplicate `payment_id` throws a SQLite unique constraint error.

---

## Architecture Flowchart

<img width="8192" height="757" alt="image" src="https://github.com/user-attachments/assets/652aa444-bd81-433d-85be-697b71fd1487" />


---

## Key Changes

1. **`DatabaseService.swift`**:
   - Added partial unique index `idx_payments_payment_id_unique` and 7 query performance indexes to `createTablesAndIndexes()` and `applyMigrations()`.

2. **`DatabaseServiceTests.swift`**:
   - `testCustomQueryIndexesAndUniquePaymentIdCreated`: Validates index creation on init.
   - `testUniquePaymentIdIndexEnforcesDeduplication`: Validates SQLite unique payment ID constraint enforcement.

---

## Related 
- Closes #214
