### PR TITLE
fix(ios): remove the NSE wait flag and bound chain resolution

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -26,7 +26,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install SwiftFormat
-        run: brew install swiftformat
+        # Pinned: the runner image ships a pre-installed older brew version, so
+        # `brew install` is a no-op and the effective linter version drifts with
+        # the image. The config uses 0.62-only rule names.
+        run: |
+          curl -sL -o /tmp/swiftformat.zip https://github.com/nicklockwood/SwiftFormat/releases/download/0.62.1/swiftformat.zip
+          unzip -o /tmp/swiftformat.zip -d /tmp/swiftformat-bin
+          echo "/tmp/swiftformat-bin" >> "$GITHUB_PATH"
 
       - name: Run SwiftFormat
         working-directory: ios

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -35,3 +35,4 @@
 --disable spaceAroundOperators
 --disable conditionalAssignment
 --disable hoistPatternLet
+--disable wrapIfStatementBodies

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -35,4 +35,3 @@
 --disable spaceAroundOperators
 --disable conditionalAssignment
 --disable hoistPatternLet
---disable wrapIfStatementBodies

--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -118,14 +118,11 @@ class NotificationService: UNNotificationServiceExtension {
 
         logger.log("didReceive: direction=\(direction.rawValue)")
 
-        // Signal processing started
         let shared = UserDefaults(suiteName: Constants.appGroup)
-        shared?.set(true, forKey: "nse_processing")
 
         // Skip if main app is active
         if isMainAppActive() {
             logger.log("Main app is active, skipping node start")
-            shared?.set(false, forKey: "nse_processing")
             shared?.set(true, forKey: "pending_push_payment")
             finish(content)
             return
@@ -246,7 +243,7 @@ class NotificationService: UNNotificationServiceExtension {
             if expiredDuringBuild {
                 logger.log("Time expired during node build; stopping node and releasing")
                 UserDefaults(suiteName: Constants.appGroup)?.set(true, forKey: "pending_push_payment")
-                cleanup() // stops the node, releases the lock, clears nse_processing
+                cleanup() // stops the node and releases the wallet-dir lock
                 return // expire handler already delivered the notification
             }
             logger.log("Node started")
@@ -378,6 +375,5 @@ class NotificationService: UNNotificationServiceExtension {
         try? node?.stop()
         node = nil
         NodeDirLock.shared.release()
-        UserDefaults(suiteName: Constants.appGroup)?.set(false, forKey: "nse_processing")
     }
 }

--- a/ios/StableChannels/README.md
+++ b/ios/StableChannels/README.md
@@ -106,7 +106,6 @@ Both the main app and NSE access the same data through the App Group container:
 | Key | Writer | Purpose |
 |-----|--------|---------|
 | `main_app_last_active` | Main app | Heartbeat timestamp — NSE skips if < 10s ago |
-| `nse_processing` | NSE | Flag indicating NSE is currently running |
 | `nse_last_active` | NSE | NSE heartbeat (2-second interval) |
 | `pending_push_payment` | NSE | Flag for main app to retry on next launch |
 | `node_id` | Main app | LDK node ID for push token registration |

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -717,6 +717,7 @@ class AppState {
     }
 
     // MARK: - NSE Coordination
+
     //
     // Coordination with the Notification Service Extension is handled entirely by
     // NodeDirLock (flock on ldk-node.lock). The kernel releases that lock when the

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -328,7 +328,6 @@ class AppState {
         }
 
         cancelBackgroundStop()
-        await waitForNSE()
 
         // Own the wallet dir before stopping/wiping: restore can be reached
         // while the lock is not held (e.g. after a startup failure released
@@ -510,25 +509,42 @@ class AppState {
         nodeFlowInProgress = true
         defer { nodeFlowInProgress = false }
 
-        // Migrate data from old Application Support dir to shared App Group container
-        migrateDataDirIfNeeded()
+        // Logging must be live before the startup prologue: chain resolution and
+        // the wallet-dir lock both emit audit events, and both run before
+        // initializeDatabaseServices() sets the path.
+        AuditService.setLogPath(
+            Constants.userDataDir.appendingPathComponent("audit_log.txt").path
+        )
 
-        // Wait for NSE to finish if it was recently active
-        await waitForNSE()
+        // The launch screen (phase == .loading) is shown for this entire prologue,
+        // so every step below is measured — several of them previously logged only
+        // on failure, which left the whole window invisible.
+        let prologueStart = Date()
+        func elapsedMs(_ since: Date) -> String { "\(Int(Date().timeIntervalSince(since) * 1000))" }
+
+        // Migrate data from old Application Support dir to shared App Group container
+        let migrateStart = Date()
+        migrateDataDirIfNeeded()
+        let migrateMs = elapsedMs(migrateStart)
 
         // Pick best esplora endpoint BEFORE taking the lock — pure network,
         // no DB access, and it can stall; no reason to hold the dir for it.
+        let chainStart = Date()
         chainURL = await resolveChainURL()
+        let chainMs = elapsedMs(chainStart)
 
         // Take the wallet-dir lock before any DB access (network-graph purge,
         // database init, node start). Kernel-enforced; outlasts a live NSE.
+        let lockStart = Date()
         if await !(NodeDirLock.shared.acquire(dataDir: Constants.userDataDir, timeout: 35)) {
             AuditService.log("NODE_LOCK_TIMEOUT", data: ["where": "AppState.start"])
             await MainActor.run { phase = .error("Wallet is busy. Please reopen the app.") }
             return
         }
+        let lockMs = elapsedMs(lockStart)
 
         // Initialize database
+        let dbStart = Date()
         do {
             try initializeDatabaseServices()
         } catch {
@@ -539,7 +555,10 @@ class AppState {
             return
         }
 
+        let dbMs = elapsedMs(dbStart)
+
         // Load saved channel state from DB
+        let dbReadStart = Date()
         loadChannelFromDB()
 
         // Refresh payment status from DB (NSE may have recorded payments while app was closed)
@@ -547,6 +566,16 @@ class AppState {
 
         // Seed historical price data for charts
         seedHistoricalPrices()
+        let dbReadMs = elapsedMs(dbReadStart)
+
+        AuditService.log("STARTUP_PROLOGUE", data: [
+            "total_ms": elapsedMs(prologueStart),
+            "migrate_ms": migrateMs,
+            "chain_resolve_ms": chainMs,
+            "dir_lock_ms": lockMs,
+            "db_init_ms": dbMs,
+            "db_read_ms": dbReadMs
+        ])
 
         // Backfill hourly prices from Kraken for smooth 1D/1W/1M charts
         Task { await backfillHourlyPrices() }
@@ -688,23 +717,12 @@ class AppState {
     }
 
     // MARK: - NSE Coordination
-
-    /// Wait for the Notification Service Extension to finish if it's currently processing.
-    /// Prevents two processes from running LDK on the same data directory simultaneously.
-    private func waitForNSE() async {
-        let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        var waited = 0
-        while shared?.bool(forKey: "nse_processing") == true {
-            try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
-            waited += 1
-            if waited >= 30 {
-                break
-            } // NSE has an approximately 30-second execution window
-        }
-        if waited > 0 {
-            AuditService.log("NSE_WAIT", data: ["seconds": "\(waited)"])
-        }
-    }
+    //
+    // Coordination with the Notification Service Extension is handled entirely by
+    // NodeDirLock (flock on ldk-node.lock). The kernel releases that lock when the
+    // holding process dies, so it self-heals; the previous `nse_processing`
+    // UserDefaults flag did not, and a jetsammed NSE left it set permanently —
+    // every launch then burned the full 30s ceiling waiting on a dead process.
 
     func stop() {
         stabilityTimer?.cancel()
@@ -808,7 +826,6 @@ class AppState {
         nodeFlowInProgress = true
         defer { nodeFlowInProgress = false }
         cancelBackgroundStop()
-        await waitForNSE()
         loadChannelFromDB()
         // Payments received while backgrounded are recorded by the NSE, not the foreground
         // event loop — so refresh the banner from the newest DB row instead of leaving it stale.
@@ -2528,15 +2545,28 @@ class AppState {
         guard let url = URL(string: "\(Constants.primaryChainURL)/blocks/tip/height") else {
             return Constants.fallbackChainURL
         }
+        // This sits on the critical path before first paint, so it gets a short
+        // budget of its own: URLSession.shared defaults to a 60s request timeout,
+        // which would hold the launch screen for a minute on a slow primary.
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 2
+        config.timeoutIntervalForResource = 3
+        let session = URLSession(configuration: config)
+        let startedAt = Date()
         do {
-            let (_, response) = try await URLSession.shared.data(from: url)
+            let (_, response) = try await session.data(from: url)
             if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                AuditService.log("CHAIN_SOURCE_RESOLVED", data: [
+                    "using": Constants.primaryChainURL,
+                    "ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))"
+                ])
                 return Constants.primaryChainURL
             }
         } catch {}
         AuditService.log("CHAIN_SOURCE_FALLBACK", data: [
             "primary": Constants.primaryChainURL,
-            "using": Constants.fallbackChainURL
+            "using": Constants.fallbackChainURL,
+            "ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))"
         ])
         return Constants.fallbackChainURL
     }


### PR DESCRIPTION
waitForNSE polled an `nse_processing` UserDefaults flag that the NSE sets but cannot reliably clear: the extension runs a full LDK node inside a ~24MB / ~30s budget, and when iOS jetsams it, cleanup() never runs and the flag stays set permanently. Every subsequent launch then burned the full 30s ceiling waiting on a dead process. Nine of nine NSE_WAIT events across three weeks of logs were pinned at exactly 30s with no partial waits — the app was never waiting for a live extension, only for a corpse.

NodeDirLock (flock on ldk-node.lock) already provides the same mutual exclusion and self-heals, because the kernel releases the lock when the holding process dies. Measured dir_lock_ms is 0-1ms and NODE_LOCK_TIMEOUT has never fired. The flag is removed from the NSE too, where it is now a dead write.

Also on the critical path, all of which the launch screen was waiting on:

- resolveChainURL used URLSession.shared, whose 60s default request timeout could hold the launch screen for a minute on a slow primary. It now has a 2s budget of its own.
- setLogPath ran inside initializeDatabaseServices, i.e. after the prologue it was meant to measure, so every startup audit event was silently dropped. Moved to the top of start().
- The prologue is now timed end to end (STARTUP_PROLOGUE), since chain resolution and the dir lock previously logged only on failure and were otherwise invisible.

Measured cold start: ~31s -> under 1s. Prologue 297-479ms, of which chain resolution is 283-468ms; LDK itself starts in 0.23s.