### PR TITLE
fix(iOS): align websocket receive tracking and reconciliation with android improvements

### DIFF
--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -1831,10 +1831,22 @@ class AppState {
     private func handleOnchainReceiveResolved(resolutionId: Int64, txid: String) {
         if let db = databaseService,
            let row = db.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId) {
-            if db.paymentRepo.paymentExists(txid: txid, excludePaymentId: row.paymentId) {
-                // WebSocket beat us to it, this fallback placeholder is a duplicate.
-                db.paymentRepo.deletePayment(paymentId: row.paymentId)
+            if let wsPayment = db.paymentRepo.payment(txid: txid) {
+                if wsPayment.amountMsat == UInt64(row.amountMsat) {
+                    // WebSocket beat us to it, this fallback placeholder is a duplicate.
+                    db.paymentRepo.deletePayment(paymentId: row.paymentId)
+                } else {
+                    // Mismatched amount! This placeholder belongs to a different deposit.
+                    // Leave it intact to prevent erasing it from history.
+                    AuditService.log("ONCHAIN_RECEIVE_RES_MISMATCHED_AMOUNT", data: [
+                        "resolution_id": "\(resolutionId)",
+                        "txid": txid,
+                        "placeholder_msat": "\(row.amountMsat)",
+                        "websocket_msat": "\(wsPayment.amountMsat)"
+                    ])
+                }
             } else {
+                // No websocket row exists. Attach the txid to this placeholder.
                 db.paymentRepo.updatePaymentTxid(paymentId: row.paymentId, txid: txid, status: "completed")
             }
         }

--- a/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
@@ -133,6 +133,18 @@ final class PaymentRepository {
         return paymentRecord(from: row)
     }
 
+    func payment(txid: String) -> PaymentRecord? {
+        let sql = """
+        SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price,
+        counterparty, status, created_at, fee_msat, txid, address, confirmations, tx_block_height
+        FROM payments
+        WHERE txid = ?
+        ORDER BY id DESC LIMIT 1
+        """
+        guard let row = try? rawSQL.query(sql, params: [.text(txid)]).first else { return nil }
+        return paymentRecord(from: row)
+    }
+
     func paymentsNeedingConfirmation() throws -> [PaymentRecord] {
         let required = ConfirmationPolicy.requiredConfirmations
         let sql = """

--- a/ios/StableChannels/StableChannels/Services/WebSocket/MempoolWebSocketService.swift
+++ b/ios/StableChannels/StableChannels/Services/WebSocket/MempoolWebSocketService.swift
@@ -396,6 +396,7 @@ final class MempoolWebSocketService: NSObject, URLSessionWebSocketDelegate, Memp
             )
 
             for match in matches {
+                guard !match.isTxid else { continue }
                 let targetKey = match.target
                 let isTxid = match.isTxid
                 let dedupKey = "\(txid)_\(targetKey)"

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -569,6 +569,32 @@ final class DatabaseServiceTests: XCTestCase {
         XCTAssertNotNil(second)
     }
 
+    func testPaymentByTxid() throws {
+        let txid = String(repeating: "c", count: 64)
+        let paymentId = "onchain_receive_\(txid)"
+        let address = "tb1qtestaddress"
+
+        let ok = try service.paymentRepo.recordPayment(
+            paymentId: paymentId,
+            paymentType: "onchain",
+            direction: "received",
+            amountMsat: 100_000_000,
+            amountUSD: 60.0,
+            btcPrice: 60_000.0,
+            counterparty: nil,
+            status: "pending",
+            txid: txid,
+            address: address
+        )
+        XCTAssertTrue(ok)
+
+        let payment = service.paymentRepo.payment(txid: txid)
+        XCTAssertNotNil(payment)
+        XCTAssertEqual(payment?.paymentId, paymentId)
+        XCTAssertEqual(payment?.amountMsat, 100_000_000)
+        XCTAssertEqual(payment?.address, address)
+    }
+
     // MARK: - Price History Pruning Tests
 
     func testPruneHistoricalDataPurgesStalePriceHistory() throws {


### PR DESCRIPTION


## Summary

Ports the Mempool WebSocket tracking and receive flow reconciliation improvements from Android PR #222 to iOS, resolving phantom receive row writes on channel closures and ensuring address reuse safety during placeholder cleanup.

---

## Problem

1. **Phantom Receive Row Generation**: Spends of tracked transaction IDs (such as channel closures) triggered address-match events in the WebSocket receive path, resulting in false `.receive` broadcasts and empty phantom database entries.
2. **Resolution Cleanup Conflicts on Reused Addresses**: The fallback HTTP receive resolution path deleted pending placeholder rows based purely on the existence of a corresponding transaction ID (`txid`), without matching the payment amounts. When a user received multiple concurrent deposits to the same reused address, resolving one deposit would wipe out the placeholder row of another deposit, causing history loss.

---

## Solution

1. **Strict Receive Loop Filtering**:
   - Filtered out `match.isTxid` events in `MempoolWebSocketService.swift`'s address transaction matching loop. Tracked transaction events (such as channel close spends) are now processed solely by the outspends tracked transactions pipeline.
2. **Transaction ID Retrieval**:
   - Added `payment(txid:)` lookup capability to `PaymentRepository.swift` to retrieve recorded payment details by transaction hash.
3. **Amount-Gated Reconciliation**:
   - Updated `handleOnchainReceiveResolved(resolutionId:txid:)` in `AppState.swift` to retrieve the WebSocket payment and check `wsPayment.amountMsat == UInt64(row.amountMsat)`.
   - The pending placeholder is only deleted if the amounts match exactly. Otherwise, the placeholder is preserved as a separate deposit.

---

## Key Changes

1. **`MempoolWebSocketService.swift`**:
   - Excluded `isTxid` matches from triggering incoming receive events.
2. **`PaymentRepository.swift`**:
   - Added `payment(txid: String) -> PaymentRecord?` query.
3. **`AppState.swift`**:
   - Guarded duplicate placeholder deletions in `handleOnchainReceiveResolved` on exact `amountMsat` matching.
4. **`DatabaseServiceTests.swift`**:
   - Added `testPaymentByTxid()` to verify database retrieval.
