### PR TITLE
fix(android): show actual fee paid in payment-sent status message

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -12,6 +12,7 @@ import com.stablechannels.app.services.CloseTxidResolver
 import com.stablechannels.app.services.*
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.LspPreferencesManager
+import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -957,7 +958,8 @@ class AppState(private val context: Context) : ViewModel() {
                 }
             }
             saveChannelToDB(preserveBacking = true)
-            val successMsg = if (displayVal != null) "Payment sent: $displayVal" else "Payment sent"
+            val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""
+            val successMsg = if (displayVal != null) "Payment sent: $displayVal$feeSuffix" else "Payment sent$feeSuffix"
             _statusMessage.value = successMsg
             _lastPaymentResult.value = successMsg
         }


### PR DESCRIPTION
## Summary

Shows the actual Lightning fee paid in the post-send status/toast message, instead of just the amount.

## Problem

`feePaidMsat` from LDK's `PaymentSuccessful` event was already captured and persisted to the payments DB, but never surfaced to the user — the success message only showed the amount sent (e.g. `"Payment sent: $5.00"`), with no way to see what it actually cost to send.

## Fix

Append the real, settled fee (not an estimate) to the success message when known:

```
Payment sent: $5.00 (fee: 4 sats)
```

Falls back to no suffix if `feePaidMsat` is `null` (unknown).

## Note

A pre-send Phoenix-style fee *estimate* breakdown was explored on this branch but removed before this PR — it read the LSP channel's advertised proportional fee rate, which is 0% on typical channels, so it always showed "0 fee" regardless of amount even when the real settled fee (shown here) was nonzero. Since `ldk-node` has no synchronous route-quote API, an accurate pre-send estimate isn't feasible without bigger changes (async route probing), so this PR only adds the post-send *actual* fee, which is always accurate by construction.

## Testing

Verified on-device: sent a real Lightning payment, confirmed the success message correctly showed `(fee: N sats)` matching the fee recorded in the LDK log for that payment.
