### PR TITLE
derive stable-channel trade backing locally on both sides

### DIFF
--- a/server/lsp-server-gui/src/state.rs
+++ b/server/lsp-server-gui/src/state.rs
@@ -62,6 +62,7 @@ pub enum DisplayUnit {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SettlementKind {
 	Stability,
+	Trade,
 	Sync,
 }
 
@@ -70,6 +71,7 @@ impl SettlementKind {
 	pub fn parse(s: &str) -> Option<Self> {
 		match s {
 			"stability" => Some(Self::Stability),
+			"trade" => Some(Self::Trade),
 			"sync" => Some(Self::Sync),
 			_ => None,
 		}

--- a/server/lsp-server-gui/src/ui/payments.rs
+++ b/server/lsp-server-gui/src/ui/payments.rs
@@ -11,7 +11,7 @@ use crate::ui::widgets;
 
 const HELP_PAYMENT_ID: &str =
 	"The server-side identifier for this payment record. It is distinct from a payment hash or on-chain transaction id.";
-const HELP_PAYMENT_TYPE: &str = "The payment protocol or kind, such as on-chain, BOLT11, BOLT12 offer, BOLT12 refund, spontaneous, stability, or sync.";
+const HELP_PAYMENT_TYPE: &str = "The payment protocol or kind, such as on-chain, BOLT11, BOLT12 offer, BOLT12 refund, spontaneous, trade, stability, or sync.";
 const HELP_PAYMENT_AMOUNT: &str =
 	"The payment amount recorded for this payment. Any fee paid by this node is shown separately when known.";
 const HELP_PAYMENT_FEE: &str =
@@ -462,6 +462,7 @@ fn payment_type_label_str(
 ) -> String {
 	match settlement {
 		Some(crate::state::SettlementKind::Stability) => "Stability".to_string(),
+		Some(crate::state::SettlementKind::Trade) => "Trade".to_string(),
 		Some(crate::state::SettlementKind::Sync) => "Sync".to_string(),
 		None => type_label.to_string(),
 	}
@@ -830,7 +831,11 @@ mod tests {
             "Stability"
         );
         assert_eq!(
-            payment_type_label_str("Spontaneous", Some(SettlementKind::Sync)),
+            payment_type_label_str("Spontaneous", Some(SettlementKind::Trade)),
+            "Trade"
+        );
+		assert_eq!(
+			payment_type_label_str("Spontaneous", Some(SettlementKind::Sync)),
             "Sync"
         );
 	}

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -70,6 +70,22 @@ pub fn parse_envelope(raw: &str) -> Option<SignedEnvelope> {
     serde_json::from_str::<SignedEnvelope>(raw).ok()
 }
 
+/// Return true when a signed envelope declares an inner `TRADE_V1` message.
+///
+/// This only classifies the payment carrier. The trade handler still parses the complete
+/// payload and verifies its signature and channel binding before applying anything.
+pub fn is_trade_v1(envelope: &SignedEnvelope) -> bool {
+    serde_json::from_str::<serde_json::Value>(&envelope.payload)
+        .ok()
+        .and_then(|payload| {
+            payload
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .map(|kind| kind == stable_channels::constants::TRADE_MESSAGE_TYPE)
+        })
+        .unwrap_or(false)
+}
+
 /// Parse the inner TRADE payload from the envelope's payload string.
 pub fn parse_trade_payload(payload: &str) -> Option<TradePayload> {
     serde_json::from_str::<TradePayload>(payload).ok()
@@ -109,6 +125,21 @@ mod tests {
         let parsed = parse_envelope(&env).unwrap();
         assert_eq!(parsed.payload, "the-payload");
         assert_eq!(parsed.signature, "the-sig");
+    }
+
+    #[test]
+    fn trade_v1_is_classified_by_inner_message_type() {
+        let trade = SignedEnvelope {
+            payload: r#"{"type":"TRADE_V1","expected_usd":12.5}"#.to_string(),
+            signature: "sig".to_string(),
+        };
+        let sync = SignedEnvelope {
+            payload: r#"{"type":"SYNC_V1","expected_usd":12.5}"#.to_string(),
+            signature: "sig".to_string(),
+        };
+
+        assert!(is_trade_v1(&trade));
+        assert!(!is_trade_v1(&sync));
     }
 
     #[test]

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -22,12 +22,9 @@ pub struct TradePayload {
     #[serde(default)]
     pub user_channel_id: Option<String>,
     pub expected_usd: f64,
-    /// BTC/USD quote used by the wallet to derive the signed sat allocation.
+    /// Wallet BTC/USD quote. The LSP uses it only for slippage and fee validation.
     #[serde(default)]
     pub quote_price: Option<f64>,
-    /// Exact stable backing allocation after the trade-fee payment settles.
-    #[serde(default)]
-    pub backing_sats: Option<u64>,
     /// Unix seconds the wallet signed at; 0 if absent (un-upgraded wallet). Drives replay freshness.
     #[serde(default)]
     pub ts: u64,
@@ -126,15 +123,13 @@ mod tests {
         );
         assert_eq!(t.expected_usd, 12.5);
         assert_eq!(t.quote_price, None);
-        assert_eq!(t.backing_sats, None);
     }
 
     #[test]
-    fn trade_payload_parses_signed_allocation() {
+    fn trade_payload_ignores_legacy_backing_allocation() {
         let payload = r#"{"type":"TRADE_V1","user_channel_id":"7","expected_usd":25.0,"quote_price":80000.0,"backing_sats":31250,"ts":123}"#;
         let t = parse_trade_payload(payload).unwrap();
         assert_eq!(t.quote_price, Some(80_000.0));
-        assert_eq!(t.backing_sats, Some(31_250));
         assert_eq!(t.ts, 123);
     }
 

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -1902,8 +1902,11 @@ impl StableChannelManager {
         };
 
         // The quote is a consent bound only. Capacity and allocation always use the LSP's price.
+        // Epsilon absorbs independent-feed skew so a full stabilization priced by the wallet a
+        // hair above the LSP's valuation is admitted rather than silently dropped.
         let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
-        if new_expected > receiver_usd {
+        let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
+        if new_expected > ceiling {
             stable_channels::audit::audit_event(
                 "TRADE_EXCEEDS_BALANCE",
                 serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd, "user_channel_id": format!("{}", target_uid), "channel_id": chan.channel_id.clone() }),
@@ -3732,7 +3735,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_rejects_target_above_lsp_valued_capacity() {
+    async fn trade_admits_at_balance_boundary_within_epsilon() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -3740,8 +3743,36 @@ mod tests {
         )]);
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        // A wallet-push lands at receiver_usd plus a sub-epsilon overshoot (independent f64 paths).
+        // A wallet-priced full stabilization lands at receiver_usd plus a sub-epsilon overshoot
+        // (independent feeds). It must be admitted, not silently dropped.
         let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert!(
+            (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
+            "a target within epsilon of the balance must be admitted, got {}",
+            mgr.stable_channels[0].expected_usd.0
+        );
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn trade_rejects_target_above_capacity_epsilon() {
+        let mut mgr = make_manager();
+        // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+        )]);
+        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+
+        let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD * 2.0;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
         handle_trade_with_valid_fee(
             &mut mgr,

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -786,16 +786,24 @@ impl StableChannelManager {
                 serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE, "payment_id": payment_id.clone() }),
             );
             let raw = raw.to_string();
-            if crate::messages::parse_envelope(&raw).is_some() {
-                if let Some(pid) = payment_id.as_deref() {
-                    if let Err(e) = self.db.record_settlement(pid, "sync") {
-                        tracing::error!("[stable] record_settlement (inbound sync) failed: {}", e);
-                        stable_channels::audit::audit_event(
-                            "DB_WRITE_FAILED",
-                            serde_json::json!({ "op": "record_settlement", "kind": "sync", "payment_id": pid, "error": e.to_string() }),
-                        );
+            if let Some(envelope) = crate::messages::parse_envelope(&raw) {
+                if crate::messages::is_trade_v1(&envelope) {
+                    if let Some(pid) = payment_id.as_deref() {
+                        if let Err(e) = self.db.record_settlement(pid, "trade") {
+                            tracing::error!(
+                                "[stable] record_settlement (inbound trade) failed: {}",
+                                e
+                            );
+                            stable_channels::audit::audit_event(
+                                "DB_WRITE_FAILED",
+                                serde_json::json!({ "op": "record_settlement", "kind": "trade", "payment_id": pid, "error": e.to_string() }),
+                            );
+                        }
                     }
                 }
+                // An envelope is a control message, even when its inner type is unknown or
+                // malformed. Let the trade handler audit/drop it; never reinterpret it as a
+                // stability payment.
                 self.handle_trade_message(&raw, amount_msat, ldk, btc_price)
                     .await;
             } else {
@@ -2572,7 +2580,7 @@ mod tests {
         assert_eq!(
             mgr.db.list_settlements().unwrap(),
             vec![
-                ("pay_test_1".to_string(), "sync".to_string()),
+                ("pay_test_1".to_string(), "trade".to_string()),
                 ("fake-payment-id".to_string(), "sync".to_string()),
             ]
         );

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -1710,7 +1710,6 @@ impl StableChannelManager {
             serde_json::json!({
                 "expected_usd": payload.expected_usd,
                 "quote_price": payload.quote_price,
-                "backing_sats": payload.backing_sats,
                 "user_channel_id": payload.user_channel_id.clone(),
                 "channel_id": payload.channel_id.clone(),
             }),
@@ -1850,8 +1849,8 @@ impl StableChannelManager {
         }
         let (our_sats, their_sats) = channel_peer_balances(&chan);
         let new_expected = payload.expected_usd;
-        let signed_allocation = match (payload.quote_price, payload.backing_sats) {
-            (Some(quote_price), Some(backing_sats)) => {
+        let quoted_trade = match payload.quote_price {
+            Some(quote_price) => {
                 if payload.ts == 0
                     || !quote_price.is_finite()
                     || quote_price <= 0.0
@@ -1889,59 +1888,14 @@ impl StableChannelManager {
                     );
                     return;
                 }
-
-                let signed_backing_usd = backing_sats as f64 / 100_000_000.0 * quote_price;
-                let allocation_delta_usd = (signed_backing_usd - new_expected).abs();
-                let zero_allocation_is_consistent = if new_expected < 0.01 {
-                    backing_sats == 0
-                } else {
-                    backing_sats > 0
-                };
-                if backing_sats > their_sats
-                    || !zero_allocation_is_consistent
-                    || allocation_delta_usd
-                        > stable_channels::constants::STABILITY_THRESHOLD_USD
-                {
-                    stable_channels::audit::audit_event(
-                        "TRADE_ALLOCATION_INVALID",
-                        serde_json::json!({
-                            "signed_backing_sats": backing_sats,
-                            "signed_backing_usd": signed_backing_usd,
-                            "allocation_delta_usd": allocation_delta_usd,
-                            "receiver_sats": their_sats,
-                            "quote_price": quote_price,
-                            "channel_id": chan.channel_id.clone(),
-                            "user_channel_id": chan.user_channel_id.clone(),
-                        }),
-                    );
-                    return;
-                }
-
-                Some((quote_price, backing_sats, quote_deviation_percent))
+                Some((quote_price, quote_deviation_percent))
             }
-            (None, None) => None,
-            _ => {
-                stable_channels::audit::audit_event(
-                    "TRADE_ALLOCATION_INCOMPLETE",
-                    serde_json::json!({
-                        "quote_price": payload.quote_price,
-                        "backing_sats": payload.backing_sats,
-                        "channel_id": chan.channel_id.clone(),
-                        "user_channel_id": chan.user_channel_id.clone(),
-                    }),
-                );
-                return;
-            }
+            None => None,
         };
 
-        let validation_price = signed_allocation
-            .map(|(quote_price, _, _)| quote_price)
-            .unwrap_or(btc_price);
-        let receiver_usd =
-            USD::from_bitcoin(Bitcoin::from_sats(their_sats), validation_price).0;
-        // Epsilon absorbs f64 boundary rounding so a spend-driven push landing at ~receiver_usd is admitted; residual drift self-heals.
-        let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
-        if new_expected > ceiling {
+        // The quote is a consent bound only. Capacity and allocation always use the LSP's price.
+        let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
+        if new_expected > receiver_usd {
             stable_channels::audit::audit_event(
                 "TRADE_EXCEEDS_BALANCE",
                 serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd, "user_channel_id": format!("{}", target_uid), "channel_id": chan.channel_id.clone() }),
@@ -1967,15 +1921,7 @@ impl StableChannelManager {
             sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
             sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
             sc.latest_price = btc_price;
-            if let Some((_, backing_sats, _)) = signed_allocation {
-                stable_channels::stable::apply_trade_allocation(
-                    sc,
-                    new_expected,
-                    backing_sats,
-                );
-            } else {
-                stable_channels::stable::apply_trade(sc, new_expected, btc_price);
-            }
+            stable_channels::stable::apply_trade(sc, new_expected, btc_price);
             (
                 format!("{}", sc.user_channel_id),
                 sc.expected_usd.0,
@@ -2010,9 +1956,9 @@ impl StableChannelManager {
                 "new_expected_usd": expected_usd_f,
                 "backing_sats": backing,
                 "native_sats": native,
-                "quote_price": signed_allocation.map(|(price, _, _)| price),
+                "quote_price": quoted_trade.map(|(price, _)| price),
                 "lsp_price": btc_price,
-                "quote_deviation_percent": signed_allocation.map(|(_, _, deviation)| deviation),
+                "quote_deviation_percent": quoted_trade.map(|(_, deviation)| deviation),
             }),
         );
         let sent = self
@@ -3600,7 +3546,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_applies_signed_allocation_without_lsp_repricing() {
+    async fn trade_uses_lsp_price_instead_of_client_allocation() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX,
@@ -3619,34 +3565,34 @@ mod tests {
             0,
             50_000,
             50_000,
-            100_500.0,
+            100_000.0,
         );
 
-        // At the wallet quote this is exactly 49,950 backing sats. Re-deriving at the LSP's
-        // slightly newer price would produce a different allocation.
+        // The client reports a 0.4% higher price and therefore fewer backing sats. The quote is
+        // inside the slippage bound, but neither it nor the legacy backing field controls the LSP.
         let env = trade_envelope_with_allocation(
             CHANNEL_ID_HEX,
             USER_CHANNEL_ID_DECIMAL,
-            49.95,
-            100_000.0,
-            49_950,
+            49.75,
+            100_400.0,
+            49_551,
         );
         handle_trade_with_valid_fee(
             &mut mgr,
             &env,
             &fake as &dyn LdkServerCalls,
-            100_500.0,
+            100_000.0,
         )
         .await;
 
-        assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
-        assert_eq!(mgr.stable_channels[0].native_sats, 50);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_750);
+        assert_eq!(mgr.stable_channels[0].native_sats, 250);
         let sends = fake.sends.lock().unwrap();
-        assert_eq!(sends.len(), 1, "accepted allocation must be synced back");
+        assert_eq!(sends.len(), 1, "the LSP must sync its own allocation");
         let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
         let sync = crate::messages::parse_envelope(raw).unwrap();
         let payload: serde_json::Value = serde_json::from_str(&sync.payload).unwrap();
-        assert_eq!(payload["backing_sats"], 49_950);
+        assert_eq!(payload["backing_sats"], 49_750);
     }
 
     #[tokio::test]
@@ -3690,12 +3636,12 @@ mod tests {
         .await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
-        assert_eq!(mgr.stable_channels[0].backing_sats, 49_995);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
         assert_eq!(fake.sends.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
-    async fn trade_rejects_allocation_not_derived_from_signed_quote() {
+    async fn trade_ignores_legacy_allocation_not_derived_from_quote() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
             CHANNEL_ID_HEX,
@@ -3732,9 +3678,9 @@ mod tests {
         )
         .await;
 
-        assert_eq!(mgr.stable_channels[0].expected_usd.0, 5.0);
-        assert_eq!(mgr.stable_channels[0].backing_sats, 5_000);
-        assert!(fake.sends.lock().unwrap().is_empty());
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 49.95);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -3778,7 +3724,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_admits_at_balance_boundary_within_epsilon() {
+    async fn trade_rejects_target_above_lsp_valued_capacity() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -3797,11 +3743,9 @@ mod tests {
         )
         .await;
 
-        assert!(
-            (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
-            "a target within epsilon of the balance must be admitted, got {}",
-            mgr.stable_channels[0].expected_usd.0
-        );
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1161,22 +1161,19 @@ impl Database {
         .optional()
     }
 
-    /// Match a signed allocation acknowledgment to a trade authored by this wallet. The LSP can
-    /// deliver SYNC_V1 before or after LDK reports the trade-fee payment as successful, so the
-    /// allocation itself is the stable correlation key.
-    pub fn get_pending_trade_by_allocation(
+    /// Match an acknowledgment to a trade authored by this wallet. Backing is deliberately not a
+    /// correlation key because each peer derives it independently from its own price.
+    pub fn get_pending_trade_by_expected_usd(
         &self,
         new_expected_usd: f64,
-        new_backing_sats: u64,
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
             "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
              WHERE status = 'pending'
-               AND new_backing_sats = ?1
-               AND ABS(new_expected_usd - ?2) <= 0.000000001
+               AND ABS(new_expected_usd - ?1) <= 0.000000001
              ORDER BY id DESC LIMIT 1",
-            params![new_backing_sats, new_expected_usd],
+            params![new_expected_usd],
             |row| {
                 Ok(PendingTradeRow {
                     id: row.get(0)?,
@@ -4020,7 +4017,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_trade_matches_signed_allocation_and_payment_id_remains_classified() {
+    fn pending_trade_matches_expected_target_and_payment_id_remains_classified() {
         let db = Database::open_in_memory().unwrap();
         let trade_id = db
             .record_trade(
@@ -4038,12 +4035,12 @@ mod tests {
             .unwrap();
 
         let matched = db
-            .get_pending_trade_by_allocation(60.0, 60_000)
+            .get_pending_trade_by_expected_usd(60.0)
             .unwrap()
-            .expect("exact wallet-authored allocation must match");
+            .expect("wallet-authored target must match even when peer backing differs");
         assert_eq!(matched.id, trade_id);
         assert!(db
-            .get_pending_trade_by_allocation(60.01, 60_000)
+            .get_pending_trade_by_expected_usd(60.01)
             .unwrap()
             .is_none());
         assert!(db.is_trade_payment("trade-payment").unwrap());
@@ -4051,7 +4048,7 @@ mod tests {
         db.update_trade_status(trade_id, "completed").unwrap();
         assert!(db.is_trade_payment("trade-payment").unwrap());
         assert!(db
-            .get_pending_trade_by_allocation(60.0, 60_000)
+            .get_pending_trade_by_expected_usd(60.0)
             .unwrap()
             .is_none());
     }

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -330,7 +330,7 @@ pub fn normalize_backing_sats(
     }
 }
 
-/// Derive the stable backing allocation for a trade at the signed quote price.
+/// Derive this peer's stable backing allocation for a trade at its local price.
 ///
 /// The result is clamped to the receiver's post-settlement balance. Sub-cent native residue is
 /// absorbed into the stable side so a full BTC-to-USD trade has no floating native remainder.
@@ -357,11 +357,10 @@ pub fn trade_backing_sats(
     )
 }
 
-/// Apply a previously agreed trade allocation without repricing it.
+/// Apply an allocation already derived by this peer.
 ///
-/// `backing_sats` is part of the signed trade intent. A peer may validate that intent against its
-/// own price and live LDK balance first, but once accepted it must not derive a different allocation
-/// from a later price snapshot.
+/// Callers must not pass a counterparty-supplied `backing_sats` value here. The shared contract is
+/// `expected_usd`; each peer derives and persists its own backing using its own price.
 pub fn apply_trade_allocation(sc: &mut StableChannel, new_expected_usd: f64, backing_sats: u64) {
     sc.expected_usd = USD::from_f64(new_expected_usd);
     sc.backing_sats = backing_sats;

--- a/src/user.rs
+++ b/src/user.rs
@@ -2881,6 +2881,8 @@ impl UserApp {
                                 &sync,
                                 live_receiver_sats,
                                 price,
+                                old_expected,
+                                sc.backing_sats,
                                 pending_trade.as_ref(),
                             ) {
                                 Ok(backing_sats) => backing_sats,
@@ -10555,11 +10557,17 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
 
 /// Derive the allocation this wallet will commit for an authenticated sync. The peer's
 /// `backing_sats` is intentionally not an input: a pending trade uses the allocation this wallet
-/// stored when it created the trade, while recovery syncs are priced from the wallet's own feed.
+/// stored when it created the trade; other syncs preserve the wallet's existing allocation
+/// (unchanged target) or shift it by the target delta valued at the wallet's own price. The full
+/// position is never repriced, so accrued-but-unsettled stability drift survives a sync, and a
+/// target at the capacity boundary clamps instead of rejecting — a fully-stabilized channel sits
+/// exactly on that boundary whenever the two feeds disagree by a hair.
 fn local_sync_backing_sats(
     sync: &IncomingSync,
     live_receiver_sats: u64,
     current_price: f64,
+    current_expected_usd: f64,
+    current_backing_sats: u64,
     pending_trade: Option<&db::PendingTradeRow>,
 ) -> Result<u64, &'static str> {
     if sync.expected_usd < 0.01 {
@@ -10572,18 +10580,21 @@ fn local_sync_backing_sats(
             Err("stored trade allocation exceeds the live balance")
         };
     }
+    let target_delta_usd = sync.expected_usd - current_expected_usd;
+    if current_backing_sats > 0 && target_delta_usd.abs() < 0.01 {
+        return Ok(current_backing_sats.min(live_receiver_sats));
+    }
     if !current_price.is_finite() || current_price <= 0.0 {
         return Err("no trusted wallet price available");
     }
-    let receiver_usd = live_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
-    if sync.expected_usd > receiver_usd {
-        return Err("stable target exceeds the wallet's local channel capacity");
-    }
-    let backing_sats = stable::trade_backing_sats(
-        live_receiver_sats,
-        sync.expected_usd,
-        current_price,
-    );
+    let backing_sats = if current_backing_sats > 0 {
+        let delta_sats = (target_delta_usd / current_price * SATS_IN_BTC as f64).round() as i64;
+        let shifted = current_backing_sats as i64 + delta_sats;
+        (shifted.max(0) as u64).min(live_receiver_sats)
+    } else {
+        // No local allocation to preserve (fresh restore): derive one at the wallet's price.
+        stable::trade_backing_sats(live_receiver_sats, sync.expected_usd, current_price)
+    };
     (backing_sats > 0)
         .then_some(backing_sats)
         .ok_or("nonzero peg has no locally derived backing")
@@ -10716,7 +10727,7 @@ mod tests {
     }
 
     #[test]
-    fn incoming_sync_uses_wallet_allocation_and_capacity() {
+    fn incoming_sync_preserves_or_shifts_wallet_allocation() {
         let sync = IncomingSync {
             channel_id: "00".repeat(32),
             expected_usd: 60.0,
@@ -10724,9 +10735,27 @@ mod tests {
             sync_version: 1,
         };
         assert_eq!(
-            local_sync_backing_sats(&sync, 100_000, 100_000.0, None),
+            local_sync_backing_sats(&sync, 100_000, 100_000.0, 0.0, 0, None),
             Ok(59_999),
-            "a recovery sync is priced by the wallet, not by the peer",
+            "a restore with no local allocation derives at the wallet's price, not the peer's",
+        );
+
+        assert_eq!(
+            local_sync_backing_sats(&sync, 100_000, 0.0, 60.0, 55_000, None),
+            Ok(55_000),
+            "an unchanged-target sync preserves the existing allocation and needs no price",
+        );
+
+        assert_eq!(
+            local_sync_backing_sats(&sync, 100_000, 100_000.0, 70.0, 65_000, None),
+            Ok(55_000),
+            "a target change moves backing by the delta at the wallet's price, never the whole position",
+        );
+
+        assert_eq!(
+            local_sync_backing_sats(&sync, 58_000, 100_000.0, 50.0, 55_000, None),
+            Ok(58_000),
+            "a delta past the live balance clamps instead of rejecting",
         );
 
         let pending = PendingTradeRow {
@@ -10737,7 +10766,7 @@ mod tests {
             action: "sell".to_owned(),
         };
         assert_eq!(
-            local_sync_backing_sats(&sync, 100_000, 0.0, Some(&pending)),
+            local_sync_backing_sats(&sync, 100_000, 0.0, 50.0, 50_000, Some(&pending)),
             Ok(59_701),
             "a trade acknowledgment uses the wallet's stored trade-time allocation",
         );
@@ -10746,14 +10775,18 @@ mod tests {
             expected_usd: 100.01,
             ..sync.clone()
         };
-        assert!(local_sync_backing_sats(&over_capacity, 100_000, 100_000.0, None).is_err());
+        assert_eq!(
+            local_sync_backing_sats(&over_capacity, 100_000, 100_000.0, 0.0, 0, None),
+            Ok(100_000),
+            "a restore at the capacity boundary clamps to all-stable instead of rejecting",
+        );
 
         let closed = IncomingSync {
             expected_usd: 0.0,
             ..sync
         };
         assert_eq!(
-            local_sync_backing_sats(&closed, 100_000, 0.0, None),
+            local_sync_backing_sats(&closed, 100_000, 0.0, 60.0, 60_000, None),
             Ok(0),
         );
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1912,7 +1912,7 @@ impl UserApp {
 
     /// Send a trade message to the LSP with the new stabilized USD amount.
     /// The fee is sent as the keysend payment amount.
-    /// Returns the PaymentId and signed backing allocation on success so the caller can track it.
+    /// Returns the PaymentId and wallet-derived backing allocation so the caller can track it.
     fn send_trade(
         &mut self,
         new_expected_usd: f64,
@@ -1920,8 +1920,8 @@ impl UserApp {
         trade_action: &str,
         trade_price: f64,
     ) -> Option<(PaymentId, u64)> {
-        // The fee is a direct keysend amount. Calculate its whole-sat channel impact before
-        // signing the allocation so both peers derive against the same post-settlement balance.
+        // The fee is a direct keysend amount. Account for its whole-sat channel impact before
+        // deriving the wallet's post-settlement allocation.
         let fee_sats = if trade_price > 0.0 && fee_usd > 0.0 {
             (fee_usd / trade_price * SATS_IN_BTC as f64) as u64
         } else {
@@ -1930,8 +1930,8 @@ impl UserApp {
         let fee_msats = fee_sats.saturating_mul(1000);
         let amt_msat = fee_msats.max(1);
 
-        // Refresh from this wallet's LDK node, then sign one exact allocation at the quote the
-        // user reviewed. The LSP independently validates this against its LDK view and price.
+        // Refresh from this wallet's LDK node and derive the allocation this wallet will commit
+        // after acceptance. The LSP independently derives its own allocation at its own price.
         let (
             channel_id_str,
             user_channel_id_str,
@@ -1963,15 +1963,14 @@ impl UserApp {
             .unwrap_or_default()
             .as_secs();
 
-        // All allocation inputs are signed. A different price observed later cannot alter this
-        // already-reviewed trade.
+        // The quote is signed as the user's slippage bound and fee input. backing_sats remains
+        // local state; a peer-supplied allocation must never become authoritative.
         let payload = json!({
             "type": TRADE_MESSAGE_TYPE,
             "channel_id": channel_id_str,
             "user_channel_id": user_channel_id_str,
             "expected_usd": new_expected_usd,
             "quote_price": trade_price,
-            "backing_sats": backing_sats,
             "ts": ts,
         });
 
@@ -2860,16 +2859,16 @@ impl UserApp {
                             let price = sc.latest_price;
                             let old_expected = sc.expected_usd.0;
                             let live_receiver_sats = sc.stable_receiver_btc.sats;
-                            let pending_trade = match self.db.get_pending_trade_by_allocation(
-                                sync.expected_usd,
-                                sync.backing_sats,
-                            ) {
+                            let pending_trade = match self
+                                .db
+                                .get_pending_trade_by_expected_usd(sync.expected_usd)
+                            {
                                 Ok(trade) => trade,
                                 Err(e) => {
                                     audit_event(
                                         "DB_READ_FAILED",
                                         json!({
-                                            "op": "get_pending_trade_by_allocation",
+                                            "op": "get_pending_trade_by_expected_usd",
                                             "payment_hash": &payment_hash_str,
                                             "error": e.to_string(),
                                         }),
@@ -2878,33 +2877,48 @@ impl UserApp {
                                     break 'sync true;
                                 }
                             };
-                            if let Err(reason) = validate_incoming_sync_allocation(
+                            let local_backing_sats = match local_sync_backing_sats(
                                 &sync,
                                 live_receiver_sats,
                                 price,
-                                pending_trade.is_some(),
+                                pending_trade.as_ref(),
                             ) {
+                                Ok(backing_sats) => backing_sats,
+                                Err(reason) => {
+                                    audit_event(
+                                        "SYNC_V1_ALLOCATION_REJECTED",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "reason": reason,
+                                            "expected_usd": sync.expected_usd,
+                                            "peer_backing_sats": sync.backing_sats,
+                                            "live_receiver_sats": live_receiver_sats,
+                                            "btc_price": price,
+                                            "sync_version": sync.sync_version,
+                                        }),
+                                    );
+                                    break 'sync true;
+                                }
+                            };
+                            if local_backing_sats != sync.backing_sats {
                                 audit_event(
-                                    "SYNC_V1_ALLOCATION_REJECTED",
+                                    "SYNC_V1_ALLOCATION_DIVERGENCE",
                                     json!({
                                         "payment_hash": &payment_hash_str,
-                                        "reason": reason,
-                                        "expected_usd": sync.expected_usd,
-                                        "backing_sats": sync.backing_sats,
-                                        "live_receiver_sats": live_receiver_sats,
-                                        "btc_price": price,
+                                        "peer_backing_sats": sync.backing_sats,
+                                        "local_backing_sats": local_backing_sats,
                                         "sync_version": sync.sync_version,
                                     }),
                                 );
-                                break 'sync true;
                             }
-                            let native_sats = live_receiver_sats.saturating_sub(sync.backing_sats);
+                            let native_sats =
+                                live_receiver_sats.saturating_sub(local_backing_sats);
                             let user_channel_id = format!("{}", sc.user_channel_id);
                             match self.db.apply_sync_if_newer_and_complete_trade(
                                 &user_channel_id,
                                 sync.sync_version,
                                 sync.expected_usd,
-                                sync.backing_sats,
+                                local_backing_sats,
                                 native_sats,
                                 pending_trade.as_ref().map(|trade| trade.id),
                             ) {
@@ -2912,14 +2926,15 @@ impl UserApp {
                                     stable::apply_trade_allocation(
                                         &mut sc,
                                         sync.expected_usd,
-                                        sync.backing_sats,
+                                        local_backing_sats,
                                     );
                                     audit_event(
                                         "SYNC_V1_APPLIED",
                                         json!({
                                             "old_expected_usd": old_expected,
                                             "new_expected_usd": sync.expected_usd,
-                                            "backing_sats": sync.backing_sats,
+                                            "backing_sats": local_backing_sats,
+                                            "peer_backing_sats": sync.backing_sats,
                                             "sync_version": sync.sync_version,
                                             "live_receiver_sats": live_receiver_sats,
                                             "btc_price": price,
@@ -2936,7 +2951,7 @@ impl UserApp {
                                                 "trade_id": trade.id,
                                                 "action": trade.action,
                                                 "expected_usd": sync.expected_usd,
-                                                "backing_sats": sync.backing_sats,
+                                                "backing_sats": local_backing_sats,
                                                 "sync_version": sync.sync_version,
                                             }),
                                         );
@@ -3150,7 +3165,7 @@ impl UserApp {
                     let payment_hash_str = format!("{payment_hash}");
 
                     // Payment success proves that the fee reached the LSP, not that it accepted the
-                    // signed allocation. Keep the trade pending until its signed SYNC_V1 arrives.
+                    // trade. Keep it pending until the LSP's signed SYNC_V1 arrives.
                     let mut pending_trade = payment_id
                         .and_then(|pid| self.pending_trade_payments.get(&pid).cloned());
                     if pending_trade.is_none() {
@@ -10538,44 +10553,40 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     })
 }
 
-fn validate_incoming_sync_allocation(
+/// Derive the allocation this wallet will commit for an authenticated sync. The peer's
+/// `backing_sats` is intentionally not an input: a pending trade uses the allocation this wallet
+/// stored when it created the trade, while recovery syncs are priced from the wallet's own feed.
+fn local_sync_backing_sats(
     sync: &IncomingSync,
     live_receiver_sats: u64,
     current_price: f64,
-    matches_pending_trade: bool,
-) -> Result<(), &'static str> {
-    if sync.backing_sats > live_receiver_sats {
-        return Err("backing exceeds live receiver balance");
-    }
+    pending_trade: Option<&db::PendingTradeRow>,
+) -> Result<u64, &'static str> {
     if sync.expected_usd < 0.01 {
-        return if sync.backing_sats == 0 {
-            Ok(())
+        return Ok(0);
+    }
+    if let Some(stored_backing) = pending_trade.and_then(|trade| trade.new_backing_sats) {
+        return if stored_backing > 0 && stored_backing <= live_receiver_sats {
+            Ok(stored_backing)
         } else {
-            Err("zero peg has nonzero backing")
+            Err("stored trade allocation exceeds the live balance")
         };
-    }
-    if sync.backing_sats == 0 {
-        return Err("nonzero peg has no backing");
-    }
-
-    // A pending trade was priced, bounded, and signed by this wallet before it was sent. Other
-    // syncs are recovery/reconciliation messages, so independently reject allocations whose
-    // implied booking price is implausibly far from the wallet's current trusted price.
-    if matches_pending_trade {
-        return Ok(());
     }
     if !current_price.is_finite() || current_price <= 0.0 {
         return Err("no trusted wallet price available");
     }
-    let implied_booking_price =
-        sync.expected_usd / sync.backing_sats as f64 * SATS_IN_BTC as f64;
-    if !implied_booking_price.is_finite()
-        || implied_booking_price < current_price / 10.0
-        || implied_booking_price > current_price * 10.0
-    {
-        return Err("allocation implies an implausible booking price");
+    let receiver_usd = live_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
+    if sync.expected_usd > receiver_usd {
+        return Err("stable target exceeds the wallet's local channel capacity");
     }
-    Ok(())
+    let backing_sats = stable::trade_backing_sats(
+        live_receiver_sats,
+        sync.expected_usd,
+        current_price,
+    );
+    (backing_sats > 0)
+        .then_some(backing_sats)
+        .ok_or("nonzero peg has no locally derived backing")
 }
 
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
@@ -10618,11 +10629,12 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        parse_incoming_sync, parse_trade_usd_cents, restrict_secret_file_permissions,
-        sats_for_usd_cents, splice_in_overlap_sats, splice_reconcile_action,
-        validate_incoming_sync_allocation, write_secret_file, IncomingSync, PendingSplice,
+        local_sync_backing_sats, parse_incoming_sync, parse_trade_usd_cents,
+        restrict_secret_file_permissions, sats_for_usd_cents, splice_in_overlap_sats,
+        splice_reconcile_action, write_secret_file, IncomingSync, PendingSplice,
         SpliceReconcileAction, UserApp,
     };
+    use stable_channels::db::PendingTradeRow;
 
     #[test]
     fn trade_usd_input_is_exactly_cent_denominated() {
@@ -10704,58 +10716,46 @@ mod tests {
     }
 
     #[test]
-    fn incoming_sync_allocation_is_bounded_by_wallet_state() {
+    fn incoming_sync_uses_wallet_allocation_and_capacity() {
         let sync = IncomingSync {
             channel_id: "00".repeat(32),
             expected_usd: 60.0,
-            backing_sats: 60_000,
+            backing_sats: 99_999,
             sync_version: 1,
         };
-        assert!(validate_incoming_sync_allocation(&sync, 100_000, 100_000.0, false).is_ok());
+        assert_eq!(
+            local_sync_backing_sats(&sync, 100_000, 100_000.0, None),
+            Ok(59_999),
+            "a recovery sync is priced by the wallet, not by the peer",
+        );
 
-        let overdrawn = IncomingSync {
-            backing_sats: 100_001,
+        let pending = PendingTradeRow {
+            id: 1,
+            new_expected_usd: 60.0,
+            btc_price: 100_500.0,
+            new_backing_sats: Some(59_701),
+            action: "sell".to_owned(),
+        };
+        assert_eq!(
+            local_sync_backing_sats(&sync, 100_000, 0.0, Some(&pending)),
+            Ok(59_701),
+            "a trade acknowledgment uses the wallet's stored trade-time allocation",
+        );
+
+        let over_capacity = IncomingSync {
+            expected_usd: 100.01,
             ..sync.clone()
         };
-        assert!(validate_incoming_sync_allocation(
-            &overdrawn,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_err());
+        assert!(local_sync_backing_sats(&over_capacity, 100_000, 100_000.0, None).is_err());
 
-        let implausible = IncomingSync {
-            expected_usd: 10_000.0,
-            ..sync.clone()
-        };
-        assert!(validate_incoming_sync_allocation(
-            &implausible,
-            100_000,
-            100_000.0,
-            false
-        )
-        .is_err());
-        assert!(validate_incoming_sync_allocation(
-            &implausible,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_ok());
-
-        let inconsistent_zero = IncomingSync {
+        let closed = IncomingSync {
             expected_usd: 0.0,
-            backing_sats: 1,
             ..sync
         };
-        assert!(validate_incoming_sync_allocation(
-            &inconsistent_zero,
-            100_000,
-            100_000.0,
-            true
-        )
-        .is_err());
+        assert_eq!(
+            local_sync_backing_sats(&closed, 100_000, 0.0, None),
+            Ok(0),
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Each peer derives backing using its own BTC price and channel balances.
- The wallet quote is used only for fee/slippage validation.
- expected_usd remains the shared agreed value.
- Peer-supplied backing fields are ignored.
- TRADE_V1 payments are explicitly displayed as trades, distinct from SYNC_V1.