### PR TITLE
add signed trade rejections, correlation, and expiry for #205

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitcoin = "0.32"
 ureq = { version = "2.10.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rand = "0.9"
 retry = "1.3"
 futures = "0.3"
 async-trait = "0.1"
@@ -67,7 +68,6 @@ long_description = "A self-custodial bitcoin wallet with USD stability."
 tempfile = "3"
 electrsd = { version = "0.36.1", features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }
 electrum-client = "0.24.0"
-rand = "0.9"
 
 [workspace]
 members = [
@@ -82,5 +82,4 @@ members = [
 # macOS / Linux builds.
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
-
 

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -258,11 +258,28 @@ async fn dispatch(
             let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
             let mut settlement_handled = false;
             if let Some(payment_id) = payment_id.as_deref() {
-                let known_settlement = state
-                    .db
-                    .settlement_exists(payment_id)
-                    .ok()
-                    .unwrap_or(false);
+                match state.db.mark_trade_response_succeeded(payment_id) {
+                    Ok(true) => {
+                        settlement_handled = true;
+                        stable_channels::audit::audit_event(
+                            "TRADE_RESPONSE_SUCCEEDED",
+                            serde_json::json!({ "response_payment_id": payment_id }),
+                        );
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "mark_trade_response_succeeded",
+                                "payment_id": payment_id,
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return DispatchOutcome::Reconnect;
+                    }
+                }
+                let known_settlement = state.db.settlement_exists(payment_id).ok().unwrap_or(false);
                 match state.db.mark_settlement_succeeded(
                     payment_id,
                     amount_msat,
@@ -301,10 +318,41 @@ async fn dispatch(
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
-            let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
-            let rollback = payment_id
-                .as_deref()
-                .and_then(|payment_id| mgr.handle_failed_stability_payment(payment_id));
+            let direction = e.payment.as_ref().map(|p| {
+                if p.direction == 1 {
+                    "outbound"
+                } else {
+                    "inbound"
+                }
+            });
+            let trade_response_failed = if let Some(payment_id) = payment_id.as_deref() {
+                match state
+                    .db
+                    .mark_trade_response_payment_failed(payment_id, now_millis() as i64 / 1000)
+                {
+                    Ok(value) => value,
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "mark_trade_response_payment_failed",
+                                "payment_id": payment_id,
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return DispatchOutcome::Reconnect;
+                    }
+                }
+            } else {
+                false
+            };
+            let rollback = (!trade_response_failed)
+                .then(|| {
+                    payment_id
+                        .as_deref()
+                        .and_then(|payment_id| mgr.handle_failed_stability_payment(payment_id))
+                })
+                .flatten();
             let user_channel_id = rollback
                 .as_ref()
                 .map(|rollback| rollback.user_channel_id.clone())
@@ -321,6 +369,7 @@ async fn dispatch(
                     "direction": direction,
                     "user_channel_id": user_channel_id,
                     "stability_rollback_applied": rollback.map(|rollback| rollback.applied),
+                    "trade_response_retry_queued": trade_response_failed,
                 }),
             );
         },

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -12,6 +12,7 @@ mod stability_tick;
 mod stable_manager;
 mod state;
 mod tls;
+mod trade_response_retry;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -178,6 +179,7 @@ async fn main() -> Result<()> {
     }
     event_loop::spawn(state.clone());
     stability_tick::spawn(state.clone());
+    trade_response_retry::spawn(state.clone());
     observability::spawn(state.clone());
 
     let router = Router::new()

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -37,36 +37,8 @@ pub struct TradePayload {
     pub ts: u64,
 }
 
-/// Stable machine-readable rejection reasons carried by `TRADE_REJECTED_V1`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TradeRejectionReason {
-    InvalidAmount,
-    StaleRequest,
-    InvalidFee,
-    InvalidQuote,
-    QuoteOutOfRange,
-    InvalidAllocation,
-    InsufficientCapacity,
-    DuplicateTrade,
-    InternalError,
-}
-
-impl TradeRejectionReason {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::InvalidAmount => "invalid_amount",
-            Self::StaleRequest => "stale_request",
-            Self::InvalidFee => "invalid_fee",
-            Self::InvalidQuote => "invalid_quote",
-            Self::QuoteOutOfRange => "quote_out_of_range",
-            Self::InvalidAllocation => "invalid_allocation",
-            Self::InsufficientCapacity => "insufficient_capacity",
-            Self::DuplicateTrade => "duplicate_trade",
-            Self::InternalError => "internal_error",
-        }
-    }
-}
+/// Rejection reasons live in the shared crate so the wallet validates against this same list.
+pub use stable_channels::trade::TradeRejectionReason;
 
 /// LSP-signed rejection returned as a nominal control keysend.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -287,18 +259,7 @@ mod tests {
 
     #[test]
     fn rejection_payload_round_trips_all_stable_reason_codes() {
-        let reasons = [
-            TradeRejectionReason::InvalidAmount,
-            TradeRejectionReason::StaleRequest,
-            TradeRejectionReason::InvalidFee,
-            TradeRejectionReason::InvalidQuote,
-            TradeRejectionReason::QuoteOutOfRange,
-            TradeRejectionReason::InvalidAllocation,
-            TradeRejectionReason::InsufficientCapacity,
-            TradeRejectionReason::DuplicateTrade,
-            TradeRejectionReason::InternalError,
-        ];
-        for reason in reasons {
+        for reason in TradeRejectionReason::ALL.iter().copied() {
             let payload = build_trade_rejected_payload(
                 "channel", "7", None, "payment", reason, "rejected", 123,
             );

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -55,6 +55,23 @@ pub struct TradeRejectedPayload {
     pub ts: u64,
 }
 
+/// Signed metadata carried by the stability-payment keysend itself.
+///
+/// The Lightning event's amount remains authoritative. `amount_msat` is signed only so the
+/// receiver can prove that the payer intended this exact transfer to alter stable bookkeeping.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StabilityPaymentPayload {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub settlement_id: String,
+    pub channel_id: String,
+    /// The sender's node-local channel id. It is audit metadata, not a cross-peer channel key.
+    pub user_channel_id: String,
+    pub amount_msat: u64,
+    pub allocation_version: u64,
+    pub ts: u64,
+}
+
 /// RegisterPush signed body. Field declaration order IS the canonical serialization order;
 /// the wallet must serialize an identical struct so the daemon can reconstruct the signed bytes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,12 +150,37 @@ pub fn build_trade_rejected_payload(
     .unwrap_or_default()
 }
 
+pub fn build_stability_payment_payload(
+    settlement_id: &str,
+    channel_id: &str,
+    user_channel_id: &str,
+    amount_msat: u64,
+    allocation_version: u64,
+    ts: u64,
+) -> String {
+    serde_json::to_string(&StabilityPaymentPayload {
+        kind: "STABILITY_PAYMENT_V1".to_owned(),
+        settlement_id: settlement_id.to_owned(),
+        channel_id: channel_id.to_owned(),
+        user_channel_id: user_channel_id.to_owned(),
+        amount_msat,
+        allocation_version,
+        ts,
+    })
+    .unwrap_or_default()
+}
+
 /// A v1 trade id is deliberately strict so alternative spellings cannot bypass deduplication.
 pub fn is_valid_trade_id(trade_id: &str) -> bool {
     trade_id.len() == 64
         && trade_id
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Settlement ids use the same canonical 256-bit lowercase-hex representation as trade ids.
+pub fn is_valid_settlement_id(settlement_id: &str) -> bool {
+    is_valid_trade_id(settlement_id)
 }
 
 /// Wrap a signed payload string + signature into the envelope JSON string.
@@ -154,6 +196,10 @@ pub fn parse_envelope(raw: &str) -> Option<SignedEnvelope> {
 /// Parse the inner TRADE payload from the envelope's payload string.
 pub fn parse_trade_payload(payload: &str) -> Option<TradePayload> {
     serde_json::from_str::<TradePayload>(payload).ok()
+}
+
+pub fn parse_stability_payment_payload(payload: &str) -> Option<StabilityPaymentPayload> {
+    serde_json::from_str::<StabilityPaymentPayload>(payload).ok()
 }
 
 /// Canonical RegisterPush signed bytes. Must match the wallet's serialization exactly.
@@ -255,6 +301,26 @@ mod tests {
             value["trade_id"],
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
+    }
+
+    #[test]
+    fn stability_payment_payload_round_trips() {
+        let settlement_id =
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let payload = build_stability_payment_payload(
+            settlement_id,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "7",
+            42_000,
+            9,
+            123,
+        );
+        let parsed = parse_stability_payment_payload(&payload).unwrap();
+        assert_eq!(parsed.kind, "STABILITY_PAYMENT_V1");
+        assert_eq!(parsed.settlement_id, settlement_id);
+        assert_eq!(parsed.amount_msat, 42_000);
+        assert_eq!(parsed.allocation_version, 9);
+        assert_eq!(parsed.ts, 123);
     }
 
     #[test]

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -21,6 +21,10 @@ pub struct TradePayload {
     pub channel_id: Option<String>,
     #[serde(default)]
     pub user_channel_id: Option<String>,
+    /// Wallet-generated correlation id. New wallets use exactly 32 random bytes encoded as
+    /// lowercase hex; the field remains optional for legacy mobile clients.
+    #[serde(default)]
+    pub trade_id: Option<String>,
     pub expected_usd: f64,
     /// BTC/USD quote used by the wallet to derive the signed sat allocation.
     #[serde(default)]
@@ -30,6 +34,52 @@ pub struct TradePayload {
     pub backing_sats: Option<u64>,
     /// Unix seconds the wallet signed at; 0 if absent (un-upgraded wallet). Drives replay freshness.
     #[serde(default)]
+    pub ts: u64,
+}
+
+/// Stable machine-readable rejection reasons carried by `TRADE_REJECTED_V1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TradeRejectionReason {
+    InvalidAmount,
+    StaleRequest,
+    InvalidFee,
+    InvalidQuote,
+    QuoteOutOfRange,
+    InvalidAllocation,
+    InsufficientCapacity,
+    DuplicateTrade,
+    InternalError,
+}
+
+impl TradeRejectionReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidAmount => "invalid_amount",
+            Self::StaleRequest => "stale_request",
+            Self::InvalidFee => "invalid_fee",
+            Self::InvalidQuote => "invalid_quote",
+            Self::QuoteOutOfRange => "quote_out_of_range",
+            Self::InvalidAllocation => "invalid_allocation",
+            Self::InsufficientCapacity => "insufficient_capacity",
+            Self::DuplicateTrade => "duplicate_trade",
+            Self::InternalError => "internal_error",
+        }
+    }
+}
+
+/// LSP-signed rejection returned as a nominal control keysend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TradeRejectedPayload {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub channel_id: String,
+    pub user_channel_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trade_id: Option<String>,
+    pub trade_payment_id: String,
+    pub reason_code: TradeRejectionReason,
+    pub explanation: String,
     pub ts: u64,
 }
 
@@ -61,6 +111,62 @@ pub fn build_sync_payload(
         "sync_version": sync_version,
     })
     .to_string()
+}
+
+/// Build a correlated trade acceptance. Correlation fields are omitted for ordinary/legacy sync
+/// messages so old mobile decoders continue to see the exact shape they already accept.
+pub fn build_trade_sync_payload(
+    channel_id: &str,
+    user_channel_id: &str,
+    expected_usd: f64,
+    backing_sats: u64,
+    sync_version: u64,
+    trade_id: Option<&str>,
+    trade_payment_id: &str,
+) -> String {
+    let mut value = serde_json::json!({
+        "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
+        "channel_id": channel_id,
+        "user_channel_id": user_channel_id,
+        "expected_usd": expected_usd,
+        "backing_sats": backing_sats,
+        "sync_version": sync_version,
+        "trade_payment_id": trade_payment_id,
+    });
+    if let Some(trade_id) = trade_id {
+        value["trade_id"] = serde_json::Value::String(trade_id.to_owned());
+    }
+    value.to_string()
+}
+
+pub fn build_trade_rejected_payload(
+    channel_id: &str,
+    user_channel_id: &str,
+    trade_id: Option<&str>,
+    trade_payment_id: &str,
+    reason_code: TradeRejectionReason,
+    explanation: &str,
+    ts: u64,
+) -> String {
+    serde_json::to_string(&TradeRejectedPayload {
+        kind: "TRADE_REJECTED_V1".to_owned(),
+        channel_id: channel_id.to_owned(),
+        user_channel_id: user_channel_id.to_owned(),
+        trade_id: trade_id.map(str::to_owned),
+        trade_payment_id: trade_payment_id.to_owned(),
+        reason_code,
+        explanation: explanation.to_owned(),
+        ts,
+    })
+    .unwrap_or_default()
+}
+
+/// A v1 trade id is deliberately strict so alternative spellings cannot bypass deduplication.
+pub fn is_valid_trade_id(trade_id: &str) -> bool {
+    trade_id.len() == 64
+        && trade_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 /// Wrap a signed payload string + signature into the envelope JSON string.
@@ -125,6 +231,7 @@ mod tests {
             Some("189476124653200987495269098788434301048")
         );
         assert_eq!(t.expected_usd, 12.5);
+        assert_eq!(t.trade_id, None);
         assert_eq!(t.quote_price, None);
         assert_eq!(t.backing_sats, None);
     }
@@ -157,5 +264,58 @@ mod tests {
         assert_eq!(String::from_utf8(a.clone()).unwrap(), expected);
         let b = register_push_signed_bytes("nodehex", "tok:en", 1717000000);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn correlated_sync_fields_are_optional_and_exact() {
+        let payload = build_trade_sync_payload(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "7",
+            25.0,
+            31_250,
+            4,
+            Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            "payment",
+        );
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["trade_payment_id"], "payment");
+        assert_eq!(
+            value["trade_id"],
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn rejection_payload_round_trips_all_stable_reason_codes() {
+        let reasons = [
+            TradeRejectionReason::InvalidAmount,
+            TradeRejectionReason::StaleRequest,
+            TradeRejectionReason::InvalidFee,
+            TradeRejectionReason::InvalidQuote,
+            TradeRejectionReason::QuoteOutOfRange,
+            TradeRejectionReason::InvalidAllocation,
+            TradeRejectionReason::InsufficientCapacity,
+            TradeRejectionReason::DuplicateTrade,
+            TradeRejectionReason::InternalError,
+        ];
+        for reason in reasons {
+            let payload = build_trade_rejected_payload(
+                "channel", "7", None, "payment", reason, "rejected", 123,
+            );
+            let parsed: TradeRejectedPayload = serde_json::from_str(&payload).unwrap();
+            assert_eq!(parsed.reason_code, reason);
+            assert_eq!(parsed.trade_payment_id, "payment");
+        }
+    }
+
+    #[test]
+    fn trade_id_requires_canonical_lowercase_hex() {
+        assert!(is_valid_trade_id(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+        assert!(!is_valid_trade_id(
+            "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+        ));
+        assert!(!is_valid_trade_id("abcd"));
     }
 }

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -14,12 +14,19 @@ use ldk_server_client::ldk_server_grpc::api::{
     SpontaneousSendResponse, VerifySignatureRequest, VerifySignatureResponse,
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
-use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
+use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord, PaymentStatus};
 use stable_channels::db::Database;
+use stable_channels::db::PendingTradeResponse;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
 
-const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
+use crate::messages::TradeRejectionReason;
+
+const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 1.0;
+const LEGACY_TRADE_FEE_PRICE_SKEW_PERCENT: f64 = 0.5;
+// The exponential schedule reaches its one-hour cap after ten attempts; this leaves roughly
+// 6.6 days for an offline wallet to recover before the response is dead-lettered.
+const MAX_TRADE_RESPONSE_ATTEMPTS: u32 = 168;
 
 /// Return each peer's own spendable-plus-reserve balance from the fields LDK exposes for that
 /// peer. `channel_value - local_balance` is not the remote balance: on outbound channels it also
@@ -86,9 +93,9 @@ fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
         return 1000;
     }
 
-    // Transitional legacy wallets did not sign their quote. Admit the same maximum price skew as
-    // signed trades, plus one sat for whole-sat rounding, while still rejecting material underpay.
-    ((expected_msat as f64 * MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0).ceil() as u64)
+    // Transitional legacy wallets did not sign their quote. Retain their existing price-skew
+    // allowance, plus one sat for whole-sat rounding, while still rejecting material underpay.
+    ((expected_msat as f64 * LEGACY_TRADE_FEE_PRICE_SKEW_PERCENT / 100.0).ceil() as u64)
         .max(1000)
 }
 
@@ -226,6 +233,285 @@ pub struct EditOutcome {
 impl StableChannelManager {
     pub fn data_dir(&self) -> &std::path::Path {
         &self.data_dir
+    }
+
+    fn unix_time_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .min(i64::MAX as u64) as i64
+    }
+
+    async fn send_pending_trade_response(
+        db: &Database,
+        ldk: &dyn LdkServerCalls,
+        response: &PendingTradeResponse,
+    ) -> bool {
+        let req = SpontaneousSendRequest {
+            amount_msat: response.response_amount_msat,
+            node_id: response.counterparty.clone(),
+            route_parameters: None,
+            custom_tlvs: vec![CustomTlvRecord {
+                type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                value: response.response_envelope.clone().into_bytes().into(),
+            }],
+        };
+        match ldk.spontaneous_send(req).await {
+            Ok(sent) if !sent.payment_id.is_empty() => {
+                if let Err(error) = db
+                    .mark_trade_response_in_flight(&response.inbound_payment_id, &sent.payment_id)
+                {
+                    // The send has already happened. Leaving the persisted obligation pending can
+                    // produce a duplicate nominal control response after restart.
+                    stable_channels::audit::audit_event(
+                        "TRADE_RESPONSE_PAYMENT_ID_PERSIST_FAILED",
+                        serde_json::json!({
+                            "trade_payment_id": response.inbound_payment_id,
+                            "response_payment_id": sent.payment_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                    return false;
+                }
+                stable_channels::audit::audit_event(
+                    "TRADE_RESPONSE_SENT",
+                    serde_json::json!({
+                        "trade_payment_id": response.inbound_payment_id,
+                        "response_payment_id": sent.payment_id,
+                        "amount_msat": response.response_amount_msat,
+                        "attempt": response.attempts.saturating_add(1),
+                    }),
+                );
+                true
+            }
+            failed => {
+                let error = match failed {
+                    Ok(_) => "spontaneous send returned an empty payment id".to_owned(),
+                    Err(error) => error.to_string(),
+                };
+                if let Err(db_error) = db.mark_trade_response_send_failed(
+                    &response.inbound_payment_id,
+                    Self::unix_time_secs(),
+                ) {
+                    stable_channels::audit::audit_event(
+                        "DB_WRITE_FAILED",
+                        serde_json::json!({
+                            "op": "mark_trade_response_send_failed",
+                            "trade_payment_id": response.inbound_payment_id,
+                            "error": db_error.to_string(),
+                        }),
+                    );
+                }
+                stable_channels::audit::audit_event(
+                    "TRADE_RESPONSE_SEND_FAILED",
+                    serde_json::json!({
+                        "trade_payment_id": response.inbound_payment_id,
+                        "amount_msat": response.response_amount_msat,
+                        "error": error,
+                    }),
+                );
+                false
+            }
+        }
+    }
+
+    /// Retry all due accepted-sync and rejection responses. Backoff and the bounded attempt
+    /// budget are stored in SQLite, so restarts neither reset nor lose an obligation.
+    pub async fn retry_pending_trade_responses(db: &Database, ldk: &dyn LdkServerCalls) {
+        let in_flight = match db.in_flight_trade_response_payment_ids() {
+            Ok(payment_ids) => payment_ids,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({
+                        "op": "in_flight_trade_response_payment_ids",
+                        "error": error.to_string(),
+                    }),
+                );
+                Vec::new()
+            }
+        };
+        for payment_id in in_flight {
+            let payment = match ldk
+                .get_payment_details(GetPaymentDetailsRequest {
+                    payment_id: payment_id.clone(),
+                })
+                .await
+            {
+                Ok(response) => response.payment,
+                Err(error) => {
+                    stable_channels::audit::audit_event(
+                        "TRADE_RESPONSE_RECONCILE_FAILED",
+                        serde_json::json!({
+                            "response_payment_id": payment_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                    None
+                }
+            };
+            match payment.map(|payment| payment.status) {
+                Some(status) if status == PaymentStatus::Succeeded as i32 => {
+                    match db.mark_trade_response_succeeded(&payment_id) {
+                        Ok(true) => {}
+                        Ok(false) => stable_channels::audit::audit_event(
+                            "TRADE_RESPONSE_RECONCILE_MISMATCH",
+                            serde_json::json!({
+                                "response_payment_id": payment_id,
+                                "status": "succeeded",
+                            }),
+                        ),
+                        Err(error) => stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "mark_trade_response_succeeded",
+                                "response_payment_id": payment_id,
+                                "error": error.to_string(),
+                            }),
+                        ),
+                    }
+                }
+                Some(status) if status == PaymentStatus::Failed as i32 => {
+                    match db.mark_trade_response_payment_failed(
+                        &payment_id,
+                        Self::unix_time_secs(),
+                    ) {
+                        Ok(true) => {}
+                        Ok(false) => stable_channels::audit::audit_event(
+                            "TRADE_RESPONSE_RECONCILE_MISMATCH",
+                            serde_json::json!({
+                                "response_payment_id": payment_id,
+                                "status": "failed",
+                            }),
+                        ),
+                        Err(error) => stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "mark_trade_response_payment_failed",
+                                "response_payment_id": payment_id,
+                                "error": error.to_string(),
+                            }),
+                        ),
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let now = Self::unix_time_secs();
+        if let Err(error) = db.abandon_exhausted_trade_responses(
+            MAX_TRADE_RESPONSE_ATTEMPTS,
+            now,
+            32,
+        ) {
+            stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({
+                    "op": "abandon_exhausted_trade_responses",
+                    "error": error.to_string(),
+                }),
+            );
+        }
+        let responses = match db.due_trade_responses(
+            now,
+            MAX_TRADE_RESPONSE_ATTEMPTS,
+            32,
+        ) {
+            Ok(responses) => responses,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({
+                        "op": "due_trade_responses",
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        for response in responses {
+            Self::send_pending_trade_response(db, ldk, &response).await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn reject_authenticated_trade(
+        &self,
+        ldk: &dyn LdkServerCalls,
+        inbound_payment_id: &str,
+        trade_id: Option<&str>,
+        channel_id: &str,
+        local_user_channel_id: &str,
+        remote_user_channel_id: Option<&str>,
+        counterparty: &str,
+        reason: TradeRejectionReason,
+        explanation: &str,
+    ) {
+        let response_user_channel_id = remote_user_channel_id.unwrap_or(local_user_channel_id);
+        let payload = crate::messages::build_trade_rejected_payload(
+            channel_id,
+            response_user_channel_id,
+            trade_id,
+            inbound_payment_id,
+            reason,
+            explanation,
+            Self::unix_time_secs() as u64,
+        );
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_REJECTION_SIGN_FAILED",
+                    serde_json::json!({
+                        "trade_payment_id": inbound_payment_id,
+                        "reason_code": reason.as_str(),
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let envelope = crate::messages::build_envelope(payload, signature);
+        match self.db.persist_trade_rejection(
+            inbound_payment_id,
+            trade_id,
+            channel_id,
+            local_user_channel_id,
+            remote_user_channel_id,
+            counterparty,
+            reason.as_str(),
+            explanation,
+            &envelope,
+        ) {
+            Ok(_) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_REJECTION_QUEUED",
+                    serde_json::json!({
+                        "trade_id": trade_id,
+                        "trade_payment_id": inbound_payment_id,
+                        "channel_id": channel_id,
+                        "user_channel_id": local_user_channel_id,
+                        "remote_user_channel_id": remote_user_channel_id,
+                        "reason_code": reason.as_str(),
+                        "explanation": explanation,
+                    }),
+                );
+            }
+            Err(error) => stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({
+                    "op": "persist_trade_rejection",
+                    "trade_payment_id": inbound_payment_id,
+                    "error": error.to_string(),
+                }),
+            ),
+        }
     }
 
     /// Consume an asynchronous failure for an outbound stability payment. The database performs
@@ -796,7 +1082,7 @@ impl StableChannelManager {
                         );
                     }
                 }
-                self.handle_trade_message(&raw, amount_msat, ldk, btc_price)
+                self.handle_trade_payment(&raw, payment_id.as_deref(), amount_msat, ldk, btc_price)
                     .await;
             } else {
                 if let Some(pid) = payment_id.as_deref() {
@@ -1674,11 +1960,13 @@ impl StableChannelManager {
         }
     }
 
-    /// Parse a TRADE_V1 envelope, verify it against the channel counterparty, validate against
-    /// balance, and apply the new USD target. Drops (with an audit line) on any failure.
-    pub async fn handle_trade_message(
+    /// Process one fee payment carrying TRADE_V1. Parsing, channel attribution, and signature
+    /// verification happen before any response is possible. Every later validation failure queues
+    /// a signed rejection as a nominal one-msat control payment.
+    pub async fn handle_trade_payment(
         &mut self,
         raw: &str,
+        inbound_payment_id: Option<&str>,
         amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
@@ -1694,160 +1982,274 @@ impl StableChannelManager {
         if payload.kind != stable_channels::constants::TRADE_MESSAGE_TYPE {
             stable_channels::audit::audit_event(
                 "TRADE_UNHANDLED_TYPE",
-                serde_json::json!({ "type": payload.kind, "user_channel_id": payload.user_channel_id.clone() }),
+                serde_json::json!({ "type": payload.kind }),
             );
             return;
         }
-        if payload.expected_usd < 0.0 || !payload.expected_usd.is_finite() {
-            stable_channels::audit::audit_event(
-                "TRADE_INVALID_AMOUNT",
-                serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone() }),
-            );
-            return;
-        }
-        stable_channels::audit::audit_event(
-            "TRADE_PARSED_PAYLOAD_OK",
-            serde_json::json!({
-                "expected_usd": payload.expected_usd,
-                "quote_price": payload.quote_price,
-                "backing_sats": payload.backing_sats,
-                "user_channel_id": payload.user_channel_id.clone(),
-                "channel_id": payload.channel_id.clone(),
-            }),
-        );
-
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
-            Ok(r) => r.channels,
-            Err(e) => {
-                error!("[trade] list_channels gRPC failed: {}", e);
+            Ok(response) => response.channels,
+            Err(error) => {
                 stable_channels::audit::audit_event(
                     "LDK_CALL_FAILED",
-                    serde_json::json!({ "op": "list_channels", "context": "handle_trade_message", "user_channel_id": payload.user_channel_id.clone(), "channel_id": payload.channel_id.clone(), "error": e.to_string() }),
+                    serde_json::json!({
+                        "op": "list_channels",
+                        "context": "handle_trade_payment",
+                        "error": error.to_string(),
+                    }),
                 );
                 return;
             }
         };
-        // channel_id is authoritative when present; user_channel_id is the fallback.
-        let chan = channels.into_iter().find(|c| {
-            if let Some(cid) = payload.channel_id.as_deref() {
-                if c.channel_id == cid {
-                    return true;
-                }
-            }
-            if let Some(ucid) = payload.user_channel_id.as_deref() {
-                let want = parse_user_channel_id(ucid);
-                if want.is_some() && want == parse_user_channel_id(&c.user_channel_id) {
-                    return true;
-                }
-            }
-            false
-        });
-        let Some(chan) = chan else {
+        // `user_channel_id` is local to each LDK node, so the wallet's value will normally differ
+        // from the LSP's. Bind new requests by the shared channel_id. The local-id fallback keeps
+        // accepting legacy requests that omitted channel_id and used the LSP-side identifier.
+        let chan = match payload.channel_id.as_deref() {
+            Some(channel_id) => channels
+                .iter()
+                .find(|channel| channel.channel_id == channel_id),
+            None => payload.user_channel_id.as_deref().and_then(|user_channel_id| {
+                let wanted = parse_user_channel_id(user_channel_id)?;
+                channels
+                    .iter()
+                    .find(|channel| parse_user_channel_id(&channel.user_channel_id) == Some(wanted))
+            }),
+        };
+        let Some(chan) = chan.cloned() else {
             stable_channels::audit::audit_event(
-                "TRADE_CHANNEL_NOT_FOUND",
+                "TRADE_CHANNEL_BINDING_INVALID",
                 serde_json::json!({
                     "channel_id": payload.channel_id,
-                    "user_channel_id": payload.user_channel_id,
+                    "remote_user_channel_id": payload.user_channel_id,
+                }),
+            );
+            return;
+        };
+        let remote_user_channel_id = payload.user_channel_id.as_deref();
+
+        let signature_valid = matches!(
+            ldk.verify_signature(VerifySignatureRequest {
+                message: envelope.payload.as_bytes().to_vec().into(),
+                signature: envelope.signature,
+                public_key: chan.counterparty_node_id.clone(),
+            })
+            .await,
+            Ok(response) if response.valid
+        );
+        if !signature_valid {
+            stable_channels::audit::audit_event(
+                "TRADE_SIGNATURE_INVALID",
+                serde_json::json!({
+                    "channel_id": chan.channel_id,
+                    "user_channel_id": chan.user_channel_id,
+                    "remote_user_channel_id": remote_user_channel_id,
+                }),
+            );
+            return;
+        }
+
+        // An event without either of these fields cannot be safely attributed or deduplicated.
+        let (Some(inbound_payment_id), Some(received_msat)) = (inbound_payment_id, amount_msat)
+        else {
+            stable_channels::audit::audit_event(
+                "TRADE_PAYMENT_UNATTRIBUTABLE",
+                serde_json::json!({
+                    "has_payment_id": inbound_payment_id.is_some(),
+                    "amount_msat": amount_msat,
+                    "channel_id": chan.channel_id,
+                    "user_channel_id": chan.user_channel_id,
+                    "remote_user_channel_id": remote_user_channel_id,
                 }),
             );
             return;
         };
 
-        let verify = ldk
-            .verify_signature(VerifySignatureRequest {
-                message: envelope.payload.as_bytes().to_vec().into(),
-                signature: envelope.signature.clone(),
-                public_key: chan.counterparty_node_id.clone(),
-            })
-            .await;
-        let valid = matches!(verify, Ok(ref r) if r.valid);
-        if !valid {
-            stable_channels::audit::audit_event(
-                "TRADE_SIGNATURE_INVALID",
-                serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
-            );
-            return;
+        let supplied_trade_id = payload.trade_id.as_deref();
+        let trade_id = supplied_trade_id.filter(|trade_id| {
+            crate::messages::is_valid_trade_id(trade_id)
+        });
+        macro_rules! reject {
+            ($reason:expr, $explanation:expr) => {{
+                self.reject_authenticated_trade(
+                    ldk,
+                    inbound_payment_id,
+                    trade_id,
+                    &chan.channel_id,
+                    &chan.user_channel_id,
+                    remote_user_channel_id,
+                    &chan.counterparty_node_id,
+                    $reason,
+                    $explanation,
+                )
+                .await;
+                return;
+            }};
         }
-        stable_channels::audit::audit_event(
-            "TRADE_SIGNATURE_VALID",
-            serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
-        );
 
-        // Replay protection: reject a signed trade with a stale `ts`; ts==0 means an un-upgraded wallet (no timestamp yet) — accepted until all wallets sign one.
-        const TRADE_SIG_WINDOW_SECS: u64 = 300;
+        if supplied_trade_id.is_some() && trade_id.is_none() {
+            stable_channels::audit::audit_event(
+                "TRADE_ID_INVALID",
+                serde_json::json!({ "trade_id": payload.trade_id }),
+            );
+            reject!(
+                TradeRejectionReason::InvalidAmount,
+                "trade_id must be 32 bytes encoded as lowercase hex"
+            );
+        }
+
+        match self.db.trade_decision_exists(inbound_payment_id) {
+            Ok(true) => {
+                let response_requeued = match self.db.requeue_abandoned_trade_response(
+                    inbound_payment_id,
+                    Self::unix_time_secs(),
+                ) {
+                    Ok(requeued) => requeued,
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "requeue_abandoned_trade_response",
+                                "trade_payment_id": inbound_payment_id,
+                                "error": error.to_string(),
+                            }),
+                        );
+                        false
+                    }
+                };
+                stable_channels::audit::audit_event(
+                    "TRADE_PAYMENT_REPLAYED",
+                    serde_json::json!({
+                        "trade_payment_id": inbound_payment_id,
+                        "response_requeued": response_requeued,
+                    }),
+                );
+                return;
+            }
+            Ok(false) => {}
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_DEDUP_READ_FAILED",
+                    serde_json::json!({
+                        "trade_payment_id": inbound_payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                reject!(
+                    TradeRejectionReason::InternalError,
+                    "could not check prior trade decisions"
+                );
+            }
+        }
+
+        if let Some(trade_id) = trade_id {
+            match self
+                .db
+                .trade_id_seen_on_other_payment(trade_id, inbound_payment_id)
+            {
+                Ok(true) => {
+                    match self.db.requeue_original_trade_response(
+                        trade_id,
+                        inbound_payment_id,
+                        Self::unix_time_secs(),
+                    ) {
+                        Ok(true) => stable_channels::audit::audit_event(
+                            "TRADE_ORIGINAL_RESPONSE_REQUEUED",
+                            serde_json::json!({
+                                "trade_id": trade_id,
+                                "duplicate_trade_payment_id": inbound_payment_id,
+                            }),
+                        ),
+                        Ok(false) => stable_channels::audit::audit_event(
+                            "TRADE_ORIGINAL_RESPONSE_NOT_FOUND",
+                            serde_json::json!({
+                                "trade_id": trade_id,
+                                "duplicate_trade_payment_id": inbound_payment_id,
+                            }),
+                        ),
+                        Err(error) => stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "requeue_original_trade_response",
+                                "trade_id": trade_id,
+                                "duplicate_trade_payment_id": inbound_payment_id,
+                                "error": error.to_string(),
+                            }),
+                        ),
+                    }
+                    reject!(
+                        TradeRejectionReason::DuplicateTrade,
+                        "trade_id was already used by another payment"
+                    );
+                }
+                Ok(false) => {}
+                Err(_) => reject!(
+                    TradeRejectionReason::InternalError,
+                    "could not check trade replay state"
+                ),
+            }
+        }
+        if payload.expected_usd < 0.0 || !payload.expected_usd.is_finite() {
+            reject!(
+                TradeRejectionReason::InvalidAmount,
+                "expected_usd must be finite and non-negative"
+            );
+        }
+
+        const TRADE_SIG_WINDOW_SECS: u64 =
+            stable_channels::constants::TRADE_ACCEPTANCE_WINDOW_SECS;
         if payload.ts != 0 {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+            let now = Self::unix_time_secs() as u64;
             if now.abs_diff(payload.ts) > TRADE_SIG_WINDOW_SECS {
                 stable_channels::audit::audit_event(
                     "TRADE_STALE",
-                    serde_json::json!({ "ts": payload.ts, "now": now, "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
+                    serde_json::json!({
+                        "ts": payload.ts,
+                        "now": now,
+                        "channel_id": chan.channel_id,
+                        "user_channel_id": chan.user_channel_id,
+                    }),
                 );
-                return;
+                reject!(
+                    TradeRejectionReason::StaleRequest,
+                    "trade timestamp is outside the acceptance window"
+                );
             }
         }
 
         let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
-            stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }));
-            return;
+            reject!(
+                TradeRejectionReason::InternalError,
+                "channel user identifier is invalid"
+            );
         };
-        let Some(current_expected_usd) = self
+        let Some(channel_index) = self
             .stable_channels
             .iter()
-            .find(|sc| sc.user_channel_id == target_uid)
-            .map(|sc| sc.expected_usd.0)
+            .position(|stable| stable.user_channel_id == target_uid)
         else {
-            stable_channels::audit::audit_event(
-                "TRADE_STABLE_ENTRY_NOT_FOUND",
-                serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": format!("{}", target_uid) }),
+            reject!(
+                TradeRejectionReason::InternalError,
+                "stable channel state is unavailable"
             );
-            return;
         };
-
+        let current_expected_usd = self.stable_channels[channel_index].expected_usd.0;
         let fee_price = payload.quote_price.unwrap_or(btc_price);
-        let Some(expected_fee_msat) = expected_trade_fee_msat(
-            current_expected_usd,
-            payload.expected_usd,
-            fee_price,
-        ) else {
-            stable_channels::audit::audit_event(
-                "TRADE_FEE_INVALID",
-                serde_json::json!({
-                    "reason": "fee inputs are invalid",
-                    "old_expected_usd": current_expected_usd,
-                    "new_expected_usd": payload.expected_usd,
-                    "fee_price": fee_price,
-                    "amount_msat": amount_msat,
-                    "channel_id": chan.channel_id.clone(),
-                    "user_channel_id": chan.user_channel_id.clone(),
-                }),
+        let Some(expected_fee_msat) =
+            expected_trade_fee_msat(current_expected_usd, payload.expected_usd, fee_price)
+        else {
+            reject!(
+                TradeRejectionReason::InvalidFee,
+                "trade fee inputs are invalid"
             );
-            return;
         };
         let tolerance_msat =
             trade_fee_tolerance_msat(expected_fee_msat, payload.quote_price.is_some());
-        let fee_matches = amount_msat
-            .map(|actual| actual.abs_diff(expected_fee_msat) <= tolerance_msat)
-            .unwrap_or(false);
-        if !fee_matches {
-            stable_channels::audit::audit_event(
-                "TRADE_FEE_INVALID",
-                serde_json::json!({
-                    "reason": if amount_msat.is_some() { "incorrect amount" } else { "missing amount" },
-                    "actual_fee_msat": amount_msat,
-                    "expected_fee_msat": expected_fee_msat,
-                    "tolerance_msat": tolerance_msat,
-                    "old_expected_usd": current_expected_usd,
-                    "new_expected_usd": payload.expected_usd,
-                    "fee_price": fee_price,
-                    "channel_id": chan.channel_id.clone(),
-                    "user_channel_id": chan.user_channel_id.clone(),
-                }),
+        if received_msat.abs_diff(expected_fee_msat) > tolerance_msat {
+            reject!(
+                TradeRejectionReason::InvalidFee,
+                "received fee does not match the signed trade"
             );
-            return;
         }
+
         let (our_sats, their_sats) = channel_peer_balances(&chan);
         let new_expected = payload.expected_usd;
         let signed_allocation = match (payload.quote_price, payload.backing_sats) {
@@ -1858,38 +2260,18 @@ impl StableChannelManager {
                     || !btc_price.is_finite()
                     || btc_price <= 0.0
                 {
-                    stable_channels::audit::audit_event(
-                        "TRADE_INVALID_QUOTE",
-                        serde_json::json!({
-                            "quote_price": quote_price,
-                            "lsp_price": btc_price,
-                            "ts": payload.ts,
-                            "channel_id": chan.channel_id.clone(),
-                            "user_channel_id": chan.user_channel_id.clone(),
-                        }),
+                    reject!(
+                        TradeRejectionReason::InvalidQuote,
+                        "signed quote or timestamp is invalid"
                     );
-                    return;
                 }
-
-                // Both peers run their own price feed. Admit small observation-time differences,
-                // but reject a quote far enough away to change the economic trade materially.
-                let quote_deviation_percent =
-                    ((quote_price - btc_price) / btc_price * 100.0).abs();
+                let quote_deviation_percent = ((quote_price - btc_price) / btc_price * 100.0).abs();
                 if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
-                    stable_channels::audit::audit_event(
-                        "TRADE_QUOTE_DEVIATION_EXCEEDED",
-                        serde_json::json!({
-                            "quote_price": quote_price,
-                            "lsp_price": btc_price,
-                            "deviation_percent": quote_deviation_percent,
-                            "maximum_percent": MAX_TRADE_QUOTE_DEVIATION_PERCENT,
-                            "channel_id": chan.channel_id.clone(),
-                            "user_channel_id": chan.user_channel_id.clone(),
-                        }),
+                    reject!(
+                        TradeRejectionReason::QuoteOutOfRange,
+                        "signed quote is outside the allowed market range"
                     );
-                    return;
                 }
-
                 let signed_backing_usd = backing_sats as f64 / 100_000_000.0 * quote_price;
                 let allocation_delta_usd = (signed_backing_usd - new_expected).abs();
                 let zero_allocation_is_consistent = if new_expected < 0.01 {
@@ -1902,132 +2284,124 @@ impl StableChannelManager {
                     || allocation_delta_usd
                         > stable_channels::constants::STABILITY_THRESHOLD_USD
                 {
-                    stable_channels::audit::audit_event(
-                        "TRADE_ALLOCATION_INVALID",
-                        serde_json::json!({
-                            "signed_backing_sats": backing_sats,
-                            "signed_backing_usd": signed_backing_usd,
-                            "allocation_delta_usd": allocation_delta_usd,
-                            "receiver_sats": their_sats,
-                            "quote_price": quote_price,
-                            "channel_id": chan.channel_id.clone(),
-                            "user_channel_id": chan.user_channel_id.clone(),
-                        }),
+                    reject!(
+                        TradeRejectionReason::InvalidAllocation,
+                        "signed backing allocation is inconsistent"
                     );
-                    return;
                 }
-
                 Some((quote_price, backing_sats, quote_deviation_percent))
             }
             (None, None) => None,
-            _ => {
-                stable_channels::audit::audit_event(
-                    "TRADE_ALLOCATION_INCOMPLETE",
-                    serde_json::json!({
-                        "quote_price": payload.quote_price,
-                        "backing_sats": payload.backing_sats,
-                        "channel_id": chan.channel_id.clone(),
-                        "user_channel_id": chan.user_channel_id.clone(),
-                    }),
-                );
-                return;
-            }
+            _ => reject!(
+                TradeRejectionReason::InvalidAllocation,
+                "quote_price and backing_sats must be supplied together"
+            ),
         };
 
         let validation_price = signed_allocation
             .map(|(quote_price, _, _)| quote_price)
             .unwrap_or(btc_price);
-        let receiver_usd =
-            USD::from_bitcoin(Bitcoin::from_sats(their_sats), validation_price).0;
-        // Epsilon absorbs f64 boundary rounding so a spend-driven push landing at ~receiver_usd is admitted; residual drift self-heals.
+        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), validation_price).0;
         let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
         if new_expected > ceiling {
-            stable_channels::audit::audit_event(
-                "TRADE_EXCEEDS_BALANCE",
-                serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd, "user_channel_id": format!("{}", target_uid), "channel_id": chan.channel_id.clone() }),
+            reject!(
+                TradeRejectionReason::InsufficientCapacity,
+                "requested stable allocation exceeds channel capacity"
             );
-            return;
         }
-        let channel_id_hex = chan.channel_id.clone();
 
-        let persisted = {
-            let Some(sc) = self
-                .stable_channels
-                .iter_mut()
-                .find(|sc| sc.user_channel_id == target_uid)
-            else {
-                stable_channels::audit::audit_event(
-                    "TRADE_STABLE_ENTRY_NOT_FOUND",
-                    serde_json::json!({ "channel_id": channel_id_hex, "user_channel_id": format!("{}", target_uid) }),
-                );
-                return;
-            };
-            sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
-            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
-            sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
-            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
-            sc.latest_price = btc_price;
-            if let Some((_, backing_sats, _)) = signed_allocation {
-                stable_channels::stable::apply_trade_allocation(
-                    sc,
-                    new_expected,
-                    backing_sats,
-                );
-            } else {
-                stable_channels::stable::apply_trade(sc, new_expected, btc_price);
-            }
-            (
-                format!("{}", sc.user_channel_id),
-                sc.expected_usd.0,
-                sc.backing_sats,
-                sc.native_sats,
-                sc.note.clone(),
-                sc.counterparty.to_string(),
-            )
+        // Compute on a clone. The live cache changes only after the allocation, version,
+        // decision, and signed response have committed in one SQLite transaction.
+        let mut accepted = self.stable_channels[channel_index].clone();
+        accepted.stable_provider_btc = Bitcoin::from_sats(our_sats);
+        accepted.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+        accepted.stable_provider_usd = USD::from_bitcoin(accepted.stable_provider_btc, btc_price);
+        accepted.stable_receiver_usd = USD::from_bitcoin(accepted.stable_receiver_btc, btc_price);
+        accepted.latest_price = btc_price;
+        if let Some((_, backing_sats, _)) = signed_allocation {
+            stable_channels::stable::apply_trade_allocation(
+                &mut accepted,
+                new_expected,
+                backing_sats,
+            );
+        } else {
+            stable_channels::stable::apply_trade(&mut accepted, new_expected, btc_price);
+        }
+
+        let sync_version = match self.db.candidate_sync_version(&chan.user_channel_id) {
+            Ok(version) => version,
+            Err(_) => reject!(
+                TradeRejectionReason::InternalError,
+                "could not reserve an acceptance version"
+            ),
         };
-
-        let (ucid_str, expected_usd_f, backing, native, note, counterparty) = persisted;
-        if let Err(e) = self.db.save_channel(
-            &channel_id_hex,
-            &ucid_str,
-            expected_usd_f,
-            backing,
-            native,
-            note.as_deref(),
-        ) {
-            error!("[trade] db.save_channel failed: {}", e);
-            stable_channels::audit::audit_event(
-                "DB_WRITE_FAILED",
-                serde_json::json!({ "op": "save_channel", "context": "handle_trade_message", "channel_id": channel_id_hex, "user_channel_id": ucid_str, "error": e.to_string() }),
-            );
-            return;
-        }
-        stable_channels::audit::audit_event(
-            "TRADE_APPLIED",
-            serde_json::json!({
-                "channel_id": channel_id_hex,
-                "user_channel_id": ucid_str,
-                "new_expected_usd": expected_usd_f,
-                "backing_sats": backing,
-                "native_sats": native,
-                "quote_price": signed_allocation.map(|(price, _, _)| price),
-                "lsp_price": btc_price,
-                "quote_deviation_percent": signed_allocation.map(|(_, _, deviation)| deviation),
-            }),
+        let response_user_channel_id = remote_user_channel_id.unwrap_or(&chan.user_channel_id);
+        let response_payload = crate::messages::build_trade_sync_payload(
+            &chan.channel_id,
+            response_user_channel_id,
+            accepted.expected_usd.0,
+            accepted.backing_sats,
+            sync_version,
+            trade_id,
+            inbound_payment_id,
         );
-        let sent = self
-            .send_sync_message(
-                ldk,
-                target_uid,
-                &channel_id_hex,
-                expected_usd_f,
-                backing,
-                &counterparty,
-            )
-            .await;
-        if !sent {
-            self.startup_sync_pending.insert(target_uid);
+        let response_signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: response_payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(_) => reject!(
+                TradeRejectionReason::InternalError,
+                "could not sign the acceptance response"
+            ),
+        };
+        let response_envelope =
+            crate::messages::build_envelope(response_payload, response_signature);
+        match self.db.persist_trade_acceptance(
+            inbound_payment_id,
+            trade_id,
+            &chan.channel_id,
+            &chan.user_channel_id,
+            remote_user_channel_id,
+            &chan.counterparty_node_id,
+            accepted.expected_usd.0,
+            accepted.backing_sats,
+            accepted.native_sats,
+            signed_allocation.map(|(price, _, _)| price),
+            btc_price,
+            signed_allocation.map(|(_, _, deviation)| deviation),
+            sync_version,
+            &response_envelope,
+        ) {
+            Ok(true) => self.stable_channels[channel_index] = accepted.clone(),
+            Ok(false) => reject!(
+                TradeRejectionReason::InternalError,
+                "acceptance state changed before it could be committed"
+            ),
+            Err(_) => reject!(
+                TradeRejectionReason::InternalError,
+                "could not persist the accepted trade"
+            ),
         }
+
+    }
+
+    #[cfg(test)]
+    pub async fn handle_trade_message(
+        &mut self,
+        raw: &str,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let test_payment_id = crate::messages::parse_envelope(raw)
+            .map(|envelope| format!("test:{}", envelope.signature))
+            .unwrap_or_else(|| "test:malformed".to_owned());
+        self.handle_trade_payment(raw, Some(&test_payment_id), amount_msat, ldk, btc_price)
+            .await;
+        Self::retry_pending_trade_responses(self.db.as_ref(), ldk).await;
     }
 }
 
@@ -2625,10 +2999,7 @@ mod tests {
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
         assert_eq!(
             mgr.db.list_settlements().unwrap(),
-            vec![
-                ("pay_test_1".to_string(), "sync".to_string()),
-                ("fake-payment-id".to_string(), "sync".to_string()),
-            ]
+            vec![("pay_test_1".to_string(), "sync".to_string())]
         );
     }
 
@@ -3359,6 +3730,16 @@ mod tests {
         receiver_sats: u64,
         price: f64,
     ) {
+        mgr.db
+            .save_channel(
+                channel_id,
+                &user_channel_id.to_string(),
+                expected_usd,
+                backing_sats,
+                native_sats,
+                None,
+            )
+            .unwrap();
         mgr.stable_channels.push(StableChannel {
             channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(
                 parse_channel_id_hex(channel_id),
@@ -3471,6 +3852,24 @@ mod tests {
         serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
     }
 
+    fn trade_envelope_with_id(
+        channel_id: &str,
+        user_channel_id: &str,
+        trade_id: &str,
+        expected_usd: f64,
+    ) -> String {
+        let payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "channel_id": channel_id,
+            "user_channel_id": user_channel_id,
+            "trade_id": trade_id,
+            "expected_usd": expected_usd,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
+    }
+
     fn test_unix_now() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3506,6 +3905,30 @@ mod tests {
         .unwrap();
         mgr.handle_trade_message(envelope, Some(fee_msat), ldk, lsp_price)
             .await;
+    }
+
+    async fn retry_trade_responses(
+        mgr: &StableChannelManager,
+        ldk: &dyn LdkServerCalls,
+    ) {
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), ldk).await;
+    }
+
+    fn rejection_from_only_send(
+        fake: &FakeLdkServer,
+    ) -> (u64, crate::messages::TradeRejectedPayload) {
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        let send = &sends[0];
+        let record = send
+            .custom_tlvs
+            .iter()
+            .find(|record| record.type_num == stable_channels::constants::STABLE_CHANNEL_TLV_TYPE)
+            .unwrap();
+        let raw = std::str::from_utf8(record.value.as_ref()).unwrap();
+        let envelope = crate::messages::parse_envelope(raw).unwrap();
+        let rejection = serde_json::from_str(&envelope.payload).unwrap();
+        (send.amount_msat, rejection)
     }
 
     #[test]
@@ -3557,6 +3980,175 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn trade_uses_shared_channel_id_and_echoes_wallet_local_id() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+        let trade_id = "abababababababababababababababababababababababababababababababab";
+        let wallet_user_channel_id = "55795660709841003592697616286364811722";
+        assert_ne!(wallet_user_channel_id, USER_CHANNEL_ID_DECIMAL);
+        let envelope = trade_envelope_with_id(
+            CHANNEL_ID_HEX,
+            wallet_user_channel_id,
+            trade_id,
+            8.0,
+        );
+        let fee_msat = expected_trade_fee_msat(0.0, 8.0, 100_000.0).unwrap();
+
+        mgr.handle_trade_payment(
+            &envelope,
+            Some("payment-one"),
+            Some(fee_msat),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        retry_trade_responses(&mgr, &fake).await;
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 8.0);
+        {
+            let sends = fake.sends.lock().unwrap();
+            assert_eq!(sends.len(), 1);
+            let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+            let envelope = crate::messages::parse_envelope(raw).unwrap();
+            let sync: serde_json::Value = serde_json::from_str(&envelope.payload).unwrap();
+            assert_eq!(sync["type"], "SYNC_V1");
+            assert_eq!(sync["channel_id"], CHANNEL_ID_HEX);
+            assert_eq!(sync["user_channel_id"], wallet_user_channel_id);
+            assert_eq!(sync["trade_id"], trade_id);
+            assert_eq!(sync["trade_payment_id"], "payment-one");
+        }
+
+        // Re-delivery of the same payment is a no-op, including its already in-flight response.
+        mgr.handle_trade_payment(
+            &envelope,
+            Some("payment-one"),
+            Some(fee_msat),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        retry_trade_responses(&mgr, &fake).await;
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 8.0);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+
+        // A distinct payment reusing the trade id requeues the original acceptance before its
+        // own signed duplicate rejection, so the secondary outcome cannot replace the first.
+        mgr.handle_trade_payment(
+            &envelope,
+            Some("payment-two"),
+            Some(77_777),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        retry_trade_responses(&mgr, &fake).await;
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 3);
+        let original_raw = std::str::from_utf8(sends[1].custom_tlvs[0].value.as_ref()).unwrap();
+        let original_payload: serde_json::Value = serde_json::from_str(
+            &crate::messages::parse_envelope(original_raw).unwrap().payload,
+        )
+        .unwrap();
+        assert_eq!(original_payload["type"], "SYNC_V1");
+        assert_eq!(original_payload["trade_payment_id"], "payment-one");
+        assert_eq!(sends[2].amount_msat, 1);
+        let raw = std::str::from_utf8(sends[2].custom_tlvs[0].value.as_ref()).unwrap();
+        let rejection: crate::messages::TradeRejectedPayload =
+            serde_json::from_str(&crate::messages::parse_envelope(raw).unwrap().payload).unwrap();
+        assert_eq!(rejection.reason_code, TradeRejectionReason::DuplicateTrade);
+        assert_eq!(rejection.user_channel_id, wallet_user_channel_id);
+    }
+
+    #[tokio::test]
+    async fn exhausted_trade_response_is_dead_lettered_and_requeued_by_exact_replay() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+        let trade_id = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+        let envelope = trade_envelope_with_id(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            trade_id,
+            8.0,
+        );
+
+        mgr.handle_trade_payment(
+            &envelope,
+            Some("offline-wallet-payment"),
+            Some(1),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        for _ in 0..MAX_TRADE_RESPONSE_ATTEMPTS {
+            mgr.db
+                .mark_trade_response_send_failed("offline-wallet-payment", 0)
+                .unwrap();
+        }
+
+        retry_trade_responses(&mgr, &fake).await;
+        assert!(fake.sends.lock().unwrap().is_empty());
+        let dead_letters = mgr
+            .db
+            .list_ledger_events(&stable_channels::ledger::LedgerQuery {
+                identifier: Some("offline-wallet-payment".to_owned()),
+                limit: 20,
+                ..Default::default()
+            })
+            .unwrap()
+            .events
+            .into_iter()
+            .filter(|event| event.event_type == "TRADE_RESPONSE_ABANDONED")
+            .count();
+        assert_eq!(dead_letters, 1);
+
+        mgr.handle_trade_payment(
+            &envelope,
+            Some("offline-wallet-payment"),
+            Some(1),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        retry_trade_responses(&mgr, &fake).await;
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
     async fn trade_rejects_underpaid_signed_fee() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -3586,17 +4178,18 @@ mod tests {
             49_950,
         );
 
-        mgr.handle_trade_message(
-            &env,
-            Some(1),
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        mgr.handle_trade_payment(&env, None, Some(1), &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert!(fake.sends.lock().unwrap().is_empty());
+
+        mgr.handle_trade_message(&env, Some(1), &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 0);
-        assert!(fake.sends.lock().unwrap().is_empty());
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(rejection.reason_code, TradeRejectionReason::InvalidFee);
     }
 
     #[tokio::test]
@@ -3619,34 +4212,82 @@ mod tests {
             0,
             50_000,
             50_000,
-            100_500.0,
+            100_000.0,
         );
 
-        // At the wallet quote this is exactly 49,950 backing sats. Re-deriving at the LSP's
-        // slightly newer price would produce a different allocation.
+        // A quote at the one-percent boundary remains valid. At the wallet quote this is exactly
+        // 49,500 backing sats; re-deriving at the LSP's price would produce a different allocation.
         let env = trade_envelope_with_allocation(
             CHANNEL_ID_HEX,
             USER_CHANNEL_ID_DECIMAL,
-            49.95,
-            100_000.0,
-            49_950,
+            49.995,
+            101_000.0,
+            49_500,
         );
         handle_trade_with_valid_fee(
             &mut mgr,
             &env,
             &fake as &dyn LdkServerCalls,
-            100_500.0,
+            100_000.0,
         )
         .await;
 
-        assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
-        assert_eq!(mgr.stable_channels[0].native_sats, 50);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_500);
+        assert_eq!(mgr.stable_channels[0].native_sats, 500);
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1, "accepted allocation must be synced back");
         let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
         let sync = crate::messages::parse_envelope(raw).unwrap();
         let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
-        assert_eq!(payload["backing_sats"], 49_950);
+        assert_eq!(payload["backing_sats"], 49_500);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_quote_over_one_percent_from_lsp_price() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            50.0445,
+            101_100.0,
+            49_500,
+        );
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(
+            rejection.reason_code,
+            TradeRejectionReason::QuoteOutOfRange
+        );
     }
 
     #[tokio::test]
@@ -3734,7 +4375,12 @@ mod tests {
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 5.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 5_000);
-        assert!(fake.sends.lock().unwrap().is_empty());
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(
+            rejection.reason_code,
+            TradeRejectionReason::InvalidAllocation
+        );
     }
 
     #[tokio::test]
@@ -3755,6 +4401,50 @@ mod tests {
         .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 3.0).abs() < 1e-6); // unchanged
+        assert!(fake.sends.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn authenticated_invalid_trade_id_gets_correlatable_rejection() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+        let env = trade_envelope_with_id(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            "NOT-CANONICAL",
+            10.0,
+        );
+
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(rejection.trade_id, None);
+        assert_eq!(rejection.reason_code, TradeRejectionReason::InvalidAmount);
     }
 
     #[tokio::test]
@@ -3846,6 +4536,47 @@ mod tests {
             "a stale signed trade must be rejected, got {}",
             mgr.stable_channels[0].expected_usd.0
         );
+    }
+
+    #[tokio::test]
+    async fn trade_accepts_within_shared_fifteen_minute_window() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
+        let within_window = test_unix_now() - 10 * 60;
+        let env = trade_envelope_with_ts(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            10.0,
+            within_window,
+        );
+
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 10.0);
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -22,7 +22,14 @@ use tracing::{error, info};
 
 use crate::messages::TradeRejectionReason;
 
-const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 1.0;
+/// A client quote is the wallet's slippage veto, never an accounting input: the target is clamped to
+/// what this side can actually back, so a quote can no longer reach a payout and the bound only has
+/// to admit honest feed spread.
+const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 =
+    stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT;
+
+/// Sat tolerance before a client's allocation checksum is treated as a real divergence.
+const TRADE_ALLOCATION_CHECKSUM_TOLERANCE_SATS: u64 = 2;
 const LEGACY_TRADE_FEE_PRICE_SKEW_PERCENT: f64 = 0.5;
 // The exponential schedule reaches its one-hour cap after ten attempts; this leaves roughly
 // 6.6 days for an offline wallet to recover before the response is dead-lettered.
@@ -83,6 +90,18 @@ fn expected_trade_fee_msat(
     }
 
     Some((fee_sats as u64).saturating_mul(1000).max(1))
+}
+
+/// How far a trade moves the stable target, in whole cents. Targets are cent-denominated but arrive
+/// as f64, where the smallest real move measures 0.0099 once a sell is netted of its fee and
+/// 0.00999999999999 once a buy is rounded to binary. Comparing the move at cent granularity keeps
+/// those trades distinguishable from a target that genuinely does not move.
+fn trade_target_move_cents(old_expected_usd: f64, new_expected_usd: f64) -> u64 {
+    let move_cents = (new_expected_usd - old_expected_usd).abs() * 100.0;
+    if !move_cents.is_finite() {
+        return 0;
+    }
+    move_cents.round() as u64
 }
 
 fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
@@ -1211,10 +1230,14 @@ impl StableChannelManager {
         sc.latest_price = btc_price;
         sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
         sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
-        // Equilibrium reset, clamped so backing can never exceed the live balance
-        // (which would immediately re-trigger the backstop we're protecting against).
+        // Equilibrium reset, clamped to the live balance, with residue absorbed so a full peg survives.
         let equilibrium = ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
-        sc.backing_sats = equilibrium.min(their_sats);
+        sc.backing_sats = stable_channels::stable::normalize_backing_sats(
+            their_sats,
+            equilibrium.min(their_sats),
+            sc.expected_usd.0,
+            btc_price,
+        );
         sc.native_sats = their_sats.saturating_sub(sc.backing_sats);
         stable_channels::stable::recompute_native(sc);
         // The drop is settled; make sure the backstop forgets any ticks it counted.
@@ -1421,8 +1444,15 @@ impl StableChannelManager {
                     let expected_usd_for_db = sc.expected_usd.0;
                     let note_for_db = sc.note.clone();
                     let backing_before = sc.backing_sats;
-                    let backing_after =
-                        ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
+                    // Normalise against the post-payment balance — the live one has not updated yet.
+                    let post_payment_sats = their_sats.saturating_add(amount_sats);
+                    let backing_after = stable_channels::stable::normalize_backing_sats(
+                        post_payment_sats,
+                        (((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64)
+                            .min(post_payment_sats),
+                        sc.expected_usd.0,
+                        btc_price,
+                    );
                     let native_before = sc.native_sats;
                     let last_stability_payment_before = sc.last_stability_payment;
                     let counterparty_for_db = sc.counterparty.to_string();
@@ -2252,6 +2282,13 @@ impl StableChannelManager {
             );
         };
         let current_expected_usd = self.stable_channels[channel_index].expected_usd.0;
+        // A target that does not move is not a trade, just a near-free way to re-book.
+        if trade_target_move_cents(current_expected_usd, payload.expected_usd) == 0 {
+            reject!(
+                TradeRejectionReason::NoOpTrade,
+                "trade does not change the stable target"
+            );
+        }
         let fee_price = payload.quote_price.unwrap_or(btc_price);
         let Some(expected_fee_msat) =
             expected_trade_fee_msat(current_expected_usd, payload.expected_usd, fee_price)
@@ -2271,7 +2308,7 @@ impl StableChannelManager {
         }
 
         let (our_sats, their_sats) = channel_peer_balances(&chan);
-        let new_expected = payload.expected_usd;
+        let requested_expected = payload.expected_usd;
         let signed_allocation = match (payload.quote_price, payload.backing_sats) {
             (Some(quote_price), Some(backing_sats)) => {
                 if payload.ts == 0
@@ -2292,18 +2329,13 @@ impl StableChannelManager {
                         "signed quote is outside the allowed market range"
                     );
                 }
-                let signed_backing_usd = backing_sats as f64 / 100_000_000.0 * quote_price;
-                let allocation_delta_usd = (signed_backing_usd - new_expected).abs();
-                let zero_allocation_is_consistent = if new_expected < 0.01 {
+                // Structural sanity only — the pair is no longer an accounting input.
+                let zero_allocation_is_consistent = if requested_expected < 0.01 {
                     backing_sats == 0
                 } else {
                     backing_sats > 0
                 };
-                if backing_sats > their_sats
-                    || !zero_allocation_is_consistent
-                    || allocation_delta_usd
-                        > stable_channels::constants::STABILITY_THRESHOLD_USD
-                {
+                if backing_sats > their_sats || !zero_allocation_is_consistent {
                     reject!(
                         TradeRejectionReason::InvalidAllocation,
                         "signed backing allocation is inconsistent"
@@ -2318,15 +2350,41 @@ impl StableChannelManager {
             ),
         };
 
-        let validation_price = signed_allocation
-            .map(|(quote_price, _, _)| quote_price)
-            .unwrap_or(btc_price);
-        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), validation_price).0;
-        let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
-        if new_expected > ceiling {
+        // Value the capacity at the LSP's own price: a client quote must never reach a payout.
+        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
+        let spread_ceiling = receiver_usd
+            * (1.0 + stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
+        if requested_expected > spread_ceiling {
             reject!(
                 TradeRejectionReason::InsufficientCapacity,
                 "requested stable allocation exceeds channel capacity"
+            );
+        }
+        // Booking a target this side cannot back would clamp the allocation and leave the difference
+        // as drift the tick pays out, so book the largest backable target instead of funding the gap.
+        let new_expected = if requested_expected > receiver_usd {
+            stable_channels::audit::audit_event(
+                "TRADE_TARGET_CLAMPED_TO_CAPACITY",
+                serde_json::json!({
+                    "channel_id": chan.channel_id,
+                    "user_channel_id": chan.user_channel_id,
+                    "trade_id": trade_id,
+                    "requested_usd": requested_expected,
+                    "booked_usd": receiver_usd,
+                    "their_sats": their_sats,
+                    "lsp_price": btc_price,
+                }),
+            );
+            receiver_usd
+        } else {
+            requested_expected
+        };
+        // The clamp can absorb the whole move; charging for a target that did not change is the
+        // no-op case again, and the client needs to hear that it is already fully allocated.
+        if trade_target_move_cents(current_expected_usd, new_expected) == 0 {
+            reject!(
+                TradeRejectionReason::InsufficientCapacity,
+                "stable target is already at the channel's backable capacity"
             );
         }
 
@@ -2338,14 +2396,32 @@ impl StableChannelManager {
         accepted.stable_provider_usd = USD::from_bitcoin(accepted.stable_provider_btc, btc_price);
         accepted.stable_receiver_usd = USD::from_bitcoin(accepted.stable_receiver_btc, btc_price);
         accepted.latest_price = btc_price;
-        if let Some((_, backing_sats, _)) = signed_allocation {
-            stable_channels::stable::apply_trade_allocation(
-                &mut accepted,
-                new_expected,
-                backing_sats,
+        stable_channels::stable::apply_trade(&mut accepted, new_expected, btc_price);
+        if let Some((quote_price, client_backing_sats, _)) = signed_allocation {
+            // Telemetry, never a gate — re-run the client's own arithmetic at its own quoted price
+            // and its own target, which is what it derived from before any clamp here.
+            let client_self_consistent_sats = stable_channels::stable::trade_backing_sats(
+                their_sats,
+                requested_expected,
+                quote_price,
             );
-        } else {
-            stable_channels::stable::apply_trade(&mut accepted, new_expected, btc_price);
+            if client_self_consistent_sats.abs_diff(client_backing_sats)
+                > TRADE_ALLOCATION_CHECKSUM_TOLERANCE_SATS
+            {
+                stable_channels::audit::audit_event(
+                    "TRADE_ALLOCATION_CHECKSUM_MISMATCH",
+                    serde_json::json!({
+                        "channel_id": chan.channel_id,
+                        "user_channel_id": chan.user_channel_id,
+                        "trade_id": trade_id,
+                        "client_backing_sats": client_backing_sats,
+                        "client_self_consistent_sats": client_self_consistent_sats,
+                        "lsp_backing_sats": accepted.backing_sats,
+                        "client_quote_price": quote_price,
+                        "lsp_price": btc_price,
+                    }),
+                );
+            }
         }
 
         let sync_version = match self.db.candidate_sync_version(&chan.user_channel_id) {
@@ -4321,101 +4397,205 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_applies_signed_allocation_without_lsp_repricing() {
+    async fn trade_reprices_client_allocation_and_creates_no_drift() {
         let mut mgr = make_manager();
-        let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX,
-            USER_CHANNEL_ID_DECIMAL,
-            COUNTERPARTY_HEX,
-            100_000,
-            50_000_000,
-            true,
-        )]);
+        let uid = 189476124653200987495269098788434301048u128;
+        // Half-pegged: 50_000 of the user's 100_000 sats back $50 at the LSP's $100_000 price.
         seed_channel(
-            &mut mgr,
-            189476124653200987495269098788434301048u128,
-            COUNTERPARTY_HEX,
-            CHANNEL_ID_HEX,
-            0.0,
-            0,
-            50_000,
-            50_000,
-            100_000.0,
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            50.0, 50_000, 50_000, 100_000, 100_000.0,
         );
-
-        // A quote at the one-percent boundary remains valid. At the wallet quote this is exactly
-        // 49,500 backing sats; re-deriving at the LSP's price would produce a different allocation.
+        // 200k channel: 100k LSP-side payout liquidity, 100k user-side.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        // Peg the rest at +0.04% (inside the consent bound): 99_960 sats is $100 at the wallet's quote but $99.96 at the LSP's price.
         let env = trade_envelope_with_allocation(
-            CHANNEL_ID_HEX,
-            USER_CHANNEL_ID_DECIMAL,
-            49.995,
-            101_000.0,
-            49_500,
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.0, 100_040.0, 99_960,
         );
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
-        assert_eq!(mgr.stable_channels[0].backing_sats, 49_500);
-        assert_eq!(mgr.stable_channels[0].native_sats, 500);
-        let sends = fake.sends.lock().unwrap();
-        assert_eq!(sends.len(), 1, "accepted allocation must be synced back");
-        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
-        let sync = crate::messages::parse_envelope(raw).unwrap();
-        let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
-        assert_eq!(payload["backing_sats"], 49_500);
+        // Booked at the LSP's own price, not stored as sent.
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
+        assert_eq!(
+            mgr.stable_channels[0].backing_sats, 100_000,
+            "LSP must derive the allocation at its own price",
+        );
+        assert_eq!(mgr.stable_channels[0].native_sats, 0);
+
+        // Drift-neutral by construction: a trade alone can never move funds.
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        let stability = stability_payment_sats(&fake);
+        assert!(stability.is_empty(), "a trade must not trigger a payout, got {:?}", stability);
+    }
+
+    #[test]
+    fn capacity_clamp_leaves_no_payable_residue() {
+        // The clamp is what keeps a trade drift-neutral, so the quote bound is free to admit honest
+        // feed spread. Walk position sizes: a target booked at the ceiling must never be payable.
+        for their_sats in [1_000u64, 50_000, 500_000, 5_000_000] {
+            let price = 100_000.0;
+            let receiver_usd = their_sats as f64 / 100_000_000.0 * price;
+            let booked = receiver_usd
+                * (1.0 + stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
+            let booked = booked.min(receiver_usd);
+            let backing = stable_channels::stable::trade_backing_sats(their_sats, booked, price);
+            let value = backing as f64 / 100_000_000.0 * price;
+            let pct = (((value - booked) / booked) * 100.0).abs();
+            let usd = (value - booked).abs();
+            assert!(
+                pct < stable_channels::constants::STABILITY_THRESHOLD_PERCENT
+                    || usd < stable_channels::constants::STABILITY_THRESHOLD_USD,
+                "clamped trade booked payable drift at {their_sats} sats: {pct}% / ${usd}",
+            );
+        }
     }
 
     #[tokio::test]
-    async fn trade_rejects_quote_over_one_percent_from_lsp_price() {
+    async fn trade_rejects_quote_beyond_consent_bound() {
         let mut mgr = make_manager();
-        let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX,
-            USER_CHANNEL_ID_DECIMAL,
-            COUNTERPARTY_HEX,
-            100_000,
-            50_000_000,
-            true,
-        )]);
+        let uid = 189476124653200987495269098788434301048u128;
         seed_channel(
-            &mut mgr,
-            189476124653200987495269098788434301048u128,
-            COUNTERPARTY_HEX,
-            CHANNEL_ID_HEX,
-            0.0,
-            0,
-            50_000,
-            50_000,
-            100_000.0,
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            50.0, 50_000, 50_000, 100_000, 100_000.0,
         );
-
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        // +0.6% is outside the consent bound; the allocation is self-consistent at that quote.
         let env = trade_envelope_with_allocation(
-            CHANNEL_ID_HEX,
-            USER_CHANNEL_ID_DECIMAL,
-            50.0445,
-            101_100.0,
-            49_500,
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.0, 100_600.0, 99_403,
         );
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
-        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
-        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0, "rejected trade must not apply");
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
         let (response_msat, rejection) = rejection_from_only_send(&fake);
         assert_eq!(response_msat, 1);
-        assert_eq!(
-            rejection.reason_code,
-            TradeRejectionReason::QuoteOutOfRange
+        assert_eq!(rejection.reason_code, TradeRejectionReason::QuoteOutOfRange);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_no_op_target() {
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        // At par: 100_000 sats back $100 at $100_000.
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            100.0, 100_000, 0, 100_000, 100_000.0,
         );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        // Same target, so nothing changes — the historical zero-cost repeat trigger.
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.0, 100_000.0, 100_000,
+        );
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 100_000);
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(rejection.reason_code, TradeRejectionReason::NoOpTrade);
+    }
+
+    #[test]
+    fn one_cent_trades_measure_as_a_move_and_a_repeat_does_not() {
+        // A one-cent buy: 10.61 - 10.60 is 0.009999999999999787 in f64, which a raw < 0.01 test rejects.
+        assert_eq!(trade_target_move_cents(10.61, 10.60), 1);
+        // A one-cent sell is netted of its 1% fee, so it only ever moves the target by 0.0099.
+        assert_eq!(trade_target_move_cents(10.61, 10.61 + 0.0099), 1);
+        // An unchanged target is the no-op this guard exists for.
+        assert_eq!(trade_target_move_cents(100.0, 100.0), 0);
+        assert_eq!(trade_target_move_cents(10.61, 10.6130), 0);
+    }
+
+    #[tokio::test]
+    async fn trade_accepts_a_one_cent_target_move() {
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        // $10.61 of a 100_000-sat balance is 10_610 sats at $100_000.
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            10.61, 10_610, 89_390, 100_000, 100_000.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        // The smallest real buy the wallet can send, and the one f64 subtraction mis-measures.
+        let env = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.60, 100_000.0, 10_600,
+        );
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert_eq!(
+            mgr.stable_channels[0].expected_usd.0, 10.60,
+            "a one-cent trade must not be rejected as a no-op",
+        );
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_600);
+        assert_eq!(mgr.stable_channels[0].native_sats, 89_400);
+    }
+
+    #[tokio::test]
+    async fn trade_audits_a_client_allocation_that_contradicts_its_own_quote() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let uid = 189476124653200987495269098788434301048u128;
+
+        // Self-consistent: 999_600 sats is $1000 at $100_040; the $1000 scale keeps the residue clear of Task 3's future dust-snap threshold.
+        let mut mgr = make_manager();
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            500.0, 500_000, 500_000, 1_000_000, 100_000.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            2_000_000, 1_000_000_000, true,
+        )]);
+        let consistent = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 1000.0, 100_040.0, 999_600,
+        );
+        stable_channels::audit::enable_test_capture();
+        handle_trade_with_valid_fee(&mut mgr, &consistent, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        assert!(
+            !events.iter().any(|(e, _)| e == "TRADE_ALLOCATION_CHECKSUM_MISMATCH"),
+            "feed spread alone must never be flagged",
+        );
+        assert_eq!(mgr.stable_channels[0].backing_sats, 1_000_000);
+
+        // Contradicts itself: 900_000 sats is not $1000 at $100_040 under any rounding.
+        let mut mgr = make_manager();
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            500.0, 500_000, 500_000, 1_000_000, 100_000.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            2_000_000, 1_000_000_000, true,
+        )]);
+        let inconsistent = trade_envelope_with_allocation(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 1000.0, 100_040.0, 900_000,
+        );
+        stable_channels::audit::enable_test_capture();
+        handle_trade_with_valid_fee(&mut mgr, &inconsistent, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
+        assert!(
+            events.iter().any(|(e, _)| e == "TRADE_ALLOCATION_CHECKSUM_MISMATCH"),
+            "a client disagreeing with its own quote must be audited",
+        );
+        // Audited, never gated: the trade still applies, booked at the LSP's own price.
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 1000.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 1_000_000);
     }
 
     #[tokio::test]
@@ -4441,8 +4621,7 @@ mod tests {
             100_000.0,
         );
 
-        // The wallet signed against a receiver balance five sats below the LSP's post-settlement
-        // observation. The pair is still fully collateralized and differs by only half a cent.
+        // The wallet's self-consistent allocation is five sats off the LSP's own derivation, which the LSP ignores.
         let env = trade_envelope_with_allocation(
             CHANNEL_ID_HEX,
             USER_CHANNEL_ID_DECIMAL,
@@ -4458,13 +4637,15 @@ mod tests {
         )
         .await;
 
+        // Booked at the LSP's own derivation (all 50_000 receiver sats), not the client's 49_995.
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
-        assert_eq!(mgr.stable_channels[0].backing_sats, 49_995);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
+        assert_eq!(mgr.stable_channels[0].native_sats, 0);
         assert_eq!(fake.sends.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
-    async fn trade_rejects_allocation_not_derived_from_signed_quote() {
+    async fn trade_reprices_allocation_not_derived_from_signed_quote() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX,
@@ -4489,7 +4670,7 @@ mod tests {
         let env = trade_envelope_with_allocation(
             CHANNEL_ID_HEX,
             USER_CHANNEL_ID_DECIMAL,
-            49.95,
+            49.5,
             100_000.0,
             49_000,
         );
@@ -4501,13 +4682,17 @@ mod tests {
         )
         .await;
 
-        assert_eq!(mgr.stable_channels[0].expected_usd.0, 5.0);
-        assert_eq!(mgr.stable_channels[0].backing_sats, 5_000);
-        let (response_msat, rejection) = rejection_from_only_send(&fake);
-        assert_eq!(response_msat, 1);
+        // A mismatched client allocation is inert: the LSP still applies the trade at its own derivation.
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 49.5);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_500);
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let sync = crate::messages::parse_envelope(raw).unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
         assert_eq!(
-            rejection.reason_code,
-            TradeRejectionReason::InvalidAllocation
+            payload["type"], stable_channels::constants::SYNC_MESSAGE_TYPE,
+            "a mismatched allocation is audited, not rejected"
         );
     }
 
@@ -4596,7 +4781,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_admits_at_balance_boundary_within_epsilon() {
+    async fn trade_over_capacity_books_the_backable_target() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -4604,7 +4789,7 @@ mod tests {
         )]);
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        // A wallet-push lands at receiver_usd plus a sub-epsilon overshoot (independent f64 paths).
+        // A peer valuing the same sats higher asks past this side's capacity: admitted, not funded.
         let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
         handle_trade_with_valid_fee(
@@ -4616,10 +4801,45 @@ mod tests {
         .await;
 
         assert!(
-            (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
-            "a target within epsilon of the balance must be admitted, got {}",
+            (mgr.stable_channels[0].expected_usd.0 - 50.0).abs() < 1e-6,
+            "target must be clamped to backable capacity, got {}",
             mgr.stable_channels[0].expected_usd.0
         );
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000, "whole side backs the peg");
+    }
+
+    #[tokio::test]
+    async fn trade_over_capacity_leaves_nothing_for_the_tick_to_pay() {
+        // The drain was: ask past capacity, let the tick settle the gap, repeat on the larger side.
+        // One request clamps and one is past the spread ceiling entirely; neither may draw a payout.
+        for target in [
+            50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD * 0.8,
+            50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD,
+        ] {
+            let mut mgr = make_manager();
+            let fake = FakeLdkServer::new(vec![make_channel(
+                CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            )]);
+            seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+            let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
+            handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+            assert!(
+                mgr.stable_channels[0].expected_usd.0 <= 50.0,
+                "booked target {} must not exceed backable capacity",
+                mgr.stable_channels[0].expected_usd.0
+            );
+
+            let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+                crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+            ));
+            mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+            assert!(
+                stability_payment_sats(&fake).is_empty(),
+                "a ${target} request must not draw a payout, got {:?}",
+                stability_payment_sats(&fake)
+            );
+        }
     }
 
     #[tokio::test]
@@ -5152,6 +5372,17 @@ mod tests {
         }
     }
 
+    /// Sat amounts of the stability payments in `fake.sends`, ignoring control keysends.
+    fn stability_payment_sats(fake: &FakeLdkServer) -> Vec<u64> {
+        fake.sends.lock().unwrap().iter()
+            .filter(|s| s.custom_tlvs.iter().any(|t| {
+                t.type_num == stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
+                    && t.value.as_ref() == &[1u8][..]
+            }))
+            .map(|s| s.amount_msat / 1000)
+            .collect()
+    }
+
     #[tokio::test]
     async fn incoming_stability_payment_resets_backing_and_preserves_native() {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
@@ -5189,6 +5420,37 @@ mod tests {
         // Native must absorb only rounding, never the settlement: 49_091 - 9_090 = 40_001.
         assert_eq!(sc.native_sats, 40_001, "native sats must be preserved across the settlement");
         assert!(sc.backing_sats <= sc.stable_receiver_btc.sats, "backing may never exceed live balance");
+    }
+
+    #[tokio::test]
+    async fn incoming_stability_reset_absorbs_residue() {
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        // Fully pegged after absorption: 100_040 sats back a $100.00 target booked slightly below par, leaving a 40-sat ($0.04) feed-spread residue at equilibrium.
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            100.0, 100_040, 0, 100_040, 100_000.0,
+        );
+        // The user paid the LSP 40 sats, so their side is now 100_000.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+
+        mgr.reconcile_incoming_stability(
+            Some("payment-1"),
+            Some(40 * 1000),
+            &fake as &dyn LdkServerCalls,
+            100_040.0,
+        )
+        .await;
+
+        // Equilibrium is 99_960 sats, leaving 40 sats ($0.04) of residue — absorb it.
+        assert_eq!(
+            mgr.stable_channels[0].backing_sats, 100_000,
+            "settlement reset must absorb sub-threshold residue, not recreate it",
+        );
+        assert_eq!(mgr.stable_channels[0].native_sats, 0);
     }
 
     #[tokio::test]
@@ -5271,4 +5533,53 @@ mod tests {
             "the miss must be audited with the candidate count"
         );
     }
+
+    #[tokio::test]
+    async fn legacy_trade_without_quote_still_books_at_lsp_price() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            50.0, 50_000, 50_000, 100_000, 100_000.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        // Android's payload shape: expected_usd only, no quote_price/backing_sats/ts.
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.0);
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 100_000);
+        assert_eq!(mgr.stable_channels[0].native_sats, 0);
+    }
+
+    #[tokio::test]
+    async fn allocation_divergence_within_feed_spread_moves_no_funds() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = make_manager();
+        let uid = 189476124653200987495269098788434301048u128;
+        // LSP holds all 100_000 sats behind $99.96 at $100_000; a wallet reading $100_040 derives 99_920 — 80 sats apart.
+        seed_channel(
+            &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
+            99.96, 100_000, 0, 100_000, 100_000.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
+            200_000, 100_000_000, true,
+        )]);
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+
+        let stability = stability_payment_sats(&fake);
+        assert!(
+            stability.is_empty(),
+            "feed-spread divergence must stay inside the deadband, got {:?}", stability,
+        );
+    }
 }
+

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -248,6 +248,37 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         response: &PendingTradeResponse,
     ) -> bool {
+        let attempt = response.attempts.saturating_add(1);
+        match db.reserve_trade_response_attempt(
+            &response.inbound_payment_id,
+            response.attempts,
+            MAX_TRADE_RESPONSE_ATTEMPTS,
+            Self::unix_time_secs(),
+        ) {
+            Ok(true) => {}
+            Ok(false) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_RESPONSE_RESERVATION_SKIPPED",
+                    serde_json::json!({
+                        "trade_payment_id": response.inbound_payment_id,
+                        "expected_attempts": response.attempts,
+                    }),
+                );
+                return false;
+            }
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({
+                        "op": "reserve_trade_response_attempt",
+                        "trade_payment_id": response.inbound_payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return false;
+            }
+        }
+
         let req = SpontaneousSendRequest {
             amount_msat: response.response_amount_msat,
             node_id: response.counterparty.clone(),
@@ -262,8 +293,9 @@ impl StableChannelManager {
                 if let Err(error) = db
                     .mark_trade_response_in_flight(&response.inbound_payment_id, &sent.payment_id)
                 {
-                    // The send has already happened. Leaving the persisted obligation pending can
-                    // produce a duplicate nominal control response after restart.
+                    // The send has already happened, but its attempt and next backoff were
+                    // persisted first. A later retry can duplicate this nominal response, but it
+                    // cannot retry immediately or bypass the bounded attempt budget.
                     stable_channels::audit::audit_event(
                         "TRADE_RESPONSE_PAYMENT_ID_PERSIST_FAILED",
                         serde_json::json!({
@@ -280,7 +312,7 @@ impl StableChannelManager {
                         "trade_payment_id": response.inbound_payment_id,
                         "response_payment_id": sent.payment_id,
                         "amount_msat": response.response_amount_msat,
-                        "attempt": response.attempts.saturating_add(1),
+                        "attempt": attempt,
                     }),
                 );
                 true
@@ -290,24 +322,12 @@ impl StableChannelManager {
                     Ok(_) => "spontaneous send returned an empty payment id".to_owned(),
                     Err(error) => error.to_string(),
                 };
-                if let Err(db_error) = db.mark_trade_response_send_failed(
-                    &response.inbound_payment_id,
-                    Self::unix_time_secs(),
-                ) {
-                    stable_channels::audit::audit_event(
-                        "DB_WRITE_FAILED",
-                        serde_json::json!({
-                            "op": "mark_trade_response_send_failed",
-                            "trade_payment_id": response.inbound_payment_id,
-                            "error": db_error.to_string(),
-                        }),
-                    );
-                }
                 stable_channels::audit::audit_event(
                     "TRADE_RESPONSE_SEND_FAILED",
                     serde_json::json!({
                         "trade_payment_id": response.inbound_payment_id,
                         "amount_msat": response.response_amount_msat,
+                        "attempt": attempt,
                         "error": error,
                     }),
                 );
@@ -4114,10 +4134,16 @@ mod tests {
             100_000.0,
         )
         .await;
-        for _ in 0..MAX_TRADE_RESPONSE_ATTEMPTS {
-            mgr.db
-                .mark_trade_response_send_failed("offline-wallet-payment", 0)
-                .unwrap();
+        for attempt in 0..MAX_TRADE_RESPONSE_ATTEMPTS {
+            assert!(mgr
+                .db
+                .reserve_trade_response_attempt(
+                    "offline-wallet-payment",
+                    attempt,
+                    MAX_TRADE_RESPONSE_ATTEMPTS,
+                    i64::MAX,
+                )
+                .unwrap());
         }
 
         retry_trade_responses(&mgr, &fake).await;
@@ -4146,6 +4172,108 @@ mod tests {
         .await;
         retry_trade_responses(&mgr, &fake).await;
         assert_eq!(fake.sends.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn response_payment_id_persist_failure_keeps_reserved_backoff() {
+        let mgr = make_manager();
+        assert!(mgr
+            .db
+            .persist_trade_rejection(
+                "persist-failure-payment",
+                None,
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                None,
+                COUNTERPARTY_HEX,
+                "internal_error",
+                "temporary failure",
+                "signed-rejection",
+            )
+            .unwrap());
+        let conn = rusqlite::Connection::open(
+            mgr.data_dir()
+                .join(stable_channels::db::DB_FILENAME),
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_response_payment_id_persist
+             BEFORE UPDATE OF response_status, response_payment_id ON trade_decisions
+             WHEN NEW.response_status = 'in_flight'
+             BEGIN
+                SELECT RAISE(ABORT, 'injected payment-id persistence failure');
+             END;",
+        )
+        .unwrap();
+        drop(conn);
+        let fake = FakeLdkServer::new(vec![]);
+        let before = StableChannelManager::unix_time_secs();
+
+        retry_trade_responses(&mgr, &fake).await;
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+        let conn = rusqlite::Connection::open(
+            mgr.data_dir()
+                .join(stable_channels::db::DB_FILENAME),
+        )
+        .unwrap();
+        let state: (String, i64, i64) = conn
+            .query_row(
+                "SELECT response_status, response_attempts, next_response_attempt_at
+                 FROM trade_decisions
+                 WHERE inbound_payment_id = 'persist-failure-payment'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(state.0, "pending");
+        assert_eq!(state.1, 1);
+        assert!(state.2 >= before + 5);
+        drop(conn);
+
+        retry_trade_responses(&mgr, &fake).await;
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "the persisted backoff must prevent an immediate duplicate keysend",
+        );
+    }
+
+    #[tokio::test]
+    async fn response_attempt_reservation_failure_sends_nothing() {
+        let mgr = make_manager();
+        assert!(mgr
+            .db
+            .persist_trade_rejection(
+                "reservation-failure-payment",
+                None,
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                None,
+                COUNTERPARTY_HEX,
+                "internal_error",
+                "temporary failure",
+                "signed-rejection",
+            )
+            .unwrap());
+        let conn = rusqlite::Connection::open(
+            mgr.data_dir()
+                .join(stable_channels::db::DB_FILENAME),
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_response_attempt_reservation
+             BEFORE UPDATE OF response_attempts ON trade_decisions
+             WHEN NEW.response_attempts > OLD.response_attempts
+             BEGIN
+                SELECT RAISE(ABORT, 'injected attempt reservation failure');
+             END;",
+        )
+        .unwrap();
+        drop(conn);
+        let fake = FakeLdkServer::new(vec![]);
+
+        retry_trade_responses(&mgr, &fake).await;
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -15,6 +15,7 @@ use ldk_server_client::ldk_server_grpc::api::{
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
 use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord, PaymentStatus};
+use ring::rand::{SecureRandom, SystemRandom};
 use stable_channels::db::Database;
 use stable_channels::db::PendingTradeResponse;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
@@ -22,14 +23,11 @@ use tracing::{error, info};
 
 use crate::messages::TradeRejectionReason;
 
-/// A client quote is the wallet's slippage veto, never an accounting input: the target is clamped to
-/// what this side can actually back, so a quote can no longer reach a payout and the bound only has
-/// to admit honest feed spread.
+/// A client quote is the wallet's slippage veto, never an accounting input. The LSP either books the
+/// exact requested target at its own price or rejects it, so the quote cannot create payable drift.
 const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 =
     stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT;
 
-/// Sat tolerance before a client's allocation checksum is treated as a real divergence.
-const TRADE_ALLOCATION_CHECKSUM_TOLERANCE_SATS: u64 = 2;
 const LEGACY_TRADE_FEE_PRICE_SKEW_PERCENT: f64 = 0.5;
 // The exponential schedule reaches its one-hour cap after ten attempts; this leaves roughly
 // 6.6 days for an offline wallet to recover before the response is dead-lettered.
@@ -116,6 +114,12 @@ fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
     // allowance, plus one sat for whole-sat rounding, while still rejecting material underpay.
     ((expected_msat as f64 * LEGACY_TRADE_FEE_PRICE_SKEW_PERCENT / 100.0).ceil() as u64)
         .max(1000)
+}
+
+fn new_stability_settlement_id() -> Option<String> {
+    let mut bytes = [0u8; 32];
+    SystemRandom::new().fill(&mut bytes).ok()?;
+    Some(hex::encode(bytes))
 }
 
 /// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
@@ -236,10 +240,12 @@ pub struct StableChannelManager {
     spend_debounce: std::collections::HashMap<u128, u8>,
     /// Per-channel last logged stability outcome + value, so run_tick only audits on state-change.
     stability_throttle: std::collections::HashMap<u128, (String, f64)>,
-    /// Persisted allocations still awaiting their one-time startup SYNC. Tracking each channel
+    /// Persisted allocations awaiting a startup or recovery SYNC. Tracking each channel
     /// independently prevents one incoherent channel from blocking every other wallet.
     startup_sync_pending: std::collections::HashSet<u128>,
-    startup_sync_initialized: bool,
+    /// A successful channel snapshot omitted at least one active database row. Keep retrying
+    /// reconciliation even when other channels remain populated; absence alone is not closure.
+    reconcile_incomplete: bool,
 }
 
 /// Outcome of an `edit_stable_channel` call.
@@ -612,7 +618,7 @@ impl StableChannelManager {
             spend_debounce: std::collections::HashMap::new(),
             stability_throttle: std::collections::HashMap::new(),
             startup_sync_pending: std::collections::HashSet::new(),
-            startup_sync_initialized: false,
+            reconcile_incomplete: false,
         }
     }
 
@@ -794,12 +800,18 @@ impl StableChannelManager {
         );
     }
 
-    /// Rebuild the in-memory stable-channel list at startup from sqlite joined with the live snapshot, dropping vanished channels.
+    /// Rebuild the in-memory stable-channel list from SQLite joined with the live snapshot.
+    /// Snapshot absence is recoverable; only an authoritative ChannelClosed event closes a row.
     pub async fn reconcile_from_grpc(
         &mut self,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
+        let previously_live: std::collections::HashSet<u128> = self
+            .stable_channels
+            .iter()
+            .map(|sc| sc.user_channel_id)
+            .collect();
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
             Ok(r) => r.channels,
             Err(e) => {
@@ -836,28 +848,19 @@ impl StableChannelManager {
 
         // Rebuild the in-memory Vec from the persisted records joined with the live snapshot.
         let mut rebuilt: Vec<StableChannel> = Vec::new();
+        let mut snapshot_incomplete = false;
         for record in &records {
             // Parse user_channel_id the same (decimal) way for db records and live channels so they match.
             let live = parse_user_channel_id(&record.user_channel_id)
                 .and_then(|uid| by_user_channel_id.get(&uid).map(|c| (uid, c)));
 
             let Some((user_channel_id_u128, c)) = live else {
-                // Channel not in current live snapshot — soft-close in DB so
-                // forensics survive a transient gRPC blip. If the channel
-                // comes back on a future reconcile or save_channel call,
-                // closed_at is cleared automatically.
-                if let Err(e) = self.db.mark_channel_closed(&record.user_channel_id) {
-                    tracing::error!(
-                        "[stable] reconcile: db.mark_channel_closed({}) failed: {}",
-                        record.user_channel_id, e
-                    );
-                    stable_channels::audit::audit_event(
-                        "DB_WRITE_FAILED",
-                        serde_json::json!({ "op": "mark_channel_closed", "context": "reconcile", "user_channel_id": record.user_channel_id, "error": e.to_string() }),
-                    );
-                }
+                // A successful ListChannels response can still be temporarily incomplete while
+                // LDK starts or reconnects. Keep the row active and retry; ChannelClosed is the
+                // only authoritative closure signal.
+                snapshot_incomplete = true;
                 stable_channels::audit::audit_event(
-                    "CHANNEL_MARKED_CLOSED_AT_STARTUP",
+                    "CHANNEL_MISSING_FROM_LIVE_SNAPSHOT",
                     serde_json::json!({ "user_channel_id": record.user_channel_id }),
                 );
                 continue;
@@ -894,16 +897,22 @@ impl StableChannelManager {
         }
 
         self.stable_channels = rebuilt;
+        self.reconcile_incomplete = snapshot_incomplete;
         info!(
             "[stable] reconciled {} stable channel(s) from sqlite",
             self.stable_channels.len()
         );
 
-        if !self.startup_sync_initialized && !self.stable_channels.is_empty() {
-            self.startup_sync_pending
-                .extend(self.stable_channels.iter().map(|sc| sc.user_channel_id));
-            self.startup_sync_initialized = true;
-        }
+        // Synchronize every persisted channel when it first becomes live in this process, and
+        // again whenever it recovers after an incomplete snapshot. A one-shot startup flag loses
+        // this transition: the missing row is removed from `startup_sync_pending`, then can never
+        // be queued again when it reappears.
+        self.startup_sync_pending.extend(
+            self.stable_channels
+                .iter()
+                .map(|sc| sc.user_channel_id)
+                .filter(|uid| !previously_live.contains(uid)),
+        );
         self.retry_startup_sync(ldk).await;
     }
 
@@ -953,9 +962,10 @@ impl StableChannelManager {
         }
     }
 
-    /// Self-heal: if the in-memory list is empty (startup/reconnect reconcile skipped on a cold price cache), rebuild it from truth; a populated list is left untouched so a transient empty snapshot can't wipe it.
+    /// Self-heal an empty or previously incomplete snapshot. A populated, complete list is left
+    /// untouched so normal ticks do not rebuild in-memory cooldown state.
     pub async fn reconcile_if_empty(&mut self, ldk: &dyn LdkServerCalls, btc_price: f64) {
-        if self.stable_channels.is_empty() {
+        if self.stable_channels.is_empty() || self.reconcile_incomplete {
             self.reconcile_from_grpc(ldk, btc_price).await;
         } else {
             self.retry_startup_sync(ldk).await;
@@ -1019,6 +1029,73 @@ impl StableChannelManager {
         };
 
         let (our_sats, their_sats) = channel_peer_balances(&c);
+
+        // A temporarily incomplete ListChannels snapshot may have removed this channel from
+        // memory while deliberately preserving its active SQLite row. Never infer "new channel"
+        // from memory alone: that would overwrite its persisted peg with zero allocation below.
+        let persisted = match self.db.load_all_channels() {
+            Ok(records) => records.into_iter().find(|record| {
+                parse_user_channel_id(&record.user_channel_id) == Some(target_uid)
+            }),
+            Err(e) => {
+                tracing::error!(
+                    "[stable] handle_channel_ready: db.load_all_channels failed: {}",
+                    e
+                );
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({ "op": "load_all_channels", "context": "handle_channel_ready", "channel_id": channel_id, "user_channel_id": user_channel_id, "error": e.to_string() }),
+                );
+                return;
+            }
+        };
+        if let Some(record) = persisted {
+            // Recreate the pre-event allocation snapshot from durable state. The splice handler
+            // then compares that total with the live balance, preserving the target/backing while
+            // still accounting for any real balance change that accompanied ChannelReady.
+            let previous_receiver_sats = record
+                .backing_sats
+                .saturating_add(record.native_sats);
+            let expected_usd = USD::from_f64(record.expected_usd);
+            let mut recovered = build_stable_channel(
+                &c,
+                target_uid,
+                expected_usd,
+                Bitcoin::from_usd(expected_usd, btc_price),
+                Bitcoin::from_sats(our_sats),
+                Bitcoin::from_sats(previous_receiver_sats),
+                USD::from_bitcoin(Bitcoin::from_sats(our_sats), btc_price),
+                USD::from_bitcoin(Bitcoin::from_sats(previous_receiver_sats), btc_price),
+                record.backing_sats,
+                record.native_sats,
+                record.note,
+                btc_price,
+                self.data_dir.clone(),
+            );
+            stable_channels::stable::recompute_native(&mut recovered);
+            self.stable_channels.push(recovered);
+            self.startup_sync_pending.insert(target_uid);
+            stable_channels::audit::audit_event(
+                "CHANNEL_READY_RECOVERED_FROM_DB",
+                serde_json::json!({
+                    "channel_id": channel_id,
+                    "user_channel_id": user_channel_id,
+                    "funding_txo": funding_txo.as_deref(),
+                    "expected_usd": record.expected_usd,
+                    "backing_sats": record.backing_sats,
+                    "native_sats": record.native_sats,
+                }),
+            );
+            self.handle_channel_ready_splice(
+                target_uid,
+                funding_txo.as_deref(),
+                ldk,
+                btc_price,
+            )
+            .await;
+            self.retry_startup_sync(ldk).await;
+            return;
+        }
 
         let new_sc = StableChannel {
             channel_id: ldk_node::lightning::ln::types::ChannelId::from_bytes(
@@ -1088,6 +1165,37 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
+        // A dual-format payment carries the legacy marker first by TLV number. Always select the
+        // authenticated record before considering that compatibility hint, or the same transfer
+        // could be applied twice.
+        if let Some(record) = custom_records.iter().find(|record| {
+            record.type_num == stable_channels::constants::SIGNED_STABILITY_TLV_TYPE
+        }) {
+            if record.value.len() > crate::messages::MAX_TLV_VALUE_BYTES {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                    serde_json::json!({ "reason": "oversize", "len": record.value.len() }),
+                );
+                return;
+            }
+            let Ok(raw) = std::str::from_utf8(record.value.as_ref()) else {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                    serde_json::json!({ "reason": "utf8" }),
+                );
+                return;
+            };
+            self.handle_signed_stability_payment(
+                raw,
+                payment_id.as_deref(),
+                amount_msat,
+                ldk,
+                btc_price,
+            )
+            .await;
+            return;
+        }
+
         for rec in &custom_records {
             if rec.type_num != stable_channels::constants::STABLE_CHANNEL_TLV_TYPE {
                 continue;
@@ -1111,34 +1219,41 @@ impl StableChannelManager {
                 serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE, "payment_id": payment_id.clone() }),
             );
             let raw = raw.to_string();
-            if crate::messages::parse_envelope(&raw).is_some() {
-                if let Some(pid) = payment_id.as_deref() {
-                    if let Err(e) = self.db.record_settlement(pid, "sync") {
-                        tracing::error!("[stable] record_settlement (inbound sync) failed: {}", e);
-                        stable_channels::audit::audit_event(
-                            "DB_WRITE_FAILED",
-                            serde_json::json!({ "op": "record_settlement", "kind": "sync", "payment_id": pid, "error": e.to_string() }),
-                        );
-                    }
-                }
-                self.handle_trade_payment(&raw, payment_id.as_deref(), amount_msat, ldk, btc_price)
+            if let Some(envelope) = crate::messages::parse_envelope(&raw) {
+                let message_type = serde_json::from_str::<serde_json::Value>(&envelope.payload)
+                    .ok()
+                    .and_then(|value| value.get("type").and_then(|kind| kind.as_str()).map(str::to_owned));
+                if message_type.as_deref() != Some("STABILITY_PAYMENT_V1") {
+                    self.handle_trade_payment(
+                        &raw,
+                        payment_id.as_deref(),
+                        amount_msat,
+                        ldk,
+                        btc_price,
+                    )
                     .await;
+                } else {
+                    stable_channels::audit::audit_event(
+                        "STABILITY_PAYMENT_WRONG_TLV_TYPE",
+                        serde_json::json!({ "payment_id": payment_id }),
+                    );
+                }
+            } else if rec.value.as_ref() == &[1u8][..] {
+                self.handle_legacy_stability_payment(
+                    payment_id.as_deref(),
+                    amount_msat,
+                    ldk,
+                    btc_price,
+                )
+                .await;
             } else {
-                if let Some(pid) = payment_id.as_deref() {
-                    if let Err(e) = self.db.record_settlement(pid, "stability") {
-                        tracing::error!("[stable] record_settlement (inbound stability) failed: {}", e);
-                        stable_channels::audit::audit_event(
-                            "DB_WRITE_FAILED",
-                            serde_json::json!({ "op": "record_settlement", "kind": "stability", "payment_id": pid, "error": e.to_string() }),
-                        );
-                    }
-                }
-                // Tagged-but-not-envelope = a user's stability payment. Reconcile the
-                // books NOW: with stale backing_sats the channel still reads above par
-                // (double-charge risk) and the balance-truth backstop would misread the
-                // user's payment as an unreconciled spend and deduct expected_usd.
-                self.reconcile_incoming_stability(payment_id.as_deref(), amount_msat, ldk, btc_price)
-                    .await;
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                    serde_json::json!({
+                        "payment_id": payment_id,
+                        "amount_msat": amount_msat,
+                    }),
+                );
             }
             return;
         }
@@ -1149,35 +1264,173 @@ impl StableChannelManager {
         );
     }
 
-    /// Settle the books for an inbound stability payment (user above par paid the LSP).
-    ///
-    /// The user's side of the channel just dropped by the payment amount, so their
-    /// stable value is back at par — reset `backing_sats` to equilibrium
-    /// (expected_usd at the current price), exactly mirroring the reset done after
-    /// the LSP *sends* a stability payment. `native_sats` is the remainder, so the
-    /// user's non-stable sats are untouched by the settlement.
-    ///
-    /// The event carries no channel id, so the channel is attributed by amount:
-    /// the tracked channel whose live user-side balance dropped by the payment
-    /// amount (±1 sat for msat rounding) since the last tick snapshot. If the match
-    /// is not unique, nothing is mutated and the miss is audited — the tick +
-    /// backstop path then handles it as before, but visibly.
-    async fn reconcile_incoming_stability(
+    /// Compatibility path for unchanged mobile wallets. The marker is only a category hint: it
+    /// cannot clear an obligation or reset to equilibrium. A uniquely attributable transfer moves
+    /// backing by the received sats and is deduplicated by its Lightning payment id.
+    async fn handle_legacy_stability_payment(
         &mut self,
         payment_id: Option<&str>,
         amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
-        let amount_sats = amount_msat.unwrap_or(0) / 1000;
+        let (Some(payment_id), Some(amount_msat)) = (payment_id, amount_msat) else {
+            return;
+        };
+        let amount_sats = amount_msat / 1000;
         if amount_sats == 0 {
-            // Sub-sat keysends are control traffic (sync/trade carriers), not settlements.
             return;
         }
-        if btc_price <= 0.0 {
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(response) => response.channels,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "LEGACY_STABILITY_PAYMENT_UNATTRIBUTABLE",
+                    serde_json::json!({
+                        "payment_id": payment_id,
+                        "reason": "list_channels_failed",
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let mut matches = Vec::new();
+        for (index, stable) in self.stable_channels.iter().enumerate() {
+            let Some(channel) = channels.iter().find(|channel| {
+                parse_user_channel_id(&channel.user_channel_id) == Some(stable.user_channel_id)
+            }) else {
+                continue;
+            };
+            let (_, their_sats) = channel_peer_balances(channel);
+            let balance_drop = stable.stable_receiver_btc.sats.saturating_sub(their_sats);
+            if balance_drop > 0 && balance_drop.abs_diff(amount_sats) <= 1 {
+                matches.push((index, channel.clone(), their_sats));
+            }
+        }
+        if matches.len() != 1 {
             stable_channels::audit::audit_event(
-                "STABILITY_RECEIVE_UNATTRIBUTED",
-                serde_json::json!({ "payment_id": payment_id, "amount_msat": amount_msat, "reason": "price_cold" }),
+                "LEGACY_STABILITY_PAYMENT_UNATTRIBUTABLE",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "amount_msat": amount_msat,
+                    "candidates": matches.len(),
+                }),
+            );
+            return;
+        }
+        let (index, channel, their_sats) = matches.remove(0);
+        if amount_sats > self.stable_channels[index].backing_sats
+            || self.stable_channels[index].backing_sats - amount_sats > their_sats
+        {
+            return;
+        }
+        let delta = match i64::try_from(amount_sats) {
+            Ok(amount) => -amount,
+            Err(_) => return,
+        };
+        let amount_usd = (btc_price > 0.0).then(|| {
+            amount_sats as f64 / stable_channels::constants::SATS_IN_BTC as f64 * btc_price
+        });
+        let persisted = match self.db.record_payment_and_maybe_update_backing(
+            Some(payment_id),
+            None,
+            "stability",
+            "received",
+            amount_msat,
+            amount_usd,
+            (btc_price > 0.0).then_some(btc_price),
+            "completed",
+            Some(&channel.user_channel_id),
+            Some(delta),
+        ) {
+            Ok(persisted) => persisted,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({
+                        "op": "record_legacy_stability_payment",
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        if persisted.is_new {
+            let stable = &mut self.stable_channels[index];
+            stable.latest_price = btc_price;
+            stable.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            stable.stable_receiver_usd = USD::from_bitcoin(stable.stable_receiver_btc, btc_price);
+            if let Some(new_backing) = persisted.new_backing {
+                stable.backing_sats = new_backing.max(0) as u64;
+            }
+            stable.native_sats = their_sats.saturating_sub(stable.backing_sats);
+            stable_channels::stable::recompute_native(stable);
+            self.spend_debounce.remove(&stable.user_channel_id);
+        }
+        stable_channels::audit::audit_event(
+            "LEGACY_STABILITY_PAYMENT_APPLIED",
+            serde_json::json!({
+                "payment_id": payment_id,
+                "channel_id": channel.channel_id,
+                "user_channel_id": channel.user_channel_id,
+                "amount_msat": amount_msat,
+                "is_new": persisted.is_new,
+                "new_backing_sats": self.stable_channels[index].backing_sats,
+            }),
+        );
+    }
+
+    /// Verify and apply a wallet-to-LSP stability payment.
+    ///
+    /// The signed envelope authenticates intent and channel binding, while the Lightning event is
+    /// authoritative for value. Accounting moves by exactly the received sats; it never jumps to
+    /// a price-derived equilibrium, so a one-sat payment can settle only one sat of drift.
+    async fn handle_signed_stability_payment(
+        &mut self,
+        raw: &str,
+        payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let Some(envelope) = crate::messages::parse_envelope(raw) else {
+            return;
+        };
+        let Some(payload) = crate::messages::parse_stability_payment_payload(&envelope.payload)
+        else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                serde_json::json!({ "payment_id": payment_id }),
+            );
+            return;
+        };
+        let (Some(payment_id), Some(received_msat)) = (payment_id, amount_msat) else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_UNATTRIBUTABLE",
+                serde_json::json!({ "payment_id": payment_id, "amount_msat": amount_msat }),
+            );
+            return;
+        };
+        if payload.kind != "STABILITY_PAYMENT_V1"
+            || !crate::messages::is_valid_settlement_id(&payload.settlement_id)
+            || payload.channel_id.len() != 64
+            || !payload.channel_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || payload.user_channel_id.is_empty()
+            || payload.amount_msat == 0
+            || payload.amount_msat % 1000 != 0
+            || payload.amount_msat != received_msat
+            || payload.ts == 0
+        {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_FIELDS_INVALID",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "settlement_id": payload.settlement_id,
+                    "signed_amount_msat": payload.amount_msat,
+                    "received_amount_msat": received_msat,
+                }),
             );
             return;
         }
@@ -1185,85 +1438,133 @@ impl StableChannelManager {
             Ok(r) => r.channels,
             Err(e) => {
                 stable_channels::audit::audit_event(
-                    "STABILITY_RECEIVE_UNATTRIBUTED",
-                    serde_json::json!({ "payment_id": payment_id, "amount_msat": amount_msat, "reason": "list_channels_failed", "error": e.to_string() }),
+                    "STABILITY_PAYMENT_UNATTRIBUTABLE",
+                    serde_json::json!({ "payment_id": payment_id, "reason": "list_channels_failed", "error": e.to_string() }),
                 );
                 return;
             }
         };
-
-        // Attribute by balance drop: (index, live channel, live user-side sats).
-        let mut matches: Vec<(usize, &Channel, u64)> = Vec::new();
-        for (i, sc) in self.stable_channels.iter().enumerate() {
-            if sc.expected_usd.0 < 0.01 {
-                continue;
-            }
-            let Some(c) = channels.iter().find(|c| {
-                parse_user_channel_id(&c.user_channel_id) == Some(sc.user_channel_id)
-            }) else {
-                continue;
-            };
-            let (_, their_sats) = channel_peer_balances(c);
-            let drop = sc.stable_receiver_btc.sats.saturating_sub(their_sats);
-            if drop > 0 && drop.abs_diff(amount_sats) <= 1 {
-                matches.push((i, c, their_sats));
-            }
-        }
-
-        if matches.len() != 1 {
+        let Some(channel) = channels
+            .iter()
+            .find(|channel| channel.channel_id.eq_ignore_ascii_case(&payload.channel_id))
+            .cloned()
+        else {
             stable_channels::audit::audit_event(
-                "STABILITY_RECEIVE_UNATTRIBUTED",
+                "STABILITY_PAYMENT_CHANNEL_MISMATCH",
                 serde_json::json!({
                     "payment_id": payment_id,
-                    "amount_msat": amount_msat,
-                    "reason": "no_unique_match",
-                    "candidates": matches.len(),
+                    "settlement_id": payload.settlement_id,
+                    "payload_channel_id": payload.channel_id,
+                }),
+            );
+            return;
+        };
+        let signature_valid = matches!(
+            ldk.verify_signature(VerifySignatureRequest {
+                message: envelope.payload.as_bytes().to_vec().into(),
+                signature: envelope.signature,
+                public_key: channel.counterparty_node_id.clone(),
+            })
+            .await,
+            Ok(response) if response.valid
+        );
+        if !signature_valid {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_SIGNATURE_INVALID",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "settlement_id": payload.settlement_id,
+                    "channel_id": channel.channel_id,
                 }),
             );
             return;
         }
-        let (idx, live, their_sats) = matches[0];
-        let channel_id = live.channel_id.clone();
-        let sc = &mut self.stable_channels[idx];
-        let uid = sc.user_channel_id;
 
-        sc.latest_price = btc_price;
-        sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
-        sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
-        // Equilibrium reset, clamped to the live balance, with residue absorbed so a full peg survives.
-        let equilibrium = ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
-        sc.backing_sats = stable_channels::stable::normalize_backing_sats(
-            their_sats,
-            equilibrium.min(their_sats),
-            sc.expected_usd.0,
-            btc_price,
-        );
-        sc.native_sats = their_sats.saturating_sub(sc.backing_sats);
-        stable_channels::stable::recompute_native(sc);
-        // The drop is settled; make sure the backstop forgets any ticks it counted.
-        self.spend_debounce.remove(&uid);
-
-        if let Err(e) = self.db.save_channel(
-            &channel_id,
-            &format!("{}", uid),
-            self.stable_channels[idx].expected_usd.0,
-            self.stable_channels[idx].backing_sats,
-            self.stable_channels[idx].native_sats,
-            self.stable_channels[idx].note.as_deref(),
-        ) {
-            tracing::error!("[stable] reconcile_incoming save_channel failed: {}", e);
+        let Some(uid) = parse_user_channel_id(&channel.user_channel_id) else {
+            return;
+        };
+        let Some(idx) = self
+            .stable_channels
+            .iter()
+            .position(|stable| stable.user_channel_id == uid)
+        else {
+            return;
+        };
+        let amount_sats = received_msat / 1000;
+        let (_, their_sats) = channel_peer_balances(&channel);
+        if amount_sats > self.stable_channels[idx].backing_sats
+            || self.stable_channels[idx].backing_sats - amount_sats > their_sats
+        {
             stable_channels::audit::audit_event(
-                "DB_WRITE_FAILED",
-                serde_json::json!({ "op": "save_channel", "context": "reconcile_incoming", "user_channel_id": format!("{}", uid), "channel_id": channel_id, "error": e.to_string() }),
+                "STABILITY_PAYMENT_ALLOCATION_INVALID",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "settlement_id": payload.settlement_id,
+                    "amount_sats": amount_sats,
+                    "backing_sats": self.stable_channels[idx].backing_sats,
+                    "live_receiver_sats": their_sats,
+                }),
             );
+            return;
+        }
+        let user_channel_id = channel.user_channel_id.clone();
+        let current_version = self.db.get_sync_version(&user_channel_id).ok().flatten();
+        let delta = match i64::try_from(amount_sats) {
+            Ok(amount) => -amount,
+            Err(_) => return,
+        };
+        let amount_usd = (btc_price > 0.0).then(|| {
+            amount_sats as f64 / stable_channels::constants::SATS_IN_BTC as f64 * btc_price
+        });
+        let persisted = match self.db.record_payment_and_maybe_update_backing(
+            Some(payment_id),
+            Some(&payload.settlement_id),
+            "stability",
+            "received",
+            received_msat,
+            amount_usd,
+            (btc_price > 0.0).then_some(btc_price),
+            "completed",
+            Some(&user_channel_id),
+            Some(delta),
+        ) {
+            Ok(persisted) => persisted,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({
+                        "op": "record_signed_stability_payment",
+                        "payment_id": payment_id,
+                        "settlement_id": payload.settlement_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        if persisted.is_new {
+            let sc = &mut self.stable_channels[idx];
+            sc.latest_price = btc_price;
+            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
+            if let Some(new_backing) = persisted.new_backing {
+                sc.backing_sats = new_backing.max(0) as u64;
+            }
+            sc.native_sats = their_sats.saturating_sub(sc.backing_sats);
+            stable_channels::stable::recompute_native(sc);
+            self.spend_debounce.remove(&uid);
         }
         stable_channels::audit::audit_event(
-            "STABILITY_RECEIVED_RECONCILED",
+            "STABILITY_PAYMENT_V1_APPLIED",
             serde_json::json!({
-                "channel_id": channel_id,
-                "user_channel_id": format!("{}", uid),
+                "channel_id": channel.channel_id,
+                "user_channel_id": user_channel_id,
                 "payment_id": payment_id,
-                "amount_msat": amount_msat,
+                "settlement_id": payload.settlement_id,
+                "amount_msat": received_msat,
+                "allocation_version": payload.allocation_version,
+                "current_allocation_version": current_version,
+                "is_new": persisted.is_new,
                 "new_backing_sats": self.stable_channels[idx].backing_sats,
                 "new_native_sats": self.stable_channels[idx].native_sats,
             }),
@@ -1429,30 +1730,82 @@ impl StableChannelManager {
 
             if c.is_usable {
                 if is_receiver_below_expected {
+                    let Some(settlement_id) = new_stability_settlement_id() else {
+                        stable_channels::audit::audit_event(
+                            "STABILITY_PAYMENT_FAILED",
+                            serde_json::json!({
+                                "channel_id": c.channel_id,
+                                "user_channel_id": c.user_channel_id,
+                                "direction": direction,
+                                "stage": "settlement_id",
+                            }),
+                        );
+                        continue;
+                    };
+                    let allocation_version = self
+                        .db
+                        .get_sync_version(&c.user_channel_id)
+                        .ok()
+                        .flatten()
+                        .unwrap_or(0);
+                    let payload = crate::messages::build_stability_payment_payload(
+                        &settlement_id,
+                        &c.channel_id,
+                        &c.user_channel_id,
+                        amount_msat,
+                        allocation_version,
+                        now as u64,
+                    );
+                    let signature = match ldk
+                        .sign_message(SignMessageRequest {
+                            message: payload.as_bytes().to_vec().into(),
+                        })
+                        .await
+                    {
+                        Ok(response) => response.signature,
+                        Err(error) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_FAILED",
+                                serde_json::json!({
+                                    "channel_id": c.channel_id,
+                                    "user_channel_id": c.user_channel_id,
+                                    "settlement_id": settlement_id,
+                                    "direction": direction,
+                                    "stage": "sign",
+                                    "error": error.to_string(),
+                                }),
+                            );
+                            continue;
+                        }
+                    };
+                    let envelope = crate::messages::build_envelope(payload, signature);
                     let send_req = SpontaneousSendRequest {
                         amount_msat,
                         node_id: sc.counterparty.to_string(),
                         route_parameters: None,
-                        // Tag as a stability payment so receiving clients can identify it.
-                        custom_tlvs: vec![CustomTlvRecord {
-                            type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
-                            value: vec![1u8].into(),
-                        }],
+                        custom_tlvs: vec![
+                            CustomTlvRecord {
+                                type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                                value: vec![1u8].into(),
+                            },
+                            CustomTlvRecord {
+                                type_num: stable_channels::constants::SIGNED_STABILITY_TLV_TYPE,
+                                value: envelope.into_bytes().into(),
+                            },
+                        ],
                     };
                     let channel_id_clone = c.channel_id.clone();
                     let user_channel_id_clone = c.user_channel_id.clone();
                     let expected_usd_for_db = sc.expected_usd.0;
                     let note_for_db = sc.note.clone();
                     let backing_before = sc.backing_sats;
-                    // Normalise against the post-payment balance — the live one has not updated yet.
+                    // Apply only the value actually sent. Never jump to a price-derived equilibrium:
+                    // a partial payment must leave the remainder of the drift outstanding.
                     let post_payment_sats = their_sats.saturating_add(amount_sats);
-                    let backing_after = stable_channels::stable::normalize_backing_sats(
-                        post_payment_sats,
-                        (((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64)
-                            .min(post_payment_sats),
-                        sc.expected_usd.0,
-                        btc_price,
-                    );
+                    let backing_after = sc
+                        .backing_sats
+                        .saturating_add(amount_sats)
+                        .min(post_payment_sats);
                     let native_before = sc.native_sats;
                     let last_stability_payment_before = sc.last_stability_payment;
                     let counterparty_for_db = sc.counterparty.to_string();
@@ -1463,6 +1816,7 @@ impl StableChannelManager {
                             } else {
                                 match self.db.record_stability_settlement_with_rollback(
                                     &resp.payment_id,
+                                    &settlement_id,
                                     &user_channel_id_clone,
                                     &channel_id_clone,
                                     backing_before,
@@ -1505,6 +1859,17 @@ impl StableChannelManager {
                             self.stability_throttle.insert(
                                 sc.user_channel_id,
                                 (if persisted { "payment_sent" } else { "payment_persist_failed" }.to_string(), stable_usd_value),
+                            );
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_V1_SENT",
+                                serde_json::json!({
+                                    "payment_id": resp.payment_id,
+                                    "settlement_id": settlement_id,
+                                    "amount_msat": amount_msat,
+                                    "allocation_version": allocation_version,
+                                    "backing_sats_before": backing_before,
+                                    "backing_sats_after": backing_after,
+                                }),
                             );
                         },
                         Err(e) => {
@@ -1923,6 +2288,7 @@ impl StableChannelManager {
             sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
             sc.latest_price = btc_price;
             stable_channels::stable::recompute_native(sc);
+            sc.native_sats = their_sats.saturating_sub(sc.backing_sats);
 
             let counterparty_hex = sc.counterparty.to_string();
             let usd_deducted = stable_channels::stable::reconcile_outgoing(sc, btc_price);
@@ -2004,7 +2370,9 @@ impl StableChannelManager {
                     &counterparty_hex,
                 )
                 .await;
-            if !sent {
+            if sent {
+                self.startup_sync_pending.remove(&uid);
+            } else {
                 self.startup_sync_pending.insert(uid);
             }
         }
@@ -2352,41 +2720,13 @@ impl StableChannelManager {
 
         // Value the capacity at the LSP's own price: a client quote must never reach a payout.
         let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
-        let spread_ceiling = receiver_usd
-            * (1.0 + stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
-        if requested_expected > spread_ceiling {
+        if requested_expected > receiver_usd {
             reject!(
                 TradeRejectionReason::InsufficientCapacity,
                 "requested stable allocation exceeds channel capacity"
             );
         }
-        // Booking a target this side cannot back would clamp the allocation and leave the difference
-        // as drift the tick pays out, so book the largest backable target instead of funding the gap.
-        let new_expected = if requested_expected > receiver_usd {
-            stable_channels::audit::audit_event(
-                "TRADE_TARGET_CLAMPED_TO_CAPACITY",
-                serde_json::json!({
-                    "channel_id": chan.channel_id,
-                    "user_channel_id": chan.user_channel_id,
-                    "trade_id": trade_id,
-                    "requested_usd": requested_expected,
-                    "booked_usd": receiver_usd,
-                    "their_sats": their_sats,
-                    "lsp_price": btc_price,
-                }),
-            );
-            receiver_usd
-        } else {
-            requested_expected
-        };
-        // The clamp can absorb the whole move; charging for a target that did not change is the
-        // no-op case again, and the client needs to hear that it is already fully allocated.
-        if trade_target_move_cents(current_expected_usd, new_expected) == 0 {
-            reject!(
-                TradeRejectionReason::InsufficientCapacity,
-                "stable target is already at the channel's backable capacity"
-            );
-        }
+        let new_expected = requested_expected;
 
         // Compute on a clone. The live cache changes only after the allocation, version,
         // decision, and signed response have committed in one SQLite transaction.
@@ -2396,34 +2736,23 @@ impl StableChannelManager {
         accepted.stable_provider_usd = USD::from_bitcoin(accepted.stable_provider_btc, btc_price);
         accepted.stable_receiver_usd = USD::from_bitcoin(accepted.stable_receiver_btc, btc_price);
         accepted.latest_price = btc_price;
-        stable_channels::stable::apply_trade(&mut accepted, new_expected, btc_price);
-        if let Some((quote_price, client_backing_sats, _)) = signed_allocation {
-            // Telemetry, never a gate — re-run the client's own arithmetic at its own quoted price
-            // and its own target, which is what it derived from before any clamp here.
-            let client_self_consistent_sats = stable_channels::stable::trade_backing_sats(
-                their_sats,
-                requested_expected,
-                quote_price,
+        let Some(lsp_backing_sats) = stable_channels::stable::trade_backing_after_delta(
+            their_sats,
+            accepted.backing_sats,
+            current_expected_usd,
+            new_expected,
+            btc_price,
+        ) else {
+            reject!(
+                TradeRejectionReason::InsufficientCapacity,
+                "trade delta cannot be applied to the current stable allocation"
             );
-            if client_self_consistent_sats.abs_diff(client_backing_sats)
-                > TRADE_ALLOCATION_CHECKSUM_TOLERANCE_SATS
-            {
-                stable_channels::audit::audit_event(
-                    "TRADE_ALLOCATION_CHECKSUM_MISMATCH",
-                    serde_json::json!({
-                        "channel_id": chan.channel_id,
-                        "user_channel_id": chan.user_channel_id,
-                        "trade_id": trade_id,
-                        "client_backing_sats": client_backing_sats,
-                        "client_self_consistent_sats": client_self_consistent_sats,
-                        "lsp_backing_sats": accepted.backing_sats,
-                        "client_quote_price": quote_price,
-                        "lsp_price": btc_price,
-                    }),
-                );
-            }
-        }
-
+        };
+        stable_channels::stable::apply_trade_allocation(
+            &mut accepted,
+            new_expected,
+            lsp_backing_sats,
+        );
         let sync_version = match self.db.candidate_sync_version(&chan.user_channel_id) {
             Ok(version) => version,
             Err(_) => reject!(
@@ -2810,10 +3139,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconcile_drops_channels_no_longer_on_server() {
+    async fn reconcile_keeps_snapshot_missing_channel_recoverable() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
             100_000, 50_000_000, true,
         )]);
         mgr.edit_stable_channel(
@@ -2826,6 +3155,125 @@ mod tests {
         let empty_server = FakeLdkServer::new(vec![]);
         mgr.reconcile_from_grpc(&empty_server as &dyn LdkServerCalls, 100_000.0).await;
         assert_eq!(mgr.stable_channels.len(), 0);
+        assert!(mgr.reconcile_incomplete);
+        assert_eq!(
+            mgr.db.load_all_channels().unwrap().len(),
+            1,
+            "snapshot absence must not soft-close an active database row",
+        );
+
+        mgr.reconcile_if_empty(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+        assert!(!mgr.reconcile_incomplete);
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "a channel recovered after an incomplete snapshot must be resynchronized",
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_ready_after_partial_snapshot_preserves_persisted_allocation() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            Some("persisted".to_owned()),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let before = mgr
+            .db
+            .load_channel(USER_CHANNEL_ID_DECIMAL)
+            .unwrap()
+            .unwrap();
+        assert_eq!(before.backing_sats, 10_000);
+        assert_eq!(before.native_sats, 40_000);
+
+        mgr.reconcile_from_grpc(
+            &FakeLdkServer::new(vec![]) as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        assert!(mgr.stable_channels.is_empty());
+        assert!(mgr.reconcile_incomplete);
+
+        // ChannelReady can race ahead of the periodic reconciliation after LDK recovers. It must
+        // hydrate the active DB row, not take the zero-allocation new-channel path.
+        mgr.handle_channel_ready(
+            CHANNEL_ID_HEX.to_owned(),
+            USER_CHANNEL_ID_DECIMAL.to_owned(),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        let after = mgr
+            .db
+            .load_channel(USER_CHANNEL_ID_DECIMAL)
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.expected_usd, before.expected_usd);
+        assert_eq!(after.backing_sats, before.backing_sats);
+        assert_eq!(after.native_sats, before.native_sats);
+        assert_eq!(after.note, before.note);
+        assert_eq!(mgr.stable_channels.len(), 1);
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 10.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(mgr.stable_channels[0].native_sats, 40_000);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+        assert!(mgr.startup_sync_pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn incomplete_snapshot_retries_even_when_another_channel_remains_live() {
+        let mut mgr = make_manager();
+        let channel_two = "abababababababababababababababababababababababababababababababab";
+        mgr.db
+            .save_channel(CHANNEL_ID_HEX, "1", 10.0, 10_000, 40_000, None)
+            .unwrap();
+        mgr.db
+            .save_channel(channel_two, "2", 20.0, 20_000, 30_000, None)
+            .unwrap();
+        let channel_one = make_channel(
+            CHANNEL_ID_HEX,
+            "1",
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        );
+        let channel_two_live = make_channel(
+            channel_two,
+            "2",
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        );
+
+        let partial = FakeLdkServer::new(vec![channel_one.clone()]);
+        mgr.reconcile_from_grpc(&partial as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels.len(), 1);
+        assert!(mgr.reconcile_incomplete);
+
+        let complete = FakeLdkServer::new(vec![channel_one, channel_two_live]);
+        mgr.reconcile_if_empty(&complete as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels.len(), 2);
+        assert!(!mgr.reconcile_incomplete);
     }
 
     #[tokio::test]
@@ -3093,10 +3541,7 @@ mod tests {
         .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 8.0).abs() < 1e-6);
-        assert_eq!(
-            mgr.db.list_settlements().unwrap(),
-            vec![("pay_test_1".to_string(), "sync".to_string())]
-        );
+        assert!(mgr.db.list_settlements().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -3112,7 +3557,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn payment_received_marker_records_settlement() {
+    async fn payment_received_legacy_marker_records_no_settlement() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
@@ -3126,11 +3571,7 @@ mod tests {
         let before = mgr.stable_channels[0].expected_usd.0;
         mgr.handle_payment_received(records, Some("pay_settlement_1".to_string()), None, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
-        // the 1-byte marker is not an envelope, so it records stability and applies no trade
-        assert_eq!(
-            mgr.db.list_settlements().unwrap(),
-            vec![("pay_settlement_1".to_string(), "stability".to_string())]
-        );
+        assert!(mgr.db.list_settlements().unwrap().is_empty());
         assert_eq!(mgr.stable_channels[0].expected_usd.0, before);
     }
 
@@ -3455,6 +3896,22 @@ mod tests {
         assert_eq!(sends.len(), 1, "expected one stability payment");
         assert_eq!(sends[0].node_id, COUNTERPARTY_HEX);
         assert!(sends[0].amount_msat > 0);
+        assert_eq!(sends[0].custom_tlvs.len(), 2);
+        assert!(sends[0].custom_tlvs.iter().any(|record| {
+            record.type_num == stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
+                && record.value.as_ref() == [1u8]
+        }));
+        let signed = sends[0]
+            .custom_tlvs
+            .iter()
+            .find(|record| {
+                record.type_num == stable_channels::constants::SIGNED_STABILITY_TLV_TYPE
+            })
+            .unwrap();
+        let raw = std::str::from_utf8(signed.value.as_ref()).unwrap();
+        let envelope = crate::messages::parse_envelope(raw).unwrap();
+        let payload = crate::messages::parse_stability_payment_payload(&envelope.payload).unwrap();
+        assert_eq!(payload.amount_msat, sends[0].amount_msat);
         assert!(mgr.stable_channels[0].last_stability_payment > 0,
             "cooldown timestamp should be set");
     }
@@ -3545,7 +4002,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_tick_resets_backing_to_equilibrium_after_send() {
+    async fn run_tick_applies_the_exact_sent_sats_to_backing() {
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
@@ -3563,8 +4020,13 @@ mod tests {
         mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
 
         assert_eq!(fake.sends.lock().unwrap().len(), 1, "should send in lsp_to_user direction");
-        // backing reset to target/price = 50/80000*1e8 = 62_500 (NOT left at stale 50_000).
-        assert_eq!(mgr.stable_channels[0].backing_sats, 62_500, "backing must reset to equilibrium, preventing oscillation");
+        // The 12_500 sent sats move backing from 50_000 to 62_500. This happens to land exactly at
+        // par, but the accounting rule is the transfer delta rather than an equilibrium reset.
+        assert_eq!(
+            mgr.stable_channels[0].backing_sats,
+            62_500,
+            "backing must increase by the exact sent amount",
+        );
     }
 
     #[tokio::test]
@@ -4397,7 +4859,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_reprices_client_allocation_and_creates_no_drift() {
+    async fn trade_books_its_delta_at_the_lsp_price_and_creates_no_drift() {
         let mut mgr = make_manager();
         let uid = 189476124653200987495269098788434301048u128;
         // Half-pegged: 50_000 of the user's 100_000 sats back $50 at the LSP's $100_000 price.
@@ -4416,11 +4878,11 @@ mod tests {
         );
         handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
-        // Booked at the LSP's own price, not stored as sent.
+        // The target delta is booked at the LSP's own price, not from client backing telemetry.
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
         assert_eq!(
             mgr.stable_channels[0].backing_sats, 100_000,
-            "LSP must derive the allocation at its own price",
+            "LSP must convert the target delta at its own price",
         );
         assert_eq!(mgr.stable_channels[0].native_sats, 0);
 
@@ -4434,25 +4896,12 @@ mod tests {
     }
 
     #[test]
-    fn capacity_clamp_leaves_no_payable_residue() {
-        // The clamp is what keeps a trade drift-neutral, so the quote bound is free to admit honest
-        // feed spread. Walk position sizes: a target booked at the ceiling must never be payable.
-        for their_sats in [1_000u64, 50_000, 500_000, 5_000_000] {
-            let price = 100_000.0;
-            let receiver_usd = their_sats as f64 / 100_000_000.0 * price;
-            let booked = receiver_usd
-                * (1.0 + stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
-            let booked = booked.min(receiver_usd);
-            let backing = stable_channels::stable::trade_backing_sats(their_sats, booked, price);
-            let value = backing as f64 / 100_000_000.0 * price;
-            let pct = (((value - booked) / booked) * 100.0).abs();
-            let usd = (value - booked).abs();
-            assert!(
-                pct < stable_channels::constants::STABILITY_THRESHOLD_PERCENT
-                    || usd < stable_channels::constants::STABILITY_THRESHOLD_USD,
-                "clamped trade booked payable drift at {their_sats} sats: {pct}% / ${usd}",
-            );
-        }
+    fn peer_price_spread_stays_inside_the_stability_deadband() {
+        assert!(
+            stable_channels::constants::MAX_PEER_VALUATION_SPREAD_PERCENT
+                < stable_channels::constants::STABILITY_THRESHOLD_PERCENT,
+            "independent trade allocations must not begin outside the stability deadband",
+        );
     }
 
     #[tokio::test]
@@ -4545,7 +4994,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_audits_a_client_allocation_that_contradicts_its_own_quote() {
+    async fn client_backing_telemetry_never_changes_lsp_accounting() {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let uid = 189476124653200987495269098788434301048u128;
 
@@ -4572,7 +5021,7 @@ mod tests {
         );
         assert_eq!(mgr.stable_channels[0].backing_sats, 1_000_000);
 
-        // Contradicts itself: 900_000 sats is not $1000 at $100_040 under any rounding.
+        // Even a wildly different peer allocation is telemetry, never an accounting input.
         let mut mgr = make_manager();
         seed_channel(
             &mut mgr, uid, COUNTERPARTY_HEX, CHANNEL_ID_HEX,
@@ -4590,10 +5039,9 @@ mod tests {
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
         assert!(
-            events.iter().any(|(e, _)| e == "TRADE_ALLOCATION_CHECKSUM_MISMATCH"),
-            "a client disagreeing with its own quote must be audited",
+            !events.iter().any(|(e, _)| e == "TRADE_ALLOCATION_CHECKSUM_MISMATCH"),
+            "delta allocations cannot be validated from the peer's total backing",
         );
-        // Audited, never gated: the trade still applies, booked at the LSP's own price.
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 1000.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 1_000_000);
     }
@@ -4645,7 +5093,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_reprices_allocation_not_derived_from_signed_quote() {
+    async fn trade_delta_is_not_derived_from_the_signed_quote() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX,
@@ -4682,7 +5130,7 @@ mod tests {
         )
         .await;
 
-        // A mismatched client allocation is inert: the LSP still applies the trade at its own derivation.
+        // A mismatched client allocation is inert: the LSP applies the delta at its own price.
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 49.5);
         assert_eq!(mgr.stable_channels[0].backing_sats, 49_500);
         let sends = fake.sends.lock().unwrap();
@@ -4781,7 +5229,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_over_capacity_books_the_backable_target() {
+    async fn trade_over_capacity_is_rejected_instead_of_partially_filled() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -4789,7 +5237,8 @@ mod tests {
         )]);
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        // A peer valuing the same sats higher asks past this side's capacity: admitted, not funded.
+        // A peer valuing the same sats higher asks past this side's capacity. The LSP must not
+        // silently execute a smaller trade because that is a different contract.
         let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
         handle_trade_with_valid_fee(
@@ -4800,18 +5249,42 @@ mod tests {
         )
         .await;
 
-        assert!(
-            (mgr.stable_channels[0].expected_usd.0 - 50.0).abs() < 1e-6,
-            "target must be clamped to backable capacity, got {}",
-            mgr.stable_channels[0].expected_usd.0
-        );
-        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000, "whole side backs the peg");
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        let (response_msat, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(response_msat, 1);
+        assert_eq!(rejection.reason_code, TradeRejectionReason::InsufficientCapacity);
     }
 
     #[tokio::test]
-    async fn trade_over_capacity_leaves_nothing_for_the_tick_to_pay() {
+    async fn over_capacity_rejection_cannot_reverse_an_underbacked_trade() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        // The target is temporarily $0.20 above this side's $50 valuation. A request to increase it
+        // by another $0.05 must not be "filled" by lowering it to $50 in the opposite direction.
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.20, 50_000, 0, 50_000, 100_000.0);
+
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 50.25);
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.20);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
+        let (_, rejection) = rejection_from_only_send(&fake);
+        assert_eq!(rejection.reason_code, TradeRejectionReason::InsufficientCapacity);
+    }
+
+    #[tokio::test]
+    async fn repeated_over_capacity_requests_cannot_draw_a_payout() {
         // The drain was: ask past capacity, let the tick settle the gap, repeat on the larger side.
-        // One request clamps and one is past the spread ceiling entirely; neither may draw a payout.
+        // Every over-capacity request must leave the existing at-par allocation untouched.
         for target in [
             50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD * 0.8,
             50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD,
@@ -4820,15 +5293,14 @@ mod tests {
             let fake = FakeLdkServer::new(vec![make_channel(
                 CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
             )]);
-            seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+            seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 50_000, 0, 50_000, 100_000.0);
 
             let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
             handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
-            assert!(
-                mgr.stable_channels[0].expected_usd.0 <= 50.0,
-                "booked target {} must not exceed backable capacity",
-                mgr.stable_channels[0].expected_usd.0
-            );
+            assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
+            assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
+            let (_, rejection) = rejection_from_only_send(&fake);
+            assert_eq!(rejection.reason_code, TradeRejectionReason::InsufficientCapacity);
 
             let push = std::sync::Arc::new(tokio::sync::Mutex::new(
                 crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
@@ -5216,6 +5688,7 @@ mod tests {
             .unwrap();
         db.record_stability_settlement_with_rollback(
             "successful-payment",
+            "settlement-successful",
             "stable",
             "physical",
             10_000,
@@ -5364,11 +5837,28 @@ mod tests {
         assert_eq!(n, 1, "identical repeated ticks must emit CHECK_ONLY once");
     }
 
-    /// TLV marker record that is NOT a signed envelope: the stability-payment carrier.
-    fn stability_marker() -> CustomTlvRecord {
+    fn stability_envelope(settlement_id: &str, amount_msat: u64) -> CustomTlvRecord {
+        stability_envelope_at(settlement_id, amount_msat, test_unix_now())
+    }
+
+    fn stability_envelope_at(
+        settlement_id: &str,
+        amount_msat: u64,
+        ts: u64,
+    ) -> CustomTlvRecord {
+        let payload = crate::messages::build_stability_payment_payload(
+            settlement_id,
+            CHANNEL_ID_HEX,
+            "wallet-user-channel-id",
+            amount_msat,
+            0,
+            ts,
+        );
         CustomTlvRecord {
-            type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
-            value: vec![1u8].into(),
+            type_num: stable_channels::constants::SIGNED_STABILITY_TLV_TYPE,
+            value: crate::messages::build_envelope(payload, "wallet-sig".to_owned())
+                .into_bytes()
+                .into(),
         }
     }
 
@@ -5376,15 +5866,24 @@ mod tests {
     fn stability_payment_sats(fake: &FakeLdkServer) -> Vec<u64> {
         fake.sends.lock().unwrap().iter()
             .filter(|s| s.custom_tlvs.iter().any(|t| {
-                t.type_num == stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
-                    && t.value.as_ref() == &[1u8][..]
+                if t.type_num != stable_channels::constants::SIGNED_STABILITY_TLV_TYPE {
+                    return false;
+                }
+                let Ok(raw) = std::str::from_utf8(t.value.as_ref()) else {
+                    return false;
+                };
+                crate::messages::parse_envelope(raw)
+                    .and_then(|envelope| {
+                        crate::messages::parse_stability_payment_payload(&envelope.payload)
+                    })
+                    .is_some()
             }))
             .map(|s| s.amount_msat / 1000)
             .collect()
     }
 
     #[tokio::test]
-    async fn incoming_stability_payment_resets_backing_and_preserves_native() {
+    async fn incoming_stability_payment_applies_exact_sats_and_preserves_native() {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = make_manager();
         // $10 target at $100k: equilibrium backing = 10_000 sats; user side 50_000 -> native 40_000.
@@ -5405,25 +5904,150 @@ mod tests {
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_909_000, true,
         )]);
+        stable_channels::audit::enable_test_capture();
         mgr.handle_payment_received(
-            vec![stability_marker()],
+            vec![stability_envelope(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                909_000,
+            )],
             Some("pay-1".to_string()),
             Some(909_000),
             &fake as &dyn LdkServerCalls,
             110_000.0,
         )
         .await;
+        let events = stable_channels::audit::drain_test_capture();
+        stable_channels::audit::disable_test_capture();
 
         let sc = &mgr.stable_channels[0];
-        // Equilibrium at $110k: 10/110_000 BTC = 9_090 sats.
-        assert_eq!(sc.backing_sats, 9_090, "backing must reset to equilibrium at the new price");
-        // Native must absorb only rounding, never the settlement: 49_091 - 9_090 = 40_001.
-        assert_eq!(sc.native_sats, 40_001, "native sats must be preserved across the settlement");
+        assert_eq!(
+            sc.backing_sats,
+            9_091,
+            "only the 909 received sats may be settled; events={events:?}"
+        );
+        assert_eq!(sc.native_sats, 40_000, "native sats must be preserved across the settlement");
         assert!(sc.backing_sats <= sc.stable_receiver_btc.sats, "backing may never exceed live balance");
     }
 
     #[tokio::test]
-    async fn incoming_stability_reset_absorbs_residue() {
+    async fn delayed_stability_payment_applies_once_and_deduplicates_replays() {
+        let mut mgr = make_manager();
+        let initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        // The wallet paid 1,000 sats while the LSP event consumer was unavailable. Processing
+        // hours later must still book the value that already settled on Lightning.
+        let after_payment = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            51_000_000,
+            true,
+        )]);
+        let settlement_id =
+            "4123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let old_ts = test_unix_now()
+            .saturating_sub(stable_channels::constants::TRADE_ACCEPTANCE_WINDOW_SECS)
+            .saturating_sub(3_600);
+        let record = stability_envelope_at(settlement_id, 1_000_000, old_ts);
+
+        mgr.handle_payment_received(
+            vec![record.clone()],
+            Some("delayed-payment".to_owned()),
+            Some(1_000_000),
+            &after_payment as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_000);
+
+        // Both event replay (same payment id) and envelope replay (same settlement id with a
+        // different payment id) are durable no-ops.
+        mgr.handle_payment_received(
+            vec![record.clone()],
+            Some("delayed-payment".to_owned()),
+            Some(1_000_000),
+            &after_payment as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        mgr.handle_payment_received(
+            vec![record],
+            Some("replayed-envelope".to_owned()),
+            Some(1_000_000),
+            &after_payment as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_000);
+    }
+
+    #[tokio::test]
+    async fn one_sat_stability_payment_cannot_clear_a_larger_obligation() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = make_manager();
+        let initial = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        // At $110k the old code reset all the way to ~9,090 sats merely because the marker was
+        // present. The signed one-sat payment may now move exactly one sat and no more.
+        let after_one_sat = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_001_000,
+            true,
+        )]);
+        mgr.handle_payment_received(
+            vec![stability_envelope(
+                "3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                1_000,
+            )],
+            Some("one-sat-payment".to_owned()),
+            Some(1_000),
+            &after_one_sat as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_999);
+        let remaining_drift =
+            mgr.stable_channels[0].backing_sats as f64 / 100_000_000.0 * 110_000.0 - 10.0;
+        assert!(remaining_drift > 0.99, "the unpaid drift must remain visible");
+    }
+
+    #[tokio::test]
+    async fn incoming_stability_payment_applies_exact_residue() {
         let mut mgr = make_manager();
         let uid = 189476124653200987495269098788434301048u128;
         // Fully pegged after absorption: 100_040 sats back a $100.00 target booked slightly below par, leaving a 40-sat ($0.04) feed-spread residue at equilibrium.
@@ -5437,18 +6061,23 @@ mod tests {
             200_000, 100_000_000, true,
         )]);
 
-        mgr.reconcile_incoming_stability(
-            Some("payment-1"),
+        let raw = stability_envelope(
+            "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            40_000,
+        );
+        mgr.handle_payment_received(
+            vec![raw],
+            Some("payment-1".to_owned()),
             Some(40 * 1000),
             &fake as &dyn LdkServerCalls,
             100_040.0,
         )
         .await;
 
-        // Equilibrium is 99_960 sats, leaving 40 sats ($0.04) of residue — absorb it.
+        // The transfer removes exactly 40 sats. No price-derived normalization is involved.
         assert_eq!(
             mgr.stable_channels[0].backing_sats, 100_000,
-            "settlement reset must absorb sub-threshold residue, not recreate it",
+            "settlement must apply the actual received amount",
         );
         assert_eq!(mgr.stable_channels[0].native_sats, 0);
     }
@@ -5471,7 +6100,10 @@ mod tests {
             CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_909_000, true,
         )]);
         mgr.handle_payment_received(
-            vec![stability_marker()], Some("pay-2".to_string()), Some(909_000),
+            vec![stability_envelope(
+                "2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                909_000,
+            )], Some("pay-2".to_string()), Some(909_000),
             &fake as &dyn LdkServerCalls, 110_000.0,
         ).await;
         let expected_before = mgr.stable_channels[0].expected_usd.0;
@@ -5495,42 +6127,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ambiguous_incoming_stability_payment_mutates_nothing() {
+    async fn legacy_stability_marker_applies_only_the_received_sats() {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = make_manager();
-        const CHAN2_ID: &str = "aa634c603646c60b0df9f07c3011708652125915c80300a9bb8fb37c9c0de05b";
-        const UID2_HEX: &str = "00000000000000000000000000000002";
-        // Two identical channels: an identical balance drop on both is unattributable.
-        let mk = |outbound_msat: u64| {
-            vec![
-                make_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, outbound_msat, true),
-                make_channel(CHAN2_ID, UID2_HEX, COUNTERPARTY_HEX, 100_000, outbound_msat, true),
-            ]
-        };
-        let fake0 = FakeLdkServer::new(mk(50_000_000));
+        let fake0 = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
         mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        mgr.edit_stable_channel(CHAN2_ID, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
         let push = std::sync::Arc::new(tokio::sync::Mutex::new(
             crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
         ));
         mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0).await;
         let backing_before: Vec<u64> = mgr.stable_channels.iter().map(|s| s.backing_sats).collect();
 
-        let fake = FakeLdkServer::new(mk(50_909_000));
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_001_000, true,
+        )]);
         stable_channels::audit::enable_test_capture();
         mgr.handle_payment_received(
-            vec![stability_marker()], Some("pay-3".to_string()), Some(909_000),
+            vec![CustomTlvRecord {
+                type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                value: vec![1u8].into(),
+            }], Some("pay-3".to_string()), Some(1_000),
             &fake as &dyn LdkServerCalls, 110_000.0,
         ).await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
 
         let backing_after: Vec<u64> = mgr.stable_channels.iter().map(|s| s.backing_sats).collect();
-        assert_eq!(backing_before, backing_after, "ambiguous attribution must not touch the books");
+        assert_eq!(backing_after[0], backing_before[0] - 1);
         assert!(
-            events.iter().any(|(e, d)| e == "STABILITY_RECEIVE_UNATTRIBUTED"
-                && d.get("candidates").and_then(|v| v.as_u64()) == Some(2)),
-            "the miss must be audited with the candidate count"
+            events.iter().any(|(event, _)| event == "LEGACY_STABILITY_PAYMENT_APPLIED"),
+            "the compatibility settlement must be audited"
         );
     }
 
@@ -5582,4 +6210,3 @@ mod tests {
         );
     }
 }
-

--- a/server/stable-channels-lsp/src/trade_response_retry.rs
+++ b/server/stable-channels-lsp/src/trade_response_retry.rs
@@ -1,0 +1,43 @@
+//! Durable TRADE_V1 acceptance/rejection response retry loop.
+
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+
+use crate::stable_manager::LdkServerCalls;
+use crate::state::AppState;
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        loop {
+            let worker_state = state.clone();
+            match tokio::spawn(async move { run(worker_state).await }).await {
+                Ok(()) => tracing::error!("trade response retry worker exited unexpectedly"),
+                Err(error) => {
+                    let error_message = error.to_string();
+                    tracing::error!("trade response retry worker failed: {error_message}");
+                    let _ = std::panic::catch_unwind(move || {
+                        stable_channels::audit::audit_event(
+                            "TRADE_RESPONSE_RETRY_WORKER_FAILED",
+                            serde_json::json!({ "error": error_message }),
+                        );
+                    });
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+}
+
+async fn run(state: AppState) {
+    let mut ticker = tokio::time::interval(Duration::from_secs(1));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        crate::stable_manager::StableChannelManager::retry_pending_trade_responses(
+            state.db.as_ref(),
+            state.ldk_server.as_ref() as &dyn LdkServerCalls,
+        )
+        .await;
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -71,6 +71,9 @@ pub const BALANCE_UPDATE_INTERVAL_SECS: u64 = 30;
 /// Stability check interval (in seconds)
 pub const STABILITY_CHECK_INTERVAL_SECS: u64 = 60;
 
+/// Shared freshness and desktop expiry window for authenticated trades.
+pub const TRADE_ACCEPTANCE_WINDOW_SECS: u64 = 15 * 60;
+
 // ============================================================================
 // BUSINESS LOGIC CONSTANTS
 // ============================================================================

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,11 @@ pub const SATS_IN_BTC: u64 = 100_000_000;
 /// Custom TLV type for stable channel messages
 pub const STABLE_CHANNEL_TLV_TYPE: u64 = 13377331;
 
+/// Signed stability-payment metadata. Payments also carry the legacy `[1]` record above so
+/// unchanged mobile wallets can categorize the transfer; upgraded peers always prefer this
+/// authenticated record and apply only the amount actually received.
+pub const SIGNED_STABILITY_TLV_TYPE: u64 = 13377333;
+
 /// Trade message type identifier
 pub const TRADE_MESSAGE_TYPE: &str = "TRADE_V1";
 
@@ -85,15 +90,12 @@ pub const MAX_RISK_LEVEL: i32 = 100;
 pub const STABILITY_THRESHOLD_PERCENT: f64 = 0.1; // 0.1% from par
 pub const STABILITY_THRESHOLD_USD: f64 = 0.25; // minimum $0.25 drift to trigger payment
 
-/// How far the two peers may legitimately disagree about what one channel side is worth.
+/// Maximum honest price-feed spread between peers.
 ///
-/// Each peer prices independently (median of the same feeds, refreshed every few seconds) and reads
-/// its own LDK balance view, so the same sats value out slightly differently on each side. This
-/// bounds a trade's quoted price against the LSP's own, how far above its valuation of the peer's
-/// balance a target may be before the request is treated as a mistake rather than spread, and how
-/// far below the request a wallet will accept the LSP's answer. It is a plausibility bound only —
-/// no accounting reads across it, so it does not need to sit inside the stability deadband.
-pub const MAX_PEER_VALUATION_SPREAD_PERCENT: f64 = 0.5;
+/// Each peer prices independently, so a small difference is expected. Keep this strictly inside
+/// the percentage stability deadband: independently derived backing must not make one peer see a
+/// payable drift immediately after their feeds converge.
+pub const MAX_PEER_VALUATION_SPREAD_PERCENT: f64 = 0.05;
 
 /// Minimum seconds between stability payments on the same channel (cooldown)
 pub const STABILITY_PAYMENT_COOLDOWN_SECS: u64 = 120;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -85,6 +85,16 @@ pub const MAX_RISK_LEVEL: i32 = 100;
 pub const STABILITY_THRESHOLD_PERCENT: f64 = 0.1; // 0.1% from par
 pub const STABILITY_THRESHOLD_USD: f64 = 0.25; // minimum $0.25 drift to trigger payment
 
+/// How far the two peers may legitimately disagree about what one channel side is worth.
+///
+/// Each peer prices independently (median of the same feeds, refreshed every few seconds) and reads
+/// its own LDK balance view, so the same sats value out slightly differently on each side. This
+/// bounds a trade's quoted price against the LSP's own, how far above its valuation of the peer's
+/// balance a target may be before the request is treated as a mistake rather than spread, and how
+/// far below the request a wallet will accept the LSP's answer. It is a plausibility bound only —
+/// no accounting reads across it, so it does not need to sit inside the stability deadband.
+pub const MAX_PEER_VALUATION_SPREAD_PERCENT: f64 = 0.5;
+
 /// Minimum seconds between stability payments on the same channel (cooldown)
 pub const STABILITY_PAYMENT_COOLDOWN_SECS: u64 = 120;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1346,36 +1346,41 @@ impl Database {
         base.saturating_add(jitter).min(60 * 60)
     }
 
-    pub fn mark_trade_response_send_failed(
+    /// Durably consume one delivery attempt and schedule its retry before any network send.
+    /// The expected-attempt CAS prevents two workers from reserving the same due response.
+    pub fn reserve_trade_response_attempt(
         &self,
         inbound_payment_id: &str,
+        expected_attempts: u32,
+        max_attempts: u32,
         now: i64,
-    ) -> SqliteResult<()> {
-        let conn = self.conn.lock().unwrap();
-        let attempts: i64 = conn.query_row(
-            "SELECT response_attempts FROM trade_decisions
-             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
-            params![inbound_payment_id],
-            |row| row.get(0),
-        )?;
-        let next_attempt = attempts.saturating_add(1).max(1) as u32;
+    ) -> SqliteResult<bool> {
+        if expected_attempts >= max_attempts {
+            return Ok(false);
+        }
+        let next_attempt = expected_attempts.saturating_add(1);
         let delay = Self::trade_response_delay_secs(next_attempt, inbound_payment_id);
+        let conn = self.conn.lock().unwrap();
         let updated = conn.execute(
             "UPDATE trade_decisions
-             SET response_status = 'pending', response_attempts = ?2,
-                 next_response_attempt_at = ?3
-             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
-            params![inbound_payment_id, next_attempt, now.saturating_add(delay)],
+             SET response_attempts = ?2, next_response_attempt_at = ?3
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'
+                   AND response_attempts = ?4 AND response_attempts < ?5
+                   AND next_response_attempt_at <= ?6",
+            params![
+                inbound_payment_id,
+                next_attempt,
+                now.saturating_add(delay),
+                expected_attempts,
+                max_attempts,
+                now,
+            ],
         )?;
-        if updated == 1 {
-            Ok(())
-        } else {
-            Err(rusqlite::Error::QueryReturnedNoRows)
-        }
+        Ok(updated == 1)
     }
 
-    /// Store the generated outbound id immediately after LDK accepts the control send. A process
-    /// crash in the preceding gap can produce a duplicate nominal response after restart.
+    /// Attach the generated outbound id after LDK accepts the control send. The attempt and its
+    /// backoff were already persisted, so a failure here cannot cause an immediate retry.
     pub fn mark_trade_response_in_flight(
         &self,
         inbound_payment_id: &str,
@@ -1384,8 +1389,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
         let updated = conn.execute(
             "UPDATE trade_decisions
-             SET response_status = 'in_flight', response_payment_id = ?2,
-                 response_attempts = response_attempts + 1
+             SET response_status = 'in_flight', response_payment_id = ?2
              WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
             params![inbound_payment_id, response_payment_id],
         )?;
@@ -4542,9 +4546,39 @@ mod tests {
             .unwrap());
         assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, 20.0);
 
-        let due = db.due_trade_responses(i64::MAX, u32::MAX, 10).unwrap();
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE trade_decisions SET next_response_attempt_at = 100
+                 WHERE inbound_payment_id = 'inbound-payment'",
+                [],
+            )
+            .unwrap();
+        let due = db.due_trade_responses(100, u32::MAX, 10).unwrap();
         assert_eq!(due.len(), 1);
         assert_eq!(due[0].response_amount_msat, 1);
+        assert!(db
+            .reserve_trade_response_attempt(
+                "inbound-payment",
+                due[0].attempts,
+                u32::MAX,
+                100,
+            )
+            .unwrap());
+        assert!(!db
+            .reserve_trade_response_attempt("inbound-payment", 0, u32::MAX, 100)
+            .unwrap());
+        assert!(db
+            .due_trade_responses(104, u32::MAX, 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            db.due_trade_responses(105, u32::MAX, 10)
+                .unwrap()[0]
+                .attempts,
+            1
+        );
         db.mark_trade_response_in_flight("inbound-payment", "response-payment")
             .unwrap();
         assert!(matches!(
@@ -4560,18 +4594,15 @@ mod tests {
             .unwrap()
             .is_empty());
         assert!(db
-            .mark_trade_response_payment_failed("response-payment", 100)
+            .mark_trade_response_payment_failed("response-payment", 200)
             .unwrap());
         assert!(db
-            .due_trade_responses(104, u32::MAX, 10)
+            .due_trade_responses(204, u32::MAX, 10)
             .unwrap()
             .is_empty());
-        assert_eq!(
-            db.due_trade_responses(105, u32::MAX, 10)
-                .unwrap()
-                .len(),
-            1
-        );
+        let retry = db.due_trade_responses(205, u32::MAX, 10).unwrap();
+        assert_eq!(retry.len(), 1);
+        assert_eq!(retry[0].attempts, 1);
         assert_eq!(Database::trade_response_delay_secs(1, "response-a"), 5);
         assert!((10..=12).contains(&Database::trade_response_delay_secs(2, "response-a")));
         assert_eq!(
@@ -4717,10 +4748,9 @@ mod tests {
             .expect("abandoned response and dead-letter event must commit together");
         assert_eq!(dead_letter.status, "failed");
         assert_eq!(dead_letter.detail["response_attempts"], 3);
-        assert!(matches!(
-            db.mark_trade_response_send_failed("exhausted-payment", 200),
-            Err(rusqlite::Error::QueryReturnedNoRows)
-        ));
+        assert!(!db
+            .reserve_trade_response_attempt("exhausted-payment", 3, MAX_ATTEMPTS, 200)
+            .unwrap());
 
         assert!(db
             .requeue_abandoned_trade_response("exhausted-payment", 456)

--- a/src/db.rs
+++ b/src/db.rs
@@ -200,6 +200,7 @@ impl Database {
                 new_expected_usd REAL NOT NULL DEFAULT 0.0,
                 new_backing_sats INTEGER,
                 payment_id TEXT,
+                settlement_id TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )",
@@ -355,6 +356,12 @@ impl Database {
             "ALTER TABLE payments ADD COLUMN stable_reconciled INTEGER NOT NULL DEFAULT 0",
             [],
         );
+        let _ = conn.execute("ALTER TABLE payments ADD COLUMN settlement_id TEXT", []);
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_settlement_id
+             ON payments(settlement_id) WHERE settlement_id IS NOT NULL",
+            [],
+        )?;
 
         // Create index for faster payment queries
         conn.execute(
@@ -423,7 +430,7 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN user_channel_id TEXT",
             [],
         ); // Ignore error if column already exists
-        // Outbound stability sends optimistically move backing to equilibrium. Persist the exact
+        // Outbound stability sends optimistically move backing by the exact sent sats. Persist the
         // transition so a later asynchronous PaymentFailed can undo it without guessing or
         // overwriting a newer trade/sync allocation.
         let _ = conn.execute(
@@ -450,6 +457,15 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN outcome TEXT NOT NULL DEFAULT 'pending'",
             [],
         );
+        let _ = conn.execute(
+            "ALTER TABLE settlement_payments ADD COLUMN settlement_id TEXT",
+            [],
+        );
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_settlement_payments_settlement_id
+             ON settlement_payments(settlement_id) WHERE settlement_id IS NOT NULL",
+            [],
+        )?;
 
         // Authenticated TRADE_V1 decisions and their durable response obligations. `trade_id` is
         // intentionally not UNIQUE: a second payment reusing one must itself be persisted as a
@@ -1534,9 +1550,9 @@ impl Database {
                     return Ok(false);
                 }
             }
-            // backing_sats is derived per-peer and not compared; expected_usd is the contract this gate protects.
+            // backing_sats is derived per-peer and not compared; expected_usd is the exact contract.
             if trade_id.is_some()
-                && !crate::trade::answered_target_honours_request(
+                && !crate::trade::answered_target_matches_request(
                     stored_expected_usd,
                     expected_usd,
                 )
@@ -1629,6 +1645,154 @@ impl Database {
                 "live_receiver_sats": backing_sats.saturating_add(native_sats),
             }),
             refs: vec![LedgerRef::new("user_channel_id", user_channel_id)],
+        };
+        let outcome = ledger::append_on_connection(&tx, &draft)?;
+        tx.commit()?;
+        if outcome.inserted {
+            crate::audit::mirror_committed_ledger_event(&draft, outcome.event_id);
+        }
+        Ok(true)
+    }
+
+    /// Resolve a correlated trade acceptance whose allocation version has already been superseded.
+    ///
+    /// A newer channel snapshot is authoritative for accounting, but it must not erase the signed
+    /// answer to an older pending trade. This transaction validates the stored trade intent and
+    /// payment correlation, marks only the trade complete, and deliberately leaves the newer
+    /// channel allocation and sync version untouched.
+    pub fn complete_trade_from_stale_correlated_sync(
+        &self,
+        user_channel_id: &str,
+        response_sync_version: u64,
+        expected_usd: f64,
+        trade_db_id: i64,
+        trade_payment_id: Option<&str>,
+    ) -> SqliteResult<bool> {
+        if response_sync_version == 0
+            || response_sync_version > i64::MAX as u64
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+        {
+            return Ok(false);
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let channel = tx
+            .query_row(
+                "SELECT channel_id, expected_usd, stable_sats, native_sats, sync_version
+                 FROM channels WHERE user_channel_id = ?1",
+                params![user_channel_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, f64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, i64>(4)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((channel_id, current_expected, current_backing, current_native, current_version)) =
+            channel
+        else {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        };
+        if current_version < response_sync_version as i64 {
+            tx.commit()?;
+            return Ok(false);
+        }
+
+        let trade = tx
+            .query_row(
+                "SELECT payment_id, new_expected_usd, trade_id, status
+                 FROM trades WHERE id = ?1",
+                params![trade_db_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, f64>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, String>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((stored_payment_id, stored_expected, trade_id, status)) = trade else {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        };
+        if status == "completed"
+            || stored_payment_id
+                .as_deref()
+                .zip(trade_payment_id)
+                .is_some_and(|(stored, received)| stored != received)
+            || (trade_id.is_some()
+                && !crate::trade::answered_target_matches_request(
+                    stored_expected,
+                    expected_usd,
+                ))
+        {
+            tx.commit()?;
+            return Ok(false);
+        }
+
+        let completed = tx.execute(
+            "UPDATE trades
+             SET status = 'completed', fee_status = 'paid',
+                 payment_id = COALESCE(payment_id, ?2),
+                 failure_code = NULL, failure_reason = NULL,
+                 resolved_at = strftime('%s', 'now')
+             WHERE id = ?1 AND status != 'completed'
+               AND (?2 IS NULL OR payment_id IS NULL OR payment_id = ?2)",
+            params![trade_db_id, trade_payment_id],
+        )?;
+        if completed != 1 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
+
+        let snapshot = AccountingSnapshot {
+            expected_usd: Some(current_expected),
+            backing_sats: u64::try_from(current_backing).ok(),
+            native_sats: u64::try_from(current_native).ok(),
+            live_receiver_sats: u64::try_from(current_backing.saturating_add(current_native)).ok(),
+            ..Default::default()
+        };
+        let mut refs = vec![
+            LedgerRef::new("channel_id", &channel_id),
+            LedgerRef::new("user_channel_id", user_channel_id),
+        ];
+        if let Some(trade_id) = trade_id.as_deref() {
+            refs.push(LedgerRef::new("trade_id", trade_id));
+        }
+        if let Some(payment_id) = trade_payment_id.or(stored_payment_id.as_deref()) {
+            refs.push(LedgerRef::new("payment_id", payment_id));
+        }
+        let draft = LedgerEventDraft {
+            event_type: "TRADE_ACCEPTANCE_CONFIRMED_AFTER_NEWER_SYNC".to_owned(),
+            category: "trade".to_owned(),
+            severity: "info".to_owned(),
+            status: "completed".to_owned(),
+            source: "signed_sync".to_owned(),
+            completeness: LedgerCompleteness::Observed,
+            occurred_at_ms: Utc::now().timestamp_millis(),
+            dedup_key: Some(format!(
+                "signed-sync:stale-trade-acceptance:{trade_db_id}:{response_sync_version}"
+            )),
+            before: Some(snapshot.clone()),
+            after: Some(snapshot),
+            detail: serde_json::json!({
+                "channel_id": channel_id,
+                "user_channel_id": user_channel_id,
+                "trade_db_id": trade_db_id,
+                "trade_id": trade_id,
+                "trade_payment_id": trade_payment_id.or(stored_payment_id.as_deref()),
+                "trade_expected_usd": expected_usd,
+                "response_sync_version": response_sync_version,
+                "current_sync_version": current_version,
+                "allocation_applied": false,
+            }),
+            refs,
         };
         let outcome = ledger::append_on_connection(&tx, &draft)?;
         tx.commit()?;
@@ -2629,6 +2793,7 @@ impl Database {
     pub fn record_pending_stability_payment(
         &self,
         payment_id: &str,
+        settlement_id: &str,
         amount_msat: u64,
         amount_usd: Option<f64>,
         btc_price: f64,
@@ -2656,12 +2821,13 @@ impl Database {
 
             conn.execute(
                 "INSERT INTO payments
-                    (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price,
+                    (payment_id, settlement_id, payment_type, direction, amount_msat, amount_usd, btc_price,
                      counterparty, status, user_channel_id, backing_sats_before,
                      backing_sats_after)
-                 VALUES (?1, 'stability', 'sent', ?2, ?3, ?4, ?5, 'pending', ?6, ?7, ?8)",
+                 VALUES (?1, ?2, 'stability', 'sent', ?3, ?4, ?5, ?6, 'pending', ?7, ?8, ?9)",
                 params![
                     payment_id,
+                    settlement_id,
                     amount,
                     amount_usd,
                     btc_price,
@@ -2723,6 +2889,7 @@ impl Database {
                 after: Some(after_snapshot),
                 detail: serde_json::json!({
                     "payment_id": payment_id,
+                    "settlement_id": settlement_id,
                     "channel_id": channel_id,
                     "user_channel_id": user_channel_id,
                     "counterparty_node_id": counterparty,
@@ -3030,6 +3197,7 @@ impl Database {
     pub fn record_payment_and_maybe_update_backing(
         &self,
         payment_id: Option<&str>,
+        settlement_id: Option<&str>,
         payment_type: &str,
         direction: &str,
         amount_msat: u64,
@@ -3060,12 +3228,37 @@ impl Database {
                     });
                 }
             }
+            if let Some(settlement_id) = settlement_id {
+                let exists: Option<i64> = conn
+                    .query_row(
+                        "SELECT 1 FROM payments WHERE settlement_id = ?1 LIMIT 1",
+                        params![settlement_id],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if exists.is_some() {
+                    return Ok(PaymentPersistence {
+                        is_new: false,
+                        new_backing: None,
+                        clamped: false,
+                    });
+                }
+            }
             conn.execute(
-                "INSERT INTO payments (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, status)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO payments
+                    (payment_id, settlement_id, payment_type, direction, amount_msat, amount_usd,
+                     btc_price, status, user_channel_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![
-                    payment_id, payment_type, direction,
-                    amount_msat as i64, amount_usd, btc_price, status
+                    payment_id,
+                    settlement_id,
+                    payment_type,
+                    direction,
+                    amount_msat as i64,
+                    amount_usd,
+                    btc_price,
+                    status,
+                    user_channel_id,
                 ],
             )?;
             let payment_row_id = conn.last_insert_rowid();
@@ -3153,6 +3346,7 @@ impl Database {
                 after: after_snapshot,
                 detail: serde_json::json!({
                     "payment_id": payment_id,
+                    "settlement_id": settlement_id,
                     "payment_type": payment_type,
                     "direction": direction,
                     "amount_msat": amount_msat,
@@ -3571,6 +3765,7 @@ impl Database {
     pub fn record_stability_settlement_with_rollback(
         &self,
         payment_id: &str,
+        settlement_id: &str,
         user_channel_id: &str,
         channel_id: &str,
         backing_sats_before: u64,
@@ -3605,12 +3800,13 @@ impl Database {
                 .optional()?;
             let inserted = conn.execute(
                 "INSERT OR IGNORE INTO settlement_payments
-                    (payment_id, kind, user_channel_id, backing_sats_before,
+                    (payment_id, settlement_id, kind, user_channel_id, backing_sats_before,
                      backing_sats_after, native_sats_before, expected_usd,
                      last_stability_payment_before)
-                 VALUES (?1, 'stability', ?2, ?3, ?4, ?5, ?6, ?7)",
+                 VALUES (?1, ?2, 'stability', ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     payment_id,
+                    settlement_id,
                     user_channel_id,
                     backing_sats_before as i64,
                     backing_sats_after as i64,
@@ -3696,6 +3892,7 @@ impl Database {
                 after: Some(after_snapshot),
                 detail: serde_json::json!({
                     "payment_id": payment_id,
+                    "settlement_id": settlement_id,
                     "channel_id": channel_id,
                     "user_channel_id": user_channel_id,
                     "counterparty_node_id": counterparty,
@@ -4173,7 +4370,7 @@ mod tests {
             .unwrap();
         assert!(db
             .record_stability_settlement_with_rollback(
-                "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 17,
+                "payment", "settlement-1", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 17,
                 12_500_000, "lsp_to_user", "counterparty", None,
             )
             .unwrap());
@@ -4203,7 +4400,7 @@ mod tests {
         db.save_channel("channel", "user-channel", 50.0, 50_000, 50_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
+            "payment", "settlement-1", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
             12_500_000, "lsp_to_user", "counterparty", None,
         )
         .unwrap();
@@ -4226,7 +4423,7 @@ mod tests {
         db.save_channel("channel", "user-channel", 50.0, 62_500, 50_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
+            "payment", "settlement-1", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
             12_500_000, "lsp_to_user", "counterparty", None,
         )
         .unwrap();
@@ -4465,6 +4662,109 @@ mod tests {
         assert_eq!(channel.backing_sats, 20_000);
         assert_eq!(channel.native_sats, 4_000);
         assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
+    }
+
+    #[test]
+    fn stale_correlated_acceptance_completes_trade_without_reverting_newer_state() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel-1", "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let trade_id = "abababababababababababababababababababababababababababababababab";
+        let trade_db_id = db
+            .record_prepared_trade(
+                "channel-1",
+                trade_id,
+                "sell",
+                5.0,
+                0.00005,
+                100_000.0,
+                0.05,
+                50_000,
+                15.0,
+                15_000,
+                100,
+            )
+            .unwrap();
+        assert!(db
+            .attach_trade_payment_id(trade_db_id, "fee-payment")
+            .unwrap());
+
+        // Version 2 overtakes the delayed version-1 trade response.
+        assert!(db
+            .apply_sync_if_newer("user-channel-1", 2, 20.0, 20_000, 4_000)
+            .unwrap());
+        assert!(!db
+            .complete_trade_from_stale_correlated_sync(
+                "user-channel-1",
+                3,
+                15.0,
+                trade_db_id,
+                Some("fee-payment"),
+            )
+            .unwrap());
+        assert!(!db
+            .complete_trade_from_stale_correlated_sync(
+                "user-channel-1",
+                1,
+                16.0,
+                trade_db_id,
+                Some("fee-payment"),
+            )
+            .unwrap());
+        assert!(!db
+            .complete_trade_from_stale_correlated_sync(
+                "user-channel-1",
+                1,
+                15.0,
+                trade_db_id,
+                Some("wrong-payment"),
+            )
+            .unwrap());
+        assert!(db
+            .complete_trade_from_stale_correlated_sync(
+                "user-channel-1",
+                1,
+                15.0,
+                trade_db_id,
+                Some("fee-payment"),
+            )
+            .unwrap());
+
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 20.0);
+        assert_eq!(channel.backing_sats, 20_000);
+        assert_eq!(channel.native_sats, 4_000);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
+        let trade = db.get_recent_trades(1).unwrap().pop().unwrap();
+        assert_eq!(trade.status, "completed");
+        assert_eq!(trade.payment_id.as_deref(), Some("fee-payment"));
+        assert!(!db
+            .complete_trade_from_stale_correlated_sync(
+                "user-channel-1",
+                1,
+                15.0,
+                trade_db_id,
+                Some("fee-payment"),
+            )
+            .unwrap());
+
+        let events = db
+            .list_ledger_events(&LedgerQuery {
+                identifier: Some(trade_id.to_owned()),
+                limit: 20,
+                ..Default::default()
+            })
+            .unwrap()
+            .events;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event.event_type == "TRADE_ACCEPTANCE_CONFIRMED_AFTER_NEWER_SYNC"
+                })
+                .count(),
+            1,
+        );
     }
 
     #[test]
@@ -4940,19 +5240,19 @@ mod tests {
     }
 
     #[test]
-    fn desktop_correlated_sync_tolerates_repriced_backing_and_a_capacity_clamp() {
+    fn desktop_correlated_sync_tolerates_peer_backing_but_not_a_changed_target() {
         let db = Database::open_in_memory().unwrap();
         db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
             .unwrap();
-        let repriced_trade_id = "1111111111111111111111111111111111111111111111111111111111111111";
-        let repriced_row_id = db
+        let correlated_trade_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let correlated_row_id = db
             .record_prepared_trade(
-                "channel", repriced_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
+                "channel", correlated_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
                 5_000, 100,
             )
             .unwrap();
 
-        // Same agreed target ($5), repriced backing_sats (each side derives at its own price) — accepted.
+        // Same agreed target ($5), different peer-local backing_sats — accepted.
         assert!(db
             .apply_correlated_sync_if_newer_and_complete_trade(
                 "user",
@@ -4960,7 +5260,7 @@ mod tests {
                 5.0,
                 5_100,
                 4_900,
-                Some(repriced_row_id),
+                Some(correlated_row_id),
                 Some("fee-payment"),
             )
             .unwrap());
@@ -4978,7 +5278,7 @@ mod tests {
             )
             .unwrap();
 
-        // A target ABOVE the request is not a capacity clamp and must still be refused.
+        // Any changed target is a different trade and must be refused.
         assert!(!db
             .apply_correlated_sync_if_newer_and_complete_trade(
                 "user",
@@ -4991,30 +5291,25 @@ mod tests {
             )
             .unwrap());
 
-        // A target clamped DOWN to what the LSP could back is the same contract honoured, so this
-        // gate has to admit it too — a stricter copy here strands the trade the sync confirms.
-        let clamped_trade_id =
+        let lower_target_trade_id =
             "3333333333333333333333333333333333333333333333333333333333333333";
-        let clamped_row_id = db
+        let lower_target_row_id = db
             .record_prepared_trade(
-                "channel", clamped_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
-                5_000, 100,
+                "channel", lower_target_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05,
+                50_000, 5.0, 5_000, 100,
             )
             .unwrap();
-        let clamped =
-            5.0 * (1.0 - crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0 / 2.0);
-        assert!(db
+        assert!(!db
             .apply_correlated_sync_if_newer_and_complete_trade(
                 "user",
                 3,
-                clamped,
-                5_000,
-                5_000,
-                Some(clamped_row_id),
+                4.99,
+                4_990,
+                5_010,
+                Some(lower_target_row_id),
                 Some("fee-payment-3"),
             )
             .unwrap());
-        assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, clamped);
     }
 
     #[test]
@@ -5070,6 +5365,7 @@ mod tests {
         let first = db
             .record_payment_and_maybe_update_backing(
                 Some("payment-1"),
+                Some("settlement-1"),
                 "stability",
                 "received",
                 100_000,
@@ -5094,6 +5390,7 @@ mod tests {
         let duplicate = db
             .record_payment_and_maybe_update_backing(
                 Some("payment-1"),
+                Some("settlement-1"),
                 "stability",
                 "received",
                 100_000,
@@ -5114,9 +5411,34 @@ mod tests {
             1_100
         );
 
+        let settlement_replay = db
+            .record_payment_and_maybe_update_backing(
+                Some("payment-replay"),
+                Some("settlement-1"),
+                "stability",
+                "received",
+                100_000,
+                Some(1.0),
+                Some(100_000.0),
+                "completed",
+                Some("user-channel-1"),
+                Some(100),
+            )
+            .unwrap();
+        assert!(!settlement_replay.is_new);
+        assert_eq!(
+            db.load_channel("user-channel-1")
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            1_100,
+            "a new payment id cannot replay an already-applied settlement id",
+        );
+
         let second = db
             .record_payment_and_maybe_update_backing(
                 Some("payment-2"),
+                Some("settlement-2"),
                 "stability",
                 "received",
                 50_000,
@@ -5147,6 +5469,7 @@ mod tests {
         let result = db
             .record_payment_and_maybe_update_backing(
                 Some("payment-neg"),
+                None,
                 "stability",
                 "sent",
                 100_000,
@@ -5176,6 +5499,7 @@ mod tests {
             .unwrap();
         db.record_pending_stability_payment(
             "stability-1",
+            "settlement-1",
             20_000_000,
             Some(20.0),
             100_000.0,
@@ -5225,6 +5549,7 @@ mod tests {
             .unwrap();
         db.record_pending_stability_payment(
             "stability-1",
+            "settlement-1",
             20_000_000,
             Some(20.0),
             100_000.0,
@@ -5258,6 +5583,7 @@ mod tests {
         let err = db
             .record_payment_and_maybe_update_backing(
                 Some("payment-orphan"),
+                None,
                 "stability",
                 "received",
                 100_000,
@@ -6082,7 +6408,7 @@ mod tests {
 
         assert!(db
             .record_pending_stability_payment(
-                "payment", 1_000_000, Some(1.0), 100_000.0, "counterparty", "physical",
+                "payment", "settlement-payment", 1_000_000, Some(1.0), 100_000.0, "counterparty", "physical",
                 "stable", 10.0, 10_000, 9_000, 5_000, None,
             )
             .is_err());
@@ -6096,7 +6422,7 @@ mod tests {
         db.save_channel("physical", "stable", 10.0, 10_000, 5_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "stable", "physical", 10_000, 9_000, 5_000, 10.0, 0,
+            "payment", "settlement-payment", "stable", "physical", 10_000, 9_000, 5_000, 10.0, 0,
             1_000_000, "lsp_to_user", "counterparty", None,
         )
         .unwrap();
@@ -6238,6 +6564,7 @@ mod tests {
             .unwrap();
         db.record_pending_stability_payment(
             "payment",
+            "settlement-payment",
             1_000_000,
             Some(1.0),
             100_000.0,
@@ -6288,6 +6615,7 @@ mod tests {
             .unwrap();
         db.record_pending_stability_payment(
             "desktop-payment",
+            "settlement-desktop",
             1_000_000,
             Some(1.0),
             100_000.0,
@@ -6303,6 +6631,7 @@ mod tests {
         .unwrap();
         db.record_stability_settlement_with_rollback(
             "lsp-payment",
+            "settlement-lsp",
             "stable",
             "physical",
             9_000,
@@ -6391,6 +6720,7 @@ mod tests {
         assert!(db
             .record_payment_and_maybe_update_backing(
                 Some("stability-payment"),
+                Some("settlement-payment"),
                 "stability",
                 "received",
                 1_000_000,

--- a/src/db.rs
+++ b/src/db.rs
@@ -87,10 +87,41 @@ pub fn forward_fingerprint(
 /// A still-pending trade recoverable after a restart (the in-memory pending-trade map is empty on launch).
 pub struct PendingTradeRow {
     pub id: i64,
+    pub channel_id: String,
+    pub trade_id: Option<String>,
+    pub payment_id: Option<String>,
+    pub fee_msat: u64,
     pub new_expected_usd: f64,
     pub btc_price: f64,
     pub new_backing_sats: Option<u64>,
     pub action: String,
+    pub status: String,
+}
+
+fn pending_trade_from_row(row: &rusqlite::Row<'_>) -> SqliteResult<PendingTradeRow> {
+    Ok(PendingTradeRow {
+        id: row.get(0)?,
+        channel_id: row.get(1)?,
+        trade_id: row.get(2)?,
+        payment_id: row.get(3)?,
+        fee_msat: row.get::<_, i64>(4)?.max(0) as u64,
+        new_expected_usd: row.get(5)?,
+        btc_price: row.get(6)?,
+        new_backing_sats: row.get::<_, Option<i64>>(7)?.map(|value| value.max(0) as u64),
+        action: row.get(8)?,
+        status: row.get(9)?,
+    })
+}
+
+/// A durable LSP response to an authenticated inbound trade. The signed envelope and amount are
+/// stored before any send is attempted, making retries independent of the original LDK event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingTradeResponse {
+    pub inbound_payment_id: String,
+    pub counterparty: String,
+    pub response_envelope: String,
+    pub response_amount_msat: u64,
+    pub attempts: u32,
 }
 
 fn finish_transaction<T>(conn: &Connection, result: SqliteResult<T>) -> SqliteResult<T> {
@@ -191,6 +222,33 @@ impl Database {
         // Exact allocation signed in TRADE_V1. NULL identifies trades written by older wallets,
         // which still need the legacy price-derived recovery path.
         let _ = conn.execute("ALTER TABLE trades ADD COLUMN new_backing_sats INTEGER", []);
+
+        // Durable desktop TRADE_V1 lifecycle. New rows are created in `sending` before LDK is
+        // called; nullable/defaulted migrations keep historical and mobile-created databases
+        // readable.
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN trade_id TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN fee_msat INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN fee_status TEXT NOT NULL DEFAULT 'legacy'",
+            [],
+        );
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN failure_code TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN failure_reason TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN expires_at INTEGER", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN resolved_at INTEGER", []);
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_trade_id
+             ON trades(trade_id) WHERE trade_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trades_expiry
+             ON trades(status, expires_at)",
+            [],
+        )?;
 
         // Migration: Add stable_sats column to channels table if missing
         // stable_sats tracks the BTC backing the stable portion (excludes native BTC)
@@ -392,6 +450,49 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN outcome TEXT NOT NULL DEFAULT 'pending'",
             [],
         );
+
+        // Authenticated TRADE_V1 decisions and their durable response obligations. `trade_id` is
+        // intentionally not UNIQUE: a second payment reusing one must itself be persisted as a
+        // rejected decision. `inbound_payment_id` is the event-level deduplication key.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS trade_decisions (
+                inbound_payment_id TEXT PRIMARY KEY,
+                trade_id TEXT,
+                channel_id TEXT NOT NULL,
+                user_channel_id TEXT NOT NULL,
+                remote_user_channel_id TEXT,
+                counterparty TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                reason_code TEXT,
+                explanation TEXT,
+                expected_usd REAL,
+                backing_sats INTEGER,
+                sync_version INTEGER,
+                response_envelope TEXT NOT NULL,
+                response_amount_msat INTEGER NOT NULL,
+                response_payment_id TEXT,
+                response_status TEXT NOT NULL DEFAULT 'pending',
+                response_attempts INTEGER NOT NULL DEFAULT 0,
+                next_response_attempt_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                resolved_at INTEGER
+            )",
+            [],
+        )?;
+        let _ = conn.execute(
+            "ALTER TABLE trade_decisions ADD COLUMN remote_user_channel_id TEXT",
+            [],
+        );
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trade_decisions_trade_id
+             ON trade_decisions(trade_id) WHERE trade_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trade_decisions_response_due
+             ON trade_decisions(response_status, next_response_attempt_at)",
+            [],
+        )?;
 
         // Forwarded-payment dedup: tracks fingerprints of forwards already audited (live or backfilled)
         conn.execute(
@@ -779,6 +880,561 @@ impl Database {
         Ok(version as u64)
     }
 
+    /// Return the next version without reserving it. Trade acceptance signs a response using this
+    /// candidate, then atomically compares/increments the version while storing the signed
+    /// response and allocation.
+    pub fn candidate_sync_version(&self, user_channel_id: &str) -> SqliteResult<u64> {
+        let conn = self.conn.lock().unwrap();
+        let version: i64 = conn.query_row(
+            "SELECT sync_version FROM channels WHERE user_channel_id = ?1",
+            params![user_channel_id],
+            |row| row.get(0),
+        )?;
+        version
+            .checked_add(1)
+            .filter(|value| *value > 0)
+            .map(|value| value as u64)
+            .ok_or(rusqlite::Error::IntegralValueOutOfRange(0, version))
+    }
+
+    /// True when another inbound payment has already claimed this caller-generated trade id.
+    pub fn trade_id_seen_on_other_payment(
+        &self,
+        trade_id: &str,
+        inbound_payment_id: &str,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM trade_decisions
+                WHERE trade_id = ?1 AND inbound_payment_id <> ?2
+             )",
+            params![trade_id, inbound_payment_id],
+            |row| row.get(0),
+        )
+    }
+
+    pub fn trade_decision_exists(&self, inbound_payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM trade_decisions WHERE inbound_payment_id = ?1)",
+            params![inbound_payment_id],
+            |row| row.get(0),
+        )
+    }
+
+    /// Requeue the original authoritative response when another payment reuses its trade id.
+    /// The new payment still receives `duplicate_trade`; sending the original decision first
+    /// prevents that secondary rejection from becoming the wallet's only observed outcome.
+    pub fn requeue_original_trade_response(
+        &self,
+        trade_id: &str,
+        inbound_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'pending', response_payment_id = NULL,
+                 response_attempts = 0, next_response_attempt_at = ?3,
+                 resolved_at = NULL
+             WHERE rowid = (
+                SELECT rowid FROM trade_decisions
+                WHERE trade_id = ?1 AND inbound_payment_id <> ?2
+                ORDER BY rowid ASC LIMIT 1
+             )",
+            params![trade_id, inbound_payment_id, now],
+        )?;
+        Ok(updated == 1)
+    }
+
+    /// Give an explicitly replayed inbound payment's abandoned response a fresh delivery budget.
+    pub fn requeue_abandoned_trade_response(
+        &self,
+        inbound_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'pending', response_payment_id = NULL,
+                 response_attempts = 0, next_response_attempt_at = ?2,
+                 resolved_at = NULL
+             WHERE inbound_payment_id = ?1 AND response_status = 'abandoned'",
+            params![inbound_payment_id, now],
+        )?;
+        Ok(updated == 1)
+    }
+
+    /// Persist an authenticated rejection and its nominal control response before sending it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn persist_trade_rejection(
+        &self,
+        inbound_payment_id: &str,
+        trade_id: Option<&str>,
+        channel_id: &str,
+        user_channel_id: &str,
+        remote_user_channel_id: Option<&str>,
+        counterparty: &str,
+        reason_code: &str,
+        explanation: &str,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO trade_decisions (
+                inbound_payment_id, trade_id, channel_id, user_channel_id,
+                remote_user_channel_id, counterparty,
+                outcome, reason_code, explanation, response_envelope,
+                response_amount_msat
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'rejected', ?7, ?8, ?9, 1)",
+            params![
+                inbound_payment_id,
+                trade_id,
+                channel_id,
+                user_channel_id,
+                remote_user_channel_id,
+                counterparty,
+                reason_code,
+                explanation,
+                response_envelope,
+            ],
+        )?;
+        Ok(inserted == 1)
+    }
+
+    /// Atomically apply an accepted allocation, advance its SYNC version, and persist the signed
+    /// response/decision. A stale candidate version or duplicate payment leaves everything intact.
+    #[allow(clippy::too_many_arguments)]
+    pub fn persist_trade_acceptance(
+        &self,
+        inbound_payment_id: &str,
+        trade_id: Option<&str>,
+        channel_id: &str,
+        user_channel_id: &str,
+        remote_user_channel_id: Option<&str>,
+        counterparty: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        quote_price: Option<f64>,
+        lsp_price: f64,
+        quote_deviation_percent: Option<f64>,
+        sync_version: u64,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        if !expected_usd.is_finite()
+            || expected_usd < 0.0
+            || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64
+            || !lsp_price.is_finite()
+            || lsp_price <= 0.0
+            || quote_price.is_some_and(|price| !price.is_finite() || price <= 0.0)
+            || quote_deviation_percent
+                .is_some_and(|deviation| !deviation.is_finite() || deviation < 0.0)
+            || sync_version == 0
+            || sync_version > i64::MAX as u64
+        {
+            return Ok(false);
+        }
+
+        let previous_version = sync_version as i64 - 1;
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let mut ledger_mirror = None;
+        let result = (|| {
+            let duplicate: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM trade_decisions WHERE inbound_payment_id = ?1)",
+                params![inbound_payment_id],
+                |row| row.get(0),
+            )?;
+            if duplicate {
+                return Ok(false);
+            }
+            let before: Option<(String, f64, i64, i64)> = tx
+                .query_row(
+                    "SELECT channel_id, expected_usd, stable_sats, native_sats
+                     FROM channels WHERE user_channel_id = ?1",
+                    params![user_channel_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()?;
+            let updated = tx.execute(
+                "UPDATE channels
+                 SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3, native_sats = ?4,
+                     sync_version = ?5, updated_at = strftime('%s', 'now'), closed_at = NULL
+                 WHERE user_channel_id = ?6 AND sync_version = ?7",
+                params![
+                    channel_id,
+                    expected_usd,
+                    backing_sats,
+                    native_sats,
+                    sync_version,
+                    user_channel_id,
+                    previous_version,
+                ],
+            )?;
+            if updated != 1 {
+                return Ok(false);
+            }
+            tx.execute(
+                "INSERT INTO trade_decisions (
+                    inbound_payment_id, trade_id, channel_id, user_channel_id,
+                    remote_user_channel_id, counterparty,
+                    outcome, expected_usd, backing_sats, sync_version, response_envelope,
+                    response_amount_msat
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'accepted', ?7, ?8, ?9, ?10, 1)",
+                params![
+                    inbound_payment_id,
+                    trade_id,
+                    channel_id,
+                    user_channel_id,
+                    remote_user_channel_id,
+                    counterparty,
+                    expected_usd,
+                    backing_sats,
+                    sync_version,
+                    response_envelope,
+                ],
+            )?;
+            let detail = serde_json::json!({
+                "trade_id": trade_id,
+                "trade_payment_id": inbound_payment_id,
+                "channel_id": channel_id,
+                "previous_channel_id": before.as_ref().map(|row| row.0.as_str()),
+                "user_channel_id": user_channel_id,
+                "remote_user_channel_id": remote_user_channel_id,
+                "counterparty_node_id": counterparty,
+                "new_expected_usd": expected_usd,
+                "backing_sats": backing_sats,
+                "native_sats": native_sats,
+                "sync_version": sync_version,
+                "quote_price": quote_price,
+                "lsp_price": lsp_price,
+                "quote_deviation_percent": quote_deviation_percent,
+            });
+            let mut refs = vec![
+                LedgerRef::new("payment_id", inbound_payment_id),
+                LedgerRef::new("channel_id", channel_id),
+                LedgerRef::new("user_channel_id", user_channel_id),
+                LedgerRef::new("node_id", counterparty),
+            ];
+            if let Some(remote_user_channel_id) = remote_user_channel_id {
+                refs.push(LedgerRef::new("user_channel_id", remote_user_channel_id));
+            }
+            if let Some(trade_id) = trade_id {
+                refs.push(LedgerRef::new("trade_id", trade_id));
+            }
+            if let Some((previous_channel_id, ..)) = before.as_ref() {
+                if previous_channel_id != channel_id {
+                    refs.push(LedgerRef::new("channel_id", previous_channel_id));
+                }
+            }
+            let draft = LedgerEventDraft {
+                event_type: "TRADE_APPLIED".to_owned(),
+                category: "trade".to_owned(),
+                severity: "info".to_owned(),
+                status: "completed".to_owned(),
+                source: "lsp_trade".to_owned(),
+                completeness: LedgerCompleteness::Observed,
+                occurred_at_ms: Utc::now().timestamp_millis(),
+                dedup_key: Some(format!("lsp:trade-applied:{inbound_payment_id}")),
+                before: before.as_ref().map(
+                    |(_, previous_expected, previous_backing, previous_native)| {
+                        AccountingSnapshot {
+                            expected_usd: Some(*previous_expected),
+                            backing_sats: u64::try_from(*previous_backing).ok(),
+                            native_sats: u64::try_from(*previous_native).ok(),
+                            live_receiver_sats: u64::try_from(
+                                previous_backing.saturating_add(*previous_native),
+                            )
+                            .ok(),
+                            ..Default::default()
+                        }
+                    },
+                ),
+                after: Some(AccountingSnapshot {
+                    expected_usd: Some(expected_usd),
+                    backing_sats: Some(backing_sats),
+                    native_sats: Some(native_sats),
+                    live_receiver_sats: Some(backing_sats.saturating_add(native_sats)),
+                    ..Default::default()
+                }),
+                detail,
+                refs,
+            };
+            let outcome = ledger::append_on_connection(&tx, &draft)?;
+            if outcome.inserted {
+                ledger_mirror = Some((draft, outcome.event_id));
+            }
+            Ok(true)
+        })();
+        match result {
+            Ok(value) => {
+                tx.commit()?;
+                if let Some((draft, event_id)) = ledger_mirror {
+                    crate::audit::mirror_committed_ledger_event(&draft, event_id);
+                }
+                Ok(value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn due_trade_responses(
+        &self,
+        now: i64,
+        max_attempts: u32,
+        limit: usize,
+    ) -> SqliteResult<Vec<PendingTradeResponse>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT inbound_payment_id, counterparty, response_envelope,
+                    response_amount_msat, response_attempts
+             FROM trade_decisions
+             WHERE response_status = 'pending' AND next_response_attempt_at <= ?1
+                   AND response_attempts < ?2
+             ORDER BY next_response_attempt_at ASC, created_at ASC, rowid ASC
+             LIMIT ?3",
+        )?;
+        let rows = stmt.query_map(params![now, max_attempts, limit as i64], |row| {
+            let amount: i64 = row.get(3)?;
+            let attempts: i64 = row.get(4)?;
+            Ok(PendingTradeResponse {
+                inbound_payment_id: row.get(0)?,
+                counterparty: row.get(1)?,
+                response_envelope: row.get(2)?,
+                response_amount_msat: amount.max(0) as u64,
+                attempts: attempts.max(0) as u32,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Move exhausted response obligations to a durable terminal state and append their
+    /// dead-letter ledger events in the same transaction. A replay can explicitly requeue one.
+    pub fn abandon_exhausted_trade_responses(
+        &self,
+        max_attempts: u32,
+        now: i64,
+        limit: usize,
+    ) -> SqliteResult<usize> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let exhausted = {
+            let mut stmt = tx.prepare(
+                "SELECT inbound_payment_id, trade_id, channel_id, user_channel_id,
+                        remote_user_channel_id, counterparty, outcome, response_attempts
+                 FROM trade_decisions
+                 WHERE response_status = 'pending' AND response_attempts >= ?1
+                 ORDER BY next_response_attempt_at ASC, created_at ASC, rowid ASC
+                 LIMIT ?2",
+            )?;
+            let rows = stmt.query_map(params![max_attempts, limit as i64], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, i64>(7)?,
+                ))
+            })?;
+            rows.collect::<SqliteResult<Vec<_>>>()?
+        };
+
+        let mut abandoned = 0;
+        let mut ledger_mirrors = Vec::new();
+        for (
+            inbound_payment_id,
+            trade_id,
+            channel_id,
+            user_channel_id,
+            remote_user_channel_id,
+            counterparty,
+            outcome,
+            response_attempts,
+        ) in exhausted
+        {
+            let updated = tx.execute(
+                "UPDATE trade_decisions
+                 SET response_status = 'abandoned', resolved_at = ?2
+                 WHERE inbound_payment_id = ?1 AND response_status = 'pending'
+                       AND response_attempts >= ?3",
+                params![inbound_payment_id, now, max_attempts],
+            )?;
+            if updated != 1 {
+                continue;
+            }
+
+            let detail = serde_json::json!({
+                "trade_id": trade_id,
+                "trade_payment_id": inbound_payment_id,
+                "channel_id": channel_id,
+                "user_channel_id": user_channel_id,
+                "remote_user_channel_id": remote_user_channel_id,
+                "counterparty_node_id": counterparty,
+                "outcome": outcome,
+                "response_attempts": response_attempts,
+                "max_response_attempts": max_attempts,
+                "response_status": "abandoned",
+            });
+            let mut refs = vec![
+                LedgerRef::new("payment_id", &inbound_payment_id),
+                LedgerRef::new("channel_id", &channel_id),
+                LedgerRef::new("user_channel_id", &user_channel_id),
+                LedgerRef::new("node_id", &counterparty),
+            ];
+            if let Some(remote_user_channel_id) = remote_user_channel_id.as_deref() {
+                refs.push(LedgerRef::new("user_channel_id", remote_user_channel_id));
+            }
+            if let Some(trade_id) = trade_id.as_deref() {
+                refs.push(LedgerRef::new("trade_id", trade_id));
+            }
+            let draft = LedgerEventDraft {
+                event_type: "TRADE_RESPONSE_ABANDONED".to_owned(),
+                category: "trade".to_owned(),
+                severity: "warning".to_owned(),
+                status: "failed".to_owned(),
+                source: "lsp_trade".to_owned(),
+                completeness: LedgerCompleteness::Observed,
+                occurred_at_ms: now.saturating_mul(1000),
+                dedup_key: Some(format!(
+                    "lsp:trade-response-abandoned:{inbound_payment_id}"
+                )),
+                before: None,
+                after: None,
+                detail,
+                refs,
+            };
+            let ledger_outcome = ledger::append_on_connection(&tx, &draft)?;
+            if ledger_outcome.inserted {
+                ledger_mirrors.push((draft, ledger_outcome.event_id));
+            }
+            abandoned += 1;
+        }
+
+        tx.commit()?;
+        for (draft, event_id) in ledger_mirrors {
+            crate::audit::mirror_committed_ledger_event(&draft, event_id);
+        }
+        Ok(abandoned)
+    }
+
+    pub fn in_flight_trade_response_payment_ids(&self) -> SqliteResult<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT response_payment_id FROM trade_decisions
+             WHERE response_status = 'in_flight' AND response_payment_id IS NOT NULL",
+        )?;
+        let rows = stmt.query_map([], |row| row.get(0))?;
+        rows.collect()
+    }
+
+    fn trade_response_delay_secs(attempts_after_failure: u32, response_key: &str) -> i64 {
+        let exponent = attempts_after_failure.saturating_sub(1).min(10);
+        let base = (5_i64.saturating_mul(1_i64 << exponent)).min(60 * 60);
+        if attempts_after_failure <= 1 || base >= 60 * 60 {
+            return base;
+        }
+        let hash = response_key.bytes().fold(0xcbf29ce484222325_u64, |hash, byte| {
+            hash.wrapping_mul(0x100000001b3) ^ u64::from(byte)
+        });
+        let jitter = (hash % (base as u64 / 5 + 1)) as i64;
+        base.saturating_add(jitter).min(60 * 60)
+    }
+
+    pub fn mark_trade_response_send_failed(
+        &self,
+        inbound_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        let attempts: i64 = conn.query_row(
+            "SELECT response_attempts FROM trade_decisions
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
+            params![inbound_payment_id],
+            |row| row.get(0),
+        )?;
+        let next_attempt = attempts.saturating_add(1).max(1) as u32;
+        let delay = Self::trade_response_delay_secs(next_attempt, inbound_payment_id);
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'pending', response_attempts = ?2,
+                 next_response_attempt_at = ?3
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
+            params![inbound_payment_id, next_attempt, now.saturating_add(delay)],
+        )?;
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        }
+    }
+
+    /// Store the generated outbound id immediately after LDK accepts the control send. A process
+    /// crash in the preceding gap can produce a duplicate nominal response after restart.
+    pub fn mark_trade_response_in_flight(
+        &self,
+        inbound_payment_id: &str,
+        response_payment_id: &str,
+    ) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'in_flight', response_payment_id = ?2,
+                 response_attempts = response_attempts + 1
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
+            params![inbound_payment_id, response_payment_id],
+        )?;
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        }
+    }
+
+    pub fn mark_trade_response_succeeded(&self, response_payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'succeeded', resolved_at = strftime('%s', 'now')
+             WHERE response_payment_id = ?1 AND response_status <> 'succeeded'",
+            params![response_payment_id],
+        )?;
+        Ok(updated > 0)
+    }
+
+    pub fn mark_trade_response_payment_failed(
+        &self,
+        response_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let attempts = conn
+            .query_row(
+                "SELECT response_attempts FROM trade_decisions
+                 WHERE response_payment_id = ?1 AND response_status = 'in_flight'",
+                params![response_payment_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?;
+        let Some(attempts) = attempts else {
+            return Ok(false);
+        };
+        let delay = Self::trade_response_delay_secs(attempts.max(1) as u32, response_payment_id);
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'pending', response_payment_id = NULL,
+                 next_response_attempt_at = ?2
+             WHERE response_payment_id = ?1 AND response_status = 'in_flight'",
+            params![response_payment_id, now.saturating_add(delay)],
+        )?;
+        Ok(updated > 0)
+    }
+
     /// Apply a signed inbound SYNC_V1 allocation only when its version is newer.
     /// The version and allocation share one SQLite statement, so a crash cannot
     /// persist one without the other. Returns false for stale/replayed versions.
@@ -810,7 +1466,30 @@ impl Database {
         expected_usd: f64,
         backing_sats: u64,
         native_sats: u64,
-        trade_id: Option<i64>,
+        trade_db_id: Option<i64>,
+    ) -> SqliteResult<bool> {
+        self.apply_correlated_sync_if_newer_and_complete_trade(
+            user_channel_id,
+            sync_version,
+            expected_usd,
+            backing_sats,
+            native_sats,
+            trade_db_id,
+            None,
+        )
+    }
+
+    /// Correlated variant that can durably repair a missing outbound payment id after a crash.
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_correlated_sync_if_newer_and_complete_trade(
+        &self,
+        user_channel_id: &str,
+        sync_version: u64,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        trade_db_id: Option<i64>,
+        trade_payment_id: Option<&str>,
     ) -> SqliteResult<bool> {
         if sync_version == 0
             || sync_version > i64::MAX as u64
@@ -823,6 +1502,41 @@ impl Database {
         }
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        if let Some(trade_db_id) = trade_db_id {
+            let stored_intent = tx
+                .query_row(
+                    "SELECT payment_id, new_expected_usd, new_backing_sats, trade_id
+                     FROM trades WHERE id = ?1",
+                    params![trade_db_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, f64>(1)?,
+                            row.get::<_, Option<i64>>(2)?,
+                            row.get::<_, Option<String>>(3)?,
+                        ))
+                    },
+                )
+                .optional()?;
+            let Some((stored_payment_id, stored_expected_usd, stored_backing_sats, trade_id)) =
+                stored_intent
+            else {
+                return Err(rusqlite::Error::QueryReturnedNoRows);
+            };
+            if let (Some(stored), Some(received)) =
+                (stored_payment_id.as_deref(), trade_payment_id)
+            {
+                if stored != received {
+                    return Ok(false);
+                }
+            }
+            if trade_id.is_some()
+                && ((stored_expected_usd - expected_usd).abs() > 0.000000001
+                    || stored_backing_sats != Some(backing_sats as i64))
+            {
+                return Ok(false);
+            }
+        }
         let before: Option<(f64, i64, i64)> = tx
             .query_row(
                 "SELECT expected_usd, stable_sats, native_sats FROM channels WHERE user_channel_id = ?1",
@@ -857,10 +1571,16 @@ impl Database {
             tx.commit()?;
             return Ok(false);
         }
-        if let Some(trade_id) = trade_id {
+        if let Some(trade_db_id) = trade_db_id {
             let completed = tx.execute(
-                "UPDATE trades SET status = 'completed' WHERE id = ?1 AND status = 'pending'",
-                params![trade_id],
+                "UPDATE trades
+                 SET status = 'completed', fee_status = 'paid',
+                     payment_id = COALESCE(payment_id, ?2),
+                     failure_code = NULL, failure_reason = NULL,
+                     resolved_at = strftime('%s', 'now')
+                 WHERE id = ?1
+                   AND (?2 IS NULL OR payment_id IS NULL OR payment_id = ?2)",
+                params![trade_db_id, trade_payment_id],
             )?;
             if completed != 1 {
                 return Err(rusqlite::Error::QueryReturnedNoRows);
@@ -894,7 +1614,8 @@ impl Database {
             detail: serde_json::json!({
                 "user_channel_id": user_channel_id,
                 "sync_version": sync_version,
-                "trade_id": trade_id,
+                "trade_db_id": trade_db_id,
+                "trade_payment_id": trade_payment_id,
                 "new_expected_usd": expected_usd,
                 "new_backing_sats": backing_sats,
                 "new_native_sats": native_sats,
@@ -1135,6 +1856,83 @@ impl Database {
         Ok(conn.last_insert_rowid())
     }
 
+    /// Persist every byte of a desktop trade's local intent before invoking LDK.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_prepared_trade(
+        &self,
+        channel_id: &str,
+        trade_id: &str,
+        action: &str,
+        amount_usd: f64,
+        amount_btc: f64,
+        btc_price: f64,
+        fee_usd: f64,
+        fee_msat: u64,
+        new_expected_usd: f64,
+        new_backing_sats: u64,
+        expires_at: i64,
+    ) -> SqliteResult<i64> {
+        if trade_id.len() != 64
+            || !trade_id
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            || fee_msat > i64::MAX as u64
+            || new_backing_sats > i64::MAX as u64
+        {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO trades (
+                channel_id, trade_id, action, amount_usd, amount_btc, btc_price, fee_usd,
+                fee_msat, fee_status, new_expected_usd, new_backing_sats, status, expires_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'sending', ?9, ?10, 'sending', ?11)",
+            params![
+                channel_id,
+                trade_id,
+                action,
+                amount_usd,
+                amount_btc,
+                btc_price,
+                fee_usd,
+                fee_msat,
+                new_expected_usd,
+                new_backing_sats,
+                expires_at,
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Attach LDK's payment id immediately after send construction succeeds.
+    pub fn attach_trade_payment_id(
+        &self,
+        trade_db_id: i64,
+        payment_id: &str,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trades
+             SET payment_id = ?2, fee_status = 'pending'
+             WHERE id = ?1 AND payment_id IS NULL AND status = 'sending'",
+            params![trade_db_id, payment_id],
+        )?;
+        Ok(updated == 1)
+    }
+
+    pub fn mark_trade_fee_awaiting_acceptance(&self, payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trades
+             SET fee_status = 'paid',
+                 status = CASE WHEN status = 'sending' THEN 'awaiting_acceptance' ELSE status END
+             WHERE payment_id = ?1
+               AND status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')",
+            params![payment_id],
+        )?;
+        Ok(updated == 1)
+    }
+
     /// Look up a still-pending trade by its payment_id, for restart recovery. Only returns rows
     /// that have either an exact allocation or a non-zero legacy target.
     pub fn get_pending_trade_by_payment_id(
@@ -1143,18 +1941,26 @@ impl Database {
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
-             WHERE payment_id = ?1 AND status = 'pending'
+            "SELECT id, channel_id, trade_id, payment_id, fee_msat, new_expected_usd, btc_price,
+                    new_backing_sats, action, status
+             FROM trades
+             WHERE payment_id = ?1
+               AND status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')
                AND (new_backing_sats IS NOT NULL OR new_expected_usd > 0.0)
              ORDER BY id DESC LIMIT 1",
             params![payment_id],
             |row| {
                 Ok(PendingTradeRow {
                     id: row.get(0)?,
-                    new_expected_usd: row.get(1)?,
-                    btc_price: row.get(2)?,
-                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
-                    action: row.get(4)?,
+                    channel_id: row.get(1)?,
+                    trade_id: row.get(2)?,
+                    payment_id: row.get(3)?,
+                    fee_msat: row.get::<_, i64>(4)?.max(0) as u64,
+                    new_expected_usd: row.get(5)?,
+                    btc_price: row.get(6)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(7)?.map(|v| v.max(0) as u64),
+                    action: row.get(8)?,
+                    status: row.get(9)?,
                 })
             },
         )
@@ -1171,8 +1977,10 @@ impl Database {
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
-             WHERE status = 'pending'
+            "SELECT id, channel_id, trade_id, payment_id, fee_msat, new_expected_usd, btc_price,
+                    new_backing_sats, action, status
+             FROM trades
+             WHERE status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')
                AND new_backing_sats = ?1
                AND ABS(new_expected_usd - ?2) <= 0.000000001
              ORDER BY id DESC LIMIT 1",
@@ -1180,14 +1988,62 @@ impl Database {
             |row| {
                 Ok(PendingTradeRow {
                     id: row.get(0)?,
-                    new_expected_usd: row.get(1)?,
-                    btc_price: row.get(2)?,
-                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
-                    action: row.get(4)?,
+                    channel_id: row.get(1)?,
+                    trade_id: row.get(2)?,
+                    payment_id: row.get(3)?,
+                    fee_msat: row.get::<_, i64>(4)?.max(0) as u64,
+                    new_expected_usd: row.get(5)?,
+                    btc_price: row.get(6)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(7)?.map(|v| v.max(0) as u64),
+                    action: row.get(8)?,
+                    status: row.get(9)?,
                 })
             },
         )
         .optional()
+    }
+
+    /// Resolve a new protocol response by caller-generated id and/or LDK payment id. When both
+    /// are present they must identify the same row. A missing stored payment id is allowed so an
+    /// authoritative response can repair the crash window after send.
+    pub fn get_trade_by_protocol_ids(
+        &self,
+        trade_id: Option<&str>,
+        trade_payment_id: Option<&str>,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
+        if trade_id.is_none() && trade_payment_id.is_none() {
+            return Ok(None);
+        }
+        let conn = self.conn.lock().unwrap();
+        let mut row = if let Some(trade_id) = trade_id {
+            conn.query_row(
+                "SELECT id, channel_id, trade_id, payment_id, fee_msat, new_expected_usd,
+                        btc_price, new_backing_sats, action, status
+                 FROM trades WHERE trade_id = ?1 LIMIT 1",
+                params![trade_id],
+                pending_trade_from_row,
+            )
+            .optional()?
+        } else {
+            conn.query_row(
+                "SELECT id, channel_id, trade_id, payment_id, fee_msat, new_expected_usd,
+                        btc_price, new_backing_sats, action, status
+                 FROM trades WHERE payment_id = ?1 ORDER BY id DESC LIMIT 1",
+                params![trade_payment_id],
+                pending_trade_from_row,
+            )
+            .optional()?
+        };
+        if let (Some(found), Some(expected_payment_id)) = (&row, trade_payment_id) {
+            if found
+                .payment_id
+                .as_deref()
+                .is_some_and(|stored| stored != expected_payment_id)
+            {
+                row = None;
+            }
+        }
+        Ok(row)
     }
 
     /// Whether this payment id belongs to any trade, including one already completed by an
@@ -1212,12 +2068,104 @@ impl Database {
         Ok(())
     }
 
+    pub fn mark_trade_send_failed(&self, trade_db_id: i64, reason: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trades
+             SET status = 'failed', fee_status = 'failed', failure_code = 'payment_failed',
+                 failure_reason = ?2, resolved_at = strftime('%s', 'now')
+             WHERE id = ?1
+               AND status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')",
+            params![trade_db_id, reason],
+        )?;
+        Ok(updated == 1)
+    }
+
+    pub fn mark_trade_payment_failed(
+        &self,
+        payment_id: &str,
+        reason: &str,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let row = tx
+            .query_row(
+                "SELECT id, channel_id, trade_id, payment_id, fee_msat, new_expected_usd,
+                        btc_price, new_backing_sats, action, status
+                 FROM trades
+                 WHERE payment_id = ?1
+                   AND status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')
+                 ORDER BY id DESC LIMIT 1",
+                params![payment_id],
+                pending_trade_from_row,
+            )
+            .optional()?;
+        let Some(row) = row else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        tx.execute(
+            "UPDATE trades
+             SET status = 'failed', fee_status = 'failed', failure_code = 'payment_failed',
+                 failure_reason = ?2, resolved_at = strftime('%s', 'now')
+             WHERE id = ?1",
+            params![row.id, reason],
+        )?;
+        tx.commit()?;
+        Ok(Some(row))
+    }
+
+    /// Atomically validate rejection correlation and resolve the order. Returns false for a
+    /// mismatch or replay; callers still treat a replayed valid control payment as handled.
+    pub fn mark_trade_rejected(
+        &self,
+        trade_db_id: i64,
+        trade_id: Option<&str>,
+        trade_payment_id: &str,
+        reason_code: &str,
+        explanation: &str,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trades
+             SET status = 'rejected', fee_status = 'paid', failure_code = ?4,
+                 failure_reason = ?5,
+                 payment_id = COALESCE(payment_id, ?3), resolved_at = strftime('%s', 'now')
+             WHERE id = ?1
+               AND status IN ('sending', 'awaiting_acceptance', 'expired', 'pending')
+               AND (?2 IS NULL OR trade_id = ?2)
+               AND (payment_id IS NULL OR payment_id = ?3)",
+            params![
+                trade_db_id,
+                trade_id,
+                trade_payment_id,
+                reason_code,
+                explanation,
+            ],
+        )?;
+        Ok(updated == 1)
+    }
+
+    /// Timer expiry is informational. Authoritative late sync, rejection, or payment-failure paths
+    /// explicitly include `expired` rows above.
+    pub fn expire_unresolved_trades(&self, now: i64) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE trades
+             SET status = 'expired', resolved_at = ?1
+             WHERE status IN ('sending', 'awaiting_acceptance')
+               AND expires_at IS NOT NULL AND expires_at <= ?1",
+            params![now],
+        )
+    }
+
     /// Get recent trades across all channels
     pub fn get_recent_trades(&self, limit: usize) -> SqliteResult<Vec<TradeRecord>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, channel_id, action, amount_usd, amount_btc, btc_price, fee_usd,
-                    payment_id, status, created_at
+                    payment_id, status, created_at, trade_id, fee_msat, fee_status,
+                    failure_code, failure_reason, expires_at, resolved_at
              FROM trades
              ORDER BY id DESC
              LIMIT ?1",
@@ -1235,6 +2183,13 @@ impl Database {
                 payment_id: row.get(7)?,
                 status: row.get(8)?,
                 created_at: row.get(9)?,
+                trade_id: row.get(10)?,
+                fee_msat: row.get::<_, i64>(11)?.max(0) as u64,
+                fee_status: row.get(12)?,
+                failure_code: row.get(13)?,
+                failure_reason: row.get(14)?,
+                expires_at: row.get(15)?,
+                resolved_at: row.get(16)?,
             })
         })?;
 
@@ -3104,6 +4059,13 @@ pub struct TradeRecord {
     pub payment_id: Option<String>,
     pub status: String,
     pub created_at: i64,
+    pub trade_id: Option<String>,
+    pub fee_msat: u64,
+    pub fee_status: String,
+    pub failure_code: Option<String>,
+    pub failure_reason: Option<String>,
+    pub expires_at: Option<i64>,
+    pub resolved_at: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -3505,6 +4467,487 @@ mod tests {
             db.apply_sync_if_newer("missing", 1, 10.0, 10_000, 5_000),
             Err(rusqlite::Error::QueryReturnedNoRows)
         ));
+    }
+
+    #[test]
+    fn lsp_trade_decision_is_atomic_deduplicated_and_retried_with_backoff() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let version = db.candidate_sync_version("user").unwrap();
+        assert!(db
+            .persist_trade_acceptance(
+                "inbound-payment",
+                Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                "channel",
+                "user",
+                Some("wallet-user"),
+                "counterparty",
+                20.0,
+                20_000,
+                4_000,
+                Some(100_000.0),
+                100_000.0,
+                Some(0.0),
+                version,
+                "signed-envelope",
+            )
+            .unwrap());
+        assert_eq!(db.get_sync_version("user").unwrap(), Some(1));
+        let channel = db.load_channel("user").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 20.0);
+        assert_eq!(channel.backing_sats, 20_000);
+        let decision_ids: (String, Option<String>) = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT user_channel_id, remote_user_channel_id
+                 FROM trade_decisions WHERE inbound_payment_id = 'inbound-payment'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(decision_ids, ("user".to_owned(), Some("wallet-user".to_owned())));
+        let trade_event = db
+            .list_ledger_events(&LedgerQuery {
+                identifier: Some("inbound-payment".to_owned()),
+                limit: 20,
+                ..Default::default()
+            })
+            .unwrap()
+            .events
+            .into_iter()
+            .find(|event| event.event_type == "TRADE_APPLIED")
+            .expect("accepted allocation and ledger event must commit together");
+        assert_eq!(trade_event.before.unwrap().expected_usd, Some(10.0));
+        assert_eq!(trade_event.after.unwrap().expected_usd, Some(20.0));
+        assert!(!db
+            .persist_trade_acceptance(
+                "inbound-payment",
+                None,
+                "channel",
+                "user",
+                None,
+                "counterparty",
+                99.0,
+                99_000,
+                0,
+                None,
+                100_000.0,
+                None,
+                2,
+                "other-envelope",
+            )
+            .unwrap());
+        assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, 20.0);
+
+        let due = db.due_trade_responses(i64::MAX, u32::MAX, 10).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].response_amount_msat, 1);
+        db.mark_trade_response_in_flight("inbound-payment", "response-payment")
+            .unwrap();
+        assert!(matches!(
+            db.mark_trade_response_in_flight("inbound-payment", "response-payment-two"),
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        ));
+        assert!(matches!(
+            db.mark_trade_response_in_flight("missing-payment", "response-payment"),
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        ));
+        assert!(db
+            .due_trade_responses(i64::MAX, u32::MAX, 10)
+            .unwrap()
+            .is_empty());
+        assert!(db
+            .mark_trade_response_payment_failed("response-payment", 100)
+            .unwrap());
+        assert!(db
+            .due_trade_responses(104, u32::MAX, 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            db.due_trade_responses(105, u32::MAX, 10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(Database::trade_response_delay_secs(1, "response-a"), 5);
+        assert!((10..=12).contains(&Database::trade_response_delay_secs(2, "response-a")));
+        assert_eq!(
+            Database::trade_response_delay_secs(u32::MAX, "response-a"),
+            60 * 60
+        );
+    }
+
+    #[test]
+    fn lsp_trade_acceptance_rolls_back_when_ledger_append_fails() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER fail_trade_ledger
+                 BEFORE INSERT ON ledger_events
+                 WHEN NEW.event_type = 'TRADE_APPLIED'
+                 BEGIN
+                    SELECT RAISE(ABORT, 'injected ledger failure');
+                 END;",
+            )
+            .unwrap();
+
+        assert!(db
+            .persist_trade_acceptance(
+                "inbound-payment",
+                Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                "channel",
+                "user",
+                Some("wallet-user"),
+                "counterparty",
+                20.0,
+                20_000,
+                4_000,
+                Some(100_000.0),
+                100_000.0,
+                Some(0.0),
+                1,
+                "signed-envelope",
+            )
+            .is_err());
+
+        let channel = db.load_channel("user").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 10.0);
+        assert_eq!(db.get_sync_version("user").unwrap(), Some(0));
+        assert!(!db.trade_decision_exists("inbound-payment").unwrap());
+    }
+
+    #[test]
+    fn lsp_rejection_uses_nominal_response_and_reused_trade_id_is_detected() {
+        let db = Database::open_in_memory().unwrap();
+        let trade_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        assert!(db
+            .persist_trade_rejection(
+                "payment-one",
+                Some(trade_id),
+                "channel",
+                "user",
+                Some("wallet-user"),
+                "counterparty",
+                "invalid_fee",
+                "wrong fee",
+                "signed-rejection",
+            )
+            .unwrap());
+        let response = db
+            .due_trade_responses(i64::MAX, u32::MAX, 10)
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(response.response_amount_msat, 1);
+        assert!(db
+            .trade_id_seen_on_other_payment(trade_id, "payment-two")
+            .unwrap());
+        assert!(!db
+            .trade_id_seen_on_other_payment(trade_id, "payment-one")
+            .unwrap());
+    }
+
+    #[test]
+    fn exhausted_trade_response_is_atomically_abandoned_and_replayable() {
+        const MAX_ATTEMPTS: u32 = 3;
+        let db = Database::open_in_memory().unwrap();
+        let trade_id = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        assert!(db
+            .persist_trade_rejection(
+                "exhausted-payment",
+                Some(trade_id),
+                "channel",
+                "user",
+                Some("wallet-user"),
+                "counterparty",
+                "invalid_fee",
+                "wrong fee",
+                "signed-rejection",
+            )
+            .unwrap());
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE trade_decisions
+                 SET response_attempts = ?1, next_response_attempt_at = 0
+                 WHERE inbound_payment_id = 'exhausted-payment'",
+                params![MAX_ATTEMPTS],
+            )
+            .unwrap();
+
+        assert!(db
+            .due_trade_responses(i64::MAX, MAX_ATTEMPTS, 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            db.abandon_exhausted_trade_responses(MAX_ATTEMPTS, 123, 10)
+                .unwrap(),
+            1
+        );
+        let abandoned: (String, i64, Option<i64>) = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT response_status, response_attempts, resolved_at
+                 FROM trade_decisions WHERE inbound_payment_id = 'exhausted-payment'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(abandoned, ("abandoned".to_owned(), 3, Some(123)));
+        let dead_letter = db
+            .list_ledger_events(&LedgerQuery {
+                identifier: Some("exhausted-payment".to_owned()),
+                limit: 20,
+                ..Default::default()
+            })
+            .unwrap()
+            .events
+            .into_iter()
+            .find(|event| event.event_type == "TRADE_RESPONSE_ABANDONED")
+            .expect("abandoned response and dead-letter event must commit together");
+        assert_eq!(dead_letter.status, "failed");
+        assert_eq!(dead_letter.detail["response_attempts"], 3);
+        assert!(matches!(
+            db.mark_trade_response_send_failed("exhausted-payment", 200),
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        ));
+
+        assert!(db
+            .requeue_abandoned_trade_response("exhausted-payment", 456)
+            .unwrap());
+        let requeued: (String, i64, i64, Option<i64>) = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT response_status, response_attempts, next_response_attempt_at, resolved_at
+                 FROM trade_decisions WHERE inbound_payment_id = 'exhausted-payment'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(requeued, ("pending".to_owned(), 0, 456, None));
+        assert_eq!(
+            db.due_trade_responses(456, MAX_ATTEMPTS, 10)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn abandoned_trade_response_rolls_back_when_dead_letter_append_fails() {
+        let db = Database::open_in_memory().unwrap();
+        assert!(db
+            .persist_trade_rejection(
+                "exhausted-payment",
+                None,
+                "channel",
+                "user",
+                None,
+                "counterparty",
+                "internal_error",
+                "temporary failure",
+                "signed-rejection",
+            )
+            .unwrap());
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "UPDATE trade_decisions SET response_attempts = 3;
+                 CREATE TRIGGER fail_dead_letter_ledger
+                 BEFORE INSERT ON ledger_events
+                 WHEN NEW.event_type = 'TRADE_RESPONSE_ABANDONED'
+                 BEGIN
+                    SELECT RAISE(ABORT, 'injected dead-letter failure');
+                 END;",
+            )
+            .unwrap();
+
+        assert!(db.abandon_exhausted_trade_responses(3, 123, 10).is_err());
+        let state: (String, Option<i64>) = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT response_status, resolved_at FROM trade_decisions
+                 WHERE inbound_payment_id = 'exhausted-payment'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, ("pending".to_owned(), None));
+    }
+
+    #[test]
+    fn desktop_trade_expires_then_accepts_late_legacy_sync() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let trade_id = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let row_id = db
+            .record_prepared_trade(
+                "channel", trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
+                5_000, 100,
+            )
+            .unwrap();
+        assert_eq!(db.expire_unresolved_trades(100).unwrap(), 1);
+        let expired = db
+            .get_trade_by_protocol_ids(Some(trade_id), Some("fee-payment"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(expired.status, "expired");
+        assert!(!db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                1,
+                6.0,
+                6_000,
+                9_000,
+                Some(row_id),
+                Some("fee-payment"),
+            )
+            .unwrap());
+        assert_eq!(db.get_sync_version("user").unwrap(), Some(0));
+        assert!(db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                1,
+                5.0,
+                5_000,
+                10_000,
+                Some(row_id),
+                None,
+            )
+            .unwrap());
+        let completed = db.get_recent_trades(1).unwrap().pop().unwrap();
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.payment_id, None);
+        assert!(completed.resolved_at.is_some());
+    }
+
+    #[test]
+    fn desktop_correlated_sync_repairs_missing_payment_id() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let trade_id = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let row_id = db
+            .record_prepared_trade(
+                "channel", trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
+                5_000, 100,
+            )
+            .unwrap();
+
+        assert!(db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                1,
+                5.0,
+                5_000,
+                10_000,
+                Some(row_id),
+                Some("fee-payment"),
+            )
+            .unwrap());
+        let completed = db.get_recent_trades(1).unwrap().pop().unwrap();
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.payment_id.as_deref(), Some("fee-payment"));
+    }
+
+    #[test]
+    fn authoritative_newer_sync_overrides_terminal_trade_status() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let trade_id = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let row_id = db
+            .record_prepared_trade(
+                "channel", trade_id, "sell", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 15.0,
+                15_000, 100,
+            )
+            .unwrap();
+        assert!(db
+            .mark_trade_rejected(
+                row_id,
+                Some(trade_id),
+                "fee-payment",
+                "internal_error",
+                "temporary rejection",
+            )
+            .unwrap());
+
+        assert!(db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                1,
+                15.0,
+                15_000,
+                0,
+                Some(row_id),
+                Some("fee-payment"),
+            )
+            .unwrap());
+        let completed = db.get_recent_trades(1).unwrap().pop().unwrap();
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.failure_code, None);
+        assert_eq!(completed.failure_reason, None);
+        assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, 15.0);
+    }
+
+    #[test]
+    fn desktop_rejection_accepts_missing_trade_id_only_with_exact_payment() {
+        let db = Database::open_in_memory().unwrap();
+        let trade_id = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let row_id = db
+            .record_prepared_trade(
+                "channel", trade_id, "sell", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 14.95,
+                14_950, 1_000,
+            )
+            .unwrap();
+        assert!(db.attach_trade_payment_id(row_id, "fee-payment").unwrap());
+        assert!(!db
+            .mark_trade_rejected(
+                row_id,
+                None,
+                "wrong-payment",
+                "invalid_quote",
+                "bad quote",
+            )
+            .unwrap());
+        assert!(db
+            .mark_trade_rejected(
+                row_id,
+                None,
+                "fee-payment",
+                "invalid_quote",
+                "bad quote",
+            )
+            .unwrap());
+        assert!(!db
+            .mark_trade_rejected(
+                row_id,
+                Some(trade_id),
+                "fee-payment",
+                "invalid_quote",
+                "bad quote",
+            )
+            .unwrap());
+        let rejected = db.get_recent_trades(1).unwrap().pop().unwrap();
+        assert_eq!(rejected.status, "rejected");
+        assert_eq!(rejected.fee_status, "paid");
+        assert_eq!(rejected.failure_code.as_deref(), Some("invalid_quote"));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1522,7 +1522,7 @@ impl Database {
                     },
                 )
                 .optional()?;
-            let Some((stored_payment_id, stored_expected_usd, stored_backing_sats, trade_id)) =
+            let Some((stored_payment_id, stored_expected_usd, _stored_backing_sats, trade_id)) =
                 stored_intent
             else {
                 return Err(rusqlite::Error::QueryReturnedNoRows);
@@ -1534,9 +1534,12 @@ impl Database {
                     return Ok(false);
                 }
             }
+            // backing_sats is derived per-peer and not compared; expected_usd is the contract this gate protects.
             if trade_id.is_some()
-                && ((stored_expected_usd - expected_usd).abs() > 0.000000001
-                    || stored_backing_sats != Some(backing_sats as i64))
+                && !crate::trade::answered_target_honours_request(
+                    stored_expected_usd,
+                    expected_usd,
+                )
             {
                 return Ok(false);
             }
@@ -4934,6 +4937,84 @@ mod tests {
         assert_eq!(completed.failure_code, None);
         assert_eq!(completed.failure_reason, None);
         assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, 15.0);
+    }
+
+    #[test]
+    fn desktop_correlated_sync_tolerates_repriced_backing_and_a_capacity_clamp() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_channel("channel", "user", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let repriced_trade_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let repriced_row_id = db
+            .record_prepared_trade(
+                "channel", repriced_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
+                5_000, 100,
+            )
+            .unwrap();
+
+        // Same agreed target ($5), repriced backing_sats (each side derives at its own price) — accepted.
+        assert!(db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                1,
+                5.0,
+                5_100,
+                4_900,
+                Some(repriced_row_id),
+                Some("fee-payment"),
+            )
+            .unwrap());
+        assert_eq!(
+            db.get_recent_trades(1).unwrap().pop().unwrap().status,
+            "completed"
+        );
+
+        let changed_target_trade_id =
+            "2222222222222222222222222222222222222222222222222222222222222222";
+        let changed_target_row_id = db
+            .record_prepared_trade(
+                "channel", changed_target_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000,
+                5.0, 5_000, 100,
+            )
+            .unwrap();
+
+        // A target ABOVE the request is not a capacity clamp and must still be refused.
+        assert!(!db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                2,
+                6.0,
+                5_100,
+                4_900,
+                Some(changed_target_row_id),
+                Some("fee-payment-2"),
+            )
+            .unwrap());
+
+        // A target clamped DOWN to what the LSP could back is the same contract honoured, so this
+        // gate has to admit it too — a stricter copy here strands the trade the sync confirms.
+        let clamped_trade_id =
+            "3333333333333333333333333333333333333333333333333333333333333333";
+        let clamped_row_id = db
+            .record_prepared_trade(
+                "channel", clamped_trade_id, "buy", 5.0, 0.00005, 100_000.0, 0.05, 50_000, 5.0,
+                5_000, 100,
+            )
+            .unwrap();
+        let clamped =
+            5.0 * (1.0 - crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0 / 2.0);
+        assert!(db
+            .apply_correlated_sync_if_newer_and_complete_trade(
+                "user",
+                3,
+                clamped,
+                5_000,
+                5_000,
+                Some(clamped_row_id),
+                Some("fee-payment-3"),
+            )
+            .unwrap());
+        assert_eq!(db.load_channel("user").unwrap().unwrap().expected_usd, clamped);
     }
 
     #[test]

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -768,7 +768,8 @@ fn extract_refs(detail: &Value) -> Vec<LedgerRef> {
             Value::Object(map) => {
                 for (key, value) in map {
                     let role = match key.as_str() {
-                        "user_channel_id" | "user_channel_ids" | "prev_user_channel_id"
+                        "user_channel_id" | "user_channel_ids" | "remote_user_channel_id"
+                        | "remote_user_channel_ids" | "prev_user_channel_id"
                         | "next_user_channel_id" => Some("user_channel_id"),
                         "channel_id" | "channel_ids" | "prev_channel_id" | "next_channel_id" => {
                             Some("channel_id")
@@ -848,14 +849,15 @@ mod tests {
                 "payment_hash": "hash",
                 "user_channel_id": "stable-id",
                 "user_channel_ids": ["stable-a", "stable-b"],
+                "remote_user_channel_id": "wallet-stable-id",
                 "channel_id": "physical-id",
                 "txid": "tx",
                 "counterparty_node_id": "node",
                 "correlation_id": "corr"
             }),
         );
-        assert_eq!(draft.refs.len(), 9);
-        for value in ["stable-a", "stable-b"] {
+        assert_eq!(draft.refs.len(), 10);
+        for value in ["stable-a", "stable-b", "wallet-stable-id"] {
             assert!(draft.refs.contains(&LedgerRef::new("user_channel_id", value)));
         }
         let unassociated = LedgerEventDraft::from_audit_event(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod historical_prices;
 pub mod ledger;
 pub mod price_feeds;
 pub mod stable;
+pub mod trade;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ pub mod db;
 pub mod ledger;
 pub mod price_feeds;
 pub mod stable;
+pub mod trade;
 pub mod types;
 pub mod user;
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -303,9 +303,10 @@ pub fn reconcile_incoming(sc: &mut StableChannel) {
     recompute_native(sc);
 }
 
-/// Stable/native allocation residue smaller than one cent is not useful to the user and cannot be
-/// entered precisely in the two-decimal trade UI. Absorb it into the stable side so a full
-/// BTC-to-USD trade produces an exact all-stable allocation.
+/// Stable/native allocation residue too small to be a balance the user cares about is absorbed into
+/// the stable side, so a full BTC-to-USD trade produces an exact all-stable allocation. The bound is
+/// a fraction of the stability deadband: large enough to swallow price-feed spread between peers,
+/// small enough that absorbing it cannot consume meaningful headroom before a payout fires.
 pub fn normalize_backing_sats(
     receiver_sats: u64,
     backing_sats: u64,
@@ -321,9 +322,10 @@ pub fn normalize_backing_sats(
         return backing_sats;
     }
 
+    let absorb_below_usd = crate::constants::STABILITY_THRESHOLD_USD / 5.0;
     let native_sats = receiver_sats - backing_sats;
     let native_usd = native_sats as f64 / SATS_IN_BTC as f64 * price;
-    if native_usd < 0.01 {
+    if native_usd < absorb_below_usd {
         receiver_sats
     } else {
         backing_sats
@@ -332,8 +334,9 @@ pub fn normalize_backing_sats(
 
 /// Derive the stable backing allocation for a trade at the signed quote price.
 ///
-/// The result is clamped to the receiver's post-settlement balance. Sub-cent native residue is
-/// absorbed into the stable side so a full BTC-to-USD trade has no floating native remainder.
+/// The result is clamped to the receiver's post-settlement balance. Native residue worth less than
+/// `STABILITY_THRESHOLD_USD / 5` is absorbed into the stable side so a full BTC-to-USD trade has no
+/// floating native remainder; see `normalize_backing_sats` for why the bound tracks the deadband.
 pub fn trade_backing_sats(
     receiver_sats: u64,
     new_expected_usd: f64,
@@ -357,11 +360,12 @@ pub fn trade_backing_sats(
     )
 }
 
-/// Apply a previously agreed trade allocation without repricing it.
+/// Apply an already-derived trade allocation without repricing it.
 ///
-/// `backing_sats` is part of the signed trade intent. A peer may validate that intent against its
-/// own price and live LDK balance first, but once accepted it must not derive a different allocation
-/// from a later price snapshot.
+/// `expected_usd` is the agreed contract; `backing_sats` is not. Each peer derives its own
+/// allocation from its own price and its own live LDK balance, so the two books legitimately differ
+/// by feed spread and neither may adopt the other's number. This applies the allocation the caller
+/// has already derived — it is not a licence to book a peer-supplied one.
 pub fn apply_trade_allocation(sc: &mut StableChannel, new_expected_usd: f64, backing_sats: u64) {
     sc.expected_usd = USD::from_f64(new_expected_usd);
     sc.backing_sats = backing_sats;
@@ -1249,17 +1253,18 @@ mod tests {
 
     #[test]
     fn signed_trade_allocation_is_not_repriced_by_the_applying_peer() {
+        // 100 sats ($0.10) is a real native residue above the absorption bound, so it survives to prove no repricing happened.
         let receiver_sats = 50_000;
         let quote_price = 100_000.0;
-        let backing_sats = trade_backing_sats(receiver_sats, 49.95, quote_price);
-        assert_eq!(backing_sats, 49_950);
+        let backing_sats = trade_backing_sats(receiver_sats, 49.9, quote_price);
+        assert_eq!(backing_sats, 49_900);
 
         let mut sc = test_sc(0.0, 100_500.0, receiver_sats);
-        apply_trade_allocation(&mut sc, 49.95, backing_sats);
+        apply_trade_allocation(&mut sc, 49.9, backing_sats);
 
-        assert_eq!(sc.expected_usd.0, 49.95);
-        assert_eq!(sc.backing_sats, 49_950);
-        assert_eq!(sc.native_sats, 50);
+        assert_eq!(sc.expected_usd.0, 49.9);
+        assert_eq!(sc.backing_sats, 49_900);
+        assert_eq!(sc.native_sats, 100);
     }
 
     #[test]
@@ -1271,6 +1276,26 @@ mod tests {
         apply_trade_allocation(&mut sc, 38.055025828575, backing_sats);
         assert_eq!(sc.backing_sats, 57_444);
         assert_eq!(sc.native_sats, 0);
+    }
+
+    #[test]
+    fn native_residue_below_deadband_fraction_is_absorbed() {
+        // 40 sats of residue is $0.04 at $100k — feed-spread noise, not a balance the user wants.
+        assert_eq!(
+            normalize_backing_sats(100_000, 99_960, 100.0, 100_000.0),
+            100_000,
+            "sub-threshold residue must be absorbed into the stable side",
+        );
+    }
+
+    #[test]
+    fn native_residue_above_deadband_fraction_is_kept() {
+        // 200 sats is $0.20 — a real native balance, must not be silently pegged.
+        assert_eq!(
+            normalize_backing_sats(100_000, 99_800, 100.0, 100_000.0),
+            99_800,
+            "a meaningful native balance must be preserved",
+        );
     }
 
     // ================================================================

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -6,6 +6,7 @@ use crate::constants::{
 use crate::price_feeds::{get_cached_price, get_fresh_cached_price_no_fetch};
 use crate::types::{Bitcoin, StableChannel, USD};
 use ldk_node::Node;
+use rand::RngCore;
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
 use ureq::Agent;
@@ -332,11 +333,10 @@ pub fn normalize_backing_sats(
     }
 }
 
-/// Derive the stable backing allocation for a trade at the signed quote price.
+/// Derive an initial stable backing allocation at a local price.
 ///
-/// The result is clamped to the receiver's post-settlement balance. Native residue worth less than
-/// `STABILITY_THRESHOLD_USD / 5` is absorbed into the stable side so a full BTC-to-USD trade has no
-/// floating native remainder; see `normalize_backing_sats` for why the bound tracks the deadband.
+/// This is retained for initialization and normalization tests. Live trade processing uses
+/// `trade_backing_after_delta` so a trade cannot reprice the whole existing peg or erase drift.
 pub fn trade_backing_sats(
     receiver_sats: u64,
     new_expected_usd: f64,
@@ -360,6 +360,50 @@ pub fn trade_backing_sats(
     )
 }
 
+/// Apply only a trade's target delta to an existing stable allocation.
+///
+/// Repricing the entire target at trade time erases any pre-existing price drift: a one-cent trade
+/// can otherwise turn a large outstanding stability obligation into native sats. This helper
+/// preserves that drift and converts only the USD amount the trade actually changes.
+pub fn trade_backing_after_delta(
+    receiver_sats: u64,
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    new_expected_usd: f64,
+    price: f64,
+) -> Option<u64> {
+    if !current_expected_usd.is_finite()
+        || current_expected_usd < 0.0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd < 0.0
+        || !price.is_finite()
+        || price <= 0.0
+    {
+        return None;
+    }
+    if new_expected_usd < 0.01 {
+        return Some(0);
+    }
+
+    let delta_usd = (new_expected_usd - current_expected_usd).abs();
+    let delta_sats_f = delta_usd / price * SATS_IN_BTC as f64;
+    if !delta_sats_f.is_finite() || delta_sats_f > u64::MAX as f64 {
+        return None;
+    }
+    let nearest_sat = delta_sats_f.round();
+    let delta_sats = if (delta_sats_f - nearest_sat).abs() < 0.000_000_001 {
+        nearest_sat as u64
+    } else {
+        delta_sats_f.floor() as u64
+    };
+    let backing = if new_expected_usd > current_expected_usd {
+        current_backing_sats.checked_add(delta_sats)?
+    } else {
+        current_backing_sats.checked_sub(delta_sats)?
+    };
+    (backing <= receiver_sats).then_some(backing)
+}
+
 /// Apply an already-derived trade allocation without repricing it.
 ///
 /// `expected_usd` is the agreed contract; `backing_sats` is not. Each peer derives its own
@@ -373,25 +417,20 @@ pub fn apply_trade_allocation(sc: &mut StableChannel, new_expected_usd: f64, bac
     recompute_native(sc);
 }
 
-/// Apply a trade — set new expected_usd and recalculate backing_sats + native_sats.
+/// Apply a trade by converting only its target delta at this peer's local price.
 ///
-/// Used after buy/sell trades and when the LSP processes a trade message.
-/// Sets `expected_usd` to the new value and recalculates `backing_sats`
-/// at the current price. Updates `native_sats` (the invariant that stays
-/// fixed between stability payments).
+/// Existing backing is deliberately not repriced: any stability debt that existed before the trade
+/// remains visible. Invalid or over-capacity deltas leave the allocation unchanged.
 pub fn apply_trade(sc: &mut StableChannel, new_expected_usd: f64, price: f64) {
-    sc.expected_usd = USD::from_f64(new_expected_usd);
-    if price > 0.0 {
-        let receiver_sats = sc.stable_receiver_btc.sats;
-        sc.backing_sats = if receiver_sats > 0 {
-            trade_backing_sats(receiver_sats, new_expected_usd, price)
-        } else {
-            (new_expected_usd / price * SATS_IN_BTC as f64) as u64
-        };
+    if let Some(backing_sats) = trade_backing_after_delta(
+        sc.stable_receiver_btc.sats,
+        sc.backing_sats,
+        sc.expected_usd.0,
+        new_expected_usd,
+        price,
+    ) {
+        apply_trade_allocation(sc, new_expected_usd, backing_sats);
     }
-    // native_sats is everything NOT backing the stable position
-    sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
-    recompute_native(sc);
 }
 
 /// Get the current BTC/USD price, preferring cached value when available
@@ -520,6 +559,7 @@ pub fn update_balances<'update_balance_lifetime>(
 /// Information about a stability payment that was sent
 #[derive(Debug, Clone)]
 pub struct StabilityPaymentInfo {
+    pub settlement_id: String,
     pub payment_id: String,
     pub amount_msat: u64,
     pub counterparty: String,
@@ -539,6 +579,17 @@ pub fn check_stability(
     node: &Node,
     sc: &mut StableChannel,
     price: f64,
+) -> Option<StabilityPaymentInfo> {
+    check_stability_with_version(node, sc, price, 0)
+}
+
+/// Version-aware production entry point. The version is correlation metadata only: an exact
+/// received-sat delta remains valid if a later allocation update wins the race.
+pub fn check_stability_with_version(
+    node: &Node,
+    sc: &mut StableChannel,
+    price: f64,
+    allocation_version: u64,
 ) -> Option<StabilityPaymentInfo> {
     if !price.is_finite() || price <= 0.0 {
         audit_event(
@@ -719,27 +770,57 @@ pub fn check_stability(
         return None;
     }
 
-    let amt = USD::to_msats(dollars_from_par, sc.latest_price);
-    let marker = ldk_node::CustomTlvRecord {
+    // Stable allocation is sat-denominated, so send whole sats and sign that exact amount.
+    let amt = (USD::to_msats(dollars_from_par, sc.latest_price) / 1000) * 1000;
+    if amt == 0 {
+        return None;
+    }
+    let mut settlement_bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut settlement_bytes);
+    let settlement_id = hex::encode(settlement_bytes);
+    let payload = json!({
+        "type": "STABILITY_PAYMENT_V1",
+        "settlement_id": &settlement_id,
+        "channel_id": sc.channel_id.to_string(),
+        "user_channel_id": format!("{}", sc.user_channel_id),
+        "amount_msat": amt,
+        "allocation_version": allocation_version,
+        "ts": now as u64,
+    })
+    .to_string();
+    let signature = node.sign_message(payload.as_bytes());
+    let envelope = json!({
+        "payload": payload,
+        "signature": signature,
+    })
+    .to_string();
+    let legacy_marker = ldk_node::CustomTlvRecord {
         type_num: crate::constants::STABLE_CHANNEL_TLV_TYPE,
         value: vec![1u8],
     };
-    match node.spontaneous_payment().send_with_custom_tlvs(amt, sc.counterparty, None, vec![marker]) {
+    let signed_payment = ldk_node::CustomTlvRecord {
+        type_num: crate::constants::SIGNED_STABILITY_TLV_TYPE,
+        value: envelope.into_bytes(),
+    };
+    match node.spontaneous_payment().send_with_custom_tlvs(
+        amt,
+        sc.counterparty,
+        None,
+        vec![legacy_marker, signed_payment],
+    ) {
         Ok(payment_id) => {
             sc.payment_made = true;
             sc.last_stability_payment = now;
 
-            // Reset backing_sats to equilibrium at current price.
-            // This accounts the payment against the stable pool, not native BTC.
-            // Don't recompute native_sats here — receiver balance hasn't updated yet
-            // (HTLC still in flight). Native will be recomputed on next balance refresh.
+            // Apply only the sats sent. Any residual price drift remains outstanding.
             let previous_backing = sc.backing_sats;
-            let new_backing = (target_usd / sc.latest_price * 100_000_000.0) as u64;
+            let new_backing = previous_backing.saturating_sub(amt / 1000);
             sc.backing_sats = new_backing;
 
             let payment_id_str = payment_id.to_string();
             let counterparty_str = sc.counterparty.to_string();
             Some(StabilityPaymentInfo {
+                settlement_id,
                 payment_id: payment_id_str,
                 amount_msat: amt,
                 counterparty: counterparty_str,
@@ -1198,19 +1279,17 @@ mod tests {
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
         let backing_before = sc.backing_sats;
         apply_trade(&mut sc, 700.0, 0.0);
-        assert_eq!(sc.expected_usd.0, 700.0); // usd updated
-        assert_eq!(sc.backing_sats, backing_before); // backing unchanged
+        assert_eq!(sc.expected_usd.0, 500.0);
+        assert_eq!(sc.backing_sats, backing_before);
     }
 
     #[test]
-    fn trade_at_different_price() {
-        // Same $500 stable, but price doubled to $200k
-        // backing should be half the sats
+    fn no_op_trade_cannot_reprice_existing_backing() {
+        // Re-submitting the same target at a new price must not erase its outstanding drift.
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
+        let backing_before = sc.backing_sats;
         apply_trade(&mut sc, 500.0, 200_000.0);
-        let expected_backing = (500.0 / 200_000.0 * 100_000_000.0) as u64; // 250k
-        assert_eq!(sc.backing_sats, expected_backing);
-        assert_eq!(expected_backing, 250_000);
+        assert_eq!(sc.backing_sats, backing_before);
     }
 
     #[test]
@@ -1223,13 +1302,13 @@ mod tests {
     }
 
     #[test]
-    fn trade_full_balance_absorbs_sub_cent_native_dust() {
+    fn trade_preserves_sub_cent_native_dust_without_clamping() {
         let mut sc = test_sc(0.0, 66_250.21, 57_444);
         apply_trade(&mut sc, 38.055025828575, 66_250.21);
 
-        assert_eq!(sc.backing_sats, 57_444);
-        assert_eq!(sc.native_sats, 0);
-        assert_eq!(sc.native_channel_btc.sats, 0);
+        assert_eq!(sc.backing_sats, 57_441);
+        assert_eq!(sc.native_sats, 3);
+        assert_eq!(sc.native_channel_btc.sats, 3);
     }
 
     #[test]
@@ -1243,12 +1322,27 @@ mod tests {
     }
 
     #[test]
-    fn trade_backing_never_exceeds_live_balance() {
+    fn trade_over_live_balance_is_not_partially_applied() {
         let mut sc = test_sc(0.0, 100_000.0, 95_000);
         apply_trade(&mut sc, 100.0, 100_000.0);
 
-        assert_eq!(sc.backing_sats, 95_000);
-        assert_eq!(sc.native_sats, 0);
+        assert_eq!(sc.expected_usd.0, 0.0);
+        assert_eq!(sc.backing_sats, 0);
+        assert_eq!(sc.native_sats, 95_000);
+    }
+
+    #[test]
+    fn tiny_trade_preserves_preexisting_stability_debt() {
+        let mut sc = test_sc(100.0, 100_000.0, 200_000);
+        assert_eq!(sc.backing_sats, 100_000);
+
+        // At $110k the original backing is worth $110 and owes a stability payment. A one-cent
+        // target increase adds only that one-cent delta; it must not re-anchor all $100.01.
+        apply_trade(&mut sc, 100.01, 110_000.0);
+
+        assert_eq!(sc.backing_sats, 100_009);
+        let value = sc.backing_sats as f64 / SATS_IN_BTC as f64 * 110_000.0;
+        assert!(value - sc.expected_usd.0 > 9.99);
     }
 
     #[test]

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -51,23 +51,15 @@ impl TradeRejectionReason {
     }
 }
 
-/// Whether the target an LSP answered with honours the target the wallet signed.
+/// Whether the LSP answered with the exact target the wallet signed.
 ///
-/// Equal is the ordinary case. Lower means the LSP booked what its own valuation of the wallet's
-/// channel side can actually back, rather than funding the shortfall out of its own liquidity;
-/// accept that as far as the two sides could honestly disagree about the value of those sats.
-/// Higher is not a clamp and is never accepted.
-///
-/// Both the sync handler and the database's own trade-completion gate have to agree on this, so the
-/// rule lives here rather than being spelled out twice — a stricter copy in either place strands the
-/// trade it was meant to confirm.
-pub fn answered_target_honours_request(requested_usd: f64, answered_usd: f64) -> bool {
-    if (requested_usd - answered_usd).abs() <= 0.000000001 {
-        return true;
-    }
-    let clamp_floor =
-        requested_usd * (1.0 - crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
-    answered_usd < requested_usd && answered_usd >= clamp_floor
+/// Backing is derived per-peer, but the USD target is the trade contract. Accepting a lower target
+/// would create an implicit partial fill and can even reverse a trade when the channel is already
+/// under-backed. Keep this shared so the sync handler and the transactional DB gate cannot disagree.
+pub fn answered_target_matches_request(requested_usd: f64, answered_usd: f64) -> bool {
+    requested_usd.is_finite()
+        && answered_usd.is_finite()
+        && (requested_usd - answered_usd).abs() <= 0.000000001
 }
 
 #[cfg(test)]
@@ -91,15 +83,12 @@ mod tests {
     }
 
     #[test]
-    fn answered_target_accepts_a_capacity_clamp_but_nothing_above_the_request() {
-        let spread = crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0;
-        assert!(answered_target_honours_request(100.0, 100.0));
-        assert!(answered_target_honours_request(100.0, 100.0 * (1.0 - spread / 2.0)));
-        assert!(answered_target_honours_request(100.0, 100.0 * (1.0 - spread)));
-        assert!(!answered_target_honours_request(100.0, 100.0 * (1.0 - spread) - 0.01));
-        assert!(!answered_target_honours_request(100.0, 100.01));
-        // Closing a peg answers zero for zero, which is equality rather than a clamp.
-        assert!(answered_target_honours_request(0.0, 0.0));
-        assert!(!answered_target_honours_request(0.0, 1.0));
+    fn answered_target_requires_the_signed_target_exactly() {
+        assert!(answered_target_matches_request(100.0, 100.0));
+        assert!(!answered_target_matches_request(100.0, 99.99));
+        assert!(!answered_target_matches_request(100.0, 100.01));
+        assert!(answered_target_matches_request(0.0, 0.0));
+        assert!(!answered_target_matches_request(0.0, 1.0));
+        assert!(!answered_target_matches_request(f64::NAN, 100.0));
     }
 }

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -1,0 +1,105 @@
+//! Wire vocabulary shared by both ends of a stable-channel trade.
+
+use serde::{Deserialize, Serialize};
+
+/// Declare the rejection reasons once, and derive the enum, the wire spelling, and the full set from
+/// that single list.
+///
+/// The wallet used to validate incoming reasons against a hand-typed copy of the daemon's enum with
+/// nothing linking the two, so a reason added on the server was silently discarded by the client and
+/// stranded the trade row it was meant to resolve. Adding a reason here reaches both sides or fails
+/// to compile.
+macro_rules! trade_rejection_reasons {
+    ($($variant:ident => $code:literal),+ $(,)?) => {
+        /// Stable machine-readable rejection reasons carried by `TRADE_REJECTED_V1`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum TradeRejectionReason {
+            $($variant),+
+        }
+
+        impl TradeRejectionReason {
+            /// Every reason a peer may legitimately send.
+            pub const ALL: &'static [Self] = &[$(Self::$variant),+];
+
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $code),+
+                }
+            }
+        }
+    };
+}
+
+trade_rejection_reasons! {
+    InvalidAmount => "invalid_amount",
+    StaleRequest => "stale_request",
+    InvalidFee => "invalid_fee",
+    InvalidQuote => "invalid_quote",
+    QuoteOutOfRange => "quote_out_of_range",
+    InvalidAllocation => "invalid_allocation",
+    NoOpTrade => "no_op_trade",
+    InsufficientCapacity => "insufficient_capacity",
+    DuplicateTrade => "duplicate_trade",
+    InternalError => "internal_error",
+}
+
+impl TradeRejectionReason {
+    /// Parse a reason off the wire. An unknown code is not this protocol's.
+    pub fn from_code(code: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|reason| reason.as_str() == code)
+    }
+}
+
+/// Whether the target an LSP answered with honours the target the wallet signed.
+///
+/// Equal is the ordinary case. Lower means the LSP booked what its own valuation of the wallet's
+/// channel side can actually back, rather than funding the shortfall out of its own liquidity;
+/// accept that as far as the two sides could honestly disagree about the value of those sats.
+/// Higher is not a clamp and is never accepted.
+///
+/// Both the sync handler and the database's own trade-completion gate have to agree on this, so the
+/// rule lives here rather than being spelled out twice — a stricter copy in either place strands the
+/// trade it was meant to confirm.
+pub fn answered_target_honours_request(requested_usd: f64, answered_usd: f64) -> bool {
+    if (requested_usd - answered_usd).abs() <= 0.000000001 {
+        return true;
+    }
+    let clamp_floor =
+        requested_usd * (1.0 - crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0);
+    answered_usd < requested_usd && answered_usd >= clamp_floor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_reason_round_trips_through_its_wire_code() {
+        for reason in TradeRejectionReason::ALL {
+            assert_eq!(TradeRejectionReason::from_code(reason.as_str()), Some(*reason));
+            // The serde spelling is what actually crosses the wire, so it must agree with as_str.
+            let serialized = serde_json::to_string(reason).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", reason.as_str()));
+        }
+    }
+
+    #[test]
+    fn unknown_reason_codes_are_rejected() {
+        assert_eq!(TradeRejectionReason::from_code("not_a_reason"), None);
+        assert_eq!(TradeRejectionReason::from_code(""), None);
+    }
+
+    #[test]
+    fn answered_target_accepts_a_capacity_clamp_but_nothing_above_the_request() {
+        let spread = crate::constants::MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0;
+        assert!(answered_target_honours_request(100.0, 100.0));
+        assert!(answered_target_honours_request(100.0, 100.0 * (1.0 - spread / 2.0)));
+        assert!(answered_target_honours_request(100.0, 100.0 * (1.0 - spread)));
+        assert!(!answered_target_honours_request(100.0, 100.0 * (1.0 - spread) - 0.01));
+        assert!(!answered_target_honours_request(100.0, 100.01));
+        // Closing a peg answers zero for zero, which is equality rather than a clamp.
+        assert!(answered_target_honours_request(0.0, 0.0));
+        assert!(!answered_target_honours_request(0.0, 1.0));
+    }
+}

--- a/src/user.rs
+++ b/src/user.rs
@@ -12,6 +12,8 @@ use image::{GrayImage, Luma};
 use ldk_node::lightning::ln::channelmanager::PaymentId;
 use ldk_node::payment::{PaymentDirection, PaymentKind};
 use qrcode::QrCode;
+use rand::RngCore;
+use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -167,6 +169,21 @@ struct PendingTradePayment {
     action: String,
 }
 
+#[derive(Clone, Debug)]
+struct PreparedTradeWire {
+    trade_id: String,
+    channel_id: String,
+    user_channel_id: String,
+    counterparty: PublicKey,
+    old_expected_usd: f64,
+    new_expected_usd: f64,
+    quote_price: f64,
+    backing_sats: u64,
+    post_fee_receiver_sats: u64,
+    fee_msat: u64,
+    ts: u64,
+}
+
 /// Outgoing payment awaiting LDK confirmation.
 #[derive(Clone, Debug)]
 struct PendingPayment {
@@ -178,9 +195,26 @@ struct PendingPayment {
 #[derive(Clone, Debug, PartialEq)]
 struct IncomingSync {
     channel_id: String,
+    user_channel_id: String,
     expected_usd: f64,
     backing_sats: u64,
     sync_version: u64,
+    trade_id: Option<String>,
+    trade_payment_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+struct IncomingTradeRejection {
+    #[serde(rename = "type")]
+    kind: String,
+    channel_id: String,
+    user_channel_id: String,
+    #[serde(default)]
+    trade_id: Option<String>,
+    trade_payment_id: String,
+    reason_code: String,
+    explanation: String,
+    ts: u64,
 }
 
 struct BackupSnapshotDir {
@@ -450,6 +484,9 @@ pub struct UserApp {
 
     // Three-step trade flow: Some(action) = show success screen
     trade_success: Option<TradeAction>,
+
+    // Durable trade expiry is checked at startup and at most once per minute thereafter.
+    trade_expiry_last_check: std::time::Instant,
 }
 
 /// Renders a single-line amount text field with iOS-style rounded, light-gray styling.
@@ -661,6 +698,17 @@ impl UserApp {
         // Initialize SQLite database
         let db =
             Database::open(&data_dir).map_err(|e| format!("Failed to open database: {}", e))?;
+        let startup_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .min(i64::MAX as u64) as i64;
+        if let Err(error) = db.expire_unresolved_trades(startup_now) {
+            audit_event(
+                "TRADE_EXPIRY_CHECK_FAILED",
+                json!({ "startup": true, "error": error.to_string() }),
+            );
+        }
 
         let mut app = Self {
             node: Arc::clone(&node),
@@ -776,6 +824,7 @@ impl UserApp {
             payment_flash_at: None,
             last_known_total_sats: 0,
             trade_success: None,
+            trade_expiry_last_check: std::time::Instant::now(),
         };
 
         // Backfill historical + intraday prices from Kraken on a background thread so a
@@ -1910,16 +1959,20 @@ impl UserApp {
     //     }
     // }
 
-    /// Send a trade message to the LSP with the new stabilized USD amount.
-    /// The fee is sent as the keysend payment amount.
-    /// Returns the PaymentId and signed backing allocation on success so the caller can track it.
-    fn send_trade(
-        &mut self,
+    fn new_trade_id() -> String {
+        let mut bytes = [0u8; 32];
+        rand::rng().fill_bytes(&mut bytes);
+        hex::encode(bytes)
+    }
+
+    /// Freeze the reviewed quote, exact fee, post-fee balance, and allocation before persistence.
+    fn prepare_trade_wire(
+        &self,
+        trade_id: String,
         new_expected_usd: f64,
         fee_usd: f64,
-        trade_action: &str,
         trade_price: f64,
-    ) -> Option<(PaymentId, u64)> {
+    ) -> PreparedTradeWire {
         // The fee is a direct keysend amount. Calculate its whole-sat channel impact before
         // signing the allocation so both peers derive against the same post-settlement balance.
         let fee_sats = if trade_price > 0.0 && fee_usd > 0.0 {
@@ -1928,7 +1981,7 @@ impl UserApp {
             0
         };
         let fee_msats = fee_sats.saturating_mul(1000);
-        let amt_msat = fee_msats.max(1);
+        let fee_msat = fee_msats.max(1);
 
         // Refresh from this wallet's LDK node, then sign one exact allocation at the quote the
         // user reviewed. The LSP independently validates this against its LDK view and price.
@@ -1958,21 +2011,46 @@ impl UserApp {
             )
         };
 
-        let ts = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
+
+        PreparedTradeWire {
+            trade_id,
+            channel_id: channel_id_str,
+            user_channel_id: user_channel_id_str,
+            counterparty,
+            old_expected_usd,
+            new_expected_usd,
+            quote_price: trade_price,
+            backing_sats,
+            post_fee_receiver_sats,
+            fee_msat,
+            ts,
+        }
+    }
+
+    /// Send an already-persisted trade and immediately attach LDK's returned payment id.
+    fn send_prepared_trade(
+        &mut self,
+        prepared: &PreparedTradeWire,
+        trade_action: &str,
+        trade_db_id: i64,
+        fee_usd: f64,
+    ) -> Option<PaymentId> {
 
         // All allocation inputs are signed. A different price observed later cannot alter this
         // already-reviewed trade.
         let payload = json!({
             "type": TRADE_MESSAGE_TYPE,
-            "channel_id": channel_id_str,
-            "user_channel_id": user_channel_id_str,
-            "expected_usd": new_expected_usd,
-            "quote_price": trade_price,
-            "backing_sats": backing_sats,
-            "ts": ts,
+            "channel_id": prepared.channel_id,
+            "user_channel_id": prepared.user_channel_id,
+            "trade_id": prepared.trade_id,
+            "expected_usd": prepared.new_expected_usd,
+            "quote_price": prepared.quote_price,
+            "backing_sats": prepared.backing_sats,
+            "ts": prepared.ts,
         });
 
         // Serialize payload and sign it with the node's key
@@ -1995,45 +2073,61 @@ impl UserApp {
         };
 
         match self.node.spontaneous_payment().send_with_custom_tlvs(
-            amt_msat,
-            counterparty,
+            prepared.fee_msat,
+            prepared.counterparty,
             None,
             vec![custom_tlv],
         ) {
             Ok(payment_id) => {
-                // Don't apply_trade yet — wait for PaymentSuccessful event.
-                // Store pending info so we can finalize or revert later.
                 let payment_id_str = format!("{payment_id}");
+                if let Err(error) = self
+                    .db
+                    .attach_trade_payment_id(trade_db_id, &payment_id_str)
+                {
+                    // The signed response can fill this missing id after a crash/write failure.
+                    audit_event(
+                        "TRADE_PAYMENT_ID_PERSIST_FAILED",
+                        json!({
+                            "trade_id": prepared.trade_id,
+                            "payment_id": payment_id_str,
+                            "error": error.to_string(),
+                        }),
+                    );
+                }
 
                 self.status_message = format!("Order pending (fee: ${:.2})", fee_usd,);
                 audit_event(
                     "TRADE_MESSAGE_SENT",
                     json!({
+                        "trade_id": prepared.trade_id,
                         "payment_id": payment_id_str,
-                        "user_channel_id": user_channel_id_str,
+                        "user_channel_id": prepared.user_channel_id,
                         "action": trade_action,
-                        "old_expected_usd": old_expected_usd,
-                        "new_expected_usd": new_expected_usd,
+                        "old_expected_usd": prepared.old_expected_usd,
+                        "new_expected_usd": prepared.new_expected_usd,
                         "fee_usd": fee_usd,
-                        "fee_msats": amt_msat,
-                        "quote_price": trade_price,
-                        "post_fee_receiver_sats": post_fee_receiver_sats,
-                        "backing_sats": backing_sats,
-                        "ts": ts,
-                        "status": "pending",
+                        "fee_msats": prepared.fee_msat,
+                        "quote_price": prepared.quote_price,
+                        "post_fee_receiver_sats": prepared.post_fee_receiver_sats,
+                        "backing_sats": prepared.backing_sats,
+                        "ts": prepared.ts,
+                        "status": "sending",
                     }),
                 );
 
-                Some((payment_id, backing_sats))
+                Some(payment_id)
             }
             Err(e) => {
+                let _ = self.db.mark_trade_send_failed(trade_db_id, &e.to_string());
                 self.status_message = format!("Failed to send order: {}", e);
+                self.trade_error = self.status_message.clone();
                 audit_event(
                     "TRADE_MESSAGE_FAILED",
                     json!({
-                        "user_channel_id": user_channel_id_str,
+                        "trade_id": prepared.trade_id,
+                        "user_channel_id": prepared.user_channel_id,
                         "action": trade_action,
-                        "new_expected_usd": new_expected_usd,
+                        "new_expected_usd": prepared.new_expected_usd,
                         "error": format!("{e}"),
                     }),
                 );
@@ -2230,44 +2324,6 @@ impl UserApp {
             );
 
             println!("Migrated channel {} from JSON to SQLite", channel_id_str);
-        }
-    }
-
-    /// Record a trade in the database. Returns the DB row id (0 on error).
-    fn record_trade(
-        &self,
-        action: &str,
-        amount_usd: f64,
-        amount_btc: f64,
-        btc_price: f64,
-        fee_usd: f64,
-        new_expected_usd: f64,
-        new_backing_sats: Option<u64>,
-        payment_id: Option<&str>,
-        status: &str,
-    ) -> i64 {
-        let user_channel_id_str = {
-            let sc = self.stable_channel.lock().unwrap();
-            format!("{}", sc.user_channel_id)
-        };
-
-        match self.db.record_trade(
-            &user_channel_id_str,
-            action,
-            amount_usd,
-            amount_btc,
-            btc_price,
-            fee_usd,
-            new_expected_usd,
-            new_backing_sats,
-            payment_id,
-            status,
-        ) {
-            Ok(id) => id,
-            Err(e) => {
-                eprintln!("Failed to record trade: {}", e);
-                0
-            }
         }
     }
 
@@ -2780,8 +2836,8 @@ impl UserApp {
                 } => {
                     let payment_hash_str = format!("{payment_hash}");
 
-                    // Check for SYNC_V1 message from LSP (expected_usd synchronization)
-                    let handled_sync = 'sync: {
+                    // Handle signed LSP control messages before ordinary payment accounting.
+                    let handled_control = 'control: {
                         for tlv in &custom_records {
                             if tlv.type_num != STABLE_CHANNEL_TLV_TYPE {
                                 continue;
@@ -2809,15 +2865,19 @@ impl UserApp {
                                 Ok(v) => v,
                                 Err(_) => continue,
                             };
-                            if payload.get("type").and_then(|v| v.as_str())
-                                != Some(SYNC_MESSAGE_TYPE)
+                            let message_type = payload.get("type").and_then(|value| value.as_str());
+                            if message_type != Some(SYNC_MESSAGE_TYPE)
+                                && message_type != Some("TRADE_REJECTED_V1")
                             {
                                 continue;
                             }
-                            // Verify signature against LSP (counterparty)
-                            let counterparty = {
+                            let (counterparty, wallet_channel_id, wallet_user_channel_id) = {
                                 let sc = self.stable_channel.lock().unwrap();
-                                sc.counterparty
+                                (
+                                    sc.counterparty,
+                                    sc.channel_id.to_string(),
+                                    format!("{}", sc.user_channel_id),
+                                )
                             };
                             let sig_ok = self.node.verify_signature(
                                 payload_str.as_bytes(),
@@ -2826,44 +2886,192 @@ impl UserApp {
                             );
                             if !sig_ok {
                                 audit_event(
-                                    "SYNC_V1_SIGNATURE_INVALID",
+                                    "LSP_CONTROL_SIGNATURE_INVALID",
                                     json!({
                                         "payment_hash": &payment_hash_str,
+                                        "message_type": message_type,
                                     }),
                                 );
-                                continue;
+                                break 'control true;
                             }
+
+                            if message_type == Some("TRADE_REJECTED_V1") {
+                                let Some(rejection) = parse_trade_rejection(payload_str) else {
+                                    audit_event(
+                                        "TRADE_REJECTION_PAYLOAD_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str }),
+                                    );
+                                    break 'control true;
+                                };
+                                if rejection.channel_id.to_ascii_lowercase() != wallet_channel_id
+                                    || rejection.user_channel_id != wallet_user_channel_id
+                                {
+                                    audit_event(
+                                        "TRADE_REJECTION_CHANNEL_MISMATCH",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "payload_channel_id": rejection.channel_id,
+                                            "payload_user_channel_id": rejection.user_channel_id,
+                                            "wallet_channel_id": wallet_channel_id,
+                                            "wallet_user_channel_id": wallet_user_channel_id,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                                let trade = match self.db.get_trade_by_protocol_ids(
+                                    rejection.trade_id.as_deref(),
+                                    Some(&rejection.trade_payment_id),
+                                ) {
+                                    Ok(Some(trade)) => trade,
+                                    Ok(None) => {
+                                        audit_event(
+                                            "TRADE_REJECTION_CORRELATION_MISMATCH",
+                                            json!({
+                                                "trade_id": rejection.trade_id,
+                                                "trade_payment_id": rejection.trade_payment_id,
+                                            }),
+                                        );
+                                        break 'control true;
+                                    }
+                                    Err(error) => {
+                                        ack = false;
+                                        audit_event(
+                                            "DB_READ_FAILED",
+                                            json!({
+                                                "op": "get_trade_by_protocol_ids",
+                                                "error": error.to_string(),
+                                            }),
+                                        );
+                                        break 'control true;
+                                    }
+                                };
+                                if trade.channel_id.to_ascii_lowercase() != wallet_channel_id
+                                    || (trade.trade_id.is_some()
+                                        && rejection.trade_id.is_some()
+                                        && trade.trade_id.as_deref()
+                                            != rejection.trade_id.as_deref())
+                                {
+                                    audit_event(
+                                        "TRADE_REJECTION_IDENTIFIER_MISMATCH",
+                                        json!({
+                                            "stored_trade_id": trade.trade_id,
+                                            "response_trade_id": rejection.trade_id,
+                                            "stored_channel_id": trade.channel_id,
+                                            "wallet_channel_id": wallet_channel_id,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                                if amount_msat != 1 {
+                                    audit_event(
+                                        "TRADE_REJECTION_RESPONSE_AMOUNT_INVALID",
+                                        json!({
+                                            "trade_id": rejection.trade_id,
+                                            "received_msat": amount_msat,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                                if !rejection_resolves_trade(&rejection.reason_code) {
+                                    audit_event(
+                                        "TRADE_DUPLICATE_PAYMENT_REJECTED",
+                                        json!({
+                                            "trade_id": rejection.trade_id,
+                                            "trade_payment_id": rejection.trade_payment_id,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                                match self.db.mark_trade_rejected(
+                                    trade.id,
+                                    rejection.trade_id.as_deref(),
+                                    &rejection.trade_payment_id,
+                                    &rejection.reason_code,
+                                    &rejection.explanation,
+                                ) {
+                                    Ok(true) => {
+                                        self.pending_trade_payments.retain(|_, pending| {
+                                            pending.trade_db_id != trade.id
+                                        });
+                                        audit_event(
+                                            "TRADE_REJECTED",
+                                            json!({
+                                                "trade_id": rejection.trade_id,
+                                                "trade_payment_id": rejection.trade_payment_id,
+                                                "reason_code": rejection.reason_code,
+                                            }),
+                                        );
+                                        self.status_message = format!(
+                                            "Order rejected: {}",
+                                            rejection.explanation
+                                        );
+                                        self.show_toast("Order rejected", "X");
+                                    }
+                                    Ok(false) => audit_event(
+                                        "TRADE_REJECTION_REPLAY_OR_MISMATCH",
+                                        json!({
+                                            "trade_id": rejection.trade_id,
+                                            "trade_payment_id": rejection.trade_payment_id,
+                                        }),
+                                    ),
+                                    Err(error) => {
+                                        ack = false;
+                                        audit_event(
+                                            "DB_WRITE_FAILED",
+                                            json!({
+                                                "op": "mark_trade_rejected",
+                                                "error": error.to_string(),
+                                            }),
+                                        );
+                                    }
+                                }
+                                break 'control true;
+                            }
+
                             let Some(sync) = parse_incoming_sync(&payload) else {
                                 audit_event(
                                     "SYNC_V1_PAYLOAD_INVALID",
                                     json!({ "payment_hash": &payment_hash_str }),
                                 );
-                                break 'sync true;
+                                break 'control true;
                             };
 
                             let mut sc = self.stable_channel.lock().unwrap();
-                            let wallet_channel_id = sc.channel_id.to_string();
-                            if sync.channel_id != wallet_channel_id {
+                            if sync.channel_id != wallet_channel_id
+                                || sync.user_channel_id != wallet_user_channel_id
+                            {
                                 audit_event(
                                     "SYNC_V1_CHANNEL_MISMATCH",
                                     json!({
                                         "payment_hash": &payment_hash_str,
                                         "payload_channel_id": sync.channel_id.clone(),
+                                        "payload_user_channel_id": sync.user_channel_id.clone(),
                                         "wallet_channel_id": wallet_channel_id,
+                                        "wallet_user_channel_id": wallet_user_channel_id,
                                         "sync_version": sync.sync_version,
                                     }),
                                 );
-                                break 'sync true;
+                                break 'control true;
                             }
 
                             stable::update_balances(&self.node, &mut sc);
                             let price = sc.latest_price;
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
-                            let pending_trade = match self.db.get_pending_trade_by_allocation(
-                                sync.expected_usd,
-                                sync.backing_sats,
-                            ) {
+                            let correlated = sync.trade_id.is_some() || sync.trade_payment_id.is_some();
+                            let pending_trade_result = if correlated {
+                                self.db.get_trade_by_protocol_ids(
+                                    sync.trade_id.as_deref(),
+                                    sync.trade_payment_id.as_deref(),
+                                )
+                            } else {
+                                // Backward-compatible desktop matching for pre-correlation LSPs.
+                                self.db.get_pending_trade_by_allocation(
+                                    sync.expected_usd,
+                                    sync.backing_sats,
+                                )
+                            };
+                            let pending_trade = match pending_trade_result {
                                 Ok(trade) => trade,
                                 Err(e) => {
                                     audit_event(
@@ -2875,9 +3083,59 @@ impl UserApp {
                                         }),
                                     );
                                     ack = false;
-                                    break 'sync true;
+                                    break 'control true;
                                 }
                             };
+                            if correlated && pending_trade.is_none() {
+                                audit_event(
+                                    "SYNC_V1_CORRELATION_MISMATCH",
+                                    json!({
+                                        "trade_id": sync.trade_id,
+                                        "trade_payment_id": sync.trade_payment_id,
+                                        "sync_version": sync.sync_version,
+                                    }),
+                                );
+                                break 'control true;
+                            }
+                            if pending_trade.as_ref().is_some_and(|trade| {
+                                trade.channel_id.to_ascii_lowercase() != wallet_channel_id
+                            }) {
+                                audit_event(
+                                    "SYNC_V1_TRADE_CHANNEL_MISMATCH",
+                                    json!({
+                                        "trade_id": sync.trade_id,
+                                        "sync_version": sync.sync_version,
+                                    }),
+                                );
+                                break 'control true;
+                            }
+                            if let Some(trade) = pending_trade.as_ref() {
+                                let new_trade_identifiers_match =
+                                    sync_trade_identifiers_match(trade, &sync, correlated);
+                                let stored_allocation_matches = trade
+                                    .new_backing_sats
+                                    .is_none_or(|backing_sats| {
+                                        backing_sats == sync.backing_sats
+                                            && (trade.new_expected_usd - sync.expected_usd).abs()
+                                                <= 0.000000001
+                                    });
+                                if !new_trade_identifiers_match || !stored_allocation_matches {
+                                    audit_event(
+                                        "SYNC_V1_TRADE_INTENT_MISMATCH",
+                                        json!({
+                                            "stored_trade_id": trade.trade_id,
+                                            "response_trade_id": sync.trade_id,
+                                            "response_trade_payment_id": sync.trade_payment_id,
+                                            "stored_expected_usd": trade.new_expected_usd,
+                                            "response_expected_usd": sync.expected_usd,
+                                            "stored_backing_sats": trade.new_backing_sats,
+                                            "response_backing_sats": sync.backing_sats,
+                                            "sync_version": sync.sync_version,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                            }
                             if let Err(reason) = validate_incoming_sync_allocation(
                                 &sync,
                                 live_receiver_sats,
@@ -2896,17 +3154,18 @@ impl UserApp {
                                         "sync_version": sync.sync_version,
                                     }),
                                 );
-                                break 'sync true;
+                                break 'control true;
                             }
                             let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
                             let user_channel_id = format!("{}", sc.user_channel_id);
-                            match self.db.apply_sync_if_newer_and_complete_trade(
+                            match self.db.apply_correlated_sync_if_newer_and_complete_trade(
                                 &user_channel_id,
                                 sync.sync_version,
                                 sync.expected_usd,
                                 sync.backing_sats,
                                 native_sats,
                                 pending_trade.as_ref().map(|trade| trade.id),
+                                sync.trade_payment_id.as_deref(),
                             ) {
                                 Ok(true) => {
                                     stable::apply_trade_allocation(
@@ -2933,7 +3192,9 @@ impl UserApp {
                                         audit_event(
                                             "TRADE_ACCEPTED_BY_LSP",
                                             json!({
-                                                "trade_id": trade.id,
+                                                "trade_db_id": trade.id,
+                                                "trade_id": trade.trade_id,
+                                                "trade_payment_id": sync.trade_payment_id,
                                                 "action": trade.action,
                                                 "expected_usd": sync.expected_usd,
                                                 "backing_sats": sync.backing_sats,
@@ -2975,13 +3236,13 @@ impl UserApp {
                                     ack = false;
                                 }
                             }
-                            break 'sync true;
+                            break 'control true;
                         }
                         false
                     };
 
-                    if handled_sync {
-                        // Sync message: update balances but don't record as a normal payment
+                    if handled_control {
+                        // Control messages update order/accounting state, never normal payment rows.
                         {
                             let mut sc = self.stable_channel.lock().unwrap();
                             update_balances(&self.node, &mut sc);
@@ -3172,6 +3433,22 @@ impl UserApp {
                     }
 
                     if let Some(trade) = pending_trade {
+                        if let Some(pid) = payment_id {
+                            if let Err(error) = self
+                                .db
+                                .mark_trade_fee_awaiting_acceptance(&format!("{pid}"))
+                            {
+                                ack = false;
+                                audit_event(
+                                    "TRADE_FEE_STATUS_PERSIST_FAILED",
+                                    json!({
+                                        "trade_db_id": trade.trade_db_id,
+                                        "payment_id": format!("{pid}"),
+                                        "error": error.to_string(),
+                                    }),
+                                );
+                            }
+                        }
                         audit_event(
                             "TRADE_FEE_CONFIRMED_AWAITING_SYNC",
                             json!({
@@ -3320,7 +3597,10 @@ impl UserApp {
 
                         if let Some(trade) = pending_trade {
                             // Trade payment failed — mark as failed, don't apply trade
-                            let _ = self.db.update_trade_status(trade.trade_db_id, "failed");
+                            let failure_reason = format!("{:?}", reason);
+                            let _ = self
+                                .db
+                                .mark_trade_send_failed(trade.trade_db_id, &failure_reason);
 
                             audit_event(
                                 "TRADE_FAILED",
@@ -7301,8 +7581,13 @@ impl UserApp {
 
                                     let (status_label, status_color) = match trade.status.as_str() {
                                         "completed" => ("Confirmed", theme::SUCCESS),
-                                        "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
+                                        "sending" => ("Sending", theme::INFO),
+                                        "awaiting_acceptance" | "pending" => {
+                                            ("Awaiting", Color32::from_rgb(234, 179, 8))
+                                        }
+                                        "rejected" => ("Rejected", theme::WARNING),
                                         "failed" => ("Failed", theme::DANGER_HOVER),
+                                        "expired" => ("Expired", theme::MUTED),
                                         _ => (&*trade.status, Color32::DARK_GRAY),
                                     };
                                     let (badge_rect, _) = ui.allocate_exact_size(
@@ -7680,8 +7965,13 @@ impl UserApp {
 
                 let (status_label, status_color) = match trade.status.as_str() {
                     "completed" => ("Confirmed", theme::SUCCESS),
-                    "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
+                    "sending" => ("Sending", theme::INFO),
+                    "awaiting_acceptance" | "pending" => {
+                        ("Awaiting LSP acceptance", Color32::from_rgb(234, 179, 8))
+                    }
+                    "rejected" => ("Rejected", theme::WARNING),
                     "failed" => ("Failed", theme::DANGER_HOVER),
+                    "expired" => ("Expired", theme::MUTED),
                     _ => (&*trade.status, Color32::DARK_GRAY),
                 };
                 ui.horizontal(|ui| {
@@ -7702,9 +7992,30 @@ impl UserApp {
 
                 row(ui, "Date", &Self::format_timestamp(trade.created_at));
 
+                if let Some(ref reason) = trade.failure_reason {
+                    ui.add_space(4.0);
+                    ui.label(RichText::new("Reason").size(11.0).color(Color32::GRAY));
+                    ui.add(
+                        egui::Label::new(
+                            RichText::new(reason).size(12.0).color(Color32::DARK_GRAY),
+                        )
+                        .wrap(),
+                    );
+                }
+                if let Some(ref trade_id) = trade.trade_id {
+                    ui.add_space(4.0);
+                    ui.label(RichText::new("Trade ID").size(11.0).color(Color32::GRAY));
+                    ui.label(
+                        RichText::new(trade_id)
+                            .size(10.0)
+                            .color(Color32::DARK_GRAY)
+                            .monospace(),
+                    );
+                }
+
                 if let Some(ref pid) = trade.payment_id {
                     ui.add_space(4.0);
-                    ui.label(RichText::new("Order ID").size(11.0).color(Color32::GRAY));
+                    ui.label(RichText::new("Fee Payment ID").size(11.0).color(Color32::GRAY));
                     ui.label(
                         RichText::new(pid)
                             .size(10.0)
@@ -9612,6 +9923,7 @@ impl UserApp {
     }
 
     fn execute_buy(&mut self, amount_usd: f64, btc_price: f64) {
+        self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
@@ -9644,26 +9956,45 @@ impl UserApp {
         } else {
             0.0
         };
-        if let Some((payment_id, backing_sats)) =
-            self.send_trade(new_expected_usd, fee_usd, "buy", btc_price)
+        let prepared = self.prepare_trade_wire(
+            Self::new_trade_id(),
+            new_expected_usd,
+            fee_usd,
+            btc_price,
+        );
+        let expires_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_add(TRADE_ACCEPTANCE_WINDOW_SECS)
+            .min(i64::MAX as u64) as i64;
+        let trade_db_id = match self.db.record_prepared_trade(
+            &prepared.channel_id,
+            &prepared.trade_id,
+            "buy",
+            amount_usd,
+            btc_amount,
+            btc_price,
+            fee_usd,
+            prepared.fee_msat,
+            new_expected_usd,
+            prepared.backing_sats,
+            expires_at,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                self.trade_error = format!("Failed to save order: {error}");
+                return;
+            }
+        };
+        if let Some(payment_id) =
+            self.send_prepared_trade(&prepared, "buy", trade_db_id, fee_usd)
         {
-            let payment_id_str = format!("{payment_id}");
-            let trade_db_id = self.record_trade(
-                "buy",
-                amount_usd,
-                btc_amount,
-                btc_price,
-                fee_usd,
-                new_expected_usd,
-                Some(backing_sats),
-                Some(&payment_id_str),
-                "pending",
-            );
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
                     new_expected_usd,
-                    backing_sats: Some(backing_sats),
+                    backing_sats: Some(prepared.backing_sats),
                     trade_db_id,
                     action: "buy".to_string(),
                 },
@@ -9673,10 +10004,10 @@ impl UserApp {
                 "...",
             );
         }
-        self.trade_error.clear();
     }
 
     fn execute_sell(&mut self, amount_usd: f64, btc_price: f64, btc_sats: u64) {
+        self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
@@ -9708,26 +10039,45 @@ impl UserApp {
         let new_expected_usd = current_expected_usd + net_amount;
 
         let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
-        if let Some((payment_id, backing_sats)) =
-            self.send_trade(new_expected_usd, fee_usd, "sell", btc_price)
+        let prepared = self.prepare_trade_wire(
+            Self::new_trade_id(),
+            new_expected_usd,
+            fee_usd,
+            btc_price,
+        );
+        let expires_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_add(TRADE_ACCEPTANCE_WINDOW_SECS)
+            .min(i64::MAX as u64) as i64;
+        let trade_db_id = match self.db.record_prepared_trade(
+            &prepared.channel_id,
+            &prepared.trade_id,
+            "sell",
+            amount_usd,
+            btc_amount,
+            btc_price,
+            fee_usd,
+            prepared.fee_msat,
+            new_expected_usd,
+            prepared.backing_sats,
+            expires_at,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                self.trade_error = format!("Failed to save order: {error}");
+                return;
+            }
+        };
+        if let Some(payment_id) =
+            self.send_prepared_trade(&prepared, "sell", trade_db_id, fee_usd)
         {
-            let payment_id_str = format!("{payment_id}");
-            let trade_db_id = self.record_trade(
-                "sell",
-                amount_usd,
-                btc_amount,
-                btc_price,
-                fee_usd,
-                new_expected_usd,
-                Some(backing_sats),
-                Some(&payment_id_str),
-                "pending",
-            );
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
                     new_expected_usd,
-                    backing_sats: Some(backing_sats),
+                    backing_sats: Some(prepared.backing_sats),
                     trade_db_id,
                     action: "sell".to_string(),
                 },
@@ -9737,7 +10087,6 @@ impl UserApp {
                 "...",
             );
         }
-        self.trade_error.clear();
     }
 
     fn show_diagnostics_window_if_open(&mut self, ctx: &egui::Context) {
@@ -9972,6 +10321,21 @@ impl App for UserApp {
         ctx.set_visuals(visuals);
 
         self.process_events();
+
+        if self.trade_expiry_last_check.elapsed() >= Duration::from_secs(60) {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                .min(i64::MAX as u64) as i64;
+            if let Err(error) = self.db.expire_unresolved_trades(now) {
+                audit_event(
+                    "TRADE_EXPIRY_CHECK_FAILED",
+                    json!({ "error": error.to_string() }),
+                );
+            }
+            self.trade_expiry_last_check = std::time::Instant::now();
+        }
 
         // Poll backup worker without blocking rendering.
         if let Some(rx) = self.backup_receiver.take() {
@@ -10519,9 +10883,30 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
         return None;
     }
     let channel_id = channel_id.to_ascii_lowercase();
+    let user_channel_id = payload.get("user_channel_id")?.as_str()?.to_owned();
+    if user_channel_id.is_empty() {
+        return None;
+    }
     let expected_usd = payload.get("expected_usd")?.as_f64()?;
     let backing_sats = payload.get("backing_sats")?.as_u64()?;
     let sync_version = payload.get("sync_version")?.as_u64()?;
+    let trade_id = match payload.get("trade_id") {
+        Some(value) => Some(value.as_str()?.to_owned()),
+        None => None,
+    };
+    if trade_id
+        .as_deref()
+        .is_some_and(|trade_id| !is_protocol_trade_id(trade_id))
+    {
+        return None;
+    }
+    let trade_payment_id = match payload.get("trade_payment_id") {
+        Some(value) => Some(value.as_str()?.to_owned()),
+        None => None,
+    };
+    if trade_payment_id.as_deref().is_some_and(str::is_empty) {
+        return None;
+    }
     if !expected_usd.is_finite()
         || expected_usd < 0.0
         || sync_version == 0
@@ -10532,10 +10917,70 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     }
     Some(IncomingSync {
         channel_id,
+        user_channel_id,
         expected_usd,
         backing_sats,
         sync_version,
+        trade_id,
+        trade_payment_id,
     })
+}
+
+fn is_protocol_trade_id(trade_id: &str) -> bool {
+    trade_id.len() == 64
+        && trade_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sync_trade_identifiers_match(
+    trade: &db::PendingTradeRow,
+    sync: &IncomingSync,
+    correlated: bool,
+) -> bool {
+    if !correlated {
+        return true;
+    }
+    trade.trade_id.is_none()
+        || (trade.trade_id.as_deref() == sync.trade_id.as_deref()
+            && sync.trade_payment_id.is_some())
+}
+
+fn rejection_resolves_trade(reason_code: &str) -> bool {
+    reason_code != "duplicate_trade"
+}
+
+fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
+    let rejection: IncomingTradeRejection = serde_json::from_str(payload).ok()?;
+    const REASONS: [&str; 9] = [
+        "invalid_amount",
+        "stale_request",
+        "invalid_fee",
+        "invalid_quote",
+        "quote_out_of_range",
+        "invalid_allocation",
+        "insufficient_capacity",
+        "duplicate_trade",
+        "internal_error",
+    ];
+    if rejection.kind != "TRADE_REJECTED_V1"
+        || rejection.channel_id.len() != 64
+        || !rejection
+            .channel_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+        || rejection.user_channel_id.is_empty()
+        || rejection.trade_payment_id.is_empty()
+        || rejection.ts == 0
+        || !REASONS.contains(&rejection.reason_code.as_str())
+        || rejection
+            .trade_id
+            .as_deref()
+            .is_some_and(|trade_id| !is_protocol_trade_id(trade_id))
+    {
+        return None;
+    }
+    Some(rejection)
 }
 
 fn validate_incoming_sync_allocation(
@@ -10618,11 +11063,14 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        parse_incoming_sync, parse_trade_usd_cents, restrict_secret_file_permissions,
+        parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
+        rejection_resolves_trade,
+        restrict_secret_file_permissions,
         sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
-        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
-        SpliceReconcileAction, UserApp,
+        sync_trade_identifiers_match, validate_incoming_sync_allocation, write_secret_file,
+        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
     };
+    use stable_channels::db::PendingTradeRow;
 
     #[test]
     fn trade_usd_input_is_exactly_cent_denominated() {
@@ -10707,9 +11155,12 @@ mod tests {
     fn incoming_sync_allocation_is_bounded_by_wallet_state() {
         let sync = IncomingSync {
             channel_id: "00".repeat(32),
+            user_channel_id: "7".to_owned(),
             expected_usd: 60.0,
             backing_sats: 60_000,
             sync_version: 1,
+            trade_id: None,
+            trade_payment_id: None,
         };
         assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_ok());
 
@@ -10859,7 +11310,7 @@ mod tests {
         let payload = serde_json::json!({
             "type": "SYNC_V1",
             "channel_id": channel_id,
-            "user_channel_id": "different-node-local-id-is-ignored",
+            "user_channel_id": "7",
             "expected_usd": 25.0,
             "backing_sats": 31_250,
             "sync_version": 4,
@@ -10868,9 +11319,12 @@ mod tests {
             parse_incoming_sync(&payload),
             Some(IncomingSync {
                 channel_id: channel_id.to_string(),
+                user_channel_id: "7".to_owned(),
                 expected_usd: 25.0,
                 backing_sats: 31_250,
                 sync_version: 4,
+                trade_id: None,
+                trade_payment_id: None,
             })
         );
 
@@ -10902,6 +11356,77 @@ mod tests {
             "sync_version": 5,
         });
         assert_eq!(parse_incoming_sync(&malformed_channel), None);
+    }
+
+    #[test]
+    fn correlated_sync_and_rejection_identifiers_are_strict() {
+        let trade_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let sync = serde_json::json!({
+            "type": "SYNC_V1",
+            "channel_id": "aa".repeat(32),
+            "user_channel_id": "7",
+            "expected_usd": 25.0,
+            "backing_sats": 31_250,
+            "sync_version": 4,
+            "trade_id": trade_id,
+            "trade_payment_id": "payment",
+        });
+        let parsed = parse_incoming_sync(&sync).unwrap();
+        assert_eq!(parsed.trade_id.as_deref(), Some(trade_id));
+        assert_eq!(parsed.trade_payment_id.as_deref(), Some("payment"));
+
+        let mut uppercase = sync;
+        uppercase["trade_id"] = serde_json::json!(trade_id.to_ascii_uppercase());
+        assert!(parse_incoming_sync(&uppercase).is_none());
+
+        let rejection = serde_json::json!({
+            "type": "TRADE_REJECTED_V1",
+            "channel_id": "aa".repeat(32),
+            "user_channel_id": "7",
+            "trade_id": trade_id,
+            "trade_payment_id": "payment",
+            "reason_code": "invalid_fee",
+            "explanation": "wrong fee",
+            "ts": 1,
+        })
+        .to_string();
+        assert_eq!(
+            parse_trade_rejection(&rejection).unwrap().reason_code,
+            "invalid_fee"
+        );
+        let unknown_reason = rejection.replace("invalid_fee", "made_up");
+        assert!(parse_trade_rejection(&unknown_reason).is_none());
+    }
+
+    #[test]
+    fn legacy_sync_matches_signed_trade_by_allocation_without_correlation_ids() {
+        let trade_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let trade = PendingTradeRow {
+            id: 1,
+            channel_id: "aa".repeat(32),
+            trade_id: Some(trade_id.to_owned()),
+            payment_id: Some("payment".to_owned()),
+            fee_msat: 1_000,
+            new_expected_usd: 25.0,
+            btc_price: 100_000.0,
+            new_backing_sats: Some(25_000),
+            action: "buy".to_owned(),
+            status: "awaiting_acceptance".to_owned(),
+        };
+        let legacy_sync = IncomingSync {
+            channel_id: "aa".repeat(32),
+            user_channel_id: "7".to_owned(),
+            expected_usd: 25.0,
+            backing_sats: 25_000,
+            sync_version: 1,
+            trade_id: None,
+            trade_payment_id: None,
+        };
+
+        assert!(sync_trade_identifiers_match(&trade, &legacy_sync, false));
+        assert!(!sync_trade_identifiers_match(&trade, &legacy_sync, true));
+        assert!(!rejection_resolves_trade("duplicate_trade"));
+        assert!(rejection_resolves_trade("invalid_fee"));
     }
 
     #[cfg(unix)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -3036,10 +3036,13 @@ impl UserApp {
                                 break 'control true;
                             };
 
+                            let correlated = sync_is_correlated(&sync);
                             let mut sc = self.stable_channel.lock().unwrap();
-                            if sync.channel_id != wallet_channel_id
-                                || sync.user_channel_id != wallet_user_channel_id
-                            {
+                            if !sync_channel_binding_matches(
+                                &sync,
+                                &wallet_channel_id,
+                                &wallet_user_channel_id,
+                            ) {
                                 audit_event(
                                     "SYNC_V1_CHANNEL_MISMATCH",
                                     json!({
@@ -3049,6 +3052,7 @@ impl UserApp {
                                         "wallet_channel_id": wallet_channel_id,
                                         "wallet_user_channel_id": wallet_user_channel_id,
                                         "sync_version": sync.sync_version,
+                                        "correlated": correlated,
                                     }),
                                 );
                                 break 'control true;
@@ -3058,7 +3062,6 @@ impl UserApp {
                             let price = sc.latest_price;
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
-                            let correlated = sync.trade_id.is_some() || sync.trade_payment_id.is_some();
                             let pending_trade_result = if correlated {
                                 self.db.get_trade_by_protocol_ids(
                                     sync.trade_id.as_deref(),
@@ -7993,14 +7996,7 @@ impl UserApp {
                 row(ui, "Date", &Self::format_timestamp(trade.created_at));
 
                 if let Some(ref reason) = trade.failure_reason {
-                    ui.add_space(4.0);
-                    ui.label(RichText::new("Reason").size(11.0).color(Color32::GRAY));
-                    ui.add(
-                        egui::Label::new(
-                            RichText::new(reason).size(12.0).color(Color32::DARK_GRAY),
-                        )
-                        .wrap(),
-                    );
+                    row(ui, "Reason", reason);
                 }
                 if let Some(ref trade_id) = trade.trade_id {
                     ui.add_space(4.0);
@@ -10933,6 +10929,21 @@ fn is_protocol_trade_id(trade_id: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
+fn sync_is_correlated(sync: &IncomingSync) -> bool {
+    sync.trade_id.is_some() || sync.trade_payment_id.is_some()
+}
+
+/// Ordinary syncs are signed by the counterparty and bind to the shared channel id. Only a
+/// correlated trade response can know and must echo this wallet's node-local user_channel_id.
+fn sync_channel_binding_matches(
+    sync: &IncomingSync,
+    wallet_channel_id: &str,
+    wallet_user_channel_id: &str,
+) -> bool {
+    sync.channel_id == wallet_channel_id
+        && (!sync_is_correlated(sync) || sync.user_channel_id == wallet_user_channel_id)
+}
+
 fn sync_trade_identifiers_match(
     trade: &db::PendingTradeRow,
     sync: &IncomingSync,
@@ -11067,8 +11078,9 @@ mod tests {
         rejection_resolves_trade,
         restrict_secret_file_permissions,
         sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
-        sync_trade_identifiers_match, validate_incoming_sync_allocation, write_secret_file,
-        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
+        sync_channel_binding_matches, sync_trade_identifiers_match,
+        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
+        SpliceReconcileAction, UserApp,
     };
     use stable_channels::db::PendingTradeRow;
 
@@ -11356,6 +11368,45 @@ mod tests {
             "sync_version": 5,
         });
         assert_eq!(parse_incoming_sync(&malformed_channel), None);
+    }
+
+    #[test]
+    fn ordinary_sync_uses_shared_channel_while_trade_response_echoes_wallet_local_id() {
+        let channel_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let wallet_user_channel_id = "wallet-local-id";
+        let ordinary_payload = serde_json::json!({
+            "type": "SYNC_V1",
+            "channel_id": channel_id,
+            "user_channel_id": "lsp-local-id",
+            "expected_usd": 25.0,
+            "backing_sats": 31_250,
+            "sync_version": 4,
+        });
+        let ordinary_sync = parse_incoming_sync(&ordinary_payload).unwrap();
+        assert!(sync_channel_binding_matches(
+            &ordinary_sync,
+            channel_id,
+            wallet_user_channel_id,
+        ));
+
+        let trade_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let mut correlated_payload = ordinary_payload;
+        correlated_payload["trade_id"] = serde_json::json!(trade_id);
+        correlated_payload["trade_payment_id"] = serde_json::json!("payment");
+        let wrong_local_id = parse_incoming_sync(&correlated_payload).unwrap();
+        assert!(!sync_channel_binding_matches(
+            &wrong_local_id,
+            channel_id,
+            wallet_user_channel_id,
+        ));
+
+        correlated_payload["user_channel_id"] = serde_json::json!(wallet_user_channel_id);
+        let wallet_bound = parse_incoming_sync(&correlated_payload).unwrap();
+        assert!(sync_channel_binding_matches(
+            &wallet_bound,
+            channel_id,
+            wallet_user_channel_id,
+        ));
     }
 
     #[test]

--- a/src/user.rs
+++ b/src/user.rs
@@ -3113,16 +3113,7 @@ impl UserApp {
                                 break 'control true;
                             }
                             if let Some(trade) = pending_trade.as_ref() {
-                                let new_trade_identifiers_match =
-                                    sync_trade_identifiers_match(trade, &sync, correlated);
-                                let stored_allocation_matches = trade
-                                    .new_backing_sats
-                                    .is_none_or(|backing_sats| {
-                                        backing_sats == sync.backing_sats
-                                            && (trade.new_expected_usd - sync.expected_usd).abs()
-                                                <= 0.000000001
-                                    });
-                                if !new_trade_identifiers_match || !stored_allocation_matches {
+                                if !sync_matches_stored_trade_intent(trade, &sync, correlated) {
                                     audit_event(
                                         "SYNC_V1_TRADE_INTENT_MISMATCH",
                                         json!({
@@ -3159,13 +3150,48 @@ impl UserApp {
                                 );
                                 break 'control true;
                             }
-                            let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
+                            // Mirror the LSP — derive locally so a peer's number cannot move our books.
+                            let Some(committed_backing) = committed_backing_sats(
+                                sync.expected_usd,
+                                live_receiver_sats,
+                                price,
+                                pending_trade.as_ref(),
+                            ) else {
+                                audit_event(
+                                    "SYNC_V1_ALLOCATION_DEFERRED",
+                                    json!({
+                                        "payment_hash": &payment_hash_str,
+                                        "trade_id": sync.trade_id,
+                                        "expected_usd": sync.expected_usd,
+                                        "peer_backing_sats": sync.backing_sats,
+                                        "live_receiver_sats": live_receiver_sats,
+                                        "btc_price": price,
+                                        "sync_version": sync.sync_version,
+                                    }),
+                                );
+                                // Leave the event unacknowledged so LDK redelivers once a price lands.
+                                ack = false;
+                                break 'control true;
+                            };
+                            if peer_allocation_diverges(sync.backing_sats, committed_backing) {
+                                audit_event(
+                                    "SYNC_V1_ALLOCATION_DIVERGENCE",
+                                    json!({
+                                        "trade_id": sync.trade_id,
+                                        "sync_version": sync.sync_version,
+                                        "peer_backing_sats": sync.backing_sats,
+                                        "local_backing_sats": committed_backing,
+                                        "btc_price": price,
+                                    }),
+                                );
+                            }
+                            let native_sats = live_receiver_sats.saturating_sub(committed_backing);
                             let user_channel_id = format!("{}", sc.user_channel_id);
                             match self.db.apply_correlated_sync_if_newer_and_complete_trade(
                                 &user_channel_id,
                                 sync.sync_version,
                                 sync.expected_usd,
-                                sync.backing_sats,
+                                committed_backing,
                                 native_sats,
                                 pending_trade.as_ref().map(|trade| trade.id),
                                 sync.trade_payment_id.as_deref(),
@@ -3174,14 +3200,14 @@ impl UserApp {
                                     stable::apply_trade_allocation(
                                         &mut sc,
                                         sync.expected_usd,
-                                        sync.backing_sats,
+                                        committed_backing,
                                     );
                                     audit_event(
                                         "SYNC_V1_APPLIED",
                                         json!({
                                             "old_expected_usd": old_expected,
                                             "new_expected_usd": sync.expected_usd,
-                                            "backing_sats": sync.backing_sats,
+                                            "backing_sats": committed_backing,
                                             "sync_version": sync.sync_version,
                                             "live_receiver_sats": live_receiver_sats,
                                             "btc_price": price,
@@ -3200,7 +3226,7 @@ impl UserApp {
                                                 "trade_payment_id": sync.trade_payment_id,
                                                 "action": trade.action,
                                                 "expected_usd": sync.expected_usd,
-                                                "backing_sats": sync.backing_sats,
+                                                "backing_sats": committed_backing,
                                                 "sync_version": sync.sync_version,
                                             }),
                                         );
@@ -10957,23 +10983,58 @@ fn sync_trade_identifiers_match(
             && sync.trade_payment_id.is_some())
 }
 
+/// Whether an LSP sync answers the trade this wallet sent. The identifiers are the contract;
+/// `backing_sats` is derived per-peer and is not compared.
+///
+/// The target may come back below what was asked for: the LSP books what its own valuation of this
+/// side can actually back, so a request that runs past that gets answered with the backable figure
+/// rather than funded from LSP liquidity. Accept that as far as the two sides could honestly
+/// disagree about the value of these sats — and never above the request, which is not a clamp.
+fn sync_matches_stored_trade_intent(
+    trade: &db::PendingTradeRow,
+    sync: &IncomingSync,
+    correlated: bool,
+) -> bool {
+    sync_trade_identifiers_match(trade, sync, correlated)
+        && stable_channels::trade::answered_target_honours_request(
+            trade.new_expected_usd,
+            sync.expected_usd,
+        )
+}
+
+/// The allocation this wallet commits, always derived locally at its own price and own live balance.
+///
+/// This holds on a recovery sync too. The peer's `backing_sats` is never an input: adopting it lets
+/// the peer state a split that puts this wallet over par, and the tick pays out of par without
+/// caring who wrote the number. Re-deriving costs nothing the peer's own book can claim — the split
+/// is only ever this wallet's own balance, so re-anchoring it cannot move funds by itself.
+///
+/// `None` means the sync cannot be committed yet and the caller must defer it. A sync can land
+/// before the first price fetch completes and the derivation is 0 at a zero price; the only
+/// permitted fallback is then this wallet's own allocation from trade preparation, which a peer
+/// cannot reach.
+fn committed_backing_sats(
+    expected_usd: f64,
+    live_receiver_sats: u64,
+    price: f64,
+    pending_trade: Option<&db::PendingTradeRow>,
+) -> Option<u64> {
+    let derived = stable::trade_backing_sats(live_receiver_sats, expected_usd, price);
+    if derived > 0 || expected_usd < 0.01 {
+        return Some(derived);
+    }
+    // Only a self-derived allocation that the live balance can still cover is a usable basis.
+    pending_trade
+        .and_then(|trade| trade.new_backing_sats)
+        .filter(|stored| *stored > 0 && *stored <= live_receiver_sats)
+}
+
 fn rejection_resolves_trade(reason_code: &str) -> bool {
     reason_code != "duplicate_trade"
 }
 
 fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
     let rejection: IncomingTradeRejection = serde_json::from_str(payload).ok()?;
-    const REASONS: [&str; 9] = [
-        "invalid_amount",
-        "stale_request",
-        "invalid_fee",
-        "invalid_quote",
-        "quote_out_of_range",
-        "invalid_allocation",
-        "insufficient_capacity",
-        "duplicate_trade",
-        "internal_error",
-    ];
     if rejection.kind != "TRADE_REJECTED_V1"
         || rejection.channel_id.len() != 64
         || !rejection
@@ -10983,7 +11044,7 @@ fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
         || rejection.user_channel_id.is_empty()
         || rejection.trade_payment_id.is_empty()
         || rejection.ts == 0
-        || !REASONS.contains(&rejection.reason_code.as_str())
+        || stable_channels::trade::TradeRejectionReason::from_code(&rejection.reason_code).is_none()
         || rejection
             .trade_id
             .as_deref()
@@ -10994,44 +11055,47 @@ fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
     Some(rejection)
 }
 
+/// Gate a sync on the one field this wallet adopts from it: `expected_usd`.
+///
+/// `backing_sats` is deliberately not checked. It is no longer an input on any path — the allocation
+/// is always derived locally — so a bound on it could only discard syncs whose target is perfectly
+/// good, including the DB-loss recovery this wallet depends on. What does need bounding is the
+/// target: nothing else stops a peer pegging this wallet above what its side can back, which books
+/// a shortfall the wallet then waits on forever.
 fn validate_incoming_sync_allocation(
     sync: &IncomingSync,
     live_receiver_sats: u64,
     current_price: f64,
     matches_pending_trade: bool,
 ) -> Result<(), &'static str> {
-    if sync.backing_sats > live_receiver_sats {
-        return Err("backing exceeds live receiver balance");
+    if !sync.expected_usd.is_finite() || sync.expected_usd < 0.0 {
+        return Err("target is not a usable amount");
     }
     if sync.expected_usd < 0.01 {
-        return if sync.backing_sats == 0 {
-            Ok(())
-        } else {
-            Err("zero peg has nonzero backing")
-        };
+        return Ok(());
     }
-    if sync.backing_sats == 0 {
-        return Err("nonzero peg has no backing");
-    }
-
-    // A pending trade was priced, bounded, and signed by this wallet before it was sent. Other
-    // syncs are recovery/reconciliation messages, so independently reject allocations whose
-    // implied booking price is implausibly far from the wallet's current trusted price.
+    // A trade response's target was already bounded against the request this wallet signed.
     if matches_pending_trade {
         return Ok(());
     }
     if !current_price.is_finite() || current_price <= 0.0 {
         return Err("no trusted wallet price available");
     }
-    let implied_booking_price =
-        sync.expected_usd / sync.backing_sats as f64 * SATS_IN_BTC as f64;
-    if !implied_booking_price.is_finite()
-        || implied_booking_price < current_price / 10.0
-        || implied_booking_price > current_price * 10.0
-    {
-        return Err("allocation implies an implausible booking price");
+    let receiver_usd = live_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
+    if sync.expected_usd > receiver_usd * (1.0 + MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0) {
+        return Err("target exceeds what this channel side can back");
     }
     Ok(())
+}
+
+/// Whether a peer's stated allocation sits further from ours than independent pricing explains.
+///
+/// The two sides derive separately now, so small differences are the design working. The line worth
+/// logging is where the gap grows past what either side's tick would treat as actionable drift.
+fn peer_allocation_diverges(peer_backing_sats: u64, local_backing_sats: u64) -> bool {
+    let actionable =
+        (local_backing_sats as f64 * STABILITY_THRESHOLD_PERCENT / 100.0).ceil() as u64;
+    peer_backing_sats.abs_diff(local_backing_sats) > actionable.max(2)
 }
 
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
@@ -11073,14 +11137,16 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
-        rejection_resolves_trade,
-        restrict_secret_file_permissions,
+        btc_amount_to_msat, channel_balance_split, collapse_double_paste, committed_backing_sats,
+        floor_usd_cents, parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
+        peer_allocation_diverges, rejection_resolves_trade, restrict_secret_file_permissions,
         sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
-        sync_channel_binding_matches, sync_trade_identifiers_match,
-        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
-        SpliceReconcileAction, UserApp,
+        sync_channel_binding_matches, sync_matches_stored_trade_intent,
+        sync_trade_identifiers_match, validate_incoming_sync_allocation, write_secret_file,
+        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
+    };
+    use stable_channels::constants::{
+        MAX_PEER_VALUATION_SPREAD_PERCENT, SATS_IN_BTC, STABILITY_THRESHOLD_USD,
     };
     use stable_channels::db::PendingTradeRow;
 
@@ -11176,18 +11242,7 @@ mod tests {
         };
         assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_ok());
 
-        let overdrawn = IncomingSync {
-            backing_sats: 100_001,
-            ..sync.clone()
-        };
-        assert!(validate_incoming_sync_allocation(
-            &overdrawn,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_err());
-
+        // A target past what this side can back is refused; the peer's own allocation is not read.
         let implausible = IncomingSync {
             expected_usd: 10_000.0,
             ..sync.clone()
@@ -11207,18 +11262,51 @@ mod tests {
         )
         .is_ok());
 
-        let inconsistent_zero = IncomingSync {
+        // Closing the peg is always representable, whatever the peer says its backing is.
+        let closing = IncomingSync {
             expected_usd: 0.0,
             backing_sats: 1,
             ..sync
         };
-        assert!(validate_incoming_sync_allocation(
-            &inconsistent_zero,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_err());
+        assert!(validate_incoming_sync_allocation(&closing, 100_000, 100_000.0, true).is_ok());
+    }
+
+    #[test]
+    fn no_peer_allocation_can_discard_a_sync_whose_target_is_sound() {
+        // The old gate bounded backing_sats and so had to guess how stale an honest peer's anchor was.
+        // Guess too tight and DB-loss recovery breaks; too loose and the manufactured case walks
+        // through. Nothing reads the field now, so neither guess is needed: whatever the peer states,
+        // a sound target recovers, and the allocation this wallet commits is its own.
+        let base = IncomingSync {
+            channel_id: "00".repeat(32),
+            user_channel_id: "7".to_owned(),
+            expected_usd: 100.0,
+            backing_sats: 100_000,
+            sync_version: 1,
+            trade_id: None,
+            trade_payment_id: None,
+        };
+
+        for backing_sats in [
+            100_100,   // anchored one settlement ago
+            102_000,   // anchored well past any settlement
+            1,         // nonsense
+            u64::MAX,  // hostile
+        ] {
+            let sync = IncomingSync {
+                backing_sats,
+                ..base.clone()
+            };
+            assert!(
+                validate_incoming_sync_allocation(&sync, 200_000, 100_000.0, false).is_ok(),
+                "a sound target must recover regardless of the peer's stated backing {backing_sats}",
+            );
+            assert_eq!(
+                committed_backing_sats(sync.expected_usd, 200_000, 100_000.0, None),
+                Some(100_000),
+                "the committed allocation is this wallet's own either way",
+            );
+        }
     }
 
     #[test]
@@ -11450,6 +11538,38 @@ mod tests {
     }
 
     #[test]
+    fn every_daemon_rejection_reason_is_accepted_by_the_wallet() {
+        // Mirrors the daemon's TradeRejectionReason; a code missing here is discarded and strands the trade row.
+        for reason_code in [
+            "invalid_amount",
+            "stale_request",
+            "invalid_fee",
+            "invalid_quote",
+            "quote_out_of_range",
+            "invalid_allocation",
+            "no_op_trade",
+            "insufficient_capacity",
+            "duplicate_trade",
+            "internal_error",
+        ] {
+            let rejection = serde_json::json!({
+                "type": "TRADE_REJECTED_V1",
+                "channel_id": "aa".repeat(32),
+                "user_channel_id": "7",
+                "trade_payment_id": "payment",
+                "reason_code": reason_code,
+                "explanation": "rejected",
+                "ts": 1,
+            })
+            .to_string();
+            let parsed = parse_trade_rejection(&rejection)
+                .unwrap_or_else(|| panic!("{reason_code} must be recognised"));
+            assert_eq!(parsed.reason_code, reason_code);
+        }
+        assert!(rejection_resolves_trade("no_op_trade"));
+    }
+
+    #[test]
     fn legacy_sync_matches_signed_trade_by_allocation_without_correlation_ids() {
         let trade_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
         let trade = PendingTradeRow {
@@ -11478,6 +11598,242 @@ mod tests {
         assert!(!sync_trade_identifiers_match(&trade, &legacy_sync, true));
         assert!(!rejection_resolves_trade("duplicate_trade"));
         assert!(rejection_resolves_trade("invalid_fee"));
+    }
+
+    #[test]
+    fn sync_intent_accepts_lsp_derived_backing_but_not_a_changed_target() {
+        let trade = PendingTradeRow {
+            id: 1,
+            channel_id: "aa".to_string(),
+            trade_id: Some("t-1".to_string()),
+            payment_id: Some("p-1".to_string()),
+            fee_msat: 1,
+            new_expected_usd: 100.0,
+            btc_price: 100_040.0,
+            new_backing_sats: Some(99_960),
+            action: "sell".to_string(),
+            status: "pending".to_string(),
+        };
+
+        // The LSP booked the same $100 contract at its own price, so backing differs by feed spread.
+        let repriced = IncomingSync {
+            channel_id: "channel".to_string(),
+            user_channel_id: "user".to_string(),
+            expected_usd: 100.0,
+            backing_sats: 100_000,
+            sync_version: 1,
+            trade_id: Some("t-1".to_string()),
+            trade_payment_id: Some("p-1".to_string()),
+        };
+        assert!(
+            sync_matches_stored_trade_intent(&trade, &repriced, true),
+            "an LSP-derived allocation for the agreed target must be accepted",
+        );
+
+        // A different target is a different contract and must still be refused.
+        let wrong_target = IncomingSync {
+            expected_usd: 90.0,
+            ..repriced.clone()
+        };
+        assert!(
+            !sync_matches_stored_trade_intent(&trade, &wrong_target, true),
+            "expected_usd is the contract and must match exactly",
+        );
+
+        // Asking past what the LSP's own valuation can back comes back as the backable figure.
+        let clamped = IncomingSync {
+            expected_usd: 100.0 * (1.0 - MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0 / 2.0),
+            ..repriced.clone()
+        };
+        assert!(
+            sync_matches_stored_trade_intent(&trade, &clamped, true),
+            "a capacity clamp inside honest spread must not strand the trade",
+        );
+
+        // Beyond that, a lower target is the peer choosing this wallet's exposure for it.
+        let over_clamped = IncomingSync {
+            expected_usd: 100.0 * (1.0 - MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0) - 0.01,
+            ..repriced.clone()
+        };
+        assert!(
+            !sync_matches_stored_trade_intent(&trade, &over_clamped, true),
+            "a clamp wider than honest spread must be refused",
+        );
+
+        // A clamp only ever reduces; answering above the request is not one.
+        let inflated = IncomingSync {
+            expected_usd: 100.01,
+            ..repriced
+        };
+        assert!(
+            !sync_matches_stored_trade_intent(&trade, &inflated, true),
+            "the peer must never answer above the signed request",
+        );
+    }
+
+    #[test]
+    fn sync_intent_rejects_changed_target_when_stored_backing_is_unset() {
+        let trade = PendingTradeRow {
+            id: 1,
+            channel_id: "aa".to_string(),
+            trade_id: Some("t-1".to_string()),
+            payment_id: Some("p-1".to_string()),
+            fee_msat: 1,
+            new_expected_usd: 100.0,
+            btc_price: 100_040.0,
+            new_backing_sats: None,
+            action: "sell".to_string(),
+            status: "pending".to_string(),
+        };
+        let wrong_target = IncomingSync {
+            channel_id: "channel".to_string(),
+            user_channel_id: "user".to_string(),
+            expected_usd: 90.0,
+            backing_sats: 100_000,
+            sync_version: 1,
+            trade_id: Some("t-1".to_string()),
+            trade_payment_id: Some("p-1".to_string()),
+        };
+        // The old inline gate used is_none_or, which skipped the expected_usd check entirely here.
+        assert!(
+            !sync_matches_stored_trade_intent(&trade, &wrong_target, true),
+            "expected_usd must be checked even when the stored trade has no recorded backing_sats",
+        );
+    }
+
+    /// A trade this wallet prepared itself, carrying the allocation it derived at that time.
+    fn prepared_trade(new_backing_sats: Option<u64>) -> PendingTradeRow {
+        PendingTradeRow {
+            id: 1,
+            channel_id: "aa".repeat(32),
+            trade_id: Some("0123456789abcdef".repeat(4)),
+            payment_id: Some("payment".to_owned()),
+            fee_msat: 1_000,
+            new_expected_usd: 100.0,
+            btc_price: 100_500.0,
+            new_backing_sats,
+            action: "buy".to_owned(),
+            status: "awaiting_acceptance".to_owned(),
+        }
+    }
+
+    #[test]
+    fn wallet_derives_its_own_backing_on_every_path() {
+        let trade = prepared_trade(Some(99_502));
+        // Peer booked $100 at $100_000 (100_000 sats); this wallet reads $100_500 so derives 99_502.
+        assert_eq!(
+            committed_backing_sats(100.0, 100_000, 100_500.0, Some(&trade)),
+            Some(99_502),
+            "a trade must commit this wallet's own derivation, not the peer's",
+        );
+        // A hostile allocation on the trade path therefore has no effect at all.
+        assert_eq!(
+            committed_backing_sats(50.0, 100_000, 100_000.0, Some(&trade)),
+            Some(50_000),
+            "a peer cannot inflate this wallet's backing on the trade path",
+        );
+        // A recovery sync derives identically — there is no path that reads the peer's allocation.
+        assert_eq!(
+            committed_backing_sats(100.0, 200_000, 100_000.0, None),
+            Some(100_000),
+            "recovery must derive locally too",
+        );
+    }
+
+    #[test]
+    fn a_recovery_sync_cannot_book_this_wallet_over_par() {
+        // The drain was: a signed recovery sync stating backing worth $0.49 more than the target, so
+        // the wallet woke up above par and settled the difference to the peer that chose it.
+        let price = 100_000.0;
+        let live = 200_000u64;
+        let peer_backing = 100_490u64;
+        let target = 100.0;
+
+        let sync = IncomingSync {
+            channel_id: "aa".repeat(32),
+            user_channel_id: "1".to_string(),
+            expected_usd: target,
+            backing_sats: peer_backing,
+            sync_version: 2,
+            trade_id: None,
+            trade_payment_id: None,
+        };
+        assert!(
+            validate_incoming_sync_allocation(&sync, live, price, false).is_ok(),
+            "a plausible target must still recover",
+        );
+
+        let committed = committed_backing_sats(target, live, price, None).unwrap();
+        assert_ne!(committed, peer_backing, "the peer's allocation must not be adopted");
+        let drift = committed as f64 / SATS_IN_BTC as f64 * price - target;
+        assert!(
+            drift.abs() < STABILITY_THRESHOLD_USD,
+            "recovery must not land above par: drift ${drift}",
+        );
+        assert!(
+            peer_allocation_diverges(peer_backing, committed),
+            "a gap this wide is worth an audit line",
+        );
+    }
+
+    #[test]
+    fn a_recovery_sync_cannot_peg_beyond_this_side_s_capacity() {
+        let sync = IncomingSync {
+            channel_id: "aa".repeat(32),
+            user_channel_id: "1".to_string(),
+            // 100_000 sats at $100k is $100 of capacity; the peer asks for ten times it.
+            expected_usd: 1_000.0,
+            backing_sats: 100_000,
+            sync_version: 2,
+            trade_id: None,
+            trade_payment_id: None,
+        };
+        assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_err());
+    }
+
+    #[test]
+    fn a_cold_price_cache_never_commits_a_peer_supplied_allocation() {
+        // The trade path skips the recovery price band, so a peer number is wholly unchecked here.
+        let hostile_full_balance = 100_000;
+
+        // A response retry can land seconds after start, while latest_price is still 0.
+        let trade = prepared_trade(Some(99_502));
+        assert_eq!(
+            committed_backing_sats(100.0, 100_000, 0.0, Some(&trade)),
+            Some(99_502),
+            "a cold cache must fall back to this wallet's own trade-time allocation",
+        );
+
+        // Backing the peg with the whole balance is what lets a compromised LSP drain the native side.
+        let legacy = prepared_trade(None);
+        assert_eq!(
+            committed_backing_sats(100.0, 100_000, 0.0, Some(&legacy)),
+            None,
+            "with no self-derived basis the trade must defer, never adopt the peer's allocation",
+        );
+
+        // A recovery sync has no stored basis at all, so a cold cache can only defer.
+        assert_eq!(
+            committed_backing_sats(100.0, hostile_full_balance, 0.0, None),
+            None,
+            "recovery on a cold cache must defer rather than adopt",
+        );
+
+        // A stored allocation the live balance can no longer cover is not a usable basis either.
+        let overdrawn = prepared_trade(Some(100_001));
+        assert_eq!(
+            committed_backing_sats(100.0, 100_000, 0.0, Some(&overdrawn)),
+            None,
+        );
+
+        // A zero balance derives 0, and a stored basis it cannot cover is refused.
+        assert_eq!(committed_backing_sats(100.0, 0, 100_000.0, Some(&trade)), None);
+
+        // Closing the peg genuinely commits zero backing.
+        assert_eq!(
+            committed_backing_sats(0.0, 100_000, 100_000.0, Some(&trade)),
+            Some(0),
+        );
     }
 
     #[cfg(unix)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -217,6 +217,18 @@ struct IncomingTradeRejection {
     ts: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+struct IncomingStabilityPayment {
+    #[serde(rename = "type")]
+    kind: String,
+    settlement_id: String,
+    channel_id: String,
+    user_channel_id: String,
+    amount_msat: u64,
+    allocation_version: u64,
+    ts: u64,
+}
+
 struct BackupSnapshotDir {
     path: PathBuf,
 }
@@ -912,15 +924,26 @@ impl UserApp {
                                 }
                             }
 
-                            if let Some(payment_info) = stable_channels::stable::check_stability(
-                                &node_arc, &mut sc, price,
-                            ) {
+                            let allocation_version = db
+                                .get_sync_version(&format!("{}", sc.user_channel_id))
+                                .ok()
+                                .flatten()
+                                .unwrap_or(0);
+                            if let Some(payment_info) =
+                                stable_channels::stable::check_stability_with_version(
+                                    &node_arc,
+                                    &mut sc,
+                                    price,
+                                    allocation_version,
+                                )
+                            {
                                 // Record sent stability payment as pending (confirmed on PaymentSuccessful)
                                 let amount_usd =
                                     (payment_info.amount_msat as f64 / 1000.0 / 100_000_000.0)
                                         * payment_info.btc_price;
                                 if let Err(e) = db.record_pending_stability_payment(
                                     &payment_info.payment_id,
+                                    &payment_info.settlement_id,
                                     payment_info.amount_msat,
                                     Some(amount_usd),
                                     payment_info.btc_price,
@@ -1972,7 +1995,7 @@ impl UserApp {
         new_expected_usd: f64,
         fee_usd: f64,
         trade_price: f64,
-    ) -> PreparedTradeWire {
+    ) -> Result<PreparedTradeWire, &'static str> {
         // The fee is a direct keysend amount. Calculate its whole-sat channel impact before
         // signing the allocation so both peers derive against the same post-settlement balance.
         let fee_sats = if trade_price > 0.0 && fee_usd > 0.0 {
@@ -1996,11 +2019,14 @@ impl UserApp {
             let mut sc = self.stable_channel.lock().unwrap();
             stable::update_balances(&self.node, &mut sc);
             let post_fee_receiver_sats = sc.stable_receiver_btc.sats.saturating_sub(fee_sats);
-            let backing_sats = stable::trade_backing_sats(
+            let backing_sats = stable::trade_backing_after_delta(
                 post_fee_receiver_sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
                 new_expected_usd,
                 trade_price,
-            );
+            )
+            .ok_or("trade delta does not fit the current allocation")?;
             (
                 sc.channel_id.to_string(),
                 format!("{}", sc.user_channel_id),
@@ -2016,7 +2042,7 @@ impl UserApp {
             .unwrap_or_default()
             .as_secs();
 
-        PreparedTradeWire {
+        Ok(PreparedTradeWire {
             trade_id,
             channel_id: channel_id_str,
             user_channel_id: user_channel_id_str,
@@ -2028,7 +2054,7 @@ impl UserApp {
             post_fee_receiver_sats,
             fee_msat,
             ts,
-        }
+        })
     }
 
     /// Send an already-persisted trade and immediately attach LDK's returned payment id.
@@ -2839,7 +2865,9 @@ impl UserApp {
                     // Handle signed LSP control messages before ordinary payment accounting.
                     let handled_control = 'control: {
                         for tlv in &custom_records {
-                            if tlv.type_num != STABLE_CHANNEL_TLV_TYPE {
+                            if tlv.type_num != STABLE_CHANNEL_TLV_TYPE
+                                && tlv.type_num != SIGNED_STABILITY_TLV_TYPE
+                            {
                                 continue;
                             }
                             let raw = match String::from_utf8(tlv.value.clone()) {
@@ -2868,6 +2896,12 @@ impl UserApp {
                             let message_type = payload.get("type").and_then(|value| value.as_str());
                             if message_type != Some(SYNC_MESSAGE_TYPE)
                                 && message_type != Some("TRADE_REJECTED_V1")
+                                && message_type != Some("STABILITY_PAYMENT_V1")
+                            {
+                                continue;
+                            }
+                            if message_type == Some("STABILITY_PAYMENT_V1")
+                                && tlv.type_num != SIGNED_STABILITY_TLV_TYPE
                             {
                                 continue;
                             }
@@ -2892,6 +2926,132 @@ impl UserApp {
                                         "message_type": message_type,
                                     }),
                                 );
+                                break 'control true;
+                            }
+
+                            if message_type == Some("STABILITY_PAYMENT_V1") {
+                                let Some(payment) = parse_stability_payment(payload_str) else {
+                                    audit_event(
+                                        "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str }),
+                                    );
+                                    break 'control true;
+                                };
+                                if !stability_payment_binding_matches(
+                                    &payment,
+                                    &wallet_channel_id,
+                                    amount_msat,
+                                ) {
+                                    audit_event(
+                                        "STABILITY_PAYMENT_BINDING_INVALID",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "settlement_id": payment.settlement_id,
+                                            "payload_channel_id": payment.channel_id,
+                                            "wallet_channel_id": wallet_channel_id,
+                                            "signed_amount_msat": payment.amount_msat,
+                                            "received_amount_msat": amount_msat,
+                                            "ts": payment.ts,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+
+                                let amount_sats = amount_msat / 1000;
+                                let (price, user_channel_id, allocation_valid) = {
+                                    let mut sc = self.stable_channel.lock().unwrap();
+                                    stable::update_balances(&self.node, &mut sc);
+                                    (
+                                        sc.latest_price,
+                                        format!("{}", sc.user_channel_id),
+                                        sc.backing_sats
+                                            .checked_add(amount_sats)
+                                            .is_some_and(|backing| {
+                                                backing <= sc.stable_receiver_btc.sats
+                                            }),
+                                    )
+                                };
+                                if !allocation_valid {
+                                    audit_event(
+                                        "STABILITY_PAYMENT_ALLOCATION_INVALID",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "settlement_id": payment.settlement_id,
+                                            "amount_sats": amount_sats,
+                                        }),
+                                    );
+                                    break 'control true;
+                                }
+                                let amount_usd = (price > 0.0).then(|| {
+                                    amount_sats as f64 / SATS_IN_BTC as f64 * price
+                                });
+                                let backing_delta = match i64::try_from(amount_sats) {
+                                    Ok(delta) => delta,
+                                    Err(_) => break 'control true,
+                                };
+                                let record = || {
+                                    self.db.record_payment_and_maybe_update_backing(
+                                        Some(&payment_hash_str),
+                                        Some(&payment.settlement_id),
+                                        "stability",
+                                        "received",
+                                        amount_msat,
+                                        amount_usd,
+                                        (price > 0.0).then_some(price),
+                                        "completed",
+                                        Some(&user_channel_id),
+                                        Some(backing_delta),
+                                    )
+                                };
+                                let db_result = match record() {
+                                    Err(ref error) if db::is_missing_channel_row(error) => {
+                                        self.save_channel_settings();
+                                        record()
+                                    }
+                                    result => result,
+                                };
+                                match db_result {
+                                    Ok(persisted) => {
+                                        if persisted.is_new {
+                                            let mut sc = self.stable_channel.lock().unwrap();
+                                            stable::update_balances(&self.node, &mut sc);
+                                            if let Some(new_backing) = persisted.new_backing {
+                                                sc.backing_sats = new_backing.max(0) as u64;
+                                            }
+                                            stable::recompute_native(&mut sc);
+                                        }
+                                        self.save_channel_settings_preserving_backing();
+                                        self.update_balances();
+                                        audit_event(
+                                            "STABILITY_PAYMENT_V1_APPLIED",
+                                            json!({
+                                                "payment_hash": payment_hash_str,
+                                                "settlement_id": payment.settlement_id,
+                                                "amount_msat": amount_msat,
+                                                "allocation_version": payment.allocation_version,
+                                                "current_allocation_version": self
+                                                    .db
+                                                    .get_sync_version(&user_channel_id)
+                                                    .ok()
+                                                    .flatten(),
+                                                "is_new": persisted.is_new,
+                                                "new_backing_sats": persisted.new_backing,
+                                            }),
+                                        );
+                                    }
+                                    Err(error) => {
+                                        ack = false;
+                                        audit_event(
+                                            "DB_WRITE_FAILED",
+                                            json!({
+                                                "op": "record_signed_stability_payment",
+                                                "payment_hash": payment_hash_str,
+                                                "settlement_id": payment.settlement_id,
+                                                "error": error.to_string(),
+                                            }),
+                                        );
+                                    }
+                                }
                                 break 'control true;
                             }
 
@@ -3062,32 +3222,27 @@ impl UserApp {
                             let price = sc.latest_price;
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
-                            let pending_trade_result = if correlated {
-                                self.db.get_trade_by_protocol_ids(
+                            let pending_trade = if correlated {
+                                match self.db.get_trade_by_protocol_ids(
                                     sync.trade_id.as_deref(),
                                     sync.trade_payment_id.as_deref(),
-                                )
-                            } else {
-                                // Backward-compatible desktop matching for pre-correlation LSPs.
-                                self.db.get_pending_trade_by_allocation(
-                                    sync.expected_usd,
-                                    sync.backing_sats,
-                                )
-                            };
-                            let pending_trade = match pending_trade_result {
-                                Ok(trade) => trade,
-                                Err(e) => {
-                                    audit_event(
-                                        "DB_READ_FAILED",
-                                        json!({
-                                            "op": "get_pending_trade_by_allocation",
-                                            "payment_hash": &payment_hash_str,
-                                            "error": e.to_string(),
-                                        }),
-                                    );
-                                    ack = false;
-                                    break 'control true;
+                                ) {
+                                    Ok(trade) => trade,
+                                    Err(e) => {
+                                        audit_event(
+                                            "DB_READ_FAILED",
+                                            json!({
+                                                "op": "get_trade_by_protocol_ids",
+                                                "payment_hash": &payment_hash_str,
+                                                "error": e.to_string(),
+                                            }),
+                                        );
+                                        ack = false;
+                                        break 'control true;
+                                    }
                                 }
+                            } else {
+                                None
                             };
                             if correlated && pending_trade.is_none() {
                                 audit_event(
@@ -3113,7 +3268,7 @@ impl UserApp {
                                 break 'control true;
                             }
                             if let Some(trade) = pending_trade.as_ref() {
-                                if !sync_matches_stored_trade_intent(trade, &sync, correlated) {
+                                if !sync_matches_stored_trade_intent(trade, &sync) {
                                     audit_event(
                                         "SYNC_V1_TRADE_INTENT_MISMATCH",
                                         json!({
@@ -3130,11 +3285,104 @@ impl UserApp {
                                     break 'control true;
                                 }
                             }
+                            let user_channel_id = format!("{}", sc.user_channel_id);
+                            if let Some(trade) = pending_trade.as_ref() {
+                                let current_sync_version = match self
+                                    .db
+                                    .get_sync_version(&user_channel_id)
+                                {
+                                    Ok(Some(version)) => version,
+                                    Ok(None) => {
+                                        audit_event(
+                                            "SYNC_V1_CHANNEL_STATE_MISSING",
+                                            json!({
+                                                "trade_id": trade.trade_id,
+                                                "sync_version": sync.sync_version,
+                                            }),
+                                        );
+                                        ack = false;
+                                        break 'control true;
+                                    }
+                                    Err(error) => {
+                                        audit_event(
+                                            "DB_READ_FAILED",
+                                            json!({
+                                                "op": "get_sync_version",
+                                                "trade_id": trade.trade_id,
+                                                "error": error.to_string(),
+                                            }),
+                                        );
+                                        ack = false;
+                                        break 'control true;
+                                    }
+                                };
+                                if current_sync_version >= sync.sync_version {
+                                    match self.db.complete_trade_from_stale_correlated_sync(
+                                        &user_channel_id,
+                                        sync.sync_version,
+                                        sync.expected_usd,
+                                        trade.id,
+                                        sync.trade_payment_id.as_deref(),
+                                    ) {
+                                        Ok(true) => {
+                                            let trade_id = trade.trade_id.clone();
+                                            let trade_db_id = trade.id;
+                                            let action = trade.action.clone();
+                                            drop(sc);
+                                            self.pending_trade_payments.retain(|_, pending| {
+                                                pending.trade_db_id != trade_db_id
+                                            });
+                                            audit_event(
+                                                "TRADE_ACCEPTED_AFTER_NEWER_SYNC",
+                                                json!({
+                                                    "trade_db_id": trade_db_id,
+                                                    "trade_id": trade_id,
+                                                    "trade_payment_id": sync.trade_payment_id,
+                                                    "response_sync_version": sync.sync_version,
+                                                    "current_sync_version": current_sync_version,
+                                                    "allocation_applied": false,
+                                                }),
+                                            );
+                                            let verb = if action == "buy" {
+                                                "USD → BTC"
+                                            } else {
+                                                "BTC → USD"
+                                            };
+                                            self.show_toast(
+                                                &format!("{} order confirmed", verb),
+                                                "OK",
+                                            );
+                                        }
+                                        Ok(false) => audit_event(
+                                            "SYNC_V1_REPLAY_REJECTED",
+                                            json!({
+                                                "payment_hash": &payment_hash_str,
+                                                "user_channel_id": user_channel_id,
+                                                "sync_version": sync.sync_version,
+                                                "current_sync_version": current_sync_version,
+                                            }),
+                                        ),
+                                        Err(error) => {
+                                            audit_event(
+                                                "DB_WRITE_FAILED",
+                                                json!({
+                                                    "op": "complete_trade_from_stale_correlated_sync",
+                                                    "trade_id": trade.trade_id,
+                                                    "error": error.to_string(),
+                                                }),
+                                            );
+                                            ack = false;
+                                        }
+                                    }
+                                    break 'control true;
+                                }
+                            }
                             if let Err(reason) = validate_incoming_sync_allocation(
                                 &sync,
+                                old_expected,
                                 live_receiver_sats,
                                 price,
-                                pending_trade.is_some(),
+                                correlated,
                             ) {
                                 audit_event(
                                     "SYNC_V1_ALLOCATION_REJECTED",
@@ -3150,11 +3398,13 @@ impl UserApp {
                                 );
                                 break 'control true;
                             }
-                            // Mirror the LSP — derive locally so a peer's number cannot move our books.
+                            // Commit this wallet's own delta allocation; the peer's number is telemetry.
                             let Some(committed_backing) = committed_backing_sats(
                                 sync.expected_usd,
                                 live_receiver_sats,
                                 price,
+                                old_expected,
+                                sc.backing_sats,
                                 pending_trade.as_ref(),
                             ) else {
                                 audit_event(
@@ -3186,7 +3436,6 @@ impl UserApp {
                                 );
                             }
                             let native_sats = live_receiver_sats.saturating_sub(committed_backing);
-                            let user_channel_id = format!("{}", sc.user_channel_id);
                             match self.db.apply_correlated_sync_if_newer_and_complete_trade(
                                 &user_channel_id,
                                 sync.sync_version,
@@ -3279,7 +3528,9 @@ impl UserApp {
                         self.update_balances();
                     } else {
                         let has_stable_control_message = custom_records.iter().any(|tlv| {
-                            tlv.type_num == STABLE_CHANNEL_TLV_TYPE && tlv.value.as_slice() != [1u8]
+                            (tlv.type_num == STABLE_CHANNEL_TLV_TYPE
+                                && tlv.value.as_slice() != [1u8])
+                                || tlv.type_num == SIGNED_STABILITY_TLV_TYPE
                         });
                         if has_stable_control_message || amount_msat < 1000 {
                             audit_event(
@@ -3328,6 +3579,7 @@ impl UserApp {
                             let record = || {
                                 self.db.record_payment_and_maybe_update_backing(
                                     Some(&payment_hash_str),
+                                    None,
                                     payment_type,
                                     "received",
                                     amount_msat,
@@ -9385,7 +9637,7 @@ impl UserApp {
         // Show the native allocation valued in USD. A price quote changes its value, not which
         // sats belong to it.
         let btc_price = get_cached_price_no_fetch();
-        let native_sats = {
+        let (native_sats, available_btc_usd_cents) = {
             let sc = self.stable_channel.lock().unwrap();
             let (_, native_sats, _) = channel_balance_split(
                 sc.stable_receiver_btc.sats,
@@ -9393,12 +9645,14 @@ impl UserApp {
                 sc.expected_usd.0,
                 btc_price,
             );
-            native_sats
+            let available_cents = sell_capacity_usd_cents(
+                sc.stable_receiver_btc.sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+                btc_price,
+            );
+            (native_sats, available_cents)
         };
-        // A hard spending limit must never be formatted upward. Otherwise an exact displayed
-        // maximum can exceed the underlying sats by a fraction of a cent.
-        let available_btc_usd_cents =
-            floor_usd_cents(native_sats as f64 / SATS_IN_BTC as f64 * btc_price);
         let available_btc_usd = available_btc_usd_cents as f64 / 100.0;
         ui.label(
             RichText::new(format!(
@@ -9978,12 +10232,18 @@ impl UserApp {
         } else {
             0.0
         };
-        let prepared = self.prepare_trade_wire(
+        let prepared = match self.prepare_trade_wire(
             Self::new_trade_id(),
             new_expected_usd,
             fee_usd,
             btc_price,
-        );
+        ) {
+            Ok(prepared) => prepared,
+            Err(reason) => {
+                self.trade_error = format!("Cannot prepare order: {reason}");
+                return;
+            }
+        };
         let expires_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -10033,19 +10293,35 @@ impl UserApp {
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
-        let (current_expected_usd, native_sats) = {
-            let sc = self.stable_channel.lock().unwrap();
+        let (current_expected_usd, native_sats, available_cents) = {
+            let mut sc = self.stable_channel.lock().unwrap();
+            stable::update_balances(&self.node, &mut sc);
             let (_, native_sats, _) = channel_balance_split(
                 sc.stable_receiver_btc.sats,
                 sc.backing_sats,
                 sc.expected_usd.0,
                 btc_price,
             );
-            (sc.expected_usd.0, native_sats)
+            let available_cents = sell_capacity_usd_cents(
+                sc.stable_receiver_btc.sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+                btc_price,
+            );
+            (sc.expected_usd.0, native_sats, available_cents)
         };
 
         if btc_price < 1.0 || !btc_price.is_finite() {
             self.trade_error = "Invalid price".to_string();
+            return;
+        }
+
+        let amount_cents = floor_usd_cents(amount_usd);
+        if amount_cents == 0 || amount_cents > available_cents {
+            self.trade_error = format!(
+                "BTC balance or price changed. You can convert up to {}.",
+                Self::format_price(available_cents as f64 / 100.0)
+            );
             return;
         }
 
@@ -10061,12 +10337,27 @@ impl UserApp {
         let new_expected_usd = current_expected_usd + net_amount;
 
         let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
-        let prepared = self.prepare_trade_wire(
+        let prepared = match self.prepare_trade_wire(
             Self::new_trade_id(),
             new_expected_usd,
             fee_usd,
             btc_price,
-        );
+        ) {
+            Ok(prepared) => prepared,
+            Err(reason) => {
+                self.trade_error = format!("Cannot prepare order: {reason}");
+                return;
+            }
+        };
+        if !target_fits_worst_case_peer_capacity(
+            prepared.post_fee_receiver_sats,
+            new_expected_usd,
+            btc_price,
+        ) {
+            self.trade_error =
+                "BTC balance or price changed before the trade could be sent.".to_string();
+            return;
+        }
         let expires_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -10770,6 +11061,64 @@ fn floor_usd_cents(usd: f64) -> u64 {
     }
 }
 
+/// Maximum gross BTC-to-USD trade amount this wallet can safely offer.
+///
+/// Native sats are only one bound. When the stable allocation has drifted below its fixed USD
+/// target, part of the channel's apparent native value is already needed to cover that gap. Also
+/// reserve the full permitted peer-price spread so a maximum trade remains backable when the LSP's
+/// independent quote is at the lower edge of the consent band.
+fn sell_capacity_usd_cents(
+    receiver_sats: u64,
+    backing_sats: u64,
+    expected_usd: f64,
+    quote_price: f64,
+) -> u64 {
+    if receiver_sats == 0
+        || !expected_usd.is_finite()
+        || expected_usd < 0.0
+        || !quote_price.is_finite()
+        || quote_price <= 0.0
+    {
+        return 0;
+    }
+
+    let (_, native_sats, native_usd) =
+        channel_balance_split(receiver_sats, backing_sats, expected_usd, quote_price);
+    if native_sats == 0 {
+        return 0;
+    }
+
+    // The LSP checks deviation relative to its own price. If our quote is the higher one, the
+    // lowest still-admissible LSP price is quote / (1 + spread), not quote * (1 - spread).
+    let spread = MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0;
+    let lowest_admissible_peer_price = quote_price / (1.0 + spread);
+    let conservative_channel_usd =
+        receiver_sats as f64 / SATS_IN_BTC as f64 * lowest_admissible_peer_price;
+    let target_headroom_usd = (conservative_channel_usd - expected_usd).max(0.0);
+
+    floor_usd_cents(native_usd.min(target_headroom_usd))
+}
+
+/// Final race guard after the exact fee sats and post-fee balance have been frozen.
+fn target_fits_worst_case_peer_capacity(
+    post_fee_receiver_sats: u64,
+    target_usd: f64,
+    quote_price: f64,
+) -> bool {
+    if !target_usd.is_finite()
+        || target_usd < 0.0
+        || !quote_price.is_finite()
+        || quote_price <= 0.0
+    {
+        return false;
+    }
+    let spread = MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0;
+    let lowest_admissible_peer_price = quote_price / (1.0 + spread);
+    let conservative_capacity = post_fee_receiver_sats as f64 / SATS_IN_BTC as f64
+        * lowest_admissible_peer_price;
+    target_usd <= conservative_capacity + 1e-9
+}
+
 /// Sats required to cover an exact cent-denominated USD amount at a fixed quote. Round up so the
 /// order can never claim more USD than the selected sats are worth.
 fn sats_for_usd_cents(cents: u64, price: f64) -> Option<u64> {
@@ -10973,41 +11322,30 @@ fn sync_channel_binding_matches(
 fn sync_trade_identifiers_match(
     trade: &db::PendingTradeRow,
     sync: &IncomingSync,
-    correlated: bool,
 ) -> bool {
-    if !correlated {
-        return true;
-    }
     trade.trade_id.is_none()
         || (trade.trade_id.as_deref() == sync.trade_id.as_deref()
             && sync.trade_payment_id.is_some())
 }
 
-/// Whether an LSP sync answers the trade this wallet sent. The identifiers are the contract;
-/// `backing_sats` is derived per-peer and is not compared.
-///
-/// The target may come back below what was asked for: the LSP books what its own valuation of this
-/// side can actually back, so a request that runs past that gets answered with the backable figure
-/// rather than funded from LSP liquidity. Accept that as far as the two sides could honestly
-/// disagree about the value of these sats — and never above the request, which is not a clamp.
+/// Whether an LSP sync answers the trade this wallet sent. The identifiers and USD target must
+/// match exactly; `backing_sats` is derived per-peer and is not compared.
 fn sync_matches_stored_trade_intent(
     trade: &db::PendingTradeRow,
     sync: &IncomingSync,
-    correlated: bool,
 ) -> bool {
-    sync_trade_identifiers_match(trade, sync, correlated)
-        && stable_channels::trade::answered_target_honours_request(
+    sync_trade_identifiers_match(trade, sync)
+        && stable_channels::trade::answered_target_matches_request(
             trade.new_expected_usd,
             sync.expected_usd,
         )
 }
 
-/// The allocation this wallet commits, always derived locally at its own price and own live balance.
+/// The allocation this wallet commits, always computed from its own prior book, price, and balance.
 ///
-/// This holds on a recovery sync too. The peer's `backing_sats` is never an input: adopting it lets
-/// the peer state a split that puts this wallet over par, and the tick pays out of par without
-/// caring who wrote the number. Re-deriving costs nothing the peer's own book can claim — the split
-/// is only ever this wallet's own balance, so re-anchoring it cannot move funds by itself.
+/// This holds on a recovery sync too. The peer's `backing_sats` is never an input, and only the
+/// change in `expected_usd` is converted. Repricing the whole target would erase pre-existing drift
+/// and let a tiny trade cancel a much larger stability obligation.
 ///
 /// `None` means the sync cannot be committed yet and the caller must defer it. A sync can land
 /// before the first price fetch completes and the derivation is 0 at a zero price; the only
@@ -11017,20 +11355,63 @@ fn committed_backing_sats(
     expected_usd: f64,
     live_receiver_sats: u64,
     price: f64,
+    current_expected_usd: f64,
+    current_backing_sats: u64,
     pending_trade: Option<&db::PendingTradeRow>,
 ) -> Option<u64> {
-    let derived = stable::trade_backing_sats(live_receiver_sats, expected_usd, price);
-    if derived > 0 || expected_usd < 0.01 {
-        return Some(derived);
-    }
-    // Only a self-derived allocation that the live balance can still cover is a usable basis.
+    // A correlated response commits the exact delta allocation this wallet persisted before
+    // sending. Repricing the whole target here would erase drift accumulated before the trade.
     pending_trade
+        .filter(|trade| {
+            stable_channels::trade::answered_target_matches_request(
+                trade.new_expected_usd,
+                expected_usd,
+            )
+        })
         .and_then(|trade| trade.new_backing_sats)
-        .filter(|stored| *stored > 0 && *stored <= live_receiver_sats)
+        .filter(|stored| *stored <= live_receiver_sats)
+        .or_else(|| {
+            stable::trade_backing_after_delta(
+                live_receiver_sats,
+                current_backing_sats,
+                current_expected_usd,
+                expected_usd,
+                price,
+            )
+        })
 }
 
 fn rejection_resolves_trade(reason_code: &str) -> bool {
     reason_code != "duplicate_trade"
+}
+
+fn parse_stability_payment(payload: &str) -> Option<IncomingStabilityPayment> {
+    let payment: IncomingStabilityPayment = serde_json::from_str(payload).ok()?;
+    if payment.kind != "STABILITY_PAYMENT_V1"
+        || !is_protocol_trade_id(&payment.settlement_id)
+        || payment.channel_id.len() != 64
+        || !payment.channel_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || payment.user_channel_id.is_empty()
+        || payment.amount_msat == 0
+        || payment.amount_msat % 1000 != 0
+        || payment.allocation_version > i64::MAX as u64
+        || payment.ts == 0
+    {
+        return None;
+    }
+    Some(payment)
+}
+
+/// A settled Lightning payment is not a time-limited instruction. Its signed timestamp remains
+/// useful audit metadata, while replay protection comes from the payment and settlement ids that
+/// are atomically deduplicated when the exact received value is recorded.
+fn stability_payment_binding_matches(
+    payment: &IncomingStabilityPayment,
+    wallet_channel_id: &str,
+    received_amount_msat: u64,
+) -> bool {
+    payment.channel_id.eq_ignore_ascii_case(wallet_channel_id)
+        && payment.amount_msat == received_amount_msat
 }
 
 fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
@@ -11058,24 +11439,35 @@ fn parse_trade_rejection(payload: &str) -> Option<IncomingTradeRejection> {
 /// Gate a sync on the one field this wallet adopts from it: `expected_usd`.
 ///
 /// `backing_sats` is deliberately not checked. It is no longer an input on any path — the allocation
-/// is always derived locally — so a bound on it could only discard syncs whose target is perfectly
-/// good, including the DB-loss recovery this wallet depends on. What does need bounding is the
-/// target: nothing else stops a peer pegging this wallet above what its side can back, which books
-/// a shortfall the wallet then waits on forever.
+/// is always derived locally. An ordinary sync may confirm the target the wallet already derived
+/// from its own payment events, but it cannot choose a different target in either direction. Only
+/// a correlated response to a trade this wallet signed authorizes a target change.
 fn validate_incoming_sync_allocation(
     sync: &IncomingSync,
+    current_expected_usd: f64,
     live_receiver_sats: u64,
     current_price: f64,
-    matches_pending_trade: bool,
+    correlated_trade_response: bool,
 ) -> Result<(), &'static str> {
     if !sync.expected_usd.is_finite() || sync.expected_usd < 0.0 {
         return Err("target is not a usable amount");
+    }
+    if !current_expected_usd.is_finite() || current_expected_usd < 0.0 {
+        return Err("current wallet target is not usable");
+    }
+    if !correlated_trade_response
+        && !stable_channels::trade::answered_target_matches_request(
+            current_expected_usd,
+            sync.expected_usd,
+        )
+    {
+        return Err("uncorrelated sync cannot change the wallet target");
     }
     if sync.expected_usd < 0.01 {
         return Ok(());
     }
     // A trade response's target was already bounded against the request this wallet signed.
-    if matches_pending_trade {
+    if correlated_trade_response {
         return Ok(());
     }
     if !current_price.is_finite() || current_price <= 0.0 {
@@ -11138,16 +11530,17 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, committed_backing_sats,
-        floor_usd_cents, parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
+        floor_usd_cents, parse_incoming_sync, parse_stability_payment, parse_trade_rejection,
+        parse_trade_usd_cents,
         peer_allocation_diverges, rejection_resolves_trade, restrict_secret_file_permissions,
-        sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
-        sync_channel_binding_matches, sync_matches_stored_trade_intent,
-        sync_trade_identifiers_match, validate_incoming_sync_allocation, write_secret_file,
-        IncomingSync, PendingSplice, SpliceReconcileAction, UserApp,
+        sats_for_usd_cents, sell_capacity_usd_cents, splice_in_overlap_sats,
+        splice_reconcile_action, target_fits_worst_case_peer_capacity,
+        stability_payment_binding_matches, sync_channel_binding_matches,
+        sync_matches_stored_trade_intent,
+        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
+        SpliceReconcileAction, UserApp,
     };
-    use stable_channels::constants::{
-        MAX_PEER_VALUATION_SPREAD_PERCENT, SATS_IN_BTC, STABILITY_THRESHOLD_USD,
-    };
+    use stable_channels::constants::{SATS_IN_BTC, STABILITY_THRESHOLD_USD};
     use stable_channels::db::PendingTradeRow;
 
     #[test]
@@ -11167,6 +11560,68 @@ mod tests {
     }
 
     #[test]
+    fn signed_stability_payment_requires_canonical_exact_fields() {
+        let settlement_id =
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let valid = serde_json::json!({
+            "type": "STABILITY_PAYMENT_V1",
+            "settlement_id": settlement_id,
+            "channel_id": "ab".repeat(32),
+            "user_channel_id": "7",
+            "amount_msat": 42_000,
+            "allocation_version": 9,
+            "ts": 123,
+        });
+        assert_eq!(
+            parse_stability_payment(&valid.to_string())
+                .map(|payment| payment.amount_msat),
+            Some(42_000),
+        );
+
+        let mut invalid_id = valid.clone();
+        invalid_id["settlement_id"] = serde_json::json!(settlement_id.to_uppercase());
+        assert!(parse_stability_payment(&invalid_id.to_string()).is_none());
+
+        let mut fractional_sat = valid;
+        fractional_sat["amount_msat"] = serde_json::json!(42_001);
+        assert!(parse_stability_payment(&fractional_sat.to_string()).is_none());
+    }
+
+    #[test]
+    fn settled_stability_payment_does_not_expire_at_processing_time() {
+        let payment = parse_stability_payment(
+            &serde_json::json!({
+                "type": "STABILITY_PAYMENT_V1",
+                "settlement_id": "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "channel_id": "ab".repeat(32),
+                "user_channel_id": "7",
+                "amount_msat": 42_000,
+                "allocation_version": 9,
+                // Deliberately ancient: timestamp is audit metadata for settled value.
+                "ts": 1,
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(stability_payment_binding_matches(
+            &payment,
+            &"AB".repeat(32),
+            42_000,
+        ));
+        assert!(!stability_payment_binding_matches(
+            &payment,
+            &"cd".repeat(32),
+            42_000,
+        ));
+        assert!(!stability_payment_binding_matches(
+            &payment,
+            &"ab".repeat(32),
+            43_000,
+        ));
+    }
+
+    #[test]
     fn displayed_native_limit_always_fits_available_sats() {
         let native_sats = 15_978;
         let price = 66_395.1;
@@ -11176,6 +11631,61 @@ mod tests {
 
         assert_eq!(available_cents, 1_060);
         assert!(required_sats <= native_sats);
+    }
+
+    #[test]
+    fn sell_limit_reserves_existing_underbacking_and_peer_price_spread() {
+        // Production regression: native sats appeared to be worth $9.91, but the existing peg was
+        // $0.165 under-backed. Three attempts paid their fee and were then rejected by the LSP.
+        let receiver_sats = 58_865;
+        let backing_sats = 43_465;
+        let expected_usd = 28.139041386425003;
+        let quote_price = 64_356.315;
+
+        let raw_native_cents = floor_usd_cents(
+            (receiver_sats - backing_sats) as f64 / SATS_IN_BTC as f64 * quote_price,
+        );
+        let safe_cents = sell_capacity_usd_cents(
+            receiver_sats,
+            backing_sats,
+            expected_usd,
+            quote_price,
+        );
+
+        assert_eq!(raw_native_cents, 991);
+        assert_eq!(safe_cents, 972);
+
+        let amount_usd = safe_cents as f64 / 100.0;
+        let fee_usd = amount_usd * stable_channels::constants::STABLE_CHANNEL_TRADE_FEE_RATE;
+        let fee_sats = (fee_usd / quote_price * SATS_IN_BTC as f64) as u64;
+        let post_fee_sats = receiver_sats - fee_sats;
+        let requested_target = expected_usd + amount_usd - fee_usd;
+        assert!(target_fits_worst_case_peer_capacity(
+            post_fee_sats,
+            requested_target,
+            quote_price,
+        ));
+    }
+
+    #[test]
+    fn sell_limit_is_bounded_by_native_sats_when_peg_is_overbacked() {
+        assert_eq!(
+            sell_capacity_usd_cents(150_000, 100_000, 90.0, 100_000.0),
+            5_000,
+        );
+    }
+
+    #[test]
+    fn sell_limit_is_zero_when_target_already_uses_conservative_capacity() {
+        assert_eq!(
+            sell_capacity_usd_cents(100_000, 50_000, 100.0, 100_000.0),
+            0,
+        );
+        assert!(!target_fits_worst_case_peer_capacity(
+            100_000,
+            100.0,
+            100_000.0,
+        ));
     }
 
     #[test]
@@ -11240,7 +11750,7 @@ mod tests {
             trade_id: None,
             trade_payment_id: None,
         };
-        assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_ok());
+        assert!(validate_incoming_sync_allocation(&sync, 60.0, 100_000, 100_000.0, false).is_ok());
 
         // A target past what this side can back is refused; the peer's own allocation is not read.
         let implausible = IncomingSync {
@@ -11249,18 +11759,15 @@ mod tests {
         };
         assert!(validate_incoming_sync_allocation(
             &implausible,
+            10_000.0,
             100_000,
             100_000.0,
             false
         )
         .is_err());
-        assert!(validate_incoming_sync_allocation(
-            &implausible,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_ok());
+        assert!(
+            validate_incoming_sync_allocation(&implausible, 60.0, 100_000, 100_000.0, true).is_ok()
+        );
 
         // Closing the peg is always representable, whatever the peer says its backing is.
         let closing = IncomingSync {
@@ -11268,15 +11775,65 @@ mod tests {
             backing_sats: 1,
             ..sync
         };
-        assert!(validate_incoming_sync_allocation(&closing, 100_000, 100_000.0, true).is_ok());
+        assert!(
+            validate_incoming_sync_allocation(&closing, 60.0, 100_000, 100_000.0, true).is_ok()
+        );
     }
 
     #[test]
-    fn no_peer_allocation_can_discard_a_sync_whose_target_is_sound() {
+    fn uncorrelated_sync_cannot_change_the_wallet_target() {
+        let sync = IncomingSync {
+            channel_id: "00".repeat(32),
+            user_channel_id: "7".to_owned(),
+            expected_usd: 60.0,
+            backing_sats: 60_000,
+            sync_version: 1,
+            trade_id: None,
+            trade_payment_id: None,
+        };
+
+        assert_eq!(
+            validate_incoming_sync_allocation(&sync, 50.0, 100_000, 100_000.0, false),
+            Err("uncorrelated sync cannot change the wallet target"),
+        );
+
+        let decrease = IncomingSync {
+            expected_usd: 49.0,
+            ..sync.clone()
+        };
+        assert_eq!(
+            validate_incoming_sync_allocation(
+                &decrease,
+                50.0,
+                100_000,
+                100_000.0,
+                false,
+            ),
+            Err("uncorrelated sync cannot change the wallet target"),
+        );
+        let confirmation = IncomingSync {
+            expected_usd: 50.0,
+            ..sync.clone()
+        };
+        assert!(validate_incoming_sync_allocation(
+            &confirmation,
+            50.0,
+            100_000,
+            100_000.0,
+            false,
+        )
+        .is_ok());
+        assert!(
+            validate_incoming_sync_allocation(&sync, 50.0, 100_000, 100_000.0, true).is_ok(),
+            "a correlated trade response may apply the target the wallet requested",
+        );
+    }
+
+    #[test]
+    fn peer_allocation_cannot_discard_a_sync_for_a_locally_known_target() {
         // The old gate bounded backing_sats and so had to guess how stale an honest peer's anchor was.
-        // Guess too tight and DB-loss recovery breaks; too loose and the manufactured case walks
-        // through. Nothing reads the field now, so neither guess is needed: whatever the peer states,
-        // a sound target recovers, and the allocation this wallet commits is its own.
+        // Nothing reads the field now, so an unchanged, locally-authorized target can reconcile
+        // regardless of the peer's stated backing; the wallet commits its own allocation.
         let base = IncomingSync {
             channel_id: "00".repeat(32),
             user_channel_id: "7".to_owned(),
@@ -11288,21 +11845,35 @@ mod tests {
         };
 
         for backing_sats in [
-            100_100,   // anchored one settlement ago
-            102_000,   // anchored well past any settlement
-            1,         // nonsense
-            u64::MAX,  // hostile
+            100_100,  // anchored one settlement ago
+            102_000,  // anchored well past any settlement
+            1,        // nonsense
+            u64::MAX, // hostile
         ] {
             let sync = IncomingSync {
                 backing_sats,
                 ..base.clone()
             };
             assert!(
-                validate_incoming_sync_allocation(&sync, 200_000, 100_000.0, false).is_ok(),
-                "a sound target must recover regardless of the peer's stated backing {backing_sats}",
+                validate_incoming_sync_allocation(
+                    &sync,
+                    100.0,
+                    200_000,
+                    100_000.0,
+                    false
+                )
+                .is_ok(),
+                "a known target must reconcile regardless of the peer's stated backing {backing_sats}",
             );
             assert_eq!(
-                committed_backing_sats(sync.expected_usd, 200_000, 100_000.0, None),
+                committed_backing_sats(
+                    sync.expected_usd,
+                    200_000,
+                    100_000.0,
+                    100.0,
+                    100_000,
+                    None,
+                ),
                 Some(100_000),
                 "the committed allocation is this wallet's own either way",
             );
@@ -11567,41 +12138,12 @@ mod tests {
             assert_eq!(parsed.reason_code, reason_code);
         }
         assert!(rejection_resolves_trade("no_op_trade"));
-    }
-
-    #[test]
-    fn legacy_sync_matches_signed_trade_by_allocation_without_correlation_ids() {
-        let trade_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-        let trade = PendingTradeRow {
-            id: 1,
-            channel_id: "aa".repeat(32),
-            trade_id: Some(trade_id.to_owned()),
-            payment_id: Some("payment".to_owned()),
-            fee_msat: 1_000,
-            new_expected_usd: 25.0,
-            btc_price: 100_000.0,
-            new_backing_sats: Some(25_000),
-            action: "buy".to_owned(),
-            status: "awaiting_acceptance".to_owned(),
-        };
-        let legacy_sync = IncomingSync {
-            channel_id: "aa".repeat(32),
-            user_channel_id: "7".to_owned(),
-            expected_usd: 25.0,
-            backing_sats: 25_000,
-            sync_version: 1,
-            trade_id: None,
-            trade_payment_id: None,
-        };
-
-        assert!(sync_trade_identifiers_match(&trade, &legacy_sync, false));
-        assert!(!sync_trade_identifiers_match(&trade, &legacy_sync, true));
         assert!(!rejection_resolves_trade("duplicate_trade"));
         assert!(rejection_resolves_trade("invalid_fee"));
     }
 
     #[test]
-    fn sync_intent_accepts_lsp_derived_backing_but_not_a_changed_target() {
+    fn sync_intent_accepts_lsp_derived_backing_but_requires_the_exact_target() {
         let trade = PendingTradeRow {
             id: 1,
             channel_id: "aa".to_string(),
@@ -11626,7 +12168,7 @@ mod tests {
             trade_payment_id: Some("p-1".to_string()),
         };
         assert!(
-            sync_matches_stored_trade_intent(&trade, &repriced, true),
+            sync_matches_stored_trade_intent(&trade, &repriced),
             "an LSP-derived allocation for the agreed target must be accepted",
         );
 
@@ -11636,37 +12178,27 @@ mod tests {
             ..repriced.clone()
         };
         assert!(
-            !sync_matches_stored_trade_intent(&trade, &wrong_target, true),
+            !sync_matches_stored_trade_intent(&trade, &wrong_target),
             "expected_usd is the contract and must match exactly",
         );
 
-        // Asking past what the LSP's own valuation can back comes back as the backable figure.
-        let clamped = IncomingSync {
-            expected_usd: 100.0 * (1.0 - MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0 / 2.0),
+        // A lower answer is an unrequested partial fill and must be refused too.
+        let lower = IncomingSync {
+            expected_usd: 99.99,
             ..repriced.clone()
         };
         assert!(
-            sync_matches_stored_trade_intent(&trade, &clamped, true),
-            "a capacity clamp inside honest spread must not strand the trade",
+            !sync_matches_stored_trade_intent(&trade, &lower),
+            "a lower target must not be treated as an implicit partial fill",
         );
 
-        // Beyond that, a lower target is the peer choosing this wallet's exposure for it.
-        let over_clamped = IncomingSync {
-            expected_usd: 100.0 * (1.0 - MAX_PEER_VALUATION_SPREAD_PERCENT / 100.0) - 0.01,
-            ..repriced.clone()
-        };
-        assert!(
-            !sync_matches_stored_trade_intent(&trade, &over_clamped, true),
-            "a clamp wider than honest spread must be refused",
-        );
-
-        // A clamp only ever reduces; answering above the request is not one.
+        // A higher answer changes the user's exposure as well.
         let inflated = IncomingSync {
             expected_usd: 100.01,
             ..repriced
         };
         assert!(
-            !sync_matches_stored_trade_intent(&trade, &inflated, true),
+            !sync_matches_stored_trade_intent(&trade, &inflated),
             "the peer must never answer above the signed request",
         );
     }
@@ -11696,7 +12228,7 @@ mod tests {
         };
         // The old inline gate used is_none_or, which skipped the expected_usd check entirely here.
         assert!(
-            !sync_matches_stored_trade_intent(&trade, &wrong_target, true),
+            !sync_matches_stored_trade_intent(&trade, &wrong_target),
             "expected_usd must be checked even when the stored trade has no recorded backing_sats",
         );
     }
@@ -11718,31 +12250,31 @@ mod tests {
     }
 
     #[test]
-    fn wallet_derives_its_own_backing_on_every_path() {
+    fn wallet_commits_its_own_delta_allocation_on_every_path() {
         let trade = prepared_trade(Some(99_502));
         // Peer booked $100 at $100_000 (100_000 sats); this wallet reads $100_500 so derives 99_502.
         assert_eq!(
-            committed_backing_sats(100.0, 100_000, 100_500.0, Some(&trade)),
+            committed_backing_sats(100.0, 100_000, 100_500.0, 50.0, 49_751, Some(&trade)),
             Some(99_502),
             "a trade must commit this wallet's own derivation, not the peer's",
         );
         // A hostile allocation on the trade path therefore has no effect at all.
         assert_eq!(
-            committed_backing_sats(50.0, 100_000, 100_000.0, Some(&trade)),
-            Some(50_000),
-            "a peer cannot inflate this wallet's backing on the trade path",
+            committed_backing_sats(50.0, 100_000, 100_000.0, 100.0, 99_502, Some(&trade)),
+            Some(49_502),
+            "the target delta must preserve the wallet's pre-existing 498-sat drift",
         );
         // A recovery sync derives identically — there is no path that reads the peer's allocation.
         assert_eq!(
-            committed_backing_sats(100.0, 200_000, 100_000.0, None),
+            committed_backing_sats(100.0, 200_000, 100_000.0, 50.0, 50_000, None),
             Some(100_000),
             "recovery must derive locally too",
         );
     }
 
     #[test]
-    fn a_recovery_sync_cannot_book_this_wallet_over_par() {
-        // The drain was: a signed recovery sync stating backing worth $0.49 more than the target, so
+    fn an_uncorrelated_reconciliation_sync_cannot_book_this_wallet_over_par() {
+        // The drain was: a signed sync stating backing worth $0.49 more than the target, so
         // the wallet woke up above par and settled the difference to the peer that chose it.
         let price = 100_000.0;
         let live = 200_000u64;
@@ -11759,12 +12291,16 @@ mod tests {
             trade_payment_id: None,
         };
         assert!(
-            validate_incoming_sync_allocation(&sync, live, price, false).is_ok(),
-            "a plausible target must still recover",
+            validate_incoming_sync_allocation(&sync, target, live, price, false).is_ok(),
+            "an unchanged target must still reconcile",
         );
 
-        let committed = committed_backing_sats(target, live, price, None).unwrap();
-        assert_ne!(committed, peer_backing, "the peer's allocation must not be adopted");
+        let committed =
+            committed_backing_sats(target, live, price, target, 100_000, None).unwrap();
+        assert_ne!(
+            committed, peer_backing,
+            "the peer's allocation must not be adopted"
+        );
         let drift = committed as f64 / SATS_IN_BTC as f64 * price - target;
         assert!(
             drift.abs() < STABILITY_THRESHOLD_USD,
@@ -11788,7 +12324,9 @@ mod tests {
             trade_id: None,
             trade_payment_id: None,
         };
-        assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_err());
+        assert!(
+            validate_incoming_sync_allocation(&sync, 1_000.0, 100_000, 100_000.0, false).is_err()
+        );
     }
 
     #[test]
@@ -11799,7 +12337,7 @@ mod tests {
         // A response retry can land seconds after start, while latest_price is still 0.
         let trade = prepared_trade(Some(99_502));
         assert_eq!(
-            committed_backing_sats(100.0, 100_000, 0.0, Some(&trade)),
+            committed_backing_sats(100.0, 100_000, 0.0, 50.0, 49_751, Some(&trade)),
             Some(99_502),
             "a cold cache must fall back to this wallet's own trade-time allocation",
         );
@@ -11807,14 +12345,14 @@ mod tests {
         // Backing the peg with the whole balance is what lets a compromised LSP drain the native side.
         let legacy = prepared_trade(None);
         assert_eq!(
-            committed_backing_sats(100.0, 100_000, 0.0, Some(&legacy)),
+            committed_backing_sats(100.0, 100_000, 0.0, 50.0, 49_751, Some(&legacy)),
             None,
             "with no self-derived basis the trade must defer, never adopt the peer's allocation",
         );
 
         // A recovery sync has no stored basis at all, so a cold cache can only defer.
         assert_eq!(
-            committed_backing_sats(100.0, hostile_full_balance, 0.0, None),
+            committed_backing_sats(100.0, hostile_full_balance, 0.0, 50.0, 49_751, None),
             None,
             "recovery on a cold cache must defer rather than adopt",
         );
@@ -11822,16 +12360,19 @@ mod tests {
         // A stored allocation the live balance can no longer cover is not a usable basis either.
         let overdrawn = prepared_trade(Some(100_001));
         assert_eq!(
-            committed_backing_sats(100.0, 100_000, 0.0, Some(&overdrawn)),
+            committed_backing_sats(100.0, 100_000, 0.0, 50.0, 49_751, Some(&overdrawn)),
             None,
         );
 
         // A zero balance derives 0, and a stored basis it cannot cover is refused.
-        assert_eq!(committed_backing_sats(100.0, 0, 100_000.0, Some(&trade)), None);
+        assert_eq!(
+            committed_backing_sats(100.0, 0, 100_000.0, 50.0, 49_751, Some(&trade)),
+            None
+        );
 
         // Closing the peg genuinely commits zero backing.
         assert_eq!(
-            committed_backing_sats(0.0, 100_000, 100_000.0, Some(&trade)),
+            committed_backing_sats(0.0, 100_000, 100_000.0, 50.0, 49_751, Some(&trade)),
             Some(0),
         );
     }

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -776,8 +776,6 @@ async fn test_outgoing_payment_deducts_from_stable() {
     for _ in 0..5 {
         match lsp_node.next_event() {
             Some(ldk_node::Event::PaymentForwarded {
-                prev_channel_id,
-                next_channel_id,
                 outbound_amount_forwarded_msat,
                 total_fee_earned_msat,
                 ..
@@ -785,8 +783,8 @@ async fn test_outgoing_payment_deducts_from_stable() {
                 forwarded_msat = outbound_amount_forwarded_msat.unwrap_or(0);
                 let fee_msat = total_fee_earned_msat.unwrap_or(0);
                 println!(
-                    "[event] LSP: PaymentForwarded {} msats (fee {} msats) prev={} next={}",
-                    forwarded_msat, fee_msat, prev_channel_id, next_channel_id
+                    "[event] LSP: PaymentForwarded {} msats (fee {} msats)",
+                    forwarded_msat, fee_msat
                 );
                 lsp_node.event_handled().unwrap();
                 break;


### PR DESCRIPTION
closes #205. Implements signed trade outcomes, durable correlation, and desktop expiry. Automatic fee refunds remain intentionally deferred.

## What changed

  - Added optional signed trade_id and payment correlation fields.
  - Added signed trade rejections with stable reason codes.
  - Desktop now waits for authoritative LSP acceptance and displays sending, awaiting, completed, rejected, failed, and expired states.
  - Added 15-minute desktop expiry with authoritative late-outcome handling.
  - Persisted decisions atomically, deduplicated replays, and added durable response retries with dead-lettering after 168 attempts.
  - Preserved legacy desktop and mobile compatibility.

  ## Rejection conditions

  - `invalid_amount`:  invalid expected_usd or malformed trade_id.
  - `stale_request`: timestamp is more than 15 minutes old or ahead.
  - `invalid_fee`: fee inputs are invalid or the received fee does not match the signed trade.
  - `invalid_quote`: missing/invalid timestamp, quote, or LSP price.
  - `quote_out_of_range`: wallet quote differs from the LSP price by more than 1%.
  - `invalid_allocation`: missing quote/backing pair, backing exceeds available sats, zero allocation is inconsistent, or backing differs from the USD target by over $0.25.
  - `insufficient_capacity`:  requested USD allocation exceeds channel capacity.
  - `duplicate_trade`: another payment already used the same trade_id.
  - `internal_error`: required state, signing, database, or persistence operation failed.

  Invalid signatures, incorrect channel binding, and unattributable payments are dropped without an authenticated rejection.