### PR TITLE
feat(android): add mempool websocket tx tracking and receive flow stabilization

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -131,4 +131,5 @@ dependencies {
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1819,31 +1819,44 @@ class AppState(private val context: Context) : ViewModel() {
                         !receiveAddress.isNullOrBlank() &&
                         lastReceiveTxidAddress == receiveAddress
                 }
-                // No pending close — record as new on-chain deposit
-                val dedupId = if (!resolvedTxid.isNullOrBlank()) {
-                    "onchain_receive_$resolvedTxid"
-                } else {
-                    "${System.currentTimeMillis() / 1000}_$depositSats"
-                }
-                val rowId = db?.recordPayment(
-                    paymentId = dedupId,
-                    paymentType = "onchain",
-                    direction = "received",
-                    amountMsat = depositSats * 1000,
-                    amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                    btcPrice = price,
-                    status = "pending",
-                    txid = resolvedTxid,
-                    address = receiveAddress
-                )
 
-                if (rowId != null && rowId != -1L) {
-                    triggerPaymentFlash()
-                    AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
-                        "sats" to depositSats,
-                        "status" to "pending",
-                        "txid_known" to (!resolvedTxid.isNullOrBlank())
-                    ))
+                // If we can't tie this balance increase to a specific txid/address, it may
+                // already be tracked under a different (now-inactive) receive address — e.g.
+                // the websocket path recorded it before the user requested a new receive
+                // address. Skip creating a second, txid-less duplicate row in that case;
+                // confirmation polling will resolve the existing pending row instead.
+                val existingPendingReceive = resolvedTxid.isNullOrBlank() &&
+                    db?.latestPendingOnchainReceive() != null
+
+                if (existingPendingReceive) {
+                    AuditService.log("ONCHAIN_DEPOSIT_SKIPPED_DUPLICATE", mapOf("sats" to depositSats))
+                } else {
+                    // No pending close — record as new on-chain deposit
+                    val dedupId = if (!resolvedTxid.isNullOrBlank()) {
+                        "onchain_receive_$resolvedTxid"
+                    } else {
+                        "${System.currentTimeMillis() / 1000}_$depositSats"
+                    }
+                    val rowId = db?.recordPayment(
+                        paymentId = dedupId,
+                        paymentType = "onchain",
+                        direction = "received",
+                        amountMsat = depositSats * 1000,
+                        amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
+                        btcPrice = price,
+                        status = "pending",
+                        txid = resolvedTxid,
+                        address = receiveAddress
+                    )
+
+                    if (rowId != null && rowId != -1L) {
+                        triggerPaymentFlash()
+                        AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
+                            "sats" to depositSats,
+                            "status" to "pending",
+                            "txid_known" to (!resolvedTxid.isNullOrBlank())
+                        ))
+                    }
                 }
             }
             // Home card now carries pending receive state; remove stale capsule text.
@@ -1868,7 +1881,7 @@ class AppState(private val context: Context) : ViewModel() {
                     val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
                     if (txid != null) {
                         setLastReceiveTxid(txid, address)
-                        databaseService?.attachTxidToLatestOnchainReceive(txid)
+                        databaseService?.attachTxidToLatestOnchainReceive(txid, address)
                     }
                 }
             }
@@ -2050,7 +2063,7 @@ class AppState(private val context: Context) : ViewModel() {
             val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
             if (txid != null) {
                 setLastReceiveTxid(txid, address)
-                databaseService?.attachTxidToLatestOnchainReceive(txid)
+                databaseService?.attachTxidToLatestOnchainReceive(txid, address)
             }
         }
     }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -10,6 +10,9 @@ import com.stablechannels.app.push.FCMService
 import com.stablechannels.app.push.StabilityProcessingService
 import com.stablechannels.app.services.CloseTxidResolver
 import com.stablechannels.app.services.*
+import com.stablechannels.app.services.websocket.MempoolWebSocketClient
+import com.stablechannels.app.services.websocket.MempoolWebSocketService
+import com.stablechannels.app.services.websocket.WebSocketEvent
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.LspPreferencesManager
 import com.stablechannels.app.util.satsFormatted
@@ -26,6 +29,8 @@ import org.json.JSONObject
 import org.lightningdevkit.ldknode.*
 import java.io.File
 import kotlin.math.abs
+import kotlin.math.min
+import kotlin.math.pow
 import kotlin.math.roundToLong
 
 enum class Phase {
@@ -55,6 +60,7 @@ class AppState(private val context: Context) : ViewModel() {
         private set
     var tradeService: TradeService? = null
         private set
+    private val mempoolWebSocketService: MempoolWebSocketClient = MempoolWebSocketService()
 
     private val _phase = MutableStateFlow(Phase.LOADING)
     val phase: StateFlow<Phase> = _phase
@@ -106,6 +112,7 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _lastReceiveTxid = MutableStateFlow<String?>(null)
     val lastReceiveTxid: StateFlow<String?> get() = _lastReceiveTxid
+    private var lastReceiveTxidAddress: String? = null
 
     private val _lastCloseTxid = MutableStateFlow<String?>(null)
     val lastCloseTxid: StateFlow<String?> get() = _lastCloseTxid
@@ -119,6 +126,25 @@ class AppState(private val context: Context) : ViewModel() {
         } else {
             editor.remove("last_close_txid")
             editor.remove("last_close_txid_at")
+        }
+        editor.apply()
+    }
+
+    private fun setLastReceiveTxid(txid: String?, address: String?) {
+        _lastReceiveTxid.value = txid
+        lastReceiveTxidAddress = address
+
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        if (txid.isNullOrBlank()) {
+            editor.remove("last_receive_txid")
+            editor.remove("last_receive_txid_address")
+        } else {
+            editor.putString("last_receive_txid", txid)
+            if (!address.isNullOrBlank()) {
+                editor.putString("last_receive_txid_address", address)
+            } else {
+                editor.remove("last_receive_txid_address")
+            }
         }
         editor.apply()
     }
@@ -142,6 +168,7 @@ class AppState(private val context: Context) : ViewModel() {
                 _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
         _onchainReceiveAddress.value = prefs.getString("onchain_receive_address", null)
         _lastReceiveTxid.value = prefs.getString("last_receive_txid", null)
+        lastReceiveTxidAddress = prefs.getString("last_receive_txid_address", null)
 
         val closeAt = prefs.getLong("last_close_txid_at", 0L)
         if (System.currentTimeMillis() - closeAt < 7 * 86400 * 1000L) {
@@ -164,6 +191,29 @@ class AppState(private val context: Context) : ViewModel() {
                 userChannelId = cachedUserChannelId,
                 expectedUSD = USD(cachedExpectedUsd.toDouble())
             )
+        }
+
+        configureMempoolWebSocket()
+    }
+
+    private fun configureMempoolWebSocket() {
+        mempoolWebSocketService.onBlockHeader = {
+            viewModelScope.launch(Dispatchers.IO) {
+                refreshBalances()
+                pollPaymentConfirmations(force = true)
+            }
+        }
+        mempoolWebSocketService.onTransactionDetected = { event ->
+            viewModelScope.launch(Dispatchers.IO) {
+                handleWebSocketTransactionDetected(event)
+            }
+        }
+    }
+
+    private fun connectMempoolWebSocket() {
+        mempoolWebSocketService.connect()
+        _onchainReceiveAddress.value?.takeIf { it.isNotBlank() }?.let {
+            mempoolWebSocketService.trackAddress(it)
         }
     }
 
@@ -189,6 +239,7 @@ class AppState(private val context: Context) : ViewModel() {
             }
         }
     var pendingClosePaymentId: String? = null
