### PR TITLE
fix(android): stabilize onchain receive confirmation flow and home/history UX

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -131,4 +131,5 @@ dependencies {
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -10,6 +10,9 @@ import com.stablechannels.app.push.FCMService
 import com.stablechannels.app.push.StabilityProcessingService
 import com.stablechannels.app.services.CloseTxidResolver
 import com.stablechannels.app.services.*
+import com.stablechannels.app.services.websocket.MempoolWebSocketClient
+import com.stablechannels.app.services.websocket.MempoolWebSocketService
+import com.stablechannels.app.services.websocket.WebSocketEvent
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.LspPreferencesManager
 import com.stablechannels.app.util.satsFormatted
@@ -26,6 +29,8 @@ import org.json.JSONObject
 import org.lightningdevkit.ldknode.*
 import java.io.File
 import kotlin.math.abs
+import kotlin.math.min
+import kotlin.math.pow
 import kotlin.math.roundToLong
 
 enum class Phase {
@@ -55,6 +60,7 @@ class AppState(private val context: Context) : ViewModel() {
         private set
     var tradeService: TradeService? = null
         private set
+    private val mempoolWebSocketService: MempoolWebSocketClient = MempoolWebSocketService()
 
     private val _phase = MutableStateFlow(Phase.LOADING)
     val phase: StateFlow<Phase> = _phase
@@ -106,6 +112,7 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _lastReceiveTxid = MutableStateFlow<String?>(null)
     val lastReceiveTxid: StateFlow<String?> get() = _lastReceiveTxid
+    private var lastReceiveTxidAddress: String? = null
 
     private val _lastCloseTxid = MutableStateFlow<String?>(null)
     val lastCloseTxid: StateFlow<String?> get() = _lastCloseTxid
@@ -119,6 +126,25 @@ class AppState(private val context: Context) : ViewModel() {
         } else {
             editor.remove("last_close_txid")
             editor.remove("last_close_txid_at")
+        }
+        editor.apply()
+    }
+
+    private fun setLastReceiveTxid(txid: String?, address: String?) {
+        _lastReceiveTxid.value = txid
+        lastReceiveTxidAddress = address
+
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        if (txid.isNullOrBlank()) {
+            editor.remove("last_receive_txid")
+            editor.remove("last_receive_txid_address")
+        } else {
+            editor.putString("last_receive_txid", txid)
+            if (!address.isNullOrBlank()) {
+                editor.putString("last_receive_txid_address", address)
+            } else {
+                editor.remove("last_receive_txid_address")
+            }
         }
         editor.apply()
     }
@@ -142,6 +168,7 @@ class AppState(private val context: Context) : ViewModel() {
                 _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
         _onchainReceiveAddress.value = prefs.getString("onchain_receive_address", null)
         _lastReceiveTxid.value = prefs.getString("last_receive_txid", null)
+        lastReceiveTxidAddress = prefs.getString("last_receive_txid_address", null)
 
         val closeAt = prefs.getLong("last_close_txid_at", 0L)
         if (System.currentTimeMillis() - closeAt < 7 * 86400 * 1000L) {
@@ -164,6 +191,29 @@ class AppState(private val context: Context) : ViewModel() {
                 userChannelId = cachedUserChannelId,
                 expectedUSD = USD(cachedExpectedUsd.toDouble())
             )
+        }
+
+        configureMempoolWebSocket()
+    }
+
+    private fun configureMempoolWebSocket() {
+        mempoolWebSocketService.onBlockHeader = {
+            viewModelScope.launch(Dispatchers.IO) {
+                refreshBalances()
+                pollPaymentConfirmations(force = true)
+            }
+        }
+        mempoolWebSocketService.onTransactionDetected = { event ->
+            viewModelScope.launch(Dispatchers.IO) {
+                handleWebSocketTransactionDetected(event)
+            }
+        }
+    }
+
+    private fun connectMempoolWebSocket() {
+        mempoolWebSocketService.connect()
+        _onchainReceiveAddress.value?.takeIf { it.isNotBlank() }?.let {
+            mempoolWebSocketService.trackAddress(it)
         }
     }
 
@@ -189,6 +239,7 @@ class AppState(private val context: Context) : ViewModel() {
             }
         }
     var pendingClosePaymentId: String? = null
+    private var trackedClosingFundingTxid: String? = null
     var spliceTxid: String? = null
     var fundingTxid: String? = null
         set(value) {
@@ -199,6 +250,9 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _paymentFlash = MutableStateFlow(false)
     val paymentFlash: StateFlow<Boolean> = _paymentFlash
+
+    private val _confirmationUpdateEpoch = MutableStateFlow(0)
+    val confirmationUpdateEpoch: StateFlow<Int> = _confirmationUpdateEpoch
 
 
     private val _isSpliceInFlight = MutableStateFlow(false)
@@ -217,8 +271,13 @@ class AppState(private val context: Context) : ViewModel() {
     private var pendingDepositJob: Job? = null
     private var channelCloseJob: Job? = null
     private var nodeStartRetryJob: Job? = null
+    private var nodeStartRetryAttempts: Int = 0
     private var spliceConfirmationJob: Job? = null
     private var monitoredSpliceTxid: String? = null
+    @Volatile
+    private var isConfirmationPolling = false
+    @Volatile
+    private var lastConfirmationPollAtMs = 0L
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
     var chainUrl: String = Constants.PRIMARY_CHAIN_URL
         private set
@@ -285,11 +344,14 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                     loadChannelFromDB()  // reload — SPS may have incremented backingSats while we waited
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    resetNodeStartRetryState()
                     nodeStartRetryJob?.cancel()
                     nodeStartRetryJob = null
                     _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
+                    pollPaymentConfirmations(force = true)
+                    connectMempoolWebSocket()
                     // Restore fundingTxid
                     fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
                         .getString("funding_txid", null)
@@ -307,11 +369,15 @@ class AppState(private val context: Context) : ViewModel() {
                                 // Resume background resolver if it hasn't found the TX yet
                                 val closeFundingTxid = fundingTxid
                                 if (closeFundingTxid != null && databaseService != null) {
+                                    trackedClosingFundingTxid = closeFundingTxid
+                                    mempoolWebSocketService.trackTx(closeFundingTxid)
                                     val resolver = CloseTxidResolver(
                                         chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
                                         onResolved = { _, txid ->
                                             Log.d("AppState", "Close TX resolved on restart: $txid")
                                             setLastCloseTxid(txid)
+                                            mempoolWebSocketService.untrackTx(closeFundingTxid)
+                                            trackedClosingFundingTxid = null
                                         }
                                     )
                                     viewModelScope.launch(Dispatchers.IO) {
@@ -345,8 +411,11 @@ class AppState(private val context: Context) : ViewModel() {
                     // New wallet — auto-create
                     _phase.value = Phase.SYNCING
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    resetNodeStartRetryState()
                     _phase.value = Phase.WALLET
                     refreshBalances()
+                    pollPaymentConfirmations(force = true)
+                    connectMempoolWebSocket()
                     reregisterPushTokenIfNeeded()
                     startStabilityTimer()
                     viewModelScope.launch(Dispatchers.IO) {
@@ -355,8 +424,7 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                 }
             } catch (e: Exception) {
-                _errorMessage.value = e.message ?: "Unknown error"
-                _phase.value = Phase.ERROR
+                handleNodeStartFailure(e, "Unknown error")
             }
         }
     }
@@ -366,13 +434,15 @@ class AppState(private val context: Context) : ViewModel() {
             try {
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, mnemonic)
+                resetNodeStartRetryState()
                 _phase.value = Phase.WALLET
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 reregisterPushTokenIfNeeded()
                 startStabilityTimer()
             } catch (e: Exception) {
-                _errorMessage.value = e.message ?: "Failed to create wallet"
-                _phase.value = Phase.ERROR
+                handleNodeStartFailure(e, "Failed to create wallet")
             }
         }
     }
@@ -388,6 +458,7 @@ class AppState(private val context: Context) : ViewModel() {
         spliceConfirmationJob = null
         monitoredSpliceTxid = null
         priceService.stopAutoRefresh()
+        mempoolWebSocketService.disconnect()
         nodeService.stop()
     }
 
@@ -483,6 +554,7 @@ class AppState(private val context: Context) : ViewModel() {
         spliceConfirmationJob?.cancel()
         spliceConfirmationJob = null
         monitoredSpliceTxid = null
+        mempoolWebSocketService.disconnect()
         if (!nodeService.isRunning) return
         Log.d("AppState", "Stopping node for background")
         nodeService.stop()
@@ -502,6 +574,8 @@ class AppState(private val context: Context) : ViewModel() {
                 loadChannelFromDB()
                 ensureLSPConnected()
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 updateStableBalances()
                 resumePendingSpliceConfirmation()
                 return@launch
@@ -515,10 +589,13 @@ class AppState(private val context: Context) : ViewModel() {
                 loadChannelFromDB()
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, null)
+                resetNodeStartRetryState()
                 nodeStartRetryJob?.cancel()
                 nodeStartRetryJob = null
                 _phase.value = Phase.WALLET
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 updateStableBalances()
                 val sc = StabilityService.reconcileIncoming(_stableChannel.value)
                 _stableChannel.value = sc
@@ -528,10 +605,46 @@ class AppState(private val context: Context) : ViewModel() {
                 startStabilityTimer()
             } catch (e: Exception) {
                 Log.e("AppState", "Node restart failed", e)
-                _phase.value = Phase.ERROR
-                _errorMessage.value = e.message ?: "Restart failed"
+                handleNodeStartFailure(e, "Restart failed")
             }
         }
+    }
+
+    private fun handleNodeStartFailure(e: Exception, fallbackMessage: String) {
+        if (isRetryableNodeStartFailure(e)) {
+            _phase.value = Phase.SYNCING
+            _errorMessage.value = ""
+            _statusMessage.value = "Network unstable. Retrying wallet sync..."
+            scheduleNodeStartRetry()
+            return
+        }
+
+        _errorMessage.value = e.message ?: fallbackMessage
+        _phase.value = Phase.ERROR
+    }
+
+    // Matched by exception type (not message text) since LDK's Display strings aren't a stable
+    // contract across ldk-node versions — only these variants indicate a transient chain-source
+    // issue that a retry can plausibly fix.
+    private fun isRetryableNodeStartFailure(e: Exception): Boolean {
+        if (e is NodeException) {
+            return e is NodeException.FeerateEstimationUpdateFailed ||
+                e is NodeException.FeerateEstimationUpdateTimeout ||
+                e is NodeException.TxSyncFailed ||
+                e is NodeException.TxSyncTimeout ||
+                e is NodeException.GossipUpdateFailed ||
+                e is NodeException.GossipUpdateTimeout ||
+                e is NodeException.WalletOperationFailed ||
+                e is NodeException.WalletOperationTimeout ||
+                e is NodeException.LiquiditySourceUnavailable ||
+                e is NodeException.ConnectionFailed
+        }
+        val msg = e.message?.lowercase() ?: return false
+        return msg.contains("fee rate estimates") ||
+            msg.contains("timed out") ||
+            msg.contains("network is unreachable") ||
+            msg.contains("dns") ||
+            msg.contains("connection refused")
     }
 
     /**
@@ -1239,6 +1352,8 @@ class AppState(private val context: Context) : ViewModel() {
                 ?: context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
                     .getString("closing_funding_txid", null)
             if (closeFundingTxid != null && databaseService != null) {
+                trackedClosingFundingTxid = closeFundingTxid
+                mempoolWebSocketService.trackTx(closeFundingTxid)
                 // Clear the pref now that we've consumed it
                 context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
                     .edit().remove("closing_funding_txid").apply()
@@ -1247,6 +1362,8 @@ class AppState(private val context: Context) : ViewModel() {
                     onResolved = { _, txid ->
                         Log.d("AppState", "Close TX resolved: $txid")
                         setLastCloseTxid(txid)
+                        mempoolWebSocketService.untrackTx(closeFundingTxid)
+                        trackedClosingFundingTxid = null
                     }
                 )
                 viewModelScope.launch(Dispatchers.IO) {
@@ -1292,7 +1409,178 @@ class AppState(private val context: Context) : ViewModel() {
                 recordCurrentPrice()
                 runStabilityCheck()
                 detectOnchainDeposit()
+                pollPaymentConfirmations()
             }
+        }
+    }
+
+    fun triggerConfirmationRefresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            pollPaymentConfirmations(force = true)
+        }
+    }
+
+    private fun requiredConfirmationsForType(paymentType: String): Int {
+        return when (paymentType) {
+            "splice_in", "splice_out" -> 1
+            else -> 6
+        }
+    }
+
+    private data class TxConfirmationStatus(
+        val confirmed: Boolean,
+        val blockHeight: Int?
+    )
+
+    private fun fetchChainTipHeight(): Int? {
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/blocks/tip/height")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string()?.trim() ?: return@use
+                    body.toIntOrNull()?.let { return it }
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private fun fetchTxConfirmationStatus(txid: String): TxConfirmationStatus? {
+        val normalizedTxid = txid.substringBefore(":").trim()
+        if (normalizedTxid.isEmpty()) return null
+
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val json = JSONObject(body)
+                    val confirmed = json.optBoolean("confirmed", false)
+                    val blockHeight = if (json.has("block_height") && !json.isNull("block_height")) {
+                        json.optInt("block_height", 0).takeIf { it > 0 }
+                    } else {
+                        null
+                    }
+                    return TxConfirmationStatus(confirmed = confirmed, blockHeight = blockHeight)
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private fun fetchTxPaysToAddress(txid: String, address: String): Boolean? {
+        val normalizedTxid = txid.substringBefore(":").trim()
+        if (normalizedTxid.isEmpty() || address.isBlank()) return null
+
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val txJson = JSONObject(body)
+                    val vouts = txJson.optJSONArray("vout") ?: return@use
+                    for (i in 0 until vouts.length()) {
+                        val vout = vouts.optJSONObject(i) ?: continue
+                        if (vout.optString("scriptpubkey_address", "") == address) {
+                            return true
+                        }
+                    }
+                    return false
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private suspend fun pollPaymentConfirmations(force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && (now - lastConfirmationPollAtMs) < 15_000) {
+            return
+        }
+        if (isConfirmationPolling) {
+            return
+        }
+
+        val db = databaseService ?: return
+        isConfirmationPolling = true
+        try {
+            val tipHeight = fetchChainTipHeight() ?: return
+            val pending = db.getPaymentsNeedingConfirmation(limit = 100)
+            var anyUpdated = false
+
+            pending.forEach { payment ->
+                val txid = payment.txid ?: return@forEach
+
+                if (payment.paymentType == "onchain" && payment.direction == "received") {
+                    val expectedAddress = payment.address?.trim().orEmpty()
+                    if (expectedAddress.isNotEmpty()) {
+                        when (fetchTxPaysToAddress(txid, expectedAddress)) {
+                            false -> {
+                                val cleared = db.clearPaymentTxidForRow(payment.id)
+                                anyUpdated = anyUpdated || cleared
+                                if (_lastReceiveTxid.value == txid) {
+                                    setLastReceiveTxid(null, null)
+                                }
+                                AuditService.log("ONCHAIN_TXID_ADDRESS_MISMATCH", mapOf(
+                                    "payment_id" to payment.id,
+                                    "txid" to txid,
+                                    "address" to expectedAddress
+                                ))
+                                return@forEach
+                            }
+                            null -> return@forEach
+                            true -> {
+                            }
+                        }
+                    }
+                }
+
+                val txStatus = fetchTxConfirmationStatus(txid) ?: return@forEach
+                val required = requiredConfirmationsForType(payment.paymentType)
+
+                val (newConfirmations, newStatus) = if (!txStatus.confirmed) {
+                    0 to "pending"
+                } else {
+                    val blockHeight = txStatus.blockHeight
+                    val confs = if (blockHeight != null) {
+                        (tipHeight - blockHeight + 1).coerceAtLeast(0).coerceAtMost(required)
+                    } else {
+                        payment.confirmations.coerceAtLeast(1).coerceAtMost(required)
+                    }
+                    confs to if (confs >= required) "completed" else "pending"
+                }
+
+                if (payment.confirmations != newConfirmations || payment.status != newStatus) {
+                    val updated = db.updatePaymentConfirmationState(
+                        paymentRowId = payment.id,
+                        confirmations = newConfirmations,
+                        status = newStatus
+                    )
+                    anyUpdated = anyUpdated || updated
+                }
+            }
+
+            if (anyUpdated) {
+                _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
+            }
+            lastConfirmationPollAtMs = now
+        } finally {
+            isConfirmationPolling = false
         }
     }
 
@@ -1401,6 +1689,12 @@ class AppState(private val context: Context) : ViewModel() {
         }
     }
 
+    private fun clearOnchainDepositStatusIfNeeded() {
+        if (_statusMessage.value.startsWith("Onchain deposit detected", ignoreCase = true)) {
+            _statusMessage.value = ""
+        }
+    }
+
     private fun reconcilePendingOutgoingStabilityPayment(): Boolean {
         val db = databaseService ?: return false
         val pending = try { db.loadPendingSend() } catch (_: Exception) { return false } ?: return true
@@ -1493,6 +1787,7 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     internal fun detectOnchainDeposit() {
+        val db = databaseService
         // Use already-updated value — refreshBalances() was just called before this
         val currentSats = _onchainBalanceSats.value
         if (currentSats > prevOnchainSats && !isSweeping && pendingSplice == null) {
@@ -1505,24 +1800,54 @@ class AppState(private val context: Context) : ViewModel() {
 
             // Check for pending channel close (in-memory or DB) to avoid duplicate entries
             val closeId = pendingClosePaymentId
-                ?: databaseService?.getPendingChannelClosePaymentId()
+                ?: db?.getPendingChannelClosePaymentId()
             if (closeId != null) {
-                databaseService?.updatePaymentStatus(closeId, "completed")
+                val knownCloseTxid = db?.getPaymentTxid(closeId) ?: _lastCloseTxid.value
+                if (!knownCloseTxid.isNullOrBlank()) {
+                    db?.updatePaymentTxid(closeId, knownCloseTxid)
+                }
+                db?.updatePaymentStatus(closeId, "completed")
                 pendingClosePaymentId = null
+                trackedClosingFundingTxid?.let { mempoolWebSocketService.untrackTx(it) }
+                trackedClosingFundingTxid = null
                 isChannelClosing = false
                 AuditService.log("CHANNEL_CLOSE_CONFIRMED", mapOf("sats" to depositSats))
             } else {
+                val receiveAddress = _onchainReceiveAddress.value
+                val resolvedTxid = _lastReceiveTxid.value?.takeIf {
+                    !it.isNullOrBlank() &&
+                        !receiveAddress.isNullOrBlank() &&
+                        lastReceiveTxidAddress == receiveAddress
+                }
                 // No pending close — record as new on-chain deposit
-                val dedupId = "${System.currentTimeMillis() / 1000}_$depositSats"
-                databaseService?.recordPayment(
-                    paymentId = dedupId, paymentType = "onchain", direction = "received",
+                val dedupId = if (!resolvedTxid.isNullOrBlank()) {
+                    "onchain_receive_$resolvedTxid"
+                } else {
+                    "${System.currentTimeMillis() / 1000}_$depositSats"
+                }
+                val rowId = db?.recordPayment(
+                    paymentId = dedupId,
+                    paymentType = "onchain",
+                    direction = "received",
                     amountMsat = depositSats * 1000,
                     amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                    btcPrice = price
+                    btcPrice = price,
+                    status = "pending",
+                    txid = resolvedTxid,
+                    address = receiveAddress
                 )
-                AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf("sats" to depositSats))
+
+                if (rowId != null && rowId != -1L) {
+                    triggerPaymentFlash()
+                    AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
+                        "sats" to depositSats,
+                        "status" to "pending",
+                        "txid_known" to (!resolvedTxid.isNullOrBlank())
+                    ))
+                }
             }
-            // Start faster polling until deposit confirms
+            // Home card now carries pending receive state; remove stale capsule text.
+            clearOnchainDepositStatusIfNeeded()
             startPendingDepositPolling()
         }
         prevOnchainSats = currentSats
@@ -1534,15 +1859,16 @@ class AppState(private val context: Context) : ViewModel() {
         pendingDepositJob = viewModelScope.launch(Dispatchers.IO) {
             // Attempt to resolve txid if we have an address but no txid yet (handles app restarts)
             val address = _onchainReceiveAddress.value
-            if (address != null && _lastReceiveTxid.value == null) {
+            val shouldResolveTxid = address != null &&
+                (_lastReceiveTxid.value == null || lastReceiveTxidAddress != address)
+            if (shouldResolveTxid) {
                 // Run txid resolution in the background so it doesn't block the polling loop
                 launch {
                     val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
                     val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
                     if (txid != null) {
-                        _lastReceiveTxid.value = txid
-                        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                            .putString("last_receive_txid", txid).apply()
+                        setLastReceiveTxid(txid, address)
+                        databaseService?.attachTxidToLatestOnchainReceive(txid)
                     }
                 }
             }
@@ -1554,12 +1880,8 @@ class AppState(private val context: Context) : ViewModel() {
             
             // Deposit confirmed — aggressively clear stale txid and address from state and cache
             if (isActive && _spendableOnchainSats.value > 0L) {
-                _lastReceiveTxid.value = null
-                _onchainReceiveAddress.value = null
-                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                    .remove("last_receive_txid")
-                    .remove("onchain_receive_address")
-                    .apply()
+                setLastReceiveTxid(null, null)
+                setOnchainReceiveAddress(null)
             }
         }
     }
@@ -1697,19 +2019,137 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     fun setOnchainReceiveAddress(address: String?) {
-        if (address == null) return
+        val oldAddress = _onchainReceiveAddress.value
         _onchainReceiveAddress.value = address
-        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-            .putString("onchain_receive_address", address).apply()
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        if (address == null) {
+            editor.remove("onchain_receive_address")
+        } else {
+            editor.putString("onchain_receive_address", address)
+        }
+        editor.apply()
+
+        if (!oldAddress.isNullOrBlank() && oldAddress != address) {
+            mempoolWebSocketService.untrackAddress(oldAddress)
+        }
+
+        if (!address.isNullOrBlank() && oldAddress != address) {
+            // New receive request: drop stale txid from previous address/session.
+            setLastReceiveTxid(null, null)
+        }
+
+        if (address == null) {
+            return
+        }
+
+        mempoolWebSocketService.trackAddress(address)
         
         // Start polling for this address to be hit
         viewModelScope.launch {
             val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
             val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
             if (txid != null) {
-                _lastReceiveTxid.value = txid
-                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                    .putString("last_receive_txid", txid).apply()
+                setLastReceiveTxid(txid, address)
+                databaseService?.attachTxidToLatestOnchainReceive(txid)
+            }
+        }
+    }
+
+    fun prepareChannelCloseTracking(userChannelId: String) {
+        setLastCloseTxid(null)
+        val liveTxid = nodeService.channels
+            .firstOrNull { it.userChannelId == userChannelId || it.isChannelReady }
+            ?.fundingTxo?.txid
+
+        if (!liveTxid.isNullOrBlank()) {
+            fundingTxid = liveTxid
+            trackedClosingFundingTxid = liveTxid
+            mempoolWebSocketService.trackTx(liveTxid)
+            context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+                .edit().putString("closing_funding_txid", liveTxid).apply()
+        }
+    }
+
+    private fun handleWebSocketTransactionDetected(event: WebSocketEvent) {
+        val db = databaseService ?: return
+
+        when (event) {
+            is WebSocketEvent.Receive -> {
+                if (isChannelClosing || isSweeping || pendingSplice != null) {
+                    return
+                }
+                if (event.amountSats < 1000) {
+                    return
+                }
+
+                val price = priceService.currentPrice.value
+                val amountUsd = if (price > 0) {
+                    (event.amountSats.toDouble() / Constants.SATS_IN_BTC) * price
+                } else {
+                    null
+                }
+
+                val paymentId = "onchain_receive_${event.txid}"
+                val rowId = db.recordPayment(
+                    paymentId = paymentId,
+                    paymentType = "onchain",
+                    direction = "received",
+                    amountMsat = event.amountSats * 1000,
+                    amountUSD = amountUsd,
+                    btcPrice = price.takeIf { it > 0 },
+                    status = "pending",
+                    txid = event.txid,
+                    address = event.target
+                )
+
+                if (rowId != -1L) {
+                    setLastReceiveTxid(event.txid, event.target)
+                    clearOnchainDepositStatusIfNeeded()
+                    triggerPaymentFlash()
+                    AuditService.log(
+                        "WEBSOCKET_INSTANT_PAYMENT_RECORDED",
+                        mapOf("txid" to event.txid, "sats" to event.amountSats)
+                    )
+                }
+            }
+
+            is WebSocketEvent.Removed -> {
+                try {
+                    db.failPaymentByTxid(event.txid)
+                    AuditService.log(
+                        "WEBSOCKET_RBF_FAILED_PAYMENT",
+                        mapOf("target" to event.target, "txid" to event.txid)
+                    )
+                } catch (e: Exception) {
+                    AuditService.log(
+                        "WEBSOCKET_RBF_FAIL_FAILED",
+                        mapOf("txid" to event.txid, "error" to (e.message ?: ""))
+                    )
+                }
+            }
+
+            is WebSocketEvent.TrackedOutspend -> {
+                if (!isChannelClosing) {
+                    return
+                }
+
+                val expectedFundingTxid = trackedClosingFundingTxid
+                    ?: fundingTxid
+                    ?: context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+                        .getString("closing_funding_txid", null)
+
+                if (!expectedFundingTxid.isNullOrBlank() && expectedFundingTxid != event.trackedTxid) {
+                    return
+                }
+
+                val closeId = pendingClosePaymentId ?: db.getPendingChannelClosePaymentId()
+                if (!closeId.isNullOrBlank()) {
+                    db.updatePaymentTxid(closeId, event.spendingTxid)
+                    setLastCloseTxid(event.spendingTxid)
+                }
+
+                mempoolWebSocketService.untrackTx(event.trackedTxid)
+                trackedClosingFundingTxid = null
             }
         }
     }
@@ -1728,7 +2168,7 @@ class AppState(private val context: Context) : ViewModel() {
             val txo = channel.fundingTxo
             if (txo != null) {
                 val currentTxid = txo.txid
-                if (currentTxid != null && currentTxid != fundingTxid) {
+                if (currentTxid != fundingTxid) {
                     fundingTxid = currentTxid
                 }
             }
@@ -1898,15 +2338,25 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun scheduleNodeStartRetry() {
         if (nodeStartRetryJob?.isActive == true) return
+        val delayMs = min((2.0.pow(nodeStartRetryAttempts.toDouble()) * 1000.0).toLong(), 60_000L)
+        nodeStartRetryAttempts = min(nodeStartRetryAttempts + 1, 6)
         nodeStartRetryJob = viewModelScope.launch(Dispatchers.IO) {
+            delay(delayMs)
             while (isActive && backgroundServiceOwnsLdk()) {
                 delay(1_000)
             }
             if (!isActive || nodeService.isRunning) return@launch
-            Log.d("AppState", "Retrying node start after LDK owner released")
+            // Re-check primary/fallback health so a retry doesn't keep hammering the same
+            // degraded esplora endpoint that just failed the fee-rate/chain-sync fetch.
+            chainUrl = resolveChainUrl()
+            Log.d("AppState", "Retrying node start after LDK owner released (chainUrl=$chainUrl)")
             _statusMessage.value = "Syncing wallet..."
             restartNodeFromForeground()
         }
+    }
+
+    private fun resetNodeStartRetryState() {
+        nodeStartRetryAttempts = 0
     }
 
     private fun reregisterPushTokenIfNeeded() {

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -483,6 +483,95 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    fun latestPendingOnchainReceive(): PaymentRecord? {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, created_at, fee_msat, txid, address, confirmations
+            FROM payments
+            WHERE payment_type = 'onchain'
+              AND direction = 'received'
+              AND status = 'pending'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """.trimIndent(),
+            null
+        )
+        return cursor.use { c ->
+            if (!c.moveToFirst()) return@use null
+            PaymentRecord(
+                id = c.getLong(0), paymentId = c.getStringOrNull(1),
+                paymentType = c.getString(2), direction = c.getString(3),
+                amountMsat = c.getLong(4), amountUSD = c.getDoubleOrNull(5),
+                btcPrice = c.getDoubleOrNull(6), counterparty = c.getStringOrNull(7),
+                status = c.getString(8), createdAt = c.getLong(9),
+                feeMsat = c.getLong(10), txid = c.getStringOrNull(11),
+                address = c.getStringOrNull(12), confirmations = c.getInt(13)
+            )
+        }
+    }
+
+    fun getPaymentsNeedingConfirmation(limit: Int = 50): List<PaymentRecord> {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, created_at, fee_msat, txid, address, confirmations
+            FROM payments
+            WHERE txid IS NOT NULL AND txid != ''
+              AND payment_type IN ('onchain', 'channel_close', 'splice_in', 'splice_out')
+              AND status != 'failed'
+              AND (
+                    (payment_type IN ('onchain', 'channel_close') AND confirmations < 6)
+                    OR
+                    (payment_type IN ('splice_in', 'splice_out') AND confirmations < 1)
+                  )
+            ORDER BY created_at DESC
+            LIMIT ?
+            """.trimIndent(),
+            arrayOf(limit.toString())
+        )
+        return cursor.use { c ->
+            val list = mutableListOf<PaymentRecord>()
+            while (c.moveToNext()) {
+                list.add(PaymentRecord(
+                    id = c.getLong(0), paymentId = c.getStringOrNull(1),
+                    paymentType = c.getString(2), direction = c.getString(3),
+                    amountMsat = c.getLong(4), amountUSD = c.getDoubleOrNull(5),
+                    btcPrice = c.getDoubleOrNull(6), counterparty = c.getStringOrNull(7),
+                    status = c.getString(8), createdAt = c.getLong(9),
+                    feeMsat = c.getLong(10), txid = c.getStringOrNull(11),
+                    address = c.getStringOrNull(12), confirmations = c.getInt(13)
+                ))
+            }
+            list
+        }
+    }
+
+    fun updatePaymentConfirmationState(paymentRowId: Long, confirmations: Int, status: String): Boolean {
+        val cv = ContentValues().apply {
+            put("confirmations", confirmations)
+            put("status", status)
+        }
+        return writableDatabase.update(
+            "payments",
+            cv,
+            "id = ?",
+            arrayOf(paymentRowId.toString())
+        ) > 0
+    }
+
+    fun clearPaymentTxidForRow(paymentRowId: Long): Boolean {
+        val cv = ContentValues().apply {
+            putNull("txid")
+            put("confirmations", 0)
+            put("status", "pending")
+        }
+        return writableDatabase.update(
+            "payments",
+            cv,
+            "id = ?",
+            arrayOf(paymentRowId.toString())
+        ) > 0
+    }
+
     fun updatePaymentStatus(paymentId: String, status: String, feeMsat: Long = 0) {
         val cv = ContentValues().apply {
             put("status", status)
@@ -504,6 +593,41 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             put("txid", txid)
         }
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
+    }
+
+    fun attachTxidToLatestOnchainReceive(txid: String): Boolean {
+        val stmt = writableDatabase.compileStatement(
+            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND (txid IS NULL OR txid = '') ORDER BY created_at DESC LIMIT 1)"
+        )
+        stmt.bindString(1, txid)
+        return stmt.executeUpdateDelete() > 0
+    }
+
+    fun paymentExists(txid: String, excludePaymentId: String): Boolean {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT 1 FROM payments WHERE txid = ? AND payment_id != ? LIMIT 1",
+            arrayOf(txid, excludePaymentId)
+        )
+        return cursor.use { it.moveToFirst() }
+    }
+
+    fun deletePayment(paymentId: String) {
+        writableDatabase.delete("payments", "payment_id = ?", arrayOf(paymentId))
+    }
+
+    fun failPaymentByTxid(txid: String) {
+        writableDatabase.execSQL(
+            "UPDATE payments SET status = 'failed' WHERE txid = ? AND status = 'pending'",
+            arrayOf(txid)
+        )
+    }
+
+    fun completePaymentByTxid(txid: String): Boolean {
+        val stmt = writableDatabase.compileStatement(
+            "UPDATE payments SET status = 'completed' WHERE txid = ? AND status = 'pending'"
+        )
+        stmt.bindString(1, txid)
+        return stmt.executeUpdateDelete() > 0
     }
 
     fun getPendingChannelClosePaymentId(): String? {

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -32,6 +32,9 @@ import com.stablechannels.app.util.relativeString
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 
+private const val REQUIRED_CONFIRMATIONS = 6
+private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
@@ -41,13 +44,30 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
     var selectedTrade by remember { mutableStateOf<TradeRecord?>(null) }
     var selectedPayment by remember { mutableStateOf<PaymentRecord?>(null) }
     val currentPrice by appState.priceService.currentPrice.collectAsState()
+    val confirmationUpdateEpoch by appState.confirmationUpdateEpoch.collectAsState()
+    val isFlashing by appState.paymentFlash.collectAsState()
 
     fun loadHistory() {
         trades = appState.databaseService?.getRecentTrades() ?: emptyList()
         payments = appState.databaseService?.getRecentPayments() ?: emptyList()
+        selectedTrade = selectedTrade?.let { selected ->
+            trades.firstOrNull { it.id == selected.id } ?: selected
+        }
+        selectedPayment = selectedPayment?.let { selected ->
+            payments.firstOrNull { it.id == selected.id } ?: selected
+        }
     }
 
-    LaunchedEffect(Unit) { loadHistory() }
+    LaunchedEffect(Unit) {
+        loadHistory()
+        appState.triggerConfirmationRefresh()
+    }
+    LaunchedEffect(confirmationUpdateEpoch) { loadHistory() }
+    LaunchedEffect(isFlashing) {
+        if (isFlashing) {
+            loadHistory()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -283,25 +303,68 @@ private fun PaymentRow(payment: PaymentRecord, currentPrice: Double, onClick: ()
                 fontWeight = FontWeight.Medium,
                 color = if (isIncoming) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurface
             )
-            StatusBadge(payment.status)
+            val statusLabel = payment.historyStatusLabel()
+            val statusColor = payment.historyStatusColor()
+            StatusBadge(statusLabel, statusColor)
         }
     }
 }
 
 @Composable
-private fun StatusBadge(status: String) {
-    val color = when (status) {
+private fun StatusBadge(status: String, color: Color? = null) {
+    val resolvedColor = color ?: when (status.lowercase()) {
         "completed" -> Color(0xFF10B981)
         "pending" -> Color(0xFFF59E0B)
         "failed" -> Color(0xFFEF4444)
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     Text(
-        text = status.replaceFirstChar { it.uppercase() },
+        text = status,
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Medium,
-        color = color
+        color = resolvedColor
     )
+}
+
+private fun PaymentRecord.shouldShowConfirmationProgress(): Boolean {
+    val onchainTypes = setOf("onchain", "channel_close", "splice_in", "splice_out")
+    val hasProgressSignal = status == "pending" || confirmations > 0
+    return paymentType in onchainTypes && hasProgressSignal
+}
+
+private fun PaymentRecord.historyStatusLabel(): String {
+    if (!shouldShowConfirmationProgress()) {
+        return status.replaceFirstChar { it.uppercase() }
+    }
+    val required = requiredConfirmationsForDisplay()
+    return if (confirmations >= required) {
+        "Confirmed"
+    } else {
+        "${confirmations}/${required} confirmed"
+    }
+}
+
+private fun PaymentRecord.historyStatusColor(): Color {
+    if (!shouldShowConfirmationProgress()) {
+        return when (status) {
+            "completed" -> Color(0xFF10B981)
+            "pending" -> Color(0xFFF59E0B)
+            "failed" -> Color(0xFFEF4444)
+            else -> Color(0xFF6B7280)
+        }
+    }
+    return when {
+        confirmations >= requiredConfirmationsForDisplay() -> Color(0xFF10B981)
+        confirmations > 0 -> Color(0xFF3B82F6)
+        else -> Color(0xFFF59E0B)
+    }
+}
+
+private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
+    return when (paymentType) {
+        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
+        else -> REQUIRED_CONFIRMATIONS
+    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -19,6 +19,10 @@ import androidx.compose.ui.platform.LocalContext
 import android.content.Intent
 import android.net.Uri
 
+private const val REQUIRED_CONFIRMATIONS = 6
+private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
+private val TXID_REGEX = Regex("^[0-9a-fA-F]{64}$")
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0, onDismiss: () -> Unit) {
@@ -111,7 +115,7 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                     }
                     
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                    DetailRow("Status", payment.status.replaceFirstChar { it.uppercase() })
+                    DetailRow("Status", payment.detailStatusLabel())
                     
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("Date", payment.date.shortString())
@@ -122,7 +126,7 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                         CopyableDetailRow("Payment ID", displayPid, pid)
                     }
                     
-                    payment.txid?.let { txid ->
+                    payment.explorerTxid()?.let { txid ->
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         val displayTxid = if (txid.length > 16) txid.take(8) + "..." + txid.takeLast(8) else txid
                         CopyableDetailRow("TXID", displayTxid, txid)
@@ -148,9 +152,15 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                         CopyableDetailRow("Address", displayAddr, addr)
                     }
                     
-                    if (payment.confirmations > 0) {
+                    if (payment.shouldShowConfirmationProgress() || payment.confirmations > 0) {
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                        DetailRow("Confirmations", payment.confirmations.toString())
+                        val required = payment.requiredConfirmationsForDisplay()
+                        val confirmationsLabel = if (payment.confirmations >= required) {
+                            "${payment.confirmations} (confirmed)"
+                        } else {
+                            "${payment.confirmations}/${required}"
+                        }
+                        DetailRow("Confirmations", confirmationsLabel)
                     }
                 }
             }
@@ -167,4 +177,47 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
             }
         }
     }
+}
+
+private fun PaymentRecord.shouldShowConfirmationProgress(): Boolean {
+    val onchainTypes = setOf("onchain", "channel_close", "splice_in", "splice_out")
+    val hasProgressSignal = status == "pending" || confirmations > 0
+    return paymentType in onchainTypes && hasProgressSignal
+}
+
+private fun PaymentRecord.detailStatusLabel(): String {
+    if (!shouldShowConfirmationProgress()) {
+        return status.replaceFirstChar { it.uppercase() }
+    }
+    val required = requiredConfirmationsForDisplay()
+    return if (confirmations >= required) {
+        "Confirmed"
+    } else {
+        "${confirmations}/${required} confirmed"
+    }
+}
+
+private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
+    return when (paymentType) {
+        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
+        else -> REQUIRED_CONFIRMATIONS
+    }
+}
+
+private fun PaymentRecord.explorerTxid(): String? {
+    val fromTxid = txid?.substringBefore(":")?.trim()
+    if (!fromTxid.isNullOrEmpty() && TXID_REGEX.matches(fromTxid)) {
+        return fromTxid
+    }
+
+    if (paymentType == "onchain") {
+        val fromPaymentId = paymentId
+            ?.removePrefix("onchain_receive_")
+            ?.trim()
+        if (!fromPaymentId.isNullOrEmpty() && TXID_REGEX.matches(fromPaymentId)) {
+            return fromPaymentId
+        }
+    }
+
+    return null
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -61,6 +61,7 @@ import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,6 +79,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
     val isSyncing by appState.isSyncing.collectAsState()
     val isFlashing by appState.paymentFlash.collectAsState()
+    val confirmationUpdateEpoch by appState.confirmationUpdateEpoch.collectAsState()
     val isChannelClosing by appState.isChannelClosingFlow.collectAsState()
 
     var showSend by remember { mutableStateOf(false) }
@@ -88,6 +90,13 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     var showSell by remember { mutableStateOf(false) }
     var prefillTradeAmount by remember { mutableDoubleStateOf(0.0) }
     var showBTC by remember { mutableStateOf(false) }
+    var latestPendingOnchainReceive by remember { mutableStateOf<PaymentRecord?>(null) }
+
+    LaunchedEffect(isFlashing, confirmationUpdateEpoch, onchainSats, spendableOnchainSats) {
+        latestPendingOnchainReceive = withContext(Dispatchers.IO) {
+            appState.databaseService?.latestPendingOnchainReceive()
+        }
+    }
 
     // Auto-dismiss receive sheet when payment arrives
     val scrollState = rememberScrollState()
@@ -336,6 +345,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
+                        val pendingReceiveTxid = latestPendingOnchainReceive?.txid
+                        val hasPendingOnchainReceive = latestPendingOnchainReceive != null
                         if (isSweeping) {
                             // 1. Splice-in in progress
                             Spacer(Modifier.height(4.dp))
@@ -364,19 +375,27 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                     Text("Move", fontSize = 13.sp)
                                 }
                             }
+                            if (hasPendingOnchainReceive) {
+                                Spacer(Modifier.height(6.dp))
+                                PendingRow("Receiving onchain...", pendingReceiveTxid, context)
+                            }
                         } else if (spendableOnchainSats == 0L) {
                             // 3. Unconfirmed deposit (with or without channel)
                             Spacer(Modifier.height(8.dp))
                             val pendingCloseId = appState.pendingClosePaymentId
                             // Prefer close txid if known — pendingClosePaymentId may already be
                             // cleared by detectOnchainDeposit even while funds are still unconfirmed
-                            val effectiveTxid = lastCloseTxid ?: lastRxTxid
+                            val effectiveTxid = if (lastCloseTxid != null) {
+                                lastCloseTxid
+                            } else {
+                                pendingReceiveTxid ?: lastRxTxid
+                            }
                             val isClosePending = pendingCloseId != null || lastCloseTxid != null
-                            // Use short text when txid is known (button fits on same row, matches iOS)
-                            // Use longer text when no txid yet (shown as two-line subtitle)
+                            // Use a receive-specific label when we have an explicit pending onchain row.
                             val text = when {
                                 isClosePending && effectiveTxid != null -> "Channel closing\u2026"
                                 isClosePending -> "Channel closed"
+                                hasPendingOnchainReceive -> "Receiving onchain..."
                                 else -> "Deposit confirming..."
                             }
                             PendingRow(text, effectiveTxid, context)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -171,6 +171,7 @@ fun ChannelView(appState: AppState) {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
                     appState.setStatus("Closing channel...")
+                    appState.prepareChannelCloseTracking(sc.userChannelId)
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -335,18 +335,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                 TextButton(onClick = {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
-                    appState.setLastCloseTxid(null) // Clear any previous close txid from cache
-                    // Snapshot the true fundingTxid NOW, while the channel still exists
-                    val liveTxid = appState.nodeService.channels
-                        .firstOrNull { it.userChannelId == sc.userChannelId || it.isChannelReady }
-                        ?.fundingTxo?.txid
-                    if (liveTxid != null) {
-                        appState.fundingTxid = liveTxid
-                        // Also persist to prefs so handleChannelClosed can recover it
-                        // even if the in-memory value is cleared by a race
-                        context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
-                            .edit().putString("closing_funding_txid", liveTxid).apply()
-                    }
+                    appState.prepareChannelCloseTracking(sc.userChannelId)
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)


### PR DESCRIPTION
## Summary
- harden onchain receive txid ownership by binding `last_receive_txid` to receive address and clearing stale values on address changes
- add confirmation polling updates for onchain/channel-close/splice rows and prevent mismatched txid/address rows from being falsely marked confirmed
- improve Home onchain UX so pending receives are visible in the onchain card even when "Move" is available
- remove noisy duplicate home status-capsule messaging for onchain receive detection
- align History and Payment Details confirmation display with type-specific targets (`onchain/channel_close=6`, `splice=1`)
- keep/expand explorer-link behavior in payment details for onchain-like payment types
- unify channel-close tracking bootstrap through `prepareChannelCloseTracking(...)`

## Files
- android/app/src/main/java/com/stablechannels/app/AppState.kt
- android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
- android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
- android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
- android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
- android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
- android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
- android/app/build.gradle.kts

## Validation
- manual device validation by QA/user across receive + history + details + explorer-link flows

## Notes
- local compile fails under JDK 25; this branch is validated with JDK 17 (project standard)
