### PR TITLE
Preserve stability drift across trades

### DIFF
--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -15,11 +15,10 @@ use ldk_server_client::ldk_server_grpc::api::{
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
 use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
+use stable_channels::constants::MAX_TRADE_QUOTE_DEVIATION_PERCENT;
 use stable_channels::db::Database;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
-
-const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
 
 /// Return each peer's own spendable-plus-reserve balance from the fields LDK exposes for that
 /// peer. `channel_value - local_balance` is not the remote balance: on outbound channels it also
@@ -1812,11 +1811,13 @@ impl StableChannelManager {
             );
             return;
         };
+        let new_expected =
+            stable_channels::stable::normalize_trade_expected_usd(payload.expected_usd);
 
         let fee_price = payload.quote_price.unwrap_or(btc_price);
         let Some(expected_fee_msat) = expected_trade_fee_msat(
             current_expected_usd,
-            payload.expected_usd,
+            new_expected,
             fee_price,
         ) else {
             stable_channels::audit::audit_event(
@@ -1824,7 +1825,7 @@ impl StableChannelManager {
                 serde_json::json!({
                     "reason": "fee inputs are invalid",
                     "old_expected_usd": current_expected_usd,
-                    "new_expected_usd": payload.expected_usd,
+                    "new_expected_usd": new_expected,
                     "fee_price": fee_price,
                     "amount_msat": amount_msat,
                     "channel_id": chan.channel_id.clone(),
@@ -1847,7 +1848,7 @@ impl StableChannelManager {
                     "expected_fee_msat": expected_fee_msat,
                     "tolerance_msat": tolerance_msat,
                     "old_expected_usd": current_expected_usd,
-                    "new_expected_usd": payload.expected_usd,
+                    "new_expected_usd": new_expected,
                     "fee_price": fee_price,
                     "channel_id": chan.channel_id.clone(),
                     "user_channel_id": chan.user_channel_id.clone(),
@@ -1856,7 +1857,6 @@ impl StableChannelManager {
             return;
         }
         let (our_sats, their_sats) = channel_peer_balances(&chan);
-        let new_expected = payload.expected_usd;
         let quoted_trade = match payload.quote_price {
             Some(quote_price) => {
                 if payload.ts == 0
@@ -1902,11 +1902,10 @@ impl StableChannelManager {
         };
 
         // The quote is a consent bound only. Capacity and allocation always use the LSP's price.
-        // Epsilon absorbs independent-feed skew so a full stabilization priced by the wallet a
-        // hair above the LSP's valuation is admitted rather than silently dropped.
+        // Never admit a target above the locally valued balance: the stability threshold is a
+        // payment deadband, not extra trade capacity.
         let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
-        let ceiling = receiver_usd + stable_channels::constants::STABILITY_THRESHOLD_USD;
-        if new_expected > ceiling {
+        if new_expected > receiver_usd {
             stable_channels::audit::audit_event(
                 "TRADE_EXCEEDS_BALANCE",
                 serde_json::json!({ "requested_usd": new_expected, "receiver_usd": receiver_usd, "user_channel_id": format!("{}", target_uid), "channel_id": chan.channel_id.clone() }),
@@ -1927,12 +1926,29 @@ impl StableChannelManager {
                 );
                 return;
             };
-            sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
-            sc.stable_receiver_btc = Bitcoin::from_sats(their_sats);
-            sc.stable_provider_usd = USD::from_bitcoin(sc.stable_provider_btc, btc_price);
-            sc.stable_receiver_usd = USD::from_bitcoin(sc.stable_receiver_btc, btc_price);
-            sc.latest_price = btc_price;
-            stable_channels::stable::apply_trade(sc, new_expected, btc_price);
+            let mut updated = sc.clone();
+            updated.stable_provider_btc = Bitcoin::from_sats(our_sats);
+            updated.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            updated.stable_provider_usd = USD::from_bitcoin(updated.stable_provider_btc, btc_price);
+            updated.stable_receiver_usd = USD::from_bitcoin(updated.stable_receiver_btc, btc_price);
+            updated.latest_price = btc_price;
+            if !stable_channels::stable::apply_trade(&mut updated, new_expected, btc_price) {
+                stable_channels::audit::audit_event(
+                    "TRADE_ALLOCATION_REJECTED",
+                    serde_json::json!({
+                        "channel_id": channel_id_hex,
+                        "user_channel_id": format!("{}", target_uid),
+                        "current_expected_usd": sc.expected_usd.0,
+                        "new_expected_usd": new_expected,
+                        "current_backing_sats": sc.backing_sats,
+                        "live_receiver_sats": their_sats,
+                        "lsp_price": btc_price,
+                        "reason": "target delta cannot preserve the current stability drift",
+                    }),
+                );
+                return;
+            }
+            *sc = updated;
             (
                 format!("{}", sc.user_channel_id),
                 sc.expected_usd.0,
@@ -3457,7 +3473,7 @@ mod tests {
             .unwrap_or(0.0);
         let fee_msat = expected_trade_fee_msat(
             current_expected,
-            payload.expected_usd,
+            stable_channels::stable::normalize_trade_expected_usd(payload.expected_usd),
             payload.quote_price.unwrap_or(lsp_price),
         )
         .unwrap();
@@ -3511,6 +3527,170 @@ mod tests {
         .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn tiny_and_noop_trades_preserve_lsp_stability_drift() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            100.0,
+            100_000,
+            100_000,
+            200_000,
+            100_000.0,
+        );
+
+        let tiny = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.01);
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &tiny,
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 100_009);
+
+        let noop = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.01);
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &noop,
+            &fake as &dyn LdkServerCalls,
+            90_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 100_009);
+    }
+
+    #[tokio::test]
+    async fn trade_arithmetic_underflow_leaves_lsp_state_unchanged() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            100.0,
+            10,
+            199_990,
+            200_000,
+            100_000.0,
+        );
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 99.0);
+
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10);
+        assert_eq!(mgr.stable_channels[0].native_sats, 199_990);
+        assert!(fake.sends.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn full_exit_is_gated_by_lsp_stability_drift() {
+        for (price, should_apply) in [(90_000.0, false), (100_001.0, true)] {
+            let mut mgr = make_manager();
+            let fake = FakeLdkServer::new(vec![make_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                COUNTERPARTY_HEX,
+                300_000,
+                100_000_000,
+                true,
+            )]);
+            seed_channel(
+                &mut mgr,
+                189476124653200987495269098788434301048u128,
+                COUNTERPARTY_HEX,
+                CHANNEL_ID_HEX,
+                100.0,
+                100_000,
+                100_000,
+                200_000,
+                100_000.0,
+            );
+            let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 0.0);
+
+            handle_trade_with_valid_fee(
+                &mut mgr,
+                &env,
+                &fake as &dyn LdkServerCalls,
+                price,
+            )
+            .await;
+
+            if should_apply {
+                assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+                assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+                assert_eq!(fake.sends.lock().unwrap().len(), 1);
+            } else {
+                assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
+                assert_eq!(mgr.stable_channels[0].backing_sats, 100_000);
+                assert!(fake.sends.lock().unwrap().is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn sub_cent_trade_target_is_persisted_as_a_full_exit() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000_000,
+            true,
+        )]);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            100.0,
+            100_000,
+            100_000,
+            200_000,
+            100_000.0,
+        );
+        let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 0.009);
+
+        handle_trade_with_valid_fee(
+            &mut mgr,
+            &env,
+            &fake as &dyn LdkServerCalls,
+            100_001.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -3735,7 +3915,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_admits_at_balance_boundary_within_epsilon() {
+    async fn trade_rejects_even_one_sat_above_balance_boundary() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -3743,9 +3923,7 @@ mod tests {
         )]);
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        // A wallet-priced full stabilization lands at receiver_usd plus a sub-epsilon overshoot
-        // (independent feeds). It must be admitted, not silently dropped.
-        let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD / 2.0;
+        let target = 50.001;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
         handle_trade_with_valid_fee(
             &mut mgr,
@@ -3755,16 +3933,13 @@ mod tests {
         )
         .await;
 
-        assert!(
-            (mgr.stable_channels[0].expected_usd.0 - target).abs() < 1e-6,
-            "a target within epsilon of the balance must be admitted, got {}",
-            mgr.stable_channels[0].expected_usd.0
-        );
-        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 0);
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn trade_rejects_target_above_capacity_epsilon() {
+    async fn trade_rejects_dollar_denominated_capacity_epsilon() {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
@@ -3772,7 +3947,7 @@ mod tests {
         )]);
         seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
 
-        let target = 50.0 + stable_channels::constants::STABILITY_THRESHOLD_USD * 2.0;
+        let target = 50.01;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
         handle_trade_with_valid_fee(
             &mut mgr,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -96,6 +96,12 @@ pub const AUTO_SWEEP_MIN_SATS: u64 = 10_000;
 /// Shared by wallet fee construction and the LSP's server-side amount validation.
 pub const STABLE_CHANNEL_TRADE_FEE_RATE: f64 = 0.01;
 
+/// Maximum difference between the wallet's signed trade quote and the LSP's local price.
+///
+/// The wallet also uses this bound to reject near-capacity trades that the LSP could not support
+/// at the lowest price permitted by the quote check.
+pub const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
+
 /// LDK channel-config defaults for outbound forwarding fees.
 pub const LIGHTNING_DEFAULT_FORWARDING_FEE_BASE_MSAT: u64 = 1_000;
 pub const LIGHTNING_DEFAULT_FORWARDING_FEE_PROPORTIONAL_MILLIONTHS: u64 = 0;

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -357,6 +357,97 @@ pub fn trade_backing_sats(
     )
 }
 
+/// Treat sub-cent stable targets as a full exit throughout trade processing.
+///
+/// The UI cannot action less than one cent, so retaining a fractional-cent target would only
+/// bypass the full-exit drift guard and leave an unusable residual allocation.
+pub fn normalize_trade_expected_usd(expected_usd: f64) -> f64 {
+    if expected_usd.is_finite() && expected_usd >= 0.0 && expected_usd < 0.01 {
+        0.0
+    } else {
+        expected_usd
+    }
+}
+
+/// Apply only the change in the stable target at this peer's local price.
+///
+/// Repricing the complete target would erase stability drift accumulated before the trade. A full
+/// exit is allowed only while that drift is inside the normal stability deadband; an actionable
+/// adjustment must settle first because a zero target cannot retain the old drift.
+pub fn trade_backing_after_delta(
+    receiver_sats: u64,
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    new_expected_usd: f64,
+    price: f64,
+) -> Option<u64> {
+    let new_expected_usd = normalize_trade_expected_usd(new_expected_usd);
+    if !current_expected_usd.is_finite()
+        || current_expected_usd < 0.0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd < 0.0
+        || !price.is_finite()
+        || price <= 0.0
+    {
+        return None;
+    }
+
+    let receiver_usd = receiver_sats as f64 / SATS_IN_BTC as f64 * price;
+    if new_expected_usd > receiver_usd {
+        return None;
+    }
+
+    if new_expected_usd == 0.0 {
+        return (!allocation_drift_is_actionable(
+            current_backing_sats,
+            current_expected_usd,
+            price,
+        ))
+        .then_some(0);
+    }
+
+    // Floor cumulative targets and subtract them instead of flooring each standalone delta. At a
+    // fixed price the differences telescope, so repeated sub-sat trades eventually apply exactly
+    // the same backing as one cumulative trade while preserving all pre-trade drift.
+    let current_target_sats_f = current_expected_usd / price * SATS_IN_BTC as f64;
+    let new_target_sats_f = new_expected_usd / price * SATS_IN_BTC as f64;
+    if !current_target_sats_f.is_finite()
+        || !new_target_sats_f.is_finite()
+        || current_target_sats_f >= u64::MAX as f64
+        || new_target_sats_f >= u64::MAX as f64
+    {
+        return None;
+    }
+    let current_target_sats = current_target_sats_f.floor() as u64;
+    let new_target_sats = new_target_sats_f.floor() as u64;
+    let mut backing_sats = if new_expected_usd >= current_expected_usd {
+        current_backing_sats.checked_add(new_target_sats.checked_sub(current_target_sats)?)?
+    } else {
+        current_backing_sats.checked_sub(current_target_sats.checked_sub(new_target_sats)?)?
+    };
+
+    // Native dust is absorbed only for a fresh allocation. normalize_backing_sats deliberately
+    // leaves an already-over-capacity value unchanged, and the final check rejects it.
+    if current_expected_usd < 0.01 && current_backing_sats == 0 {
+        backing_sats = normalize_backing_sats(receiver_sats, backing_sats, new_expected_usd, price);
+    }
+    (backing_sats <= receiver_sats).then_some(backing_sats)
+}
+
+fn allocation_drift_is_actionable(
+    backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+) -> bool {
+    let current_value = backing_sats as f64 / SATS_IN_BTC as f64 * price;
+    let drift_usd = (current_value - expected_usd).abs();
+    if expected_usd < 0.01 {
+        return drift_usd >= STABILITY_THRESHOLD_USD;
+    }
+    let drift_percent = drift_usd / expected_usd * 100.0;
+    drift_usd >= STABILITY_THRESHOLD_USD && drift_percent >= STABILITY_THRESHOLD_PERCENT
+}
+
 /// Apply an allocation already derived by this peer.
 ///
 /// Callers must not pass a counterparty-supplied `backing_sats` value here. The shared contract is
@@ -368,25 +459,24 @@ pub fn apply_trade_allocation(sc: &mut StableChannel, new_expected_usd: f64, bac
     recompute_native(sc);
 }
 
-/// Apply a trade — set new expected_usd and recalculate backing_sats + native_sats.
+/// Apply a trade without repricing its existing backing.
 ///
-/// Used after buy/sell trades and when the LSP processes a trade message.
-/// Sets `expected_usd` to the new value and recalculates `backing_sats`
-/// at the current price. Updates `native_sats` (the invariant that stays
-/// fixed between stability payments).
-pub fn apply_trade(sc: &mut StableChannel, new_expected_usd: f64, price: f64) {
-    sc.expected_usd = USD::from_f64(new_expected_usd);
-    if price > 0.0 {
-        let receiver_sats = sc.stable_receiver_btc.sats;
-        sc.backing_sats = if receiver_sats > 0 {
-            trade_backing_sats(receiver_sats, new_expected_usd, price)
-        } else {
-            (new_expected_usd / price * SATS_IN_BTC as f64) as u64
-        };
-    }
-    // native_sats is everything NOT backing the stable position
-    sc.native_sats = sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
-    recompute_native(sc);
+/// Only the target delta is converted at the current price. Returns `false` and leaves the
+/// allocation untouched if the delta cannot be represented safely or fit the live balance.
+#[must_use]
+pub fn apply_trade(sc: &mut StableChannel, new_expected_usd: f64, price: f64) -> bool {
+    let new_expected_usd = normalize_trade_expected_usd(new_expected_usd);
+    let Some(backing_sats) = trade_backing_after_delta(
+        sc.stable_receiver_btc.sats,
+        sc.backing_sats,
+        sc.expected_usd.0,
+        new_expected_usd,
+        price,
+    ) else {
+        return false;
+    };
+    apply_trade_allocation(sc, new_expected_usd, backing_sats);
+    true
 }
 
 /// Get the current BTC/USD price, preferring cached value when available
@@ -1164,7 +1254,7 @@ mod tests {
     fn trade_buy_reduces_stable() {
         // Buy $200 BTC: expected_usd $500 → $300
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 300.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 300.0, 100_000.0));
         assert_eq!(sc.expected_usd.0, 300.0);
         let expected_backing = (300.0 / 100_000.0 * 100_000_000.0) as u64;
         assert_eq!(sc.backing_sats, expected_backing);
@@ -1174,7 +1264,7 @@ mod tests {
     fn trade_sell_increases_stable() {
         // Sell $200 BTC: expected_usd $500 → $700
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 700.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 700.0, 100_000.0));
         assert_eq!(sc.expected_usd.0, 700.0);
         let expected_backing = (700.0 / 100_000.0 * 100_000_000.0) as u64;
         assert_eq!(sc.backing_sats, expected_backing);
@@ -1183,7 +1273,7 @@ mod tests {
     #[test]
     fn trade_to_zero() {
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 0.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 0.0, 100_000.0));
         assert_eq!(sc.expected_usd.0, 0.0);
         assert_eq!(sc.backing_sats, 0);
     }
@@ -1192,27 +1282,26 @@ mod tests {
     fn trade_zero_price_skips_backing_update() {
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
         let backing_before = sc.backing_sats;
-        apply_trade(&mut sc, 700.0, 0.0);
-        assert_eq!(sc.expected_usd.0, 700.0); // usd updated
-        assert_eq!(sc.backing_sats, backing_before); // backing unchanged
+        assert!(!apply_trade(&mut sc, 700.0, 0.0));
+        assert_eq!(sc.expected_usd.0, 500.0);
+        assert_eq!(sc.backing_sats, backing_before);
     }
 
     #[test]
-    fn trade_at_different_price() {
-        // Same $500 stable, but price doubled to $200k
-        // backing should be half the sats
+    fn no_op_trades_preserve_above_and_below_par_drift() {
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 500.0, 200_000.0);
-        let expected_backing = (500.0 / 200_000.0 * 100_000_000.0) as u64; // 250k
-        assert_eq!(sc.backing_sats, expected_backing);
-        assert_eq!(expected_backing, 250_000);
+        assert!(apply_trade(&mut sc, 500.0, 200_000.0));
+        assert_eq!(sc.backing_sats, 500_000);
+
+        assert!(apply_trade(&mut sc, 500.0, 80_000.0));
+        assert_eq!(sc.backing_sats, 500_000);
     }
 
     #[test]
     fn trade_full_balance_to_stable() {
         // Convert all $1000 to stable
         let mut sc = test_sc(0.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 1000.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 1000.0, 100_000.0));
         assert_eq!(sc.expected_usd.0, 1000.0);
         assert_eq!(sc.backing_sats, 1_000_000);
     }
@@ -1220,7 +1309,7 @@ mod tests {
     #[test]
     fn trade_full_balance_absorbs_sub_cent_native_dust() {
         let mut sc = test_sc(0.0, 66_250.21, 57_444);
-        apply_trade(&mut sc, 38.055025828575, 66_250.21);
+        assert!(apply_trade(&mut sc, 38.055025828575, 66_250.21));
 
         assert_eq!(sc.backing_sats, 57_444);
         assert_eq!(sc.native_sats, 0);
@@ -1230,7 +1319,7 @@ mod tests {
     #[test]
     fn trade_keeps_meaningful_native_allocation() {
         let mut sc = test_sc(0.0, 100_000.0, 100_000);
-        apply_trade(&mut sc, 99.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 99.0, 100_000.0));
 
         assert_eq!(sc.backing_sats, 99_000);
         assert_eq!(sc.native_sats, 1_000);
@@ -1238,12 +1327,134 @@ mod tests {
     }
 
     #[test]
-    fn trade_backing_never_exceeds_live_balance() {
+    fn trade_over_live_balance_is_not_partially_applied() {
         let mut sc = test_sc(0.0, 100_000.0, 95_000);
-        apply_trade(&mut sc, 100.0, 100_000.0);
+        assert!(!apply_trade(&mut sc, 100.0, 100_000.0));
 
-        assert_eq!(sc.backing_sats, 95_000);
-        assert_eq!(sc.native_sats, 0);
+        assert_eq!(sc.expected_usd.0, 0.0);
+        assert_eq!(sc.backing_sats, 0);
+        assert_eq!(sc.native_sats, 95_000);
+    }
+
+    #[test]
+    fn normal_trades_apply_only_the_locally_priced_delta() {
+        let mut increase = test_sc(100.0, 100_000.0, 200_000);
+        assert!(apply_trade(&mut increase, 110.0, 110_000.0));
+        assert_eq!(increase.backing_sats, 109_091);
+
+        let mut decrease = test_sc(100.0, 100_000.0, 200_000);
+        assert!(apply_trade(&mut decrease, 90.0, 110_000.0));
+        assert_eq!(decrease.backing_sats, 90_909);
+    }
+
+    #[test]
+    fn tiny_trade_preserves_preexisting_stability_drift() {
+        let mut sc = test_sc(100.0, 100_000.0, 200_000);
+
+        assert!(apply_trade(&mut sc, 100.01, 110_000.0));
+
+        assert_eq!(sc.backing_sats, 100_009);
+        let value = sc.backing_sats as f64 / SATS_IN_BTC as f64 * 110_000.0;
+        assert!(value - sc.expected_usd.0 > 9.99);
+    }
+
+    #[test]
+    fn repeated_sub_sat_target_changes_apply_the_cumulative_backing() {
+        let price = 63_734.35;
+        let mut current_expected = 0.0;
+        let mut backing = 0;
+
+        for step in 1..=10_000 {
+            let new_expected =
+                normalize_trade_expected_usd(step as f64 / 10_000.0);
+            backing = trade_backing_after_delta(
+                1_000_000,
+                backing,
+                current_expected,
+                new_expected,
+                price,
+            )
+            .unwrap();
+            current_expected = new_expected;
+        }
+
+        assert_eq!(
+            backing,
+            (current_expected / price * SATS_IN_BTC as f64).floor() as u64,
+        );
+    }
+
+    #[test]
+    fn arithmetic_underflow_leaves_trade_state_unchanged() {
+        let mut sc = test_sc(100.0, 100_000.0, 200_000);
+        sc.backing_sats = 10;
+        sc.native_sats = 199_990;
+
+        assert!(!apply_trade(&mut sc, 99.0, 100_000.0));
+        assert_eq!(sc.expected_usd.0, 100.0);
+        assert_eq!(sc.backing_sats, 10);
+        assert_eq!(sc.native_sats, 199_990);
+    }
+
+    #[test]
+    fn full_exit_waits_for_actionable_drift_to_settle() {
+        for price in [90_000.0, 110_000.0] {
+            let mut sc = test_sc(100.0, 100_000.0, 200_000);
+            assert!(!apply_trade(&mut sc, 0.0, price));
+            assert_eq!(sc.expected_usd.0, 100.0);
+            assert_eq!(sc.backing_sats, 100_000);
+        }
+    }
+
+    #[test]
+    fn full_exit_allows_non_actionable_drift() {
+        let mut sc = test_sc(100.0, 100_000.0, 200_000);
+        assert!(apply_trade(&mut sc, 0.0, 100_001.0));
+        assert_eq!(sc.expected_usd.0, 0.0);
+        assert_eq!(sc.backing_sats, 0);
+    }
+
+    #[test]
+    fn sub_cent_target_is_normalized_through_the_full_exit_guard() {
+        let mut safe = test_sc(100.0, 100_000.0, 200_000);
+        assert!(apply_trade(&mut safe, 0.009, 100_001.0));
+        assert_eq!(safe.expected_usd.0, 0.0);
+        assert_eq!(safe.backing_sats, 0);
+
+        let mut actionable = test_sc(100.0, 100_000.0, 200_000);
+        assert!(!apply_trade(&mut actionable, 0.009, 90_000.0));
+        assert_eq!(actionable.expected_usd.0, 100.0);
+        assert_eq!(actionable.backing_sats, 100_000);
+    }
+
+    #[test]
+    fn full_exit_does_not_hide_large_absolute_drift_on_sub_cent_target() {
+        let mut sc = test_sc(0.005, 100_000.0, 200_000);
+        sc.backing_sats = 100_000;
+        sc.native_sats = 100_000;
+
+        assert!(!apply_trade(&mut sc, 0.0, 100_000.0));
+        assert_eq!(sc.expected_usd.0, 0.005);
+        assert_eq!(sc.backing_sats, 100_000);
+    }
+
+    #[test]
+    fn capacity_overflow_is_rejected_instead_of_clamped() {
+        assert_eq!(
+            trade_backing_after_delta(100_000, 0, 0.0, 100.001, 100_000.0),
+            None,
+        );
+        assert_eq!(
+            trade_backing_after_delta(100_000, 0, 0.0, 100.10, 100_000.0),
+            None,
+        );
+
+        // Existing backing is $0.30 above a $10 target. Clamping this increase would silently
+        // erase that actionable pre-trade obligation.
+        assert_eq!(
+            trade_backing_after_delta(20_000, 10_300, 10.0, 20.001, 100_000.0),
+            None,
+        );
     }
 
     #[test]
@@ -1315,7 +1526,7 @@ mod tests {
     fn native_updated_after_apply_trade() {
         // Sell BTC: increase stable from $500 to $800
         let mut sc = test_sc(500.0, 100_000.0, 1_000_000);
-        apply_trade(&mut sc, 800.0, 100_000.0);
+        assert!(apply_trade(&mut sc, 800.0, 100_000.0));
         let expected_backing = (800.0 / 100_000.0 * 100_000_000.0) as u64;
         assert_eq!(sc.native_channel_btc.sats, 1_000_000 - expected_backing);
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -183,6 +183,17 @@ struct IncomingSync {
     sync_version: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LocalTradeAllocationError {
+    InvalidValues,
+    LiveBalanceUnavailable,
+    FeeExceedsBalance,
+    TargetExceedsCapacity,
+    TargetExceedsSafeCapacity,
+    SettlementRequired,
+    UnsafeAllocation,
+}
+
 struct BackupSnapshotDir {
     path: PathBuf,
 }
@@ -1920,6 +1931,7 @@ impl UserApp {
         trade_action: &str,
         trade_price: f64,
     ) -> Option<(PaymentId, u64)> {
+        let new_expected_usd = stable::normalize_trade_expected_usd(new_expected_usd);
         // The fee is a direct keysend amount. Account for its whole-sat channel impact before
         // deriving the wallet's post-settlement allocation.
         let fee_sats = if trade_price > 0.0 && fee_usd > 0.0 {
@@ -1932,6 +1944,32 @@ impl UserApp {
 
         // Refresh from this wallet's LDK node and derive the allocation this wallet will commit
         // after acceptance. The LSP independently derives its own allocation at its own price.
+        let local_allocation = {
+            let mut sc = self.stable_channel.lock().unwrap();
+            let (balances_updated, _) = stable::update_balances(&self.node, &mut sc);
+            if !balances_updated {
+                Err(LocalTradeAllocationError::LiveBalanceUnavailable)
+            } else {
+                local_trade_backing_sats(
+                    sc.stable_receiver_btc.sats,
+                    fee_sats,
+                    sc.backing_sats,
+                    sc.expected_usd.0,
+                    new_expected_usd,
+                    trade_price,
+                )
+                .map(|(post_fee_receiver_sats, backing_sats)| {
+                    (
+                        sc.channel_id.to_string(),
+                        format!("{}", sc.user_channel_id),
+                        sc.counterparty,
+                        sc.expected_usd.0,
+                        post_fee_receiver_sats,
+                        backing_sats,
+                    )
+                })
+            }
+        };
         let (
             channel_id_str,
             user_channel_id_str,
@@ -1939,23 +1977,47 @@ impl UserApp {
             old_expected_usd,
             post_fee_receiver_sats,
             backing_sats,
-        ) = {
-            let mut sc = self.stable_channel.lock().unwrap();
-            stable::update_balances(&self.node, &mut sc);
-            let post_fee_receiver_sats = sc.stable_receiver_btc.sats.saturating_sub(fee_sats);
-            let backing_sats = stable::trade_backing_sats(
-                post_fee_receiver_sats,
-                new_expected_usd,
-                trade_price,
-            );
-            (
-                sc.channel_id.to_string(),
-                format!("{}", sc.user_channel_id),
-                sc.counterparty,
-                sc.expected_usd.0,
-                post_fee_receiver_sats,
-                backing_sats,
-            )
+        ) = match local_allocation {
+            Ok(allocation) => allocation,
+            Err(reason) => {
+                self.trade_error = match reason {
+                    LocalTradeAllocationError::SettlementRequired => {
+                        "Settle the current stability adjustment, then retry this trade."
+                            .to_string()
+                    }
+                    LocalTradeAllocationError::FeeExceedsBalance => {
+                        "The trade fee exceeds the live channel balance.".to_string()
+                    }
+                    LocalTradeAllocationError::TargetExceedsCapacity => {
+                        "The trade target exceeds the wallet's local channel capacity.".to_string()
+                    }
+                    LocalTradeAllocationError::TargetExceedsSafeCapacity => {
+                        "The trade target is too close to the channel limit for independent price feeds. Reduce the amount and retry."
+                            .to_string()
+                    }
+                    LocalTradeAllocationError::InvalidValues => {
+                        "A trusted local price is required before trading.".to_string()
+                    }
+                    LocalTradeAllocationError::LiveBalanceUnavailable => {
+                        "The live channel balance is unavailable. Retry when the channel is ready."
+                            .to_string()
+                    }
+                    LocalTradeAllocationError::UnsafeAllocation => {
+                        "This trade cannot preserve the current stability allocation safely."
+                            .to_string()
+                    }
+                };
+                self.status_message = self.trade_error.clone();
+                audit_event(
+                    "TRADE_LOCAL_ALLOCATION_REJECTED",
+                    json!({
+                        "reason": format!("{reason:?}"),
+                        "new_expected_usd": new_expected_usd,
+                        "quote_price": trade_price,
+                    }),
+                );
+                return None;
+            }
         };
 
         let ts = std::time::SystemTime::now()
@@ -2027,6 +2089,7 @@ impl UserApp {
             }
             Err(e) => {
                 self.status_message = format!("Failed to send order: {}", e);
+                self.trade_error = self.status_message.clone();
                 audit_event(
                     "TRADE_MESSAGE_FAILED",
                     json!({
@@ -8988,7 +9051,18 @@ impl UserApp {
                 });
             });
 
-        ui.add_space(20.0);
+        let confirmation_blocked = !self.trade_error.is_empty();
+        if confirmation_blocked {
+            ui.add_space(12.0);
+            ui.label(
+                RichText::new(&self.trade_error)
+                    .color(theme::DANGER_HOVER)
+                    .size(12.0),
+            );
+            ui.add_space(8.0);
+        } else {
+            ui.add_space(20.0);
+        }
 
         // Confirm button
         let mut should_confirm = false;
@@ -9002,7 +9076,10 @@ impl UserApp {
             .fill(theme::IOS_BLUE)
             .corner_radius(theme::RADIUS_PILL)
             .min_size(egui::vec2(280.0, 50.0));
-            if ui.add(confirm_btn).clicked() {
+            if ui
+                .add_enabled(!confirmation_blocked, confirm_btn)
+                .clicked()
+            {
                 should_confirm = true;
             }
         });
@@ -9347,7 +9424,18 @@ impl UserApp {
                 });
             });
 
-        ui.add_space(20.0);
+        let confirmation_blocked = !self.trade_error.is_empty();
+        if confirmation_blocked {
+            ui.add_space(12.0);
+            ui.label(
+                RichText::new(&self.trade_error)
+                    .color(theme::DANGER_HOVER)
+                    .size(12.0),
+            );
+            ui.add_space(8.0);
+        } else {
+            ui.add_space(20.0);
+        }
 
         // Confirm button
         let mut should_confirm = false;
@@ -9361,7 +9449,10 @@ impl UserApp {
             .fill(theme::IOS_BLUE)
             .corner_radius(theme::RADIUS_PILL)
             .min_size(egui::vec2(280.0, 50.0));
-            if ui.add(confirm_btn).clicked() {
+            if ui
+                .add_enabled(!confirmation_blocked, confirm_btn)
+                .clicked()
+            {
                 should_confirm = true;
             }
         });
@@ -9629,6 +9720,7 @@ impl UserApp {
     }
 
     fn execute_buy(&mut self, amount_usd: f64, btc_price: f64) {
+        self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
@@ -9690,10 +9782,10 @@ impl UserApp {
                 "...",
             );
         }
-        self.trade_error.clear();
     }
 
     fn execute_sell(&mut self, amount_usd: f64, btc_price: f64, btc_sats: u64) {
+        self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
         let net_amount = amount_usd - fee_usd;
 
@@ -9754,7 +9846,6 @@ impl UserApp {
                 "...",
             );
         }
-        self.trade_error.clear();
     }
 
     fn show_diagnostics_window_if_open(&mut self, ctx: &egui::Context) {
@@ -10536,7 +10627,8 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
         return None;
     }
     let channel_id = channel_id.to_ascii_lowercase();
-    let expected_usd = payload.get("expected_usd")?.as_f64()?;
+    let expected_usd =
+        stable::normalize_trade_expected_usd(payload.get("expected_usd")?.as_f64()?);
     let backing_sats = payload.get("backing_sats")?.as_u64()?;
     let sync_version = payload.get("sync_version")?.as_u64()?;
     if !expected_usd.is_finite()
@@ -10555,13 +10647,96 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     })
 }
 
+fn trade_reduction_underflows_backing(
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    new_expected_usd: f64,
+    current_price: f64,
+) -> bool {
+    if new_expected_usd >= current_expected_usd {
+        return false;
+    }
+    let current_target = current_expected_usd / current_price * SATS_IN_BTC as f64;
+    let new_target = new_expected_usd / current_price * SATS_IN_BTC as f64;
+    if !current_target.is_finite()
+        || !new_target.is_finite()
+        || current_target >= u64::MAX as f64
+        || new_target >= u64::MAX as f64
+    {
+        return false;
+    }
+    let reduction = (current_target.floor() as u64).saturating_sub(new_target.floor() as u64);
+    reduction > current_backing_sats
+}
+
+/// Calculate the allocation the wallet must persist before it sends the trade fee.
+fn local_trade_backing_sats(
+    live_receiver_sats: u64,
+    fee_sats: u64,
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    new_expected_usd: f64,
+    current_price: f64,
+) -> Result<(u64, u64), LocalTradeAllocationError> {
+    let new_expected_usd = stable::normalize_trade_expected_usd(new_expected_usd);
+    if !current_expected_usd.is_finite()
+        || current_expected_usd < 0.0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd < 0.0
+        || !current_price.is_finite()
+        || current_price <= 0.0
+    {
+        return Err(LocalTradeAllocationError::InvalidValues);
+    }
+    let post_fee_receiver_sats = live_receiver_sats
+        .checked_sub(fee_sats)
+        .ok_or(LocalTradeAllocationError::FeeExceedsBalance)?;
+    let receiver_usd =
+        post_fee_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
+    if new_expected_usd > receiver_usd {
+        return Err(LocalTradeAllocationError::TargetExceedsCapacity);
+    }
+    if new_expected_usd > current_expected_usd {
+        // The LSP accepts a signed quote up to this deviation from its own price. Use the exact
+        // inverse of that check so every permitted lower LSP price still supports this target.
+        let minimum_permitted_lsp_price =
+            current_price / (1.0 + MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0);
+        let conservative_receiver_usd =
+            post_fee_receiver_sats as f64 / SATS_IN_BTC as f64
+                * minimum_permitted_lsp_price;
+        if new_expected_usd > conservative_receiver_usd {
+            return Err(LocalTradeAllocationError::TargetExceedsSafeCapacity);
+        }
+    }
+    let backing_sats = stable::trade_backing_after_delta(
+        post_fee_receiver_sats,
+        current_backing_sats,
+        current_expected_usd,
+        new_expected_usd,
+        current_price,
+    )
+    .ok_or(if new_expected_usd == 0.0
+        || trade_reduction_underflows_backing(
+            current_backing_sats,
+            current_expected_usd,
+            new_expected_usd,
+            current_price,
+        )
+    {
+        LocalTradeAllocationError::SettlementRequired
+    } else {
+        LocalTradeAllocationError::UnsafeAllocation
+    })?;
+    Ok((post_fee_receiver_sats, backing_sats))
+}
+
 /// Derive the allocation this wallet will commit for an authenticated sync. The peer's
 /// `backing_sats` is intentionally not an input: a pending trade uses the allocation this wallet
 /// stored when it created the trade; other syncs preserve the wallet's existing allocation
 /// (unchanged target) or shift it by the target delta valued at the wallet's own price. The full
-/// position is never repriced, so accrued-but-unsettled stability drift survives a sync, and a
-/// target at the capacity boundary clamps instead of rejecting — a fully-stabilized channel sits
-/// exactly on that boundary whenever the two feeds disagree by a hair.
+/// position is never repriced, so accrued-but-unsettled stability drift survives a sync. If an
+/// authenticated, uncorrelated sync lands just outside the wallet's local capacity, reconcile it
+/// to the live balance instead of consuming the event while leaving the expected target stale.
 fn local_sync_backing_sats(
     sync: &IncomingSync,
     live_receiver_sats: u64,
@@ -10570,34 +10745,62 @@ fn local_sync_backing_sats(
     current_backing_sats: u64,
     pending_trade: Option<&db::PendingTradeRow>,
 ) -> Result<u64, &'static str> {
-    if sync.expected_usd < 0.01 {
+    let expected_usd = stable::normalize_trade_expected_usd(sync.expected_usd);
+    if expected_usd == 0.0 {
         return Ok(0);
     }
     if let Some(stored_backing) = pending_trade.and_then(|trade| trade.new_backing_sats) {
-        return if stored_backing > 0 && stored_backing <= live_receiver_sats {
+        return if stored_backing <= live_receiver_sats {
             Ok(stored_backing)
         } else {
             Err("stored trade allocation exceeds the live balance")
         };
     }
-    let target_delta_usd = sync.expected_usd - current_expected_usd;
-    if current_backing_sats > 0 && target_delta_usd.abs() < 0.01 {
+    let target_delta_usd = expected_usd - current_expected_usd;
+    if current_backing_sats > 0 && target_delta_usd == 0.0 {
         return Ok(current_backing_sats.min(live_receiver_sats));
     }
     if !current_price.is_finite() || current_price <= 0.0 {
         return Err("no trusted wallet price available");
     }
-    let backing_sats = if current_backing_sats > 0 {
-        let delta_sats = (target_delta_usd / current_price * SATS_IN_BTC as f64).round() as i64;
-        let shifted = current_backing_sats as i64 + delta_sats;
-        (shifted.max(0) as u64).min(live_receiver_sats)
+    if let Some(backing_sats) = stable::trade_backing_after_delta(
+        live_receiver_sats,
+        current_backing_sats,
+        current_expected_usd,
+        expected_usd,
+        current_price,
+    ) {
+        return Ok(backing_sats);
+    }
+
+    // This is reconciliation of an already authenticated LSP decision, not capacity admission
+    // for a new trade. Preserve the same cumulative-floor delta and bound it by the live balance
+    // so a hairline feed disagreement cannot leave the wallet permanently on an older target.
+    let current_target = current_expected_usd / current_price * SATS_IN_BTC as f64;
+    let new_target = expected_usd / current_price * SATS_IN_BTC as f64;
+    if !current_target.is_finite()
+        || !new_target.is_finite()
+        || current_target < 0.0
+        || new_target < 0.0
+        || current_target >= u64::MAX as f64
+        || new_target >= u64::MAX as f64
+    {
+        return Err("sync target cannot be represented at the wallet's local price");
+    }
+    let current_target_sats = current_target.floor() as u64;
+    let new_target_sats = new_target.floor() as u64;
+    let backing_sats = if expected_usd >= current_expected_usd {
+        current_backing_sats
+            .saturating_add(new_target_sats.saturating_sub(current_target_sats))
+            .min(live_receiver_sats)
     } else {
-        // No local allocation to preserve (fresh restore): derive one at the wallet's price.
-        stable::trade_backing_sats(live_receiver_sats, sync.expected_usd, current_price)
+        current_backing_sats
+            .saturating_sub(current_target_sats.saturating_sub(new_target_sats))
+            .min(live_receiver_sats)
     };
     (backing_sats > 0)
         .then_some(backing_sats)
-        .ok_or("nonzero peg has no locally derived backing")
+        .ok_or("nonzero sync target has no locally derived backing")
 }
 
 fn write_secret_file(path: &Path, contents: &str) -> std::io::Result<()> {
@@ -10640,10 +10843,10 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        local_sync_backing_sats, parse_incoming_sync, parse_trade_usd_cents,
-        restrict_secret_file_permissions, sats_for_usd_cents, splice_in_overlap_sats,
-        splice_reconcile_action, write_secret_file, IncomingSync, PendingSplice,
-        SpliceReconcileAction, UserApp,
+        local_sync_backing_sats, local_trade_backing_sats, parse_incoming_sync,
+        parse_trade_usd_cents, restrict_secret_file_permissions, sats_for_usd_cents,
+        splice_in_overlap_sats, splice_reconcile_action, write_secret_file, IncomingSync,
+        LocalTradeAllocationError, PendingSplice, SpliceReconcileAction, UserApp,
     };
     use stable_channels::db::PendingTradeRow;
 
@@ -10727,6 +10930,53 @@ mod tests {
     }
 
     #[test]
+    fn wallet_trade_preflight_rejects_before_unsafe_fee_send() {
+        assert_eq!(
+            local_trade_backing_sats(200_000, 500, 100_000, 100.0, 0.0, 110_000.0),
+            Err(LocalTradeAllocationError::SettlementRequired),
+        );
+        assert_eq!(
+            local_trade_backing_sats(100_000, 0, 0, 0.0, 100.001, 100_000.0),
+            Err(LocalTradeAllocationError::TargetExceedsCapacity),
+        );
+        assert_eq!(
+            local_trade_backing_sats(100, 101, 0, 0.0, 0.01, 100_000.0),
+            Err(LocalTradeAllocationError::FeeExceedsBalance),
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 0, 10, 100.0, 99.0, 100_000.0),
+            Err(LocalTradeAllocationError::SettlementRequired),
+        );
+        assert_eq!(
+            local_trade_backing_sats(100_000, 0, 0, 0.0, 99.51, 100_000.0),
+            Err(LocalTradeAllocationError::TargetExceedsSafeCapacity),
+            "the preflight reserves the full permitted quote-deviation band",
+        );
+    }
+
+    #[test]
+    fn wallet_trade_preflight_preserves_drift_and_allows_safe_exit() {
+        assert_eq!(
+            local_trade_backing_sats(100_000, 0, 0, 0.0, 99.50, 100_000.0),
+            Ok((100_000, 99_500)),
+            "a target below the conservative cross-feed limit remains available",
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 100, 100_000, 100.0, 100.01, 110_000.0),
+            Ok((199_900, 100_009)),
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 500, 100_000, 100.0, 0.0, 100_001.0),
+            Ok((199_500, 0)),
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 500, 100_000, 100.0, 0.009, 100_001.0),
+            Ok((199_500, 0)),
+            "a sub-cent target follows the same guarded full-exit path",
+        );
+    }
+
+    #[test]
     fn incoming_sync_preserves_or_shifts_wallet_allocation() {
         let sync = IncomingSync {
             channel_id: "00".repeat(32),
@@ -10748,14 +10998,14 @@ mod tests {
 
         assert_eq!(
             local_sync_backing_sats(&sync, 100_000, 100_000.0, 70.0, 65_000, None),
-            Ok(55_000),
+            Ok(54_999),
             "a target change moves backing by the delta at the wallet's price, never the whole position",
         );
 
         assert_eq!(
             local_sync_backing_sats(&sync, 58_000, 100_000.0, 50.0, 55_000, None),
             Ok(58_000),
-            "a delta past the live balance clamps instead of rejecting",
+            "an authenticated sync clamps to the live balance instead of leaving stale state",
         );
 
         let pending = PendingTradeRow {
@@ -10772,13 +11022,13 @@ mod tests {
         );
 
         let over_capacity = IncomingSync {
-            expected_usd: 100.01,
+            expected_usd: 100.001,
             ..sync.clone()
         };
         assert_eq!(
             local_sync_backing_sats(&over_capacity, 100_000, 100_000.0, 0.0, 0, None),
             Ok(100_000),
-            "a restore at the capacity boundary clamps to all-stable instead of rejecting",
+            "sync reconciliation cannot admit capacity but must converge authenticated state",
         );
 
         let closed = IncomingSync {
@@ -10788,6 +11038,24 @@ mod tests {
         assert_eq!(
             local_sync_backing_sats(&closed, 100_000, 0.0, 60.0, 60_000, None),
             Ok(0),
+            "an authenticated full-exit sync needs no local price",
+        );
+        assert_eq!(
+            local_sync_backing_sats(
+                &closed,
+                100_000,
+                100_001.0,
+                60.0,
+                59_999,
+                None,
+            ),
+            Ok(0),
+            "a full exit with insignificant drift is safe",
+        );
+        assert_eq!(
+            local_sync_backing_sats(&closed, 100_000, 90_000.0, 60.0, 60_000, None),
+            Ok(0),
+            "a signed LSP decision is reconciled rather than silently dropped",
         );
     }
 
@@ -10906,6 +11174,10 @@ mod tests {
                 sync_version: 4,
             })
         );
+
+        let mut sub_cent = payload.clone();
+        sub_cent["expected_usd"] = serde_json::json!(0.009);
+        assert_eq!(parse_incoming_sync(&sub_cent).unwrap().expected_usd, 0.0);
 
         let mut missing_version = payload.clone();
         missing_version

--- a/tests/regtest.rs
+++ b/tests/regtest.rs
@@ -776,8 +776,8 @@ async fn test_outgoing_payment_deducts_from_stable() {
     for _ in 0..5 {
         match lsp_node.next_event() {
             Some(ldk_node::Event::PaymentForwarded {
-                prev_channel_id,
-                next_channel_id,
+                prev_htlcs,
+                next_htlcs,
                 outbound_amount_forwarded_msat,
                 total_fee_earned_msat,
                 ..
@@ -785,8 +785,8 @@ async fn test_outgoing_payment_deducts_from_stable() {
                 forwarded_msat = outbound_amount_forwarded_msat.unwrap_or(0);
                 let fee_msat = total_fee_earned_msat.unwrap_or(0);
                 println!(
-                    "[event] LSP: PaymentForwarded {} msats (fee {} msats) prev={} next={}",
-                    forwarded_msat, fee_msat, prev_channel_id, next_channel_id
+                    "[event] LSP: PaymentForwarded {} msats (fee {} msats) prev={:?} next={:?}",
+                    forwarded_msat, fee_msat, prev_htlcs, next_htlcs
                 );
                 lsp_node.event_handled().unwrap();
                 break;
@@ -993,8 +993,8 @@ async fn test_buy_btc_reduces_stable_position() {
     println!("[event] LSP: PaymentReceived (trade fee)");
 
     // Apply trade on both sides (same shared code as app handlers)
-    apply_trade(&mut user_sc, new_expected_usd, price);
-    apply_trade(&mut lsp_sc, new_expected_usd, price);
+    assert!(apply_trade(&mut user_sc, new_expected_usd, price));
+    assert!(apply_trade(&mut lsp_sc, new_expected_usd, price));
 
     // Refresh balances after payment
     let (ok, _) = update_balances(&user_node, &mut user_sc);
@@ -1199,8 +1199,8 @@ async fn test_sell_btc_increases_stable_position() {
     println!("[event] LSP: PaymentReceived (trade fee)");
 
     // Apply trade on both sides (same shared code as app handlers)
-    apply_trade(&mut user_sc, new_expected_usd, price);
-    apply_trade(&mut lsp_sc, new_expected_usd, price);
+    assert!(apply_trade(&mut user_sc, new_expected_usd, price));
+    assert!(apply_trade(&mut lsp_sc, new_expected_usd, price));
 
     // Refresh balances
     let (ok, _) = update_balances(&user_node, &mut user_sc);
@@ -1312,9 +1312,25 @@ async fn test_sell_btc_increases_stable_position() {
     expect_payment_successful_event!(user_node);
     expect_payment_received_event!(lsp_node);
 
-    // Apply trade on both sides at the NEW price
-    apply_trade(&mut user_sc, new_expected_usd2, rise_price);
-    apply_trade(&mut lsp_sc, new_expected_usd2, rise_price);
+    // Apply only the target delta at the NEW price. Each peer preserves whatever stability drift
+    // its own backing carried before this trade.
+    let user_backing_before_trade = user_sc.backing_sats;
+    let lsp_backing_before_trade = lsp_sc.backing_sats;
+    let old_target_sats =
+        (pre_sell2_expected / rise_price * 100_000_000.0).floor() as u64;
+    let new_target_sats =
+        (new_expected_usd2 / rise_price * 100_000_000.0).floor() as u64;
+    let expected_delta_sats = new_target_sats - old_target_sats;
+    assert!(apply_trade(&mut user_sc, new_expected_usd2, rise_price));
+    assert!(apply_trade(&mut lsp_sc, new_expected_usd2, rise_price));
+    assert_eq!(
+        user_sc.backing_sats,
+        user_backing_before_trade + expected_delta_sats,
+    );
+    assert_eq!(
+        lsp_sc.backing_sats,
+        lsp_backing_before_trade + expected_delta_sats,
+    );
 
     update_balances(&user_node, &mut user_sc);
     update_balances(&lsp_node, &mut lsp_sc);


### PR DESCRIPTION
## Problem

  Trades repriced the entire stable position at the latest price, so even tiny or no-op trades could erase existing stability drift.

  Independent wallet/LSP prices could also disagree near channel capacity.

  ## Fix

  - Apply only the `expected_usd` delta at each peer’s local price.
  - Preserve existing drift and cumulative rounding.
  - Reject underflow and allocations above the live balance.
  - Validate locally before sending the fee.
  - Keep LSP capacity strict; `$0.25` remains only a settlement threshold.
  - Reserve the 0.5% quote-deviation band in the wallet.
  - Treat sub-cent targets as zero.
  - Require settlement before unsafe reductions or full exits.

  Both peers derive backing independently. No wire-format or schema changes.

  ## Trade-off

  Near-capacity trades may leave a small native BTC remainder. Exact `peg_all` negotiation is deferred.

  ## Follow-ups

  1. **Signed stability payments:** bind the channel, exact amount, direction, settlement ID, and expiry. This replaces the unsafe one-byte marker and prevents replay or incorrect settlement accounting.

  2. **Signed trade results:** add authorization, correlation, expiry, deduplication, retries, and `peg_all` negotiation. This prevents fees from leaving wallets stuck waiting for an uncorrelated sync.