+    private var trackedClosingFundingTxid: String? = null
     var spliceTxid: String? = null
     var fundingTxid: String? = null
         set(value) {
@@ -199,6 +250,9 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _paymentFlash = MutableStateFlow(false)
     val paymentFlash: StateFlow<Boolean> = _paymentFlash
+
+    private val _confirmationUpdateEpoch = MutableStateFlow(0)
+    val confirmationUpdateEpoch: StateFlow<Int> = _confirmationUpdateEpoch
 
 
     private val _isSpliceInFlight = MutableStateFlow(false)
@@ -217,8 +271,13 @@ class AppState(private val context: Context) : ViewModel() {
     private var pendingDepositJob: Job? = null
     private var channelCloseJob: Job? = null
     private var nodeStartRetryJob: Job? = null
+    private var nodeStartRetryAttempts: Int = 0
     private var spliceConfirmationJob: Job? = null
     private var monitoredSpliceTxid: String? = null
+    @Volatile
+    private var isConfirmationPolling = false
+    @Volatile
+    private var lastConfirmationPollAtMs = 0L
     /** Resolved esplora URL — Blockstream primary, mempool.space fallback. */
     var chainUrl: String = Constants.PRIMARY_CHAIN_URL
         private set
@@ -285,11 +344,14 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                     loadChannelFromDB()  // reload — SPS may have incremented backingSats while we waited
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    resetNodeStartRetryState()
                     nodeStartRetryJob?.cancel()
                     nodeStartRetryJob = null
                     _phase.value = Phase.WALLET
                     _isSyncing.value = false
                     refreshBalances()
+                    pollPaymentConfirmations(force = true)
+                    connectMempoolWebSocket()
                     // Restore fundingTxid
                     fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
                         .getString("funding_txid", null)
@@ -307,11 +369,15 @@ class AppState(private val context: Context) : ViewModel() {
                                 // Resume background resolver if it hasn't found the TX yet
                                 val closeFundingTxid = fundingTxid
                                 if (closeFundingTxid != null && databaseService != null) {
+                                    trackedClosingFundingTxid = closeFundingTxid
+                                    mempoolWebSocketService.trackTx(closeFundingTxid)
                                     val resolver = CloseTxidResolver(
                                         chainURLs = listOf(Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL),
                                         onResolved = { _, txid ->
                                             Log.d("AppState", "Close TX resolved on restart: $txid")
                                             setLastCloseTxid(txid)
+                                            mempoolWebSocketService.untrackTx(closeFundingTxid)
+                                            trackedClosingFundingTxid = null
                                         }
                                     )
                                     viewModelScope.launch(Dispatchers.IO) {
@@ -345,8 +411,11 @@ class AppState(private val context: Context) : ViewModel() {
                     // New wallet — auto-create
                     _phase.value = Phase.SYNCING
                     nodeService.start(Network.BITCOIN, chainUrl, null)
+                    resetNodeStartRetryState()
                     _phase.value = Phase.WALLET
                     refreshBalances()
+                    pollPaymentConfirmations(force = true)
+                    connectMempoolWebSocket()
                     reregisterPushTokenIfNeeded()
                     startStabilityTimer()
                     viewModelScope.launch(Dispatchers.IO) {
@@ -355,8 +424,7 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                 }
             } catch (e: Exception) {
-                _errorMessage.value = e.message ?: "Unknown error"
-                _phase.value = Phase.ERROR
+                handleNodeStartFailure(e, "Unknown error")
             }
         }
     }
@@ -366,13 +434,15 @@ class AppState(private val context: Context) : ViewModel() {
             try {
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, mnemonic)
+                resetNodeStartRetryState()
                 _phase.value = Phase.WALLET
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 reregisterPushTokenIfNeeded()
                 startStabilityTimer()
             } catch (e: Exception) {
-                _errorMessage.value = e.message ?: "Failed to create wallet"
-                _phase.value = Phase.ERROR
+                handleNodeStartFailure(e, "Failed to create wallet")
             }
         }
     }
@@ -388,6 +458,7 @@ class AppState(private val context: Context) : ViewModel() {
         spliceConfirmationJob = null
         monitoredSpliceTxid = null
         priceService.stopAutoRefresh()
+        mempoolWebSocketService.disconnect()
         nodeService.stop()
     }
 
@@ -483,6 +554,7 @@ class AppState(private val context: Context) : ViewModel() {
         spliceConfirmationJob?.cancel()
         spliceConfirmationJob = null
         monitoredSpliceTxid = null
+        mempoolWebSocketService.disconnect()
         if (!nodeService.isRunning) return
         Log.d("AppState", "Stopping node for background")
         nodeService.stop()
@@ -502,6 +574,8 @@ class AppState(private val context: Context) : ViewModel() {
                 loadChannelFromDB()
                 ensureLSPConnected()
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 updateStableBalances()
                 resumePendingSpliceConfirmation()
                 return@launch
@@ -515,10 +589,13 @@ class AppState(private val context: Context) : ViewModel() {
                 loadChannelFromDB()
                 _phase.value = Phase.SYNCING
                 nodeService.start(Network.BITCOIN, chainUrl, null)
+                resetNodeStartRetryState()
                 nodeStartRetryJob?.cancel()
                 nodeStartRetryJob = null
                 _phase.value = Phase.WALLET
                 refreshBalances()
+                pollPaymentConfirmations(force = true)
+                connectMempoolWebSocket()
                 updateStableBalances()
                 val sc = StabilityService.reconcileIncoming(_stableChannel.value)
                 _stableChannel.value = sc
@@ -528,10 +605,46 @@ class AppState(private val context: Context) : ViewModel() {
                 startStabilityTimer()
             } catch (e: Exception) {
                 Log.e("AppState", "Node restart failed", e)
-                _phase.value = Phase.ERROR
-                _errorMessage.value = e.message ?: "Restart failed"
+                handleNodeStartFailure(e, "Restart failed")
             }
         }
+    }
+
+    private fun handleNodeStartFailure(e: Exception, fallbackMessage: String) {
+        if (isRetryableNodeStartFailure(e)) {
+            _phase.value = Phase.SYNCING
+            _errorMessage.value = ""
+            _statusMessage.value = "Network unstable. Retrying wallet sync..."
+            scheduleNodeStartRetry()
+            return
+        }
+
+        _errorMessage.value = e.message ?: fallbackMessage
+        _phase.value = Phase.ERROR
+    }
+
+    // Matched by exception type (not message text) since LDK's Display strings aren't a stable
+    // contract across ldk-node versions — only these variants indicate a transient chain-source
+    // issue that a retry can plausibly fix.
+    private fun isRetryableNodeStartFailure(e: Exception): Boolean {
+        if (e is NodeException) {
+            return e is NodeException.FeerateEstimationUpdateFailed ||
+                e is NodeException.FeerateEstimationUpdateTimeout ||
+                e is NodeException.TxSyncFailed ||
+                e is NodeException.TxSyncTimeout ||
+                e is NodeException.GossipUpdateFailed ||
+                e is NodeException.GossipUpdateTimeout ||
+                e is NodeException.WalletOperationFailed ||
+                e is NodeException.WalletOperationTimeout ||
+                e is NodeException.LiquiditySourceUnavailable ||
+                e is NodeException.ConnectionFailed
+        }
+        val msg = e.message?.lowercase() ?: return false
+        return msg.contains("fee rate estimates") ||
+            msg.contains("timed out") ||
+            msg.contains("network is unreachable") ||
+            msg.contains("dns") ||
+            msg.contains("connection refused")
     }
 
     /**
@@ -1239,6 +1352,8 @@ class AppState(private val context: Context) : ViewModel() {
                 ?: context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
                     .getString("closing_funding_txid", null)
             if (closeFundingTxid != null && databaseService != null) {
+                trackedClosingFundingTxid = closeFundingTxid
+                mempoolWebSocketService.trackTx(closeFundingTxid)
                 // Clear the pref now that we've consumed it
                 context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
                     .edit().remove("closing_funding_txid").apply()
@@ -1247,6 +1362,8 @@ class AppState(private val context: Context) : ViewModel() {
                     onResolved = { _, txid ->
                         Log.d("AppState", "Close TX resolved: $txid")
                         setLastCloseTxid(txid)
+                        mempoolWebSocketService.untrackTx(closeFundingTxid)
+                        trackedClosingFundingTxid = null
                     }
                 )
                 viewModelScope.launch(Dispatchers.IO) {
@@ -1292,7 +1409,178 @@ class AppState(private val context: Context) : ViewModel() {
                 recordCurrentPrice()
                 runStabilityCheck()
                 detectOnchainDeposit()
+                pollPaymentConfirmations()
             }
+        }
+    }
+
+    fun triggerConfirmationRefresh() {
+        viewModelScope.launch(Dispatchers.IO) {
+            pollPaymentConfirmations(force = true)
+        }
+    }
+
+    private fun requiredConfirmationsForType(paymentType: String): Int {
+        return when (paymentType) {
+            "splice_in", "splice_out" -> 1
+            else -> 6
+        }
+    }
+
+    private data class TxConfirmationStatus(
+        val confirmed: Boolean,
+        val blockHeight: Int?
+    )
+
+    private fun fetchChainTipHeight(): Int? {
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/blocks/tip/height")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string()?.trim() ?: return@use
+                    body.toIntOrNull()?.let { return it }
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private fun fetchTxConfirmationStatus(txid: String): TxConfirmationStatus? {
+        val normalizedTxid = txid.substringBefore(":").trim()
+        if (normalizedTxid.isEmpty()) return null
+
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val json = JSONObject(body)
+                    val confirmed = json.optBoolean("confirmed", false)
+                    val blockHeight = if (json.has("block_height") && !json.isNull("block_height")) {
+                        json.optInt("block_height", 0).takeIf { it > 0 }
+                    } else {
+                        null
+                    }
+                    return TxConfirmationStatus(confirmed = confirmed, blockHeight = blockHeight)
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private fun fetchTxPaysToAddress(txid: String, address: String): Boolean? {
+        val normalizedTxid = txid.substringBefore(":").trim()
+        if (normalizedTxid.isEmpty() || address.isBlank()) return null
+
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        for (baseUrl in urls) {
+            try {
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val txJson = JSONObject(body)
+                    val vouts = txJson.optJSONArray("vout") ?: return@use
+                    for (i in 0 until vouts.length()) {
+                        val vout = vouts.optJSONObject(i) ?: continue
+                        if (vout.optString("scriptpubkey_address", "") == address) {
+                            return true
+                        }
+                    }
+                    return false
+                }
+            } catch (_: Exception) {
+            }
+        }
+        return null
+    }
+
+    private suspend fun pollPaymentConfirmations(force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && (now - lastConfirmationPollAtMs) < 15_000) {
+            return
+        }
+        if (isConfirmationPolling) {
+            return
+        }
+
+        val db = databaseService ?: return
+        isConfirmationPolling = true
+        try {
+            val tipHeight = fetchChainTipHeight() ?: return
+            val pending = db.getPaymentsNeedingConfirmation(limit = 100)
+            var anyUpdated = false
+
+            pending.forEach { payment ->
+                val txid = payment.txid ?: return@forEach
+
+                if (payment.paymentType == "onchain" && payment.direction == "received") {
+                    val expectedAddress = payment.address?.trim().orEmpty()
+                    if (expectedAddress.isNotEmpty()) {
+                        when (fetchTxPaysToAddress(txid, expectedAddress)) {
+                            false -> {
+                                val cleared = db.clearPaymentTxidForRow(payment.id)
+                                anyUpdated = anyUpdated || cleared
+                                if (_lastReceiveTxid.value == txid) {
+                                    setLastReceiveTxid(null, null)
+                                }
+                                AuditService.log("ONCHAIN_TXID_ADDRESS_MISMATCH", mapOf(
+                                    "payment_id" to payment.id,
+                                    "txid" to txid,
+                                    "address" to expectedAddress
+                                ))
+                                return@forEach
+                            }
+                            null -> return@forEach
+                            true -> {
+                            }
+                        }
+                    }
+                }
+
+                val txStatus = fetchTxConfirmationStatus(txid) ?: return@forEach
+                val required = requiredConfirmationsForType(payment.paymentType)
+
+                val (newConfirmations, newStatus) = if (!txStatus.confirmed) {
+                    0 to "pending"
+                } else {
+                    val blockHeight = txStatus.blockHeight
+                    val confs = if (blockHeight != null) {
+                        (tipHeight - blockHeight + 1).coerceAtLeast(0).coerceAtMost(required)
+                    } else {
+                        payment.confirmations.coerceAtLeast(1).coerceAtMost(required)
+                    }
+                    confs to if (confs >= required) "completed" else "pending"
+                }
+
+                if (payment.confirmations != newConfirmations || payment.status != newStatus) {
+                    val updated = db.updatePaymentConfirmationState(
+                        paymentRowId = payment.id,
+                        confirmations = newConfirmations,
+                        status = newStatus
+                    )
+                    anyUpdated = anyUpdated || updated
+                }
+            }
+
+            if (anyUpdated) {
+                _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
+            }
+            lastConfirmationPollAtMs = now
+        } finally {
+            isConfirmationPolling = false
         }
     }
 
@@ -1401,6 +1689,12 @@ class AppState(private val context: Context) : ViewModel() {
         }
     }
 
+    private fun clearOnchainDepositStatusIfNeeded() {
+        if (_statusMessage.value.startsWith("Onchain deposit detected", ignoreCase = true)) {
+            _statusMessage.value = ""
+        }
+    }
+
     private fun reconcilePendingOutgoingStabilityPayment(): Boolean {
         val db = databaseService ?: return false
         val pending = try { db.loadPendingSend() } catch (_: Exception) { return false } ?: return true
@@ -1493,6 +1787,7 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     internal fun detectOnchainDeposit() {
+        val db = databaseService
         // Use already-updated value — refreshBalances() was just called before this
         val currentSats = _onchainBalanceSats.value
         if (currentSats > prevOnchainSats && !isSweeping && pendingSplice == null) {
@@ -1505,24 +1800,54 @@ class AppState(private val context: Context) : ViewModel() {
 
             // Check for pending channel close (in-memory or DB) to avoid duplicate entries
             val closeId = pendingClosePaymentId
-                ?: databaseService?.getPendingChannelClosePaymentId()
+                ?: db?.getPendingChannelClosePaymentId()
             if (closeId != null) {
-                databaseService?.updatePaymentStatus(closeId, "completed")
+                val knownCloseTxid = db?.getPaymentTxid(closeId) ?: _lastCloseTxid.value
+                if (!knownCloseTxid.isNullOrBlank()) {
+                    db?.updatePaymentTxid(closeId, knownCloseTxid)
+                }
+                db?.updatePaymentStatus(closeId, "completed")
                 pendingClosePaymentId = null
+                trackedClosingFundingTxid?.let { mempoolWebSocketService.untrackTx(it) }
+                trackedClosingFundingTxid = null
                 isChannelClosing = false
                 AuditService.log("CHANNEL_CLOSE_CONFIRMED", mapOf("sats" to depositSats))
             } else {
+                val receiveAddress = _onchainReceiveAddress.value
+                val resolvedTxid = _lastReceiveTxid.value?.takeIf {
+                    !it.isNullOrBlank() &&
+                        !receiveAddress.isNullOrBlank() &&
+                        lastReceiveTxidAddress == receiveAddress
+                }
                 // No pending close — record as new on-chain deposit
-                val dedupId = "${System.currentTimeMillis() / 1000}_$depositSats"
-                databaseService?.recordPayment(
-                    paymentId = dedupId, paymentType = "onchain", direction = "received",
+                val dedupId = if (!resolvedTxid.isNullOrBlank()) {
+                    "onchain_receive_$resolvedTxid"
+                } else {
+                    "${System.currentTimeMillis() / 1000}_$depositSats"
+                }
+                val rowId = db?.recordPayment(
+                    paymentId = dedupId,
+                    paymentType = "onchain",
+                    direction = "received",
                     amountMsat = depositSats * 1000,
                     amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                    btcPrice = price
+                    btcPrice = price,
+                    status = "pending",
+                    txid = resolvedTxid,
+                    address = receiveAddress
                 )
-                AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf("sats" to depositSats))
+
+                if (rowId != null && rowId != -1L) {
+                    triggerPaymentFlash()
+                    AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
+                        "sats" to depositSats,
+                        "status" to "pending",
+                        "txid_known" to (!resolvedTxid.isNullOrBlank())
+                    ))
+                }
             }
-            // Start faster polling until deposit confirms
+            // Home card now carries pending receive state; remove stale capsule text.
+            clearOnchainDepositStatusIfNeeded()
             startPendingDepositPolling()
         }
         prevOnchainSats = currentSats
@@ -1534,15 +1859,16 @@ class AppState(private val context: Context) : ViewModel() {
         pendingDepositJob = viewModelScope.launch(Dispatchers.IO) {
             // Attempt to resolve txid if we have an address but no txid yet (handles app restarts)
             val address = _onchainReceiveAddress.value
-            if (address != null && _lastReceiveTxid.value == null) {
+            val shouldResolveTxid = address != null &&
+                (_lastReceiveTxid.value == null || lastReceiveTxidAddress != address)
+            if (shouldResolveTxid) {
                 // Run txid resolution in the background so it doesn't block the polling loop
                 launch {
                     val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
                     val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
                     if (txid != null) {
-                        _lastReceiveTxid.value = txid
-                        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                            .putString("last_receive_txid", txid).apply()
+                        setLastReceiveTxid(txid, address)
+                        databaseService?.attachTxidToLatestOnchainReceive(txid)
                     }
                 }
             }
@@ -1554,12 +1880,8 @@ class AppState(private val context: Context) : ViewModel() {
             
             // Deposit confirmed — aggressively clear stale txid and address from state and cache
             if (isActive && _spendableOnchainSats.value > 0L) {
-                _lastReceiveTxid.value = null
-                _onchainReceiveAddress.value = null
-                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                    .remove("last_receive_txid")
-                    .remove("onchain_receive_address")
-                    .apply()
+                setLastReceiveTxid(null, null)
+                setOnchainReceiveAddress(null)
             }
         }
     }
@@ -1697,19 +2019,137 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     fun setOnchainReceiveAddress(address: String?) {
-        if (address == null) return
+        val oldAddress = _onchainReceiveAddress.value
         _onchainReceiveAddress.value = address
-        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-            .putString("onchain_receive_address", address).apply()
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        if (address == null) {
+            editor.remove("onchain_receive_address")
+        } else {
+            editor.putString("onchain_receive_address", address)
+        }
+        editor.apply()
+
+        if (!oldAddress.isNullOrBlank() && oldAddress != address) {
+            mempoolWebSocketService.untrackAddress(oldAddress)
+        }
+
+        if (!address.isNullOrBlank() && oldAddress != address) {
+            // New receive request: drop stale txid from previous address/session.
+            setLastReceiveTxid(null, null)
+        }
+
+        if (address == null) {
+            return
+        }
+
+        mempoolWebSocketService.trackAddress(address)
         
         // Start polling for this address to be hit
         viewModelScope.launch {
             val esploraUrl = com.stablechannels.app.util.Constants.PRIMARY_CHAIN_URL
             val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
             if (txid != null) {
-                _lastReceiveTxid.value = txid
-                context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-                    .putString("last_receive_txid", txid).apply()
+                setLastReceiveTxid(txid, address)
+                databaseService?.attachTxidToLatestOnchainReceive(txid)
+            }
+        }
+    }
+
+    fun prepareChannelCloseTracking(userChannelId: String) {
+        setLastCloseTxid(null)
+        val liveTxid = nodeService.channels
+            .firstOrNull { it.userChannelId == userChannelId || it.isChannelReady }
+            ?.fundingTxo?.txid
+
+        if (!liveTxid.isNullOrBlank()) {
+            fundingTxid = liveTxid
+            trackedClosingFundingTxid = liveTxid
+            mempoolWebSocketService.trackTx(liveTxid)
+            context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+                .edit().putString("closing_funding_txid", liveTxid).apply()
+        }
+    }
+
+    private fun handleWebSocketTransactionDetected(event: WebSocketEvent) {
+        val db = databaseService ?: return
+
+        when (event) {
+            is WebSocketEvent.Receive -> {
+                if (isChannelClosing || isSweeping || pendingSplice != null) {
+                    return
+                }
+                if (event.amountSats < 1000) {
+                    return
+                }
+
+                val price = priceService.currentPrice.value
+                val amountUsd = if (price > 0) {
+                    (event.amountSats.toDouble() / Constants.SATS_IN_BTC) * price
+                } else {
+                    null
+                }
+
+                val paymentId = "onchain_receive_${event.txid}"
+                val rowId = db.recordPayment(
+                    paymentId = paymentId,
+                    paymentType = "onchain",
+                    direction = "received",
+                    amountMsat = event.amountSats * 1000,
+                    amountUSD = amountUsd,
+                    btcPrice = price.takeIf { it > 0 },
+                    status = "pending",
+                    txid = event.txid,
+                    address = event.target
+                )
+
+                if (rowId != -1L) {
+                    setLastReceiveTxid(event.txid, event.target)
+                    clearOnchainDepositStatusIfNeeded()
+                    triggerPaymentFlash()
+                    AuditService.log(
+                        "WEBSOCKET_INSTANT_PAYMENT_RECORDED",
+                        mapOf("txid" to event.txid, "sats" to event.amountSats)
+                    )
+                }
+            }
+
+            is WebSocketEvent.Removed -> {
+                try {
+                    db.failPaymentByTxid(event.txid)
+                    AuditService.log(
+                        "WEBSOCKET_RBF_FAILED_PAYMENT",
+                        mapOf("target" to event.target, "txid" to event.txid)
+                    )
+                } catch (e: Exception) {
+                    AuditService.log(
+                        "WEBSOCKET_RBF_FAIL_FAILED",
+                        mapOf("txid" to event.txid, "error" to (e.message ?: ""))
+                    )
+                }
+            }
+
+            is WebSocketEvent.TrackedOutspend -> {
+                if (!isChannelClosing) {
+                    return
+                }
+
+                val expectedFundingTxid = trackedClosingFundingTxid
+                    ?: fundingTxid
+                    ?: context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+                        .getString("closing_funding_txid", null)
+
+                if (!expectedFundingTxid.isNullOrBlank() && expectedFundingTxid != event.trackedTxid) {
+                    return
+                }
+
+                val closeId = pendingClosePaymentId ?: db.getPendingChannelClosePaymentId()
+                if (!closeId.isNullOrBlank()) {
+                    db.updatePaymentTxid(closeId, event.spendingTxid)
+                    setLastCloseTxid(event.spendingTxid)
+                }
+
+                mempoolWebSocketService.untrackTx(event.trackedTxid)
+                trackedClosingFundingTxid = null
             }
         }
     }
@@ -1728,7 +2168,7 @@ class AppState(private val context: Context) : ViewModel() {
             val txo = channel.fundingTxo
             if (txo != null) {
                 val currentTxid = txo.txid
-                if (currentTxid != null && currentTxid != fundingTxid) {
+                if (currentTxid != fundingTxid) {
                     fundingTxid = currentTxid
                 }
             }
@@ -1898,15 +2338,25 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun scheduleNodeStartRetry() {
         if (nodeStartRetryJob?.isActive == true) return
+        val delayMs = min((2.0.pow(nodeStartRetryAttempts.toDouble()) * 1000.0).toLong(), 60_000L)
+        nodeStartRetryAttempts = min(nodeStartRetryAttempts + 1, 6)
         nodeStartRetryJob = viewModelScope.launch(Dispatchers.IO) {
+            delay(delayMs)
             while (isActive && backgroundServiceOwnsLdk()) {
                 delay(1_000)
             }
             if (!isActive || nodeService.isRunning) return@launch
-            Log.d("AppState", "Retrying node start after LDK owner released")
+            // Re-check primary/fallback health so a retry doesn't keep hammering the same
+            // degraded esplora endpoint that just failed the fee-rate/chain-sync fetch.
+            chainUrl = resolveChainUrl()
+            Log.d("AppState", "Retrying node start after LDK owner released (chainUrl=$chainUrl)")
             _statusMessage.value = "Syncing wallet..."
             restartNodeFromForeground()
         }
+    }
+
+    private fun resetNodeStartRetryState() {
+        nodeStartRetryAttempts = 0
     }
 
     private fun reregisterPushTokenIfNeeded() {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1820,43 +1820,36 @@ class AppState(private val context: Context) : ViewModel() {
                         lastReceiveTxidAddress == receiveAddress
                 }
 
-                // If we can't tie this balance increase to a specific txid/address, it may
-                // already be tracked under a different (now-inactive) receive address — e.g.
-                // the websocket path recorded it before the user requested a new receive
-                // address. Skip creating a second, txid-less duplicate row in that case;
-                // confirmation polling will resolve the existing pending row instead.
-                val existingPendingReceive = resolvedTxid.isNullOrBlank() &&
-                    db?.latestPendingOnchainReceive() != null
-
-                if (existingPendingReceive) {
-                    AuditService.log("ONCHAIN_DEPOSIT_SKIPPED_DUPLICATE", mapOf("sats" to depositSats))
+                // Always record the deposit, mirroring iOS. When the websocket and this
+                // balance-delta path both see the same deposit, the pair is reconciled at
+                // txid time instead of skipped up front: recordWebSocketReceive adopts a
+                // txid-less placeholder, and reconcileResolvedReceiveTxid deletes it when
+                // the websocket row already exists. A skip heuristic here silently omits a
+                // second deposit arriving while any earlier receive is still confirming.
+                val dedupId = if (!resolvedTxid.isNullOrBlank()) {
+                    "onchain_receive_$resolvedTxid"
                 } else {
-                    // No pending close — record as new on-chain deposit
-                    val dedupId = if (!resolvedTxid.isNullOrBlank()) {
-                        "onchain_receive_$resolvedTxid"
-                    } else {
-                        "${System.currentTimeMillis() / 1000}_$depositSats"
-                    }
-                    val rowId = db?.recordPayment(
-                        paymentId = dedupId,
-                        paymentType = "onchain",
-                        direction = "received",
-                        amountMsat = depositSats * 1000,
-                        amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                        btcPrice = price,
-                        status = "pending",
-                        txid = resolvedTxid,
-                        address = receiveAddress
-                    )
+                    "onchain_deposit_${java.util.UUID.randomUUID()}"
+                }
+                val rowId = db?.recordPayment(
+                    paymentId = dedupId,
+                    paymentType = "onchain",
+                    direction = "received",
+                    amountMsat = depositSats * 1000,
+                    amountUSD = (depositSats.toDouble() / Constants.SATS_IN_BTC) * price,
+                    btcPrice = price,
+                    status = "pending",
+                    txid = resolvedTxid,
+                    address = receiveAddress
+                )
 
-                    if (rowId != null && rowId != -1L) {
-                        triggerPaymentFlash()
-                        AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
-                            "sats" to depositSats,
-                            "status" to "pending",
-                            "txid_known" to (!resolvedTxid.isNullOrBlank())
-                        ))
-                    }
+                if (rowId != null && rowId != -1L) {
+                    triggerPaymentFlash()
+                    AuditService.log("ONCHAIN_DEPOSIT_DETECTED", mapOf(
+                        "sats" to depositSats,
+                        "status" to "pending",
+                        "txid_known" to (!resolvedTxid.isNullOrBlank())
+                    ))
                 }
             }
             // Home card now carries pending receive state; remove stale capsule text.
@@ -1881,7 +1874,7 @@ class AppState(private val context: Context) : ViewModel() {
                     val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
                     if (txid != null) {
                         setLastReceiveTxid(txid, address)
-                        databaseService?.attachTxidToLatestOnchainReceive(txid, address)
+                        databaseService?.reconcileResolvedReceiveTxid(txid, address)
                     }
                 }
             }
@@ -2063,7 +2056,7 @@ class AppState(private val context: Context) : ViewModel() {
             val txid = com.stablechannels.app.services.OnchainTxidResolver.resolve(address, esploraUrl)
             if (txid != null) {
                 setLastReceiveTxid(txid, address)
-                databaseService?.attachTxidToLatestOnchainReceive(txid, address)
+                databaseService?.reconcileResolvedReceiveTxid(txid, address)
             }
         }
     }
@@ -2103,14 +2096,11 @@ class AppState(private val context: Context) : ViewModel() {
                 }
 
                 val paymentId = "onchain_receive_${event.txid}"
-                val rowId = db.recordPayment(
+                val rowId = db.recordWebSocketReceive(
                     paymentId = paymentId,
-                    paymentType = "onchain",
-                    direction = "received",
                     amountMsat = event.amountSats * 1000,
                     amountUSD = amountUsd,
                     btcPrice = price.takeIf { it > 0 },
-                    status = "pending",
                     txid = event.txid,
                     address = event.target
                 )

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -598,12 +598,21 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     private data class PendingPlaceholder(val id: Long, val amountMsat: Long)
 
     /** The newest txid-less pending receive placeholder for an address — the row the
-     *  balance-delta path writes before the txid is known. */
-    private fun findPendingPlaceholder(db: SQLiteDatabase, address: String): PendingPlaceholder? =
-        db.rawQuery(
-            "SELECT id, amount_msat FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
-            arrayOf(address)
+     *  balance-delta path writes before the txid is known. When `amountMsat` is given, only a
+     *  placeholder with exactly that amount matches: several deposits to the same (reused)
+     *  address can be pending at once, and amount is what tells their placeholders apart. */
+    private fun findPendingPlaceholder(
+        db: SQLiteDatabase,
+        address: String,
+        amountMsat: Long? = null
+    ): PendingPlaceholder? {
+        val amountFilter = if (amountMsat != null) "AND amount_msat = ? " else ""
+        val args = if (amountMsat != null) arrayOf(address, amountMsat.toString()) else arrayOf(address)
+        return db.rawQuery(
+            "SELECT id, amount_msat FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') AND status = 'pending' " + amountFilter + "ORDER BY created_at DESC LIMIT 1",
+            args
         ).use { c -> if (c.moveToFirst()) PendingPlaceholder(c.getLong(0), c.getLong(1)) else null }
+    }
 
     /** Record a websocket-detected receive unless its txid is already tracked. Check and write
      *  run in one transaction so a concurrent balance-delta detection can't double-insert. If the
@@ -633,9 +642,9 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             // Adopt only on an exact amount match: for a single deposit the balance delta
             // equals the vout sum, so a placeholder with a different amount is a DIFFERENT
             // deposit still awaiting its own txid — adopting it would erase that deposit
-            // from history. Amount-mismatched pairs converge via reconcileResolvedReceiveTxid.
-            val placeholder = findPendingPlaceholder(db, address)
-                ?.takeIf { it.amountMsat == amountMsat }
+            // from history. The amount is part of the lookup (not a post-check on the newest
+            // row) so the right placeholder is found even when several are pending.
+            val placeholder = findPendingPlaceholder(db, address, amountMsat)
 
             val rowId: Long
             if (placeholder != null) {
@@ -684,16 +693,21 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 arrayOf(txid)
             ).use { c -> if (c.moveToFirst()) c.getLong(0) else null }
 
-            val placeholder = findPendingPlaceholder(db, address)
-            val changed = when {
-                placeholder == null -> false
-                websocketRowAmountMsat == null -> {
+            val changed = if (websocketRowAmountMsat != null) {
+                // The websocket already recorded this deposit; only the placeholder with the
+                // SAME amount is its duplicate — a different-amount placeholder belongs to
+                // another deposit and must survive.
+                findPendingPlaceholder(db, address, websocketRowAmountMsat)?.let {
+                    db.delete("payments", "id = ?", arrayOf(it.id.toString())) > 0
+                } ?: false
+            } else {
+                // No amount to disambiguate by (the resolver returns only a txid), so this
+                // attaches to the newest placeholder — with several deposits pending it can
+                // pick the wrong one. Making the resolver return per-tx vout sums would fix it.
+                findPendingPlaceholder(db, address)?.let {
                     val cv = ContentValues().apply { put("txid", txid) }
-                    db.update("payments", cv, "id = ?", arrayOf(placeholder.id.toString())) > 0
-                }
-                websocketRowAmountMsat == placeholder.amountMsat ->
-                    db.delete("payments", "id = ?", arrayOf(placeholder.id.toString())) > 0
-                else -> false
+                    db.update("payments", cv, "id = ?", arrayOf(it.id.toString())) > 0
+                } ?: false
             }
             db.setTransactionSuccessful()
             return changed

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -595,12 +595,15 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
     }
 
+    private data class PendingPlaceholder(val id: Long, val amountMsat: Long)
+
     /** The newest txid-less pending receive placeholder for an address — the row the
      *  balance-delta path writes before the txid is known. */
-    private fun findPendingPlaceholderId(db: SQLiteDatabase, address: String): Long? = db.rawQuery(
-        "SELECT id FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
-        arrayOf(address)
-    ).use { c -> if (c.moveToFirst()) c.getLong(0) else null }
+    private fun findPendingPlaceholder(db: SQLiteDatabase, address: String): PendingPlaceholder? =
+        db.rawQuery(
+            "SELECT id, amount_msat FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
+            arrayOf(address)
+        ).use { c -> if (c.moveToFirst()) PendingPlaceholder(c.getLong(0), c.getLong(1)) else null }
 
     /** Record a websocket-detected receive unless its txid is already tracked. Check and write
      *  run in one transaction so a concurrent balance-delta detection can't double-insert. If the
@@ -627,12 +630,15 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 return -1L
             }
 
-            val placeholderId = findPendingPlaceholderId(db, address)
+            // Adopt only on an exact amount match: for a single deposit the balance delta
+            // equals the vout sum, so a placeholder with a different amount is a DIFFERENT
+            // deposit still awaiting its own txid — adopting it would erase that deposit
+            // from history. Amount-mismatched pairs converge via reconcileResolvedReceiveTxid.
+            val placeholder = findPendingPlaceholder(db, address)
+                ?.takeIf { it.amountMsat == amountMsat }
 
             val rowId: Long
-            if (placeholderId != null) {
-                // The websocket amount is the exact output sum; it supersedes the
-                // balance-delta estimate the placeholder was created with.
+            if (placeholder != null) {
                 val cv = ContentValues().apply {
                     put("payment_id", paymentId)
                     put("txid", txid)
@@ -640,8 +646,8 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                     amountUSD?.let { put("amount_usd", it) }
                     btcPrice?.let { put("btc_price", it) }
                 }
-                db.update("payments", cv, "id = ?", arrayOf(placeholderId.toString()))
-                rowId = placeholderId
+                db.update("payments", cv, "id = ?", arrayOf(placeholder.id.toString()))
+                rowId = placeholder.id
             } else {
                 val cv = ContentValues().apply {
                     put("payment_id", paymentId)
@@ -664,26 +670,30 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     }
 
     /** Reconcile an HTTP-resolver-resolved txid against the receive rows, in one transaction.
-     *  If any row already carries the txid, the websocket recorded this deposit first and the
-     *  txid-less placeholder for this address is a duplicate — delete it. Otherwise attach the
-     *  txid to that placeholder. */
+     *  If a row already carries the txid AND its amount matches the placeholder's, the websocket
+     *  recorded this same deposit first — the placeholder is a duplicate, delete it. On an amount
+     *  mismatch the placeholder is a different deposit whose txid the resolver couldn't tell
+     *  apart (the resolver looks up by address, not per-deposit), so it is left alone rather
+     *  than deleted or mislabeled. With no websocket row, attach the txid to the placeholder. */
     fun reconcileResolvedReceiveTxid(txid: String, address: String): Boolean {
         val db = writableDatabase
         db.beginTransaction()
         try {
-            val websocketRowExists = db.rawQuery(
-                "SELECT 1 FROM payments WHERE txid = ? LIMIT 1",
+            val websocketRowAmountMsat = db.rawQuery(
+                "SELECT amount_msat FROM payments WHERE txid = ? LIMIT 1",
                 arrayOf(txid)
-            ).use { it.moveToFirst() }
+            ).use { c -> if (c.moveToFirst()) c.getLong(0) else null }
 
-            val placeholderId = findPendingPlaceholderId(db, address)
-            val changed = if (placeholderId == null) {
-                false
-            } else if (websocketRowExists) {
-                db.delete("payments", "id = ?", arrayOf(placeholderId.toString())) > 0
-            } else {
-                val cv = ContentValues().apply { put("txid", txid) }
-                db.update("payments", cv, "id = ?", arrayOf(placeholderId.toString())) > 0
+            val placeholder = findPendingPlaceholder(db, address)
+            val changed = when {
+                placeholder == null -> false
+                websocketRowAmountMsat == null -> {
+                    val cv = ContentValues().apply { put("txid", txid) }
+                    db.update("payments", cv, "id = ?", arrayOf(placeholder.id.toString())) > 0
+                }
+                websocketRowAmountMsat == placeholder.amountMsat ->
+                    db.delete("payments", "id = ?", arrayOf(placeholder.id.toString())) > 0
+                else -> false
             }
             db.setTransactionSuccessful()
             return changed

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -595,11 +595,12 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
     }
 
-    fun attachTxidToLatestOnchainReceive(txid: String): Boolean {
+    fun attachTxidToLatestOnchainReceive(txid: String, address: String): Boolean {
         val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND (txid IS NULL OR txid = '') ORDER BY created_at DESC LIMIT 1)"
+            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') ORDER BY created_at DESC LIMIT 1)"
         )
         stmt.bindString(1, txid)
+        stmt.bindString(2, address)
         return stmt.executeUpdateDelete() > 0
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -595,25 +595,101 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
     }
 
-    fun attachTxidToLatestOnchainReceive(txid: String, address: String): Boolean {
-        val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') ORDER BY created_at DESC LIMIT 1)"
-        )
-        stmt.bindString(1, txid)
-        stmt.bindString(2, address)
-        return stmt.executeUpdateDelete() > 0
+    /** The newest txid-less pending receive placeholder for an address — the row the
+     *  balance-delta path writes before the txid is known. */
+    private fun findPendingPlaceholderId(db: SQLiteDatabase, address: String): Long? = db.rawQuery(
+        "SELECT id FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND address = ? AND (txid IS NULL OR txid = '') AND status = 'pending' ORDER BY created_at DESC LIMIT 1",
+        arrayOf(address)
+    ).use { c -> if (c.moveToFirst()) c.getLong(0) else null }
+
+    /** Record a websocket-detected receive unless its txid is already tracked. Check and write
+     *  run in one transaction so a concurrent balance-delta detection can't double-insert. If the
+     *  balance-delta path already wrote a txid-less placeholder for this address, that row is
+     *  adopted (txid + exact websocket amount attached) instead of inserting a second row.
+     *  Returns the row id, or -1 when the txid is already on any row. */
+    fun recordWebSocketReceive(
+        paymentId: String,
+        amountMsat: Long,
+        amountUSD: Double?,
+        btcPrice: Double?,
+        txid: String,
+        address: String
+    ): Long {
+        val db = writableDatabase
+        db.beginTransaction()
+        try {
+            val alreadyTracked = db.rawQuery(
+                "SELECT 1 FROM payments WHERE txid = ? OR payment_id = ? LIMIT 1",
+                arrayOf(txid, paymentId)
+            ).use { it.moveToFirst() }
+            if (alreadyTracked) {
+                db.setTransactionSuccessful()
+                return -1L
+            }
+
+            val placeholderId = findPendingPlaceholderId(db, address)
+
+            val rowId: Long
+            if (placeholderId != null) {
+                // The websocket amount is the exact output sum; it supersedes the
+                // balance-delta estimate the placeholder was created with.
+                val cv = ContentValues().apply {
+                    put("payment_id", paymentId)
+                    put("txid", txid)
+                    put("amount_msat", amountMsat)
+                    amountUSD?.let { put("amount_usd", it) }
+                    btcPrice?.let { put("btc_price", it) }
+                }
+                db.update("payments", cv, "id = ?", arrayOf(placeholderId.toString()))
+                rowId = placeholderId
+            } else {
+                val cv = ContentValues().apply {
+                    put("payment_id", paymentId)
+                    put("payment_type", "onchain")
+                    put("direction", "received")
+                    put("amount_msat", amountMsat)
+                    put("amount_usd", amountUSD)
+                    put("btc_price", btcPrice)
+                    put("status", "pending")
+                    put("txid", txid)
+                    put("address", address)
+                }
+                rowId = db.insert("payments", null, cv)
+            }
+            db.setTransactionSuccessful()
+            return rowId
+        } finally {
+            db.endTransaction()
+        }
     }
 
-    fun paymentExists(txid: String, excludePaymentId: String): Boolean {
-        val cursor = readableDatabase.rawQuery(
-            "SELECT 1 FROM payments WHERE txid = ? AND payment_id != ? LIMIT 1",
-            arrayOf(txid, excludePaymentId)
-        )
-        return cursor.use { it.moveToFirst() }
-    }
+    /** Reconcile an HTTP-resolver-resolved txid against the receive rows, in one transaction.
+     *  If any row already carries the txid, the websocket recorded this deposit first and the
+     *  txid-less placeholder for this address is a duplicate — delete it. Otherwise attach the
+     *  txid to that placeholder. */
+    fun reconcileResolvedReceiveTxid(txid: String, address: String): Boolean {
+        val db = writableDatabase
+        db.beginTransaction()
+        try {
+            val websocketRowExists = db.rawQuery(
+                "SELECT 1 FROM payments WHERE txid = ? LIMIT 1",
+                arrayOf(txid)
+            ).use { it.moveToFirst() }
 
-    fun deletePayment(paymentId: String) {
-        writableDatabase.delete("payments", "payment_id = ?", arrayOf(paymentId))
+            val placeholderId = findPendingPlaceholderId(db, address)
+            val changed = if (placeholderId == null) {
+                false
+            } else if (websocketRowExists) {
+                db.delete("payments", "id = ?", arrayOf(placeholderId.toString())) > 0
+            } else {
+                val cv = ContentValues().apply { put("txid", txid) }
+                db.update("payments", cv, "id = ?", arrayOf(placeholderId.toString())) > 0
+            }
+            db.setTransactionSuccessful()
+            return changed
+        } finally {
+            db.endTransaction()
+        }
     }
 
     fun failPaymentByTxid(txid: String) {
@@ -621,14 +697,6 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             "UPDATE payments SET status = 'failed' WHERE txid = ? AND status = 'pending'",
             arrayOf(txid)
         )
-    }
-
-    fun completePaymentByTxid(txid: String): Boolean {
-        val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET status = 'completed' WHERE txid = ? AND status = 'pending'"
-        )
-        stmt.bindString(1, txid)
-        return stmt.executeUpdateDelete() > 0
     }
 
     fun getPendingChannelClosePaymentId(): String? {

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -483,6 +483,95 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    fun latestPendingOnchainReceive(): PaymentRecord? {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, created_at, fee_msat, txid, address, confirmations
+            FROM payments
+            WHERE payment_type = 'onchain'
+              AND direction = 'received'
+              AND status = 'pending'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """.trimIndent(),
+            null
+        )
+        return cursor.use { c ->
+            if (!c.moveToFirst()) return@use null
+            PaymentRecord(
+                id = c.getLong(0), paymentId = c.getStringOrNull(1),
+                paymentType = c.getString(2), direction = c.getString(3),
+                amountMsat = c.getLong(4), amountUSD = c.getDoubleOrNull(5),
+                btcPrice = c.getDoubleOrNull(6), counterparty = c.getStringOrNull(7),
+                status = c.getString(8), createdAt = c.getLong(9),
+                feeMsat = c.getLong(10), txid = c.getStringOrNull(11),
+                address = c.getStringOrNull(12), confirmations = c.getInt(13)
+            )
+        }
+    }
+
+    fun getPaymentsNeedingConfirmation(limit: Int = 50): List<PaymentRecord> {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, created_at, fee_msat, txid, address, confirmations
+            FROM payments
+            WHERE txid IS NOT NULL AND txid != ''
+              AND payment_type IN ('onchain', 'channel_close', 'splice_in', 'splice_out')
+              AND status != 'failed'
+              AND (
+                    (payment_type IN ('onchain', 'channel_close') AND confirmations < 6)
+                    OR
+                    (payment_type IN ('splice_in', 'splice_out') AND confirmations < 1)
+                  )
+            ORDER BY created_at DESC
+            LIMIT ?
+            """.trimIndent(),
+            arrayOf(limit.toString())
+        )
+        return cursor.use { c ->
+            val list = mutableListOf<PaymentRecord>()
+            while (c.moveToNext()) {
+                list.add(PaymentRecord(
+                    id = c.getLong(0), paymentId = c.getStringOrNull(1),
+                    paymentType = c.getString(2), direction = c.getString(3),
+                    amountMsat = c.getLong(4), amountUSD = c.getDoubleOrNull(5),
+                    btcPrice = c.getDoubleOrNull(6), counterparty = c.getStringOrNull(7),
+                    status = c.getString(8), createdAt = c.getLong(9),
+                    feeMsat = c.getLong(10), txid = c.getStringOrNull(11),
+                    address = c.getStringOrNull(12), confirmations = c.getInt(13)
+                ))
+            }
+            list
+        }
+    }
+
+    fun updatePaymentConfirmationState(paymentRowId: Long, confirmations: Int, status: String): Boolean {
+        val cv = ContentValues().apply {
+            put("confirmations", confirmations)
+            put("status", status)
+        }
+        return writableDatabase.update(
+            "payments",
+            cv,
+            "id = ?",
+            arrayOf(paymentRowId.toString())
+        ) > 0
+    }
+
+    fun clearPaymentTxidForRow(paymentRowId: Long): Boolean {
+        val cv = ContentValues().apply {
+            putNull("txid")
+            put("confirmations", 0)
+            put("status", "pending")
+        }
+        return writableDatabase.update(
+            "payments",
+            cv,
+            "id = ?",
+            arrayOf(paymentRowId.toString())
+        ) > 0
+    }
+
     fun updatePaymentStatus(paymentId: String, status: String, feeMsat: Long = 0) {
         val cv = ContentValues().apply {
             put("status", status)
@@ -504,6 +593,41 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             put("txid", txid)
         }
         writableDatabase.update("payments", cv, "payment_id = ?", arrayOf(paymentId))
+    }
+
+    fun attachTxidToLatestOnchainReceive(txid: String): Boolean {
+        val stmt = writableDatabase.compileStatement(
+            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'onchain' AND direction = 'received' AND (txid IS NULL OR txid = '') ORDER BY created_at DESC LIMIT 1)"
+        )
+        stmt.bindString(1, txid)
+        return stmt.executeUpdateDelete() > 0
+    }
+
+    fun paymentExists(txid: String, excludePaymentId: String): Boolean {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT 1 FROM payments WHERE txid = ? AND payment_id != ? LIMIT 1",
+            arrayOf(txid, excludePaymentId)
+        )
+        return cursor.use { it.moveToFirst() }
+    }
+
+    fun deletePayment(paymentId: String) {
+        writableDatabase.delete("payments", "payment_id = ?", arrayOf(paymentId))
+    }
+
+    fun failPaymentByTxid(txid: String) {
+        writableDatabase.execSQL(
+            "UPDATE payments SET status = 'failed' WHERE txid = ? AND status = 'pending'",
+            arrayOf(txid)
+        )
+    }
+
+    fun completePaymentByTxid(txid: String): Boolean {
+        val stmt = writableDatabase.compileStatement(
+            "UPDATE payments SET status = 'completed' WHERE txid = ? AND status = 'pending'"
+        )
+        stmt.bindString(1, txid)
+        return stmt.executeUpdateDelete() > 0
     }
 
     fun getPendingChannelClosePaymentId(): String? {

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolMessage.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolMessage.kt
@@ -1,0 +1,58 @@
+package com.stablechannels.app.services.websocket
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MempoolWSBlock(
+    val height: Int
+)
+
+@Serializable
+data class MempoolWSVout(
+    @SerialName("scriptpubkey_address") val scriptpubkeyAddress: String? = null,
+    val value: Long? = null
+)
+
+@Serializable
+data class MempoolWSVin(
+    val txid: String? = null
+)
+
+@Serializable
+data class MempoolWSTransaction(
+    val txid: String,
+    val vout: List<MempoolWSVout>? = null,
+    val vin: List<MempoolWSVin>? = null
+)
+
+@Serializable
+data class MempoolWSAddressTransactions(
+    val mempool: List<MempoolWSTransaction>? = null,
+    val confirmed: List<MempoolWSTransaction>? = null,
+    val removed: List<MempoolWSTransaction>? = null
+)
+
+@Serializable
+data class MempoolWSOutspend(
+    val txid: String,
+    val vin: Int
+)
+
+@Serializable
+data class MempoolWSTxTrackingInfo(
+    @SerialName("utxoSpent") val utxoSpent: Map<String, MempoolWSOutspend>? = null,
+    val confirmed: Boolean? = null
+)
+
+@Serializable
+data class MempoolWSMessage(
+    val block: MempoolWSBlock? = null,
+    val blocks: List<MempoolWSBlock>? = null,
+    @SerialName("address-transactions") val addressTransactions: List<MempoolWSTransaction>? = null,
+    @SerialName("block-transactions") val blockTransactions: List<MempoolWSTransaction>? = null,
+    val address: String? = null,
+    val txid: String? = null,
+    @SerialName("multi-address-transactions") val multiAddressTransactions: Map<String, MempoolWSAddressTransactions>? = null,
+    @SerialName("tracked-txs") val trackedTxs: Map<String, MempoolWSTxTrackingInfo>? = null
+)

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolWebSocketService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolWebSocketService.kt
@@ -1,0 +1,351 @@
+package com.stablechannels.app.services.websocket
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+class MempoolWebSocketService(
+    private val endpointUrl: String = "wss://mempool.space/api/v1/ws",
+    private val serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val dedupStore: ProcessedTxStore = ProcessedTxStore(),
+    private val matcher: TransactionMatcher = TransactionMatcher(),
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .pingInterval(30, TimeUnit.SECONDS)
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .build(),
+    private val connectionFactory: WebSocketConnectionFactory = OkHttpWebSocketConnectionFactory(client)
+) : MempoolWebSocketClient {
+
+    companion object {
+        private const val TAG = "MempoolWebSocket"
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val reconnectManager = ReconnectionManager(serviceScope)
+
+    private val trackedAddresses = linkedSetOf<String>()
+    private val trackedTxids = linkedSetOf<String>()
+    private val pendingOutboundMessages = ArrayDeque<String>()
+
+    private val socketConnected = AtomicBoolean(false)
+    private val socketConnecting = AtomicBoolean(false)
+
+    private var webSocket: WebSocketConnection? = null
+
+    override val isConnected: Boolean
+        get() = socketConnected.get()
+
+    override var onTransactionDetected: ((WebSocketEvent) -> Unit)? = null
+    override var onBlockHeader: ((Int) -> Unit)? = null
+
+    init {
+        reconnectManager.onReconnect = {
+            connect()
+        }
+    }
+
+    // Avoid test-runtime crashes when android.util.Log is not mocked in JVM unit tests.
+    private fun logInfo(message: String) {
+        try {
+            Log.i(TAG, message)
+        } catch (_: Throwable) {
+        }
+    }
+
+    private fun logWarn(message: String) {
+        try {
+            Log.w(TAG, message)
+        } catch (_: Throwable) {
+        }
+    }
+
+    override fun connect() {
+        if (socketConnected.get() || socketConnecting.get()) {
+            return
+        }
+
+        reconnectManager.reset()
+        reconnectManager.stopReconnectTask()
+        socketConnecting.set(true)
+
+        webSocket?.cancel()
+        webSocket = null
+
+        webSocket = connectionFactory.create(
+            endpointUrl,
+            WebSocketCallbacks(
+                onOpen = {
+                    socketConnecting.set(false)
+                    socketConnected.set(true)
+                    reconnectManager.connected()
+                    logInfo("WebSocket connected")
+
+                    syncTracking()
+                    subscribeToBlocks()
+                    flushPendingMessages()
+                },
+                onMessage = { text ->
+                    handleMessage(text)
+                },
+                onClosing = { code, reason ->
+                    // Do not echo peer close codes; some reserved codes (e.g. 1005) are invalid to send.
+                    handleDisconnection("onClosing: $code $reason")
+                },
+                onClosed = { code, reason ->
+                    handleDisconnection("onClosed: $code $reason")
+                },
+                onFailure = { throwable ->
+                    handleDisconnection("onFailure: ${throwable.message}")
+                }
+            )
+        )
+        logInfo("Connecting to $endpointUrl")
+    }
+
+    override fun disconnect() {
+        reconnectManager.stop()
+        socketConnecting.set(false)
+        socketConnected.set(false)
+        webSocket?.close(1000, "manual disconnect")
+        webSocket = null
+        logInfo("Disconnected")
+    }
+
+    override fun trackAddress(address: String) {
+        val normalized = address.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        synchronized(trackedAddresses) {
+            trackedAddresses.add(normalized)
+        }
+
+        if (isConnected) {
+            syncTracking()
+        } else {
+            connect()
+        }
+    }
+
+    override fun untrackAddress(address: String) {
+        val normalized = address.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        synchronized(trackedAddresses) {
+            trackedAddresses.remove(normalized)
+        }
+        if (isConnected) {
+            syncTracking()
+        }
+    }
+
+    override fun trackTx(txid: String) {
+        val normalized = txid.trim()
+        if (!isValidTxid(normalized)) {
+            return
+        }
+        synchronized(trackedTxids) {
+            trackedTxids.add(normalized)
+        }
+
+        if (isConnected) {
+            syncTracking()
+        } else {
+            connect()
+        }
+    }
+
+    override fun untrackTx(txid: String) {
+        val normalized = txid.trim()
+        if (normalized.isEmpty()) {
+            return
+        }
+        synchronized(trackedTxids) {
+            trackedTxids.remove(normalized)
+        }
+        if (isConnected) {
+            syncTracking()
+        }
+    }
+
+    private fun handleDisconnection(message: String) {
+        if (!socketConnected.get() && !socketConnecting.get()) {
+            return
+        }
+        socketConnecting.set(false)
+        socketConnected.set(false)
+        webSocket = null
+        logWarn("Disconnected: $message")
+        reconnectManager.disconnected()
+    }
+
+    private fun subscribeToBlocks() {
+        send("""{ "action": "want", "data": ["blocks", "mempool-blocks"] }""")
+    }
+
+    private fun send(text: String) {
+        val socket = webSocket
+        if (!isConnected || socket == null) {
+            synchronized(pendingOutboundMessages) {
+                pendingOutboundMessages.addLast(text)
+                if (pendingOutboundMessages.size > 50) {
+                    pendingOutboundMessages.removeFirst()
+                }
+            }
+            return
+        }
+        socket.send(text)
+    }
+
+    private fun flushPendingMessages() {
+        val queued = mutableListOf<String>()
+        synchronized(pendingOutboundMessages) {
+            while (pendingOutboundMessages.isNotEmpty()) {
+                queued.add(pendingOutboundMessages.removeFirst())
+            }
+        }
+        queued.forEach(::send)
+    }
+
+    private fun syncTracking() {
+        val addresses = synchronized(trackedAddresses) { trackedAddresses.toList() }
+        val txids = synchronized(trackedTxids) { trackedTxids.toList() }
+
+        send(json.encodeToString(mapOf("track-addresses" to addresses)))
+        send(json.encodeToString(mapOf("track-txs" to txids)))
+    }
+
+    private fun handleMessage(text: String) {
+        val msg = try {
+            json.decodeFromString<MempoolWSMessage>(text)
+        } catch (_: Exception) {
+            logWarn("Failed to decode message: ${text.take(200)}")
+            return
+        }
+
+        val trackedAddressesSnapshot = synchronized(trackedAddresses) { trackedAddresses.toSet() }
+        val trackedTxidsSnapshot = synchronized(trackedTxids) { trackedTxids.toSet() }
+
+        val transactions = aggregateTransactions(msg)
+        transactions.forEach { tx ->
+            if (!isValidTxid(tx.txid)) {
+                return@forEach
+            }
+            val matches = matcher.matchAll(
+                trackedAddresses = trackedAddressesSnapshot,
+                trackedTxids = trackedTxidsSnapshot,
+                msg = msg,
+                tx = tx
+            )
+            matches.forEach { match ->
+                val dedupKey = "${tx.txid}_${match.target}"
+                if (dedupStore.isRecentlyProcessed(dedupKey)) {
+                    return@forEach
+                }
+                dedupStore.recordProcessedTx(dedupKey)
+
+                val amountSats = sumAmount(tx, match.target)
+                notifyTransaction(WebSocketEvent.Receive(match.target, tx.txid, amountSats))
+            }
+        }
+
+        handleRemovedTransactions(msg, trackedAddressesSnapshot)
+
+        val blockHeight = msg.block?.height ?: msg.blocks?.lastOrNull()?.height
+        if (blockHeight != null) {
+            notifyBlock(blockHeight)
+        }
+
+        val tracked = msg.trackedTxs ?: emptyMap()
+        tracked.forEach { (trackedTxid, trackingInfo) ->
+            if (!trackedTxidsSnapshot.contains(trackedTxid)) {
+                return@forEach
+            }
+            val outspends = trackingInfo.utxoSpent ?: emptyMap()
+            outspends.forEach { (_, outspend) ->
+                val spendingTxid = outspend.txid
+                if (!isValidTxid(spendingTxid)) {
+                    return@forEach
+                }
+                val dedupKey = "${spendingTxid}_outspend_$trackedTxid"
+                if (dedupStore.isRecentlyProcessed(dedupKey)) {
+                    return@forEach
+                }
+                dedupStore.recordProcessedTx(dedupKey)
+                notifyTransaction(WebSocketEvent.TrackedOutspend(trackedTxid, spendingTxid))
+            }
+        }
+    }
+
+    private fun aggregateTransactions(msg: MempoolWSMessage): List<MempoolWSTransaction> {
+        val all = mutableListOf<MempoolWSTransaction>()
+        all.addAll(msg.addressTransactions ?: emptyList())
+        all.addAll(msg.blockTransactions ?: emptyList())
+
+        msg.multiAddressTransactions?.forEach { (_, txGroup) ->
+            all.addAll(txGroup.mempool ?: emptyList())
+            all.addAll(txGroup.confirmed ?: emptyList())
+        }
+
+        return all
+    }
+
+    private fun handleRemovedTransactions(
+        msg: MempoolWSMessage,
+        trackedAddressesSnapshot: Set<String>
+    ) {
+        msg.multiAddressTransactions?.forEach { (addr, txGroup) ->
+            if (!trackedAddressesSnapshot.contains(addr)) {
+                return@forEach
+            }
+            (txGroup.removed ?: emptyList()).forEach { tx ->
+                if (!isValidTxid(tx.txid)) {
+                    return@forEach
+                }
+                val dedupKey = "removed_${tx.txid}_$addr"
+                if (dedupStore.isRecentlyProcessed(dedupKey)) {
+                    return@forEach
+                }
+                dedupStore.recordProcessedTx(dedupKey)
+                notifyTransaction(WebSocketEvent.Removed(addr, tx.txid))
+            }
+        }
+    }
+
+    private fun sumAmount(tx: MempoolWSTransaction, target: String): Long {
+        var amountSats = 0L
+        tx.vout?.forEach { vout ->
+            if (vout.scriptpubkeyAddress == target) {
+                amountSats += vout.value ?: 0L
+            }
+        }
+        return amountSats
+    }
+
+    private fun notifyTransaction(event: WebSocketEvent) {
+        val callback = onTransactionDetected ?: return
+        serviceScope.launch(Dispatchers.Main.immediate) {
+            callback(event)
+        }
+    }
+
+    private fun notifyBlock(height: Int) {
+        val callback = onBlockHeader ?: return
+        serviceScope.launch(Dispatchers.Main.immediate) {
+            callback(height)
+        }
+    }
+
+    private fun isValidTxid(txid: String): Boolean {
+        return txid.length == 64 && txid.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolWebSocketService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/MempoolWebSocketService.kt
@@ -246,7 +246,10 @@ class MempoolWebSocketService(
                 msg = msg,
                 tx = tx
             )
-            matches.forEach { match ->
+            // isTxid matches (spends of a tracked txid) are handled by the dedicated
+            // tracked-txs/utxoSpent branch below via TrackedOutspend; only address
+            // matches represent an actual incoming receive.
+            matches.filterNot { it.isTxid }.forEach { match ->
                 val dedupKey = "${tx.txid}_${match.target}"
                 if (dedupStore.isRecentlyProcessed(dedupKey)) {
                     return@forEach

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/ProcessedTxStore.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/ProcessedTxStore.kt
@@ -1,0 +1,49 @@
+package com.stablechannels.app.services.websocket
+
+import java.util.concurrent.ConcurrentHashMap
+
+class ProcessedTxStore(
+    private val ttlMs: Long = 900_000L,
+    private val maxEntries: Int = 500
+) {
+    private val entries = ConcurrentHashMap<String, Long>()
+
+    @Volatile
+    private var lastPurgeAtMs: Long = 0L
+
+    private val purgeIntervalMs: Long = 300_000L
+
+    fun isRecentlyProcessed(key: String): Boolean {
+        val seenAt = entries[key] ?: return false
+        return (System.currentTimeMillis() - seenAt) < ttlMs
+    }
+
+    fun recordProcessedTx(key: String) {
+        entries[key] = System.currentTimeMillis()
+        enforceCap()
+        purgeExpiredIfDue()
+    }
+
+    fun count(): Int = entries.size
+
+    private fun enforceCap() {
+        if (entries.size <= maxEntries) {
+            return
+        }
+        val evictCount = (maxEntries / 5).coerceAtLeast(1)
+        val sortedOldest = entries.entries.sortedBy { it.value }
+        sortedOldest.take(evictCount).forEach { (key, _) ->
+            entries.remove(key)
+        }
+    }
+
+    private fun purgeExpiredIfDue() {
+        val now = System.currentTimeMillis()
+        if ((now - lastPurgeAtMs) < purgeIntervalMs) {
+            return
+        }
+        val cutoff = now - ttlMs
+        entries.entries.removeIf { it.value <= cutoff }
+        lastPurgeAtMs = now
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/ReconnectionManager.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/ReconnectionManager.kt
@@ -1,0 +1,68 @@
+package com.stablechannels.app.services.websocket
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.min
+import kotlin.math.pow
+
+class ReconnectionManager(
+    private val scope: CoroutineScope,
+    private val maxReconnectDelaySeconds: Long = 60L,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    @Volatile
+    var reconnectAttempts: Int = 0
+        private set
+
+    @Volatile
+    var isManualDisconnect: Boolean = false
+
+    private var reconnectJob: Job? = null
+
+    var onReconnect: (() -> Unit)? = null
+
+    fun connected() {
+        reconnectAttempts = 0
+        stopReconnectTask()
+    }
+
+    fun disconnected() {
+        if (isManualDisconnect) {
+            return
+        }
+        scheduleReconnect()
+    }
+
+    fun stop() {
+        isManualDisconnect = true
+        stopReconnectTask()
+    }
+
+    fun reset() {
+        isManualDisconnect = false
+        reconnectAttempts = 0
+    }
+
+    private fun scheduleReconnect() {
+        stopReconnectTask()
+
+        val delaySeconds = min((2.0.pow(reconnectAttempts.toDouble())).toLong(), maxReconnectDelaySeconds)
+        reconnectAttempts += 1
+
+        reconnectJob = scope.launch(dispatcher) {
+            delay(delaySeconds * 1000)
+            if (!isManualDisconnect) {
+                onReconnect?.invoke()
+            }
+        }
+    }
+
+    fun stopReconnectTask() {
+        reconnectJob?.cancel()
+        reconnectJob = null
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/TransactionMatcher.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/TransactionMatcher.kt
@@ -1,0 +1,64 @@
+package com.stablechannels.app.services.websocket
+
+data class MatchResult(val target: String, val isTxid: Boolean)
+
+class TransactionMatcher {
+    fun matchAll(
+        trackedAddresses: Set<String>,
+        trackedTxids: Set<String>,
+        msg: MempoolWSMessage,
+        tx: MempoolWSTransaction
+    ): List<MatchResult> {
+        val results = mutableListOf<MatchResult>()
+
+        if (!msg.address.isNullOrBlank() && trackedAddresses.contains(msg.address)) {
+            results.add(MatchResult(target = msg.address, isTxid = false))
+        }
+
+        tx.vout?.forEach { vout ->
+            val addr = vout.scriptpubkeyAddress
+            if (!addr.isNullOrBlank() && trackedAddresses.contains(addr)) {
+                val res = MatchResult(target = addr, isTxid = false)
+                if (!results.contains(res)) {
+                    results.add(res)
+                }
+            }
+        }
+
+        tx.vin?.forEach { vin ->
+            val inputTxid = vin.txid
+            if (!inputTxid.isNullOrBlank() && trackedTxids.contains(inputTxid)) {
+                val res = MatchResult(target = inputTxid, isTxid = true)
+                if (!results.contains(res)) {
+                    results.add(res)
+                }
+            }
+        }
+
+        if (!msg.txid.isNullOrBlank() && trackedTxids.contains(msg.txid)) {
+            val res = MatchResult(target = msg.txid, isTxid = true)
+            if (!results.contains(res)) {
+                results.add(res)
+            }
+        }
+
+        msg.multiAddressTransactions?.forEach { (addr, txGroup) ->
+            if (!trackedAddresses.contains(addr)) {
+                return@forEach
+            }
+
+            val inMempool = txGroup.mempool?.any { it.txid == tx.txid } == true
+            val inConfirmed = txGroup.confirmed?.any { it.txid == tx.txid } == true
+            val inRemoved = txGroup.removed?.any { it.txid == tx.txid } == true
+
+            if (inMempool || inConfirmed || inRemoved) {
+                val res = MatchResult(target = addr, isTxid = false)
+                if (!results.contains(res)) {
+                    results.add(res)
+                }
+            }
+        }
+
+        return results
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/WebSocketConnection.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/WebSocketConnection.kt
@@ -1,0 +1,64 @@
+package com.stablechannels.app.services.websocket
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+
+interface WebSocketConnection {
+    fun send(text: String): Boolean
+    fun close(code: Int, reason: String?): Boolean
+    fun cancel()
+}
+
+data class WebSocketCallbacks(
+    val onOpen: () -> Unit,
+    val onMessage: (text: String) -> Unit,
+    val onClosing: (code: Int, reason: String) -> Unit,
+    val onClosed: (code: Int, reason: String) -> Unit,
+    val onFailure: (Throwable) -> Unit
+)
+
+interface WebSocketConnectionFactory {
+    fun create(endpointUrl: String, callbacks: WebSocketCallbacks): WebSocketConnection
+}
+
+class OkHttpWebSocketConnectionFactory(
+    private val client: OkHttpClient
+) : WebSocketConnectionFactory {
+    override fun create(endpointUrl: String, callbacks: WebSocketCallbacks): WebSocketConnection {
+        val request = Request.Builder().url(endpointUrl).build()
+        val webSocket = client.newWebSocket(request, object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                callbacks.onOpen()
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                callbacks.onMessage(text)
+            }
+
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                callbacks.onClosing(code, reason)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                callbacks.onClosed(code, reason)
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                callbacks.onFailure(t)
+            }
+        })
+
+        return object : WebSocketConnection {
+            override fun send(text: String): Boolean = webSocket.send(text)
+
+            override fun close(code: Int, reason: String?): Boolean = webSocket.close(code, reason)
+
+            override fun cancel() {
+                webSocket.cancel()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/websocket/WebSocketEvent.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/websocket/WebSocketEvent.kt
@@ -1,0 +1,20 @@
+package com.stablechannels.app.services.websocket
+
+sealed class WebSocketEvent {
+    data class Receive(val target: String, val txid: String, val amountSats: Long) : WebSocketEvent()
+    data class Removed(val target: String, val txid: String) : WebSocketEvent()
+    data class TrackedOutspend(val trackedTxid: String, val spendingTxid: String) : WebSocketEvent()
+}
+
+interface MempoolWebSocketClient {
+    val isConnected: Boolean
+    var onTransactionDetected: ((WebSocketEvent) -> Unit)?
+    var onBlockHeader: ((Int) -> Unit)?
+
+    fun connect()
+    fun disconnect()
+    fun trackAddress(address: String)
+    fun untrackAddress(address: String)
+    fun trackTx(txid: String)
+    fun untrackTx(txid: String)
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -32,6 +32,9 @@ import com.stablechannels.app.util.relativeString
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 
+private const val REQUIRED_CONFIRMATIONS = 6
+private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
@@ -41,13 +44,30 @@ fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
     var selectedTrade by remember { mutableStateOf<TradeRecord?>(null) }
     var selectedPayment by remember { mutableStateOf<PaymentRecord?>(null) }
     val currentPrice by appState.priceService.currentPrice.collectAsState()
+    val confirmationUpdateEpoch by appState.confirmationUpdateEpoch.collectAsState()
+    val isFlashing by appState.paymentFlash.collectAsState()
 
     fun loadHistory() {
         trades = appState.databaseService?.getRecentTrades() ?: emptyList()
         payments = appState.databaseService?.getRecentPayments() ?: emptyList()
+        selectedTrade = selectedTrade?.let { selected ->
+            trades.firstOrNull { it.id == selected.id } ?: selected
+        }
+        selectedPayment = selectedPayment?.let { selected ->
+            payments.firstOrNull { it.id == selected.id } ?: selected
+        }
     }
 
-    LaunchedEffect(Unit) { loadHistory() }
+    LaunchedEffect(Unit) {
+        loadHistory()
+        appState.triggerConfirmationRefresh()
+    }
+    LaunchedEffect(confirmationUpdateEpoch) { loadHistory() }
+    LaunchedEffect(isFlashing) {
+        if (isFlashing) {
+            loadHistory()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -283,25 +303,68 @@ private fun PaymentRow(payment: PaymentRecord, currentPrice: Double, onClick: ()
                 fontWeight = FontWeight.Medium,
                 color = if (isIncoming) Color(0xFF10B981) else MaterialTheme.colorScheme.onSurface
             )
-            StatusBadge(payment.status)
+            val statusLabel = payment.historyStatusLabel()
+            val statusColor = payment.historyStatusColor()
+            StatusBadge(statusLabel, statusColor)
         }
     }
 }
 
 @Composable
-private fun StatusBadge(status: String) {
-    val color = when (status) {
+private fun StatusBadge(status: String, color: Color? = null) {
+    val resolvedColor = color ?: when (status.lowercase()) {
         "completed" -> Color(0xFF10B981)
         "pending" -> Color(0xFFF59E0B)
         "failed" -> Color(0xFFEF4444)
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     Text(
-        text = status.replaceFirstChar { it.uppercase() },
+        text = status,
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Medium,
-        color = color
+        color = resolvedColor
     )
+}
+
+private fun PaymentRecord.shouldShowConfirmationProgress(): Boolean {
+    val onchainTypes = setOf("onchain", "channel_close", "splice_in", "splice_out")
+    val hasProgressSignal = status == "pending" || confirmations > 0
+    return paymentType in onchainTypes && hasProgressSignal
+}
+
+private fun PaymentRecord.historyStatusLabel(): String {
+    if (!shouldShowConfirmationProgress()) {
+        return status.replaceFirstChar { it.uppercase() }
+    }
+    val required = requiredConfirmationsForDisplay()
+    return if (confirmations >= required) {
+        "Confirmed"
+    } else {
+        "${confirmations}/${required} confirmed"
+    }
+}
+
+private fun PaymentRecord.historyStatusColor(): Color {
+    if (!shouldShowConfirmationProgress()) {
+        return when (status) {
+            "completed" -> Color(0xFF10B981)
+            "pending" -> Color(0xFFF59E0B)
+            "failed" -> Color(0xFFEF4444)
+            else -> Color(0xFF6B7280)
+        }
+    }
+    return when {
+        confirmations >= requiredConfirmationsForDisplay() -> Color(0xFF10B981)
+        confirmations > 0 -> Color(0xFF3B82F6)
+        else -> Color(0xFFF59E0B)
+    }
+}
+
+private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
+    return when (paymentType) {
+        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
+        else -> REQUIRED_CONFIRMATIONS
+    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -19,6 +19,10 @@ import androidx.compose.ui.platform.LocalContext
 import android.content.Intent
 import android.net.Uri
 
+private const val REQUIRED_CONFIRMATIONS = 6
+private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
+private val TXID_REGEX = Regex("^[0-9a-fA-F]{64}$")
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0, onDismiss: () -> Unit) {
@@ -111,7 +115,7 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                     }
                     
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                    DetailRow("Status", payment.status.replaceFirstChar { it.uppercase() })
+                    DetailRow("Status", payment.detailStatusLabel())
                     
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                     DetailRow("Date", payment.date.shortString())
@@ -122,7 +126,7 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                         CopyableDetailRow("Payment ID", displayPid, pid)
                     }
                     
-                    payment.txid?.let { txid ->
+                    payment.explorerTxid()?.let { txid ->
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
                         val displayTxid = if (txid.length > 16) txid.take(8) + "..." + txid.takeLast(8) else txid
                         CopyableDetailRow("TXID", displayTxid, txid)
@@ -148,9 +152,15 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
                         CopyableDetailRow("Address", displayAddr, addr)
                     }
                     
-                    if (payment.confirmations > 0) {
+                    if (payment.shouldShowConfirmationProgress() || payment.confirmations > 0) {
                         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.outlineVariant)
-                        DetailRow("Confirmations", payment.confirmations.toString())
+                        val required = payment.requiredConfirmationsForDisplay()
+                        val confirmationsLabel = if (payment.confirmations >= required) {
+                            "${payment.confirmations} (confirmed)"
+                        } else {
+                            "${payment.confirmations}/${required}"
+                        }
+                        DetailRow("Confirmations", confirmationsLabel)
                     }
                 }
             }
@@ -167,4 +177,47 @@ fun PaymentDetailBottomSheet(payment: PaymentRecord, currentPrice: Double = 0.0,
             }
         }
     }
+}
+
+private fun PaymentRecord.shouldShowConfirmationProgress(): Boolean {
+    val onchainTypes = setOf("onchain", "channel_close", "splice_in", "splice_out")
+    val hasProgressSignal = status == "pending" || confirmations > 0
+    return paymentType in onchainTypes && hasProgressSignal
+}
+
+private fun PaymentRecord.detailStatusLabel(): String {
+    if (!shouldShowConfirmationProgress()) {
+        return status.replaceFirstChar { it.uppercase() }
+    }
+    val required = requiredConfirmationsForDisplay()
+    return if (confirmations >= required) {
+        "Confirmed"
+    } else {
+        "${confirmations}/${required} confirmed"
+    }
+}
+
+private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
+    return when (paymentType) {
+        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
+        else -> REQUIRED_CONFIRMATIONS
+    }
+}
+
+private fun PaymentRecord.explorerTxid(): String? {
+    val fromTxid = txid?.substringBefore(":")?.trim()
+    if (!fromTxid.isNullOrEmpty() && TXID_REGEX.matches(fromTxid)) {
+        return fromTxid
+    }
+
+    if (paymentType == "onchain") {
+        val fromPaymentId = paymentId
+            ?.removePrefix("onchain_receive_")
+            ?.trim()
+        if (!fromPaymentId.isNullOrEmpty() && TXID_REGEX.matches(fromPaymentId)) {
+            return fromPaymentId
+        }
+    }
+
+    return null
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -61,6 +61,7 @@ import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,6 +79,7 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     val spendableOnchainSats by appState.spendableOnchainSats.collectAsState()
     val isSyncing by appState.isSyncing.collectAsState()
     val isFlashing by appState.paymentFlash.collectAsState()
+    val confirmationUpdateEpoch by appState.confirmationUpdateEpoch.collectAsState()
     val isChannelClosing by appState.isChannelClosingFlow.collectAsState()
 
     var showSend by remember { mutableStateOf(false) }
@@ -88,6 +90,13 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
     var showSell by remember { mutableStateOf(false) }
     var prefillTradeAmount by remember { mutableDoubleStateOf(0.0) }
     var showBTC by remember { mutableStateOf(false) }
+    var latestPendingOnchainReceive by remember { mutableStateOf<PaymentRecord?>(null) }
+
+    LaunchedEffect(isFlashing, confirmationUpdateEpoch, onchainSats, spendableOnchainSats) {
+        latestPendingOnchainReceive = withContext(Dispatchers.IO) {
+            appState.databaseService?.latestPendingOnchainReceive()
+        }
+    }
 
     // Auto-dismiss receive sheet when payment arrives
     val scrollState = rememberScrollState()
@@ -336,6 +345,8 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
+                        val pendingReceiveTxid = latestPendingOnchainReceive?.txid
+                        val hasPendingOnchainReceive = latestPendingOnchainReceive != null
                         if (isSweeping) {
                             // 1. Splice-in in progress
                             Spacer(Modifier.height(4.dp))
@@ -364,19 +375,27 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                                     Text("Move", fontSize = 13.sp)
                                 }
                             }
+                            if (hasPendingOnchainReceive) {
+                                Spacer(Modifier.height(6.dp))
+                                PendingRow("Receiving onchain...", pendingReceiveTxid, context)
+                            }
                         } else if (spendableOnchainSats == 0L) {
                             // 3. Unconfirmed deposit (with or without channel)
                             Spacer(Modifier.height(8.dp))
                             val pendingCloseId = appState.pendingClosePaymentId
                             // Prefer close txid if known — pendingClosePaymentId may already be
                             // cleared by detectOnchainDeposit even while funds are still unconfirmed
-                            val effectiveTxid = lastCloseTxid ?: lastRxTxid
+                            val effectiveTxid = if (lastCloseTxid != null) {
+                                lastCloseTxid
+                            } else {
+                                pendingReceiveTxid ?: lastRxTxid
+                            }
                             val isClosePending = pendingCloseId != null || lastCloseTxid != null
-                            // Use short text when txid is known (button fits on same row, matches iOS)
-                            // Use longer text when no txid yet (shown as two-line subtitle)
+                            // Use a receive-specific label when we have an explicit pending onchain row.
                             val text = when {
                                 isClosePending && effectiveTxid != null -> "Channel closing\u2026"
                                 isClosePending -> "Channel closed"
+                                hasPendingOnchainReceive -> "Receiving onchain..."
                                 else -> "Deposit confirming..."
                             }
                             PendingRow(text, effectiveTxid, context)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/ChannelView.kt
@@ -171,6 +171,7 @@ fun ChannelView(appState: AppState) {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
                     appState.setStatus("Closing channel...")
+                    appState.prepareChannelCloseTracking(sc.userChannelId)
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -335,18 +335,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                 TextButton(onClick = {
                     showCloseConfirm = false
                     appState.isChannelClosing = true
-                    appState.setLastCloseTxid(null) // Clear any previous close txid from cache
-                    // Snapshot the true fundingTxid NOW, while the channel still exists
-                    val liveTxid = appState.nodeService.channels
-                        .firstOrNull { it.userChannelId == sc.userChannelId || it.isChannelReady }
-                        ?.fundingTxo?.txid
-                    if (liveTxid != null) {
-                        appState.fundingTxid = liveTxid
-                        // Also persist to prefs so handleChannelClosed can recover it
-                        // even if the in-memory value is cleared by a race
-                        context.getSharedPreferences("balance_cache", android.content.Context.MODE_PRIVATE)
-                            .edit().putString("closing_funding_txid", liveTxid).apply()
-                    }
+                    appState.prepareChannelCloseTracking(sc.userChannelId)
                     scope.launch(Dispatchers.IO) {
                         try {
                             appState.nodeService.closeChannel(sc.userChannelId, sc.counterparty)

--- a/android/app/src/test/java/com/stablechannels/app/services/websocket/MempoolWebSocketServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/services/websocket/MempoolWebSocketServiceTest.kt
@@ -1,0 +1,533 @@
+package com.stablechannels.app.services.websocket
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MempoolWebSocketServiceTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `emits receive for tracked address and dedups duplicate message`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qtrackedaddress"
+        val txid = validTxid('a')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+
+        setTrackedAddresses(service, setOf(address))
+
+        val message =
+            """
+            {
+              "address-transactions": [
+                {
+                  "txid": "$txid",
+                  "vout": [
+                    { "scriptpubkey_address": "$address", "value": 12345 }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+
+        invokeHandleMessage(service, message)
+        invokeHandleMessage(service, message)
+        advanceUntilIdle()
+
+        assertEquals(1, events.size)
+        assertEquals(WebSocketEvent.Receive(address, txid, 12345L), events.first())
+    }
+
+    @Test
+    fun `emits removed event for tracked address`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qremovedaddress"
+        val txid = validTxid('b')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+
+        setTrackedAddresses(service, setOf(address))
+
+        val message =
+            """
+            {
+              "multi-address-transactions": {
+                "$address": {
+                  "removed": [
+                    { "txid": "$txid" }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+
+        invokeHandleMessage(service, message)
+        advanceUntilIdle()
+
+        assertEquals(1, events.size)
+        assertEquals(WebSocketEvent.Removed(address, txid), events.first())
+    }
+
+    @Test
+    fun `emits tracked outspend for tracked txid`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val trackedTxid = validTxid('c')
+        val spendingTxid = validTxid('d')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+
+        setTrackedTxids(service, setOf(trackedTxid))
+
+        val message =
+            """
+            {
+              "tracked-txs": {
+                "$trackedTxid": {
+                  "utxoSpent": {
+                    "0": { "txid": "$spendingTxid", "vin": 0 }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+
+        invokeHandleMessage(service, message)
+        advanceUntilIdle()
+
+        assertEquals(1, events.size)
+        assertEquals(WebSocketEvent.TrackedOutspend(trackedTxid, spendingTxid), events.first())
+    }
+
+    @Test
+    fun `uses last block height from blocks array`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val blockHeights = mutableListOf<Int>()
+        service.onBlockHeader = { blockHeights.add(it) }
+
+        val message =
+            """
+            {
+              "blocks": [
+                { "height": 810001 },
+                { "height": 810002 }
+              ]
+            }
+            """.trimIndent()
+
+        invokeHandleMessage(service, message)
+        advanceUntilIdle()
+
+        assertEquals(listOf(810002), blockHeights)
+    }
+
+    @Test
+    fun `ignores empty payloads without emitting events`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+
+        invokeHandleMessage(service, "{}")
+        advanceUntilIdle()
+
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `ignores malformed json payload without emitting events`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+
+        invokeHandleMessage(service, "this is not json {{{")
+        advanceUntilIdle()
+
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `ignores invalid txid in address transactions`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qignoreinvalid"
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+        setTrackedAddresses(service, setOf(address))
+
+        invokeHandleMessage(
+            service,
+            """
+            {
+              "address-transactions": [
+                { "txid": "short", "vout": [{ "scriptpubkey_address": "$address", "value": 1000 }] }
+              ]
+            }
+            """.trimIndent()
+        )
+        advanceUntilIdle()
+
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `handles block and transaction in same payload`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qcombined"
+        val txid = validTxid('e')
+        val events = mutableListOf<WebSocketEvent>()
+        val blocks = mutableListOf<Int>()
+
+        service.onTransactionDetected = { events.add(it) }
+        service.onBlockHeader = { blocks.add(it) }
+        setTrackedAddresses(service, setOf(address))
+
+        invokeHandleMessage(
+            service,
+            """
+            {
+              "address-transactions": [
+                {
+                  "txid": "$txid",
+                  "vout": [{ "scriptpubkey_address": "$address", "value": 25000 }]
+                }
+              ],
+              "block": { "height": 800001 }
+            }
+            """.trimIndent()
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf(WebSocketEvent.Receive(address, txid, 25000L)), events)
+        assertEquals(listOf(800001), blocks)
+    }
+
+    @Test
+    fun `sums matching vouts for same address`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qmultivout"
+        val txid = validTxid('f')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+        setTrackedAddresses(service, setOf(address))
+
+        invokeHandleMessage(
+            service,
+            """
+            {
+              "address-transactions": [
+                {
+                  "txid": "$txid",
+                  "vout": [
+                    { "scriptpubkey_address": "$address", "value": 100000 },
+                    { "scriptpubkey_address": "$address", "value": 50000 },
+                    { "scriptpubkey_address": "bc1qother", "value": 999 }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf(WebSocketEvent.Receive(address, txid, 150000L)), events)
+    }
+
+    @Test
+    fun `handles multiple deposits to same address`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qmultiple"
+        val txid1 = validTxid('1')
+        val txid2 = validTxid('2')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+        setTrackedAddresses(service, setOf(address))
+
+        invokeHandleMessage(
+            service,
+            """
+            {
+              "address-transactions": [
+                { "txid": "$txid1", "vout": [{ "scriptpubkey_address": "$address", "value": 1000 }] },
+                { "txid": "$txid2", "vout": [{ "scriptpubkey_address": "$address", "value": 2000 }] }
+              ]
+            }
+            """.trimIndent()
+        )
+        advanceUntilIdle()
+
+        val receives = events.filterIsInstance<WebSocketEvent.Receive>()
+        assertEquals(2, receives.size)
+        assertEquals(setOf(1000L, 2000L), receives.map { it.amountSats }.toSet())
+    }
+
+    @Test
+    fun `removed only payload emits removed and not receive`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val address = "bc1qremovedonly"
+        val txid = validTxid('a')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+        setTrackedAddresses(service, setOf(address))
+
+        invokeHandleMessage(
+            service,
+            """
+            {
+              "multi-address-transactions": {
+                "$address": {
+                  "mempool": [],
+                  "confirmed": [],
+                  "removed": [{ "txid": "$txid" }]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+        advanceUntilIdle()
+
+        assertEquals(1, events.size)
+        assertTrue(events.first() is WebSocketEvent.Removed)
+        assertNull(events.filterIsInstance<WebSocketEvent.Receive>().firstOrNull())
+    }
+
+    @Test
+    fun `multiple tracked txids can emit outspends with same spending txid and dedup repeats`() = runTest {
+        val service = MempoolWebSocketService(serviceScope = this)
+        val trackedTxid1 = validTxid('b')
+        val trackedTxid2 = validTxid('c')
+        val spendingTxid = validTxid('d')
+        val events = mutableListOf<WebSocketEvent>()
+        service.onTransactionDetected = { events.add(it) }
+        setTrackedTxids(service, setOf(trackedTxid1, trackedTxid2))
+
+        val payload =
+            """
+            {
+              "tracked-txs": {
+                "$trackedTxid1": {
+                  "utxoSpent": { "0": { "txid": "$spendingTxid", "vin": 0 } }
+                },
+                "$trackedTxid2": {
+                  "utxoSpent": { "0": { "txid": "$spendingTxid", "vin": 0 } }
+                }
+              }
+            }
+            """.trimIndent()
+
+        invokeHandleMessage(service, payload)
+        invokeHandleMessage(service, payload)
+        advanceUntilIdle()
+
+        val outspends = events.filterIsInstance<WebSocketEvent.TrackedOutspend>()
+        assertEquals(2, outspends.size)
+        assertEquals(setOf(trackedTxid1, trackedTxid2), outspends.map { it.trackedTxid }.toSet())
+    }
+
+    @Test
+    fun `send buffer is capped at fifty while disconnected`() {
+        val service = MempoolWebSocketService()
+
+        repeat(60) { idx ->
+            invokeSend(service, "{ \"track-addresses\": [\"addr$idx\"] }")
+        }
+
+        assertEquals(50, pendingOutboundSize(service))
+    }
+
+    @Test
+    fun `connect resets reconnect attempts`() {
+        val service = MempoolWebSocketService()
+        setReconnectAttempts(service, 5)
+
+        service.connect()
+
+        assertEquals(0, reconnectAttempts(service))
+    }
+
+  @Test
+  fun `connect open syncs tracking and flushes queued messages`() {
+    val factory = FakeWebSocketConnectionFactory()
+    val service = MempoolWebSocketService(connectionFactory = factory)
+
+    setTrackedAddresses(service, setOf("bc1qflush"))
+    setTrackedTxids(service, setOf(validTxid('a')))
+    invokeSend(service, "{ \"preopen\": true }")
+
+    service.connect()
+    assertFalse(service.isConnected)
+
+    factory.callbacks?.onOpen?.invoke()
+
+    val sent = factory.connection.sent
+    val blockSub = sent.first { it.contains("mempool-blocks") }
+    assertTrue(service.isConnected)
+    assertTrue(sent.any { it.contains("track-addresses") })
+    assertTrue(sent.any { it.contains("track-txs") })
+    assertTrue(sent.any { it.contains("mempool-blocks") })
+    assertFalse(blockSub.contains("\\\""))
+    assertEquals("{ \"preopen\": true }", sent.last())
+    assertEquals(0, pendingOutboundSize(service))
+  }
+
+  @Test
+  fun `on closing schedules reconnect without attempting to echo close code`() {
+    val factory = FakeWebSocketConnectionFactory()
+    val service = MempoolWebSocketService(connectionFactory = factory)
+
+    service.connect()
+    factory.callbacks?.onOpen?.invoke()
+
+    factory.callbacks?.onClosing?.invoke(1001, "going away")
+
+    assertFalse(service.isConnected)
+    assertEquals(1, reconnectAttempts(service))
+    assertNull(factory.connection.closeCode)
+    assertNull(factory.connection.closeReason)
+  }
+
+  @Test
+  fun `on failure after open schedules reconnect`() {
+    val factory = FakeWebSocketConnectionFactory()
+    val service = MempoolWebSocketService(connectionFactory = factory)
+
+    service.connect()
+    factory.callbacks?.onOpen?.invoke()
+
+    factory.callbacks?.onFailure?.invoke(IllegalStateException("boom"))
+
+    assertFalse(service.isConnected)
+    assertEquals(1, reconnectAttempts(service))
+  }
+
+  @Test
+  fun `manual disconnect stops reconnect on subsequent closed callback`() {
+    val factory = FakeWebSocketConnectionFactory()
+    val service = MempoolWebSocketService(connectionFactory = factory)
+
+    service.connect()
+    factory.callbacks?.onOpen?.invoke()
+    service.disconnect()
+    factory.callbacks?.onClosed?.invoke(1000, "normal")
+
+    assertFalse(service.isConnected)
+    assertEquals(0, reconnectAttempts(service))
+  }
+
+    private fun invokeHandleMessage(service: MempoolWebSocketService, payload: String) {
+        val method = service.javaClass.getDeclaredMethod("handleMessage", String::class.java)
+        method.isAccessible = true
+        method.invoke(service, payload)
+    }
+
+    private fun invokeSend(service: MempoolWebSocketService, payload: String) {
+      val method = service.javaClass.getDeclaredMethod("send", String::class.java)
+      method.isAccessible = true
+      method.invoke(service, payload)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun setTrackedAddresses(service: MempoolWebSocketService, addresses: Set<String>) {
+        val field = service.javaClass.getDeclaredField("trackedAddresses")
+        field.isAccessible = true
+        val set = field.get(service) as MutableSet<String>
+        set.clear()
+        set.addAll(addresses)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun setTrackedTxids(service: MempoolWebSocketService, txids: Set<String>) {
+        val field = service.javaClass.getDeclaredField("trackedTxids")
+        field.isAccessible = true
+        val set = field.get(service) as MutableSet<String>
+        set.clear()
+        set.addAll(txids)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun pendingOutboundSize(service: MempoolWebSocketService): Int {
+      val field = service.javaClass.getDeclaredField("pendingOutboundMessages")
+      field.isAccessible = true
+      val queue = field.get(service) as ArrayDeque<String>
+      return queue.size
+    }
+
+    private fun setReconnectAttempts(service: MempoolWebSocketService, value: Int) {
+      val managerField = service.javaClass.getDeclaredField("reconnectManager")
+      managerField.isAccessible = true
+      val manager = managerField.get(service)
+      val attemptsField = manager.javaClass.getDeclaredField("reconnectAttempts")
+      attemptsField.isAccessible = true
+      attemptsField.setInt(manager, value)
+    }
+
+    private fun reconnectAttempts(service: MempoolWebSocketService): Int {
+      val managerField = service.javaClass.getDeclaredField("reconnectManager")
+      managerField.isAccessible = true
+      val manager = managerField.get(service)
+      val attemptsField = manager.javaClass.getDeclaredField("reconnectAttempts")
+      attemptsField.isAccessible = true
+      return attemptsField.getInt(manager)
+    }
+
+    private fun validTxid(char: Char): String = char.toString().repeat(64)
+}
+
+  private class FakeWebSocketConnectionFactory : WebSocketConnectionFactory {
+    var callbacks: WebSocketCallbacks? = null
+    val connection = FakeWebSocketConnection()
+
+    override fun create(endpointUrl: String, callbacks: WebSocketCallbacks): WebSocketConnection {
+      this.callbacks = callbacks
+      return connection
+    }
+  }
+
+  private class FakeWebSocketConnection : WebSocketConnection {
+    val sent = mutableListOf<String>()
+    var closeCode: Int? = null
+    var closeReason: String? = null
+    var canceled = false
+
+    override fun send(text: String): Boolean {
+      sent.add(text)
+      return true
+    }
+
+    override fun close(code: Int, reason: String?): Boolean {
+      closeCode = code
+      closeReason = reason
+      return true
+    }
+
+    override fun cancel() {
+      canceled = true
+    }
+  }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/services/websocket/ProcessedTxStoreTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/services/websocket/ProcessedTxStoreTest.kt
@@ -1,0 +1,38 @@
+package com.stablechannels.app.services.websocket
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProcessedTxStoreTest {
+
+    @Test
+    fun `records key and marks as recently processed`() {
+        val store = ProcessedTxStore(ttlMs = 60_000L, maxEntries = 500)
+
+        store.recordProcessedTx("tx_a")
+
+        assertTrue(store.isRecentlyProcessed("tx_a"))
+    }
+
+    @Test
+    fun `expires key after ttl`() {
+        val store = ProcessedTxStore(ttlMs = 10L, maxEntries = 500)
+
+        store.recordProcessedTx("tx_b")
+        Thread.sleep(20)
+
+        assertFalse(store.isRecentlyProcessed("tx_b"))
+    }
+
+    @Test
+    fun `evicts oldest when exceeding cap`() {
+        val store = ProcessedTxStore(ttlMs = 60_000L, maxEntries = 10)
+
+        repeat(15) { idx ->
+            store.recordProcessedTx("tx_$idx")
+        }
+
+        assertTrue(store.count() <= 10)
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/services/websocket/ReconnectionManagerTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/services/websocket/ReconnectionManagerTest.kt
@@ -1,0 +1,98 @@
+package com.stablechannels.app.services.websocket
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReconnectionManagerTest {
+
+    @Test
+    fun `disconnected schedules reconnect with exponential delays`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val manager = ReconnectionManager(this, dispatcher = dispatcher)
+        var reconnectCount = 0
+        manager.onReconnect = { reconnectCount += 1 }
+
+        manager.disconnected()
+        assertEquals(1, manager.reconnectAttempts)
+        advanceTimeBy(999)
+        runCurrent()
+        assertEquals(0, reconnectCount)
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(1, reconnectCount)
+
+        manager.disconnected()
+        assertEquals(2, manager.reconnectAttempts)
+        advanceTimeBy(1999)
+        runCurrent()
+        assertEquals(1, reconnectCount)
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(2, reconnectCount)
+    }
+
+    @Test
+    fun `backoff delay is capped at max reconnect delay`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val manager = ReconnectionManager(this, maxReconnectDelaySeconds = 3, dispatcher = dispatcher)
+        var reconnectCount = 0
+        manager.onReconnect = { reconnectCount += 1 }
+
+        manager.disconnected()
+        advanceTimeBy(1000)
+        runCurrent()
+        assertEquals(1, reconnectCount)
+
+        manager.disconnected()
+        advanceTimeBy(2000)
+        runCurrent()
+        assertEquals(2, reconnectCount)
+
+        manager.disconnected()
+        advanceTimeBy(2999)
+        runCurrent()
+        assertEquals(2, reconnectCount)
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals(3, reconnectCount)
+    }
+
+    @Test
+    fun `stop prevents pending reconnect callback`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val manager = ReconnectionManager(this, dispatcher = dispatcher)
+        var reconnectCount = 0
+        manager.onReconnect = { reconnectCount += 1 }
+
+        manager.disconnected()
+        manager.stop()
+        assertTrue(manager.isManualDisconnect)
+        advanceTimeBy(2000)
+        runCurrent()
+
+        assertEquals(0, reconnectCount)
+    }
+
+    @Test
+    fun `reset clears manual mode and attempts`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val manager = ReconnectionManager(this, dispatcher = dispatcher)
+
+        manager.disconnected()
+        manager.stop()
+        assertTrue(manager.isManualDisconnect)
+        assertEquals(1, manager.reconnectAttempts)
+
+        manager.reset()
+        assertFalse(manager.isManualDisconnect)
+        assertEquals(0, manager.reconnectAttempts)
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/services/websocket/TransactionMatcherTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/services/websocket/TransactionMatcherTest.kt
@@ -1,0 +1,159 @@
+package com.stablechannels.app.services.websocket
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransactionMatcherTest {
+
+    private val matcher = TransactionMatcher()
+
+    @Test
+    fun `matches tracked address from vout`() {
+        val trackedAddress = "bc1qtestaddress123"
+        val tx = MempoolWSTransaction(
+            txid = validTxid('a'),
+            vout = listOf(MempoolWSVout(scriptpubkeyAddress = trackedAddress, value = 50_000))
+        )
+        val msg = MempoolWSMessage(addressTransactions = listOf(tx))
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf(trackedAddress),
+            trackedTxids = emptySet(),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(1, matches.size)
+        assertEquals(MatchResult(target = trackedAddress, isTxid = false), matches.first())
+    }
+
+    @Test
+    fun `matches tracked txid from vin`() {
+        val trackedTxid = validTxid('b')
+        val tx = MempoolWSTransaction(
+            txid = validTxid('c'),
+            vin = listOf(MempoolWSVin(txid = trackedTxid))
+        )
+        val msg = MempoolWSMessage(addressTransactions = listOf(tx))
+
+        val matches = matcher.matchAll(
+            trackedAddresses = emptySet(),
+            trackedTxids = setOf(trackedTxid),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(1, matches.size)
+        assertEquals(MatchResult(target = trackedTxid, isTxid = true), matches.first())
+    }
+
+    @Test
+    fun `returns empty list when nothing matches`() {
+        val tx = MempoolWSTransaction(txid = validTxid('d'))
+        val msg = MempoolWSMessage(addressTransactions = listOf(tx))
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf("bc1qother"),
+            trackedTxids = setOf(validTxid('e')),
+            msg = msg,
+            tx = tx
+        )
+
+        assertTrue(matches.isEmpty())
+    }
+
+    @Test
+    fun `matches tracked address from message address field`() {
+        val trackedAddress = "bc1qdirectaddress"
+        val tx = MempoolWSTransaction(txid = validTxid('f'))
+        val msg = MempoolWSMessage(address = trackedAddress, addressTransactions = listOf(tx))
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf(trackedAddress),
+            trackedTxids = emptySet(),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(listOf(MatchResult(target = trackedAddress, isTxid = false)), matches)
+    }
+
+    @Test
+    fun `matches tracked txid from message txid field`() {
+        val trackedTxid = validTxid('1')
+        val tx = MempoolWSTransaction(txid = validTxid('2'))
+        val msg = MempoolWSMessage(txid = trackedTxid)
+
+        val matches = matcher.matchAll(
+            trackedAddresses = emptySet(),
+            trackedTxids = setOf(trackedTxid),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(listOf(MatchResult(target = trackedTxid, isTxid = true)), matches)
+    }
+
+    @Test
+    fun `multi address payload matches tracked address when tx appears in mempool group`() {
+        val trackedAddress = "bc1qmulti"
+        val tx = MempoolWSTransaction(txid = validTxid('3'))
+        val msg = MempoolWSMessage(
+            multiAddressTransactions = mapOf(
+                trackedAddress to MempoolWSAddressTransactions(mempool = listOf(tx))
+            )
+        )
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf(trackedAddress),
+            trackedTxids = emptySet(),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(listOf(MatchResult(target = trackedAddress, isTxid = false)), matches)
+    }
+
+    @Test
+    fun `address in message is prioritized before vout match`() {
+        val directAddress = "bc1qdirectpriority"
+        val voutAddress = "bc1qvoutpriority"
+        val tx = MempoolWSTransaction(
+            txid = validTxid('4'),
+            vout = listOf(MempoolWSVout(scriptpubkeyAddress = voutAddress, value = 1000))
+        )
+        val msg = MempoolWSMessage(address = directAddress)
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf(directAddress, voutAddress),
+            trackedTxids = emptySet(),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(directAddress, matches.first().target)
+    }
+
+    @Test
+    fun `dedups repeated address match from message and vout`() {
+        val trackedAddress = "bc1qdedupresult"
+        val tx = MempoolWSTransaction(
+            txid = validTxid('5'),
+            vout = listOf(MempoolWSVout(scriptpubkeyAddress = trackedAddress, value = 500))
+        )
+        val msg = MempoolWSMessage(address = trackedAddress)
+
+        val matches = matcher.matchAll(
+            trackedAddresses = setOf(trackedAddress),
+            trackedTxids = emptySet(),
+            msg = msg,
+            tx = tx
+        )
+
+        assertEquals(1, matches.size)
+        assertEquals(MatchResult(target = trackedAddress, isTxid = false), matches.first())
+    }
+
+    private fun validTxid(char: Char): String = char.toString().repeat(64)
+}


### PR DESCRIPTION
## Summary
- add Android mempool websocket implementation for real-time onchain transaction detection
- add reconnect, dedup, and transaction matching support services for websocket event handling
- wire websocket receive and outspend events into app state and channel-close/onchain flows
- add websocket unit tests for service, matcher, reconnect, and dedup components
- include onchain confirmation-flow hardening and home/history/details UX consistency updates validated during websocket integration

## Main Changes
- new websocket services under android app services websocket package
- app state integration for receive, removed, and tracked-outspend handling
- confirmation polling and receive txid ownership/address-safety logic
- history and payment detail confirmation/explorer-link improvements
- home onchain section pending-receive visibility improvements

## Validation
- manual on-device receive and confirmation-state checks performed
- manual channel close tested
- manual splice in tested

