### PR TITLE
harden LSP REST + keysend surfaces against unauthenticated DoS

### DIFF
--- a/server/stable-channels-lsp/src/auth.rs
+++ b/server/stable-channels-lsp/src/auth.rs
@@ -7,6 +7,26 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Maximum allowed clock skew between client and server, in seconds.
 pub const TIMESTAMP_TOLERANCE_SECS: u64 = 60;
 
+/// Maximum request body the auth layer will buffer before validating `X-Auth`.
+///
+/// REST payloads here are small prost/JSON documents. The middleware reads the body in full to
+/// compute the HMAC, and `axum`'s default 2 MiB extractor limit does NOT apply to a manual
+/// `to_bytes` read — so without this cap an unauthenticated client on the public `/api/*` proxy
+/// could POST a multi-gigabyte body and OOM-kill the daemon (which also halts stability payments).
+/// 1 MiB is generous for every real request and small enough that concurrent maxima stay bounded.
+pub const MAX_AUTH_BODY_BYTES: usize = 1024 * 1024;
+
+/// Whether a declared `Content-Length` already exceeds the cap, so the body can be rejected
+/// before a single byte is buffered. A missing or unparseable header returns `false` — the
+/// streaming read is still hard-capped at [`MAX_AUTH_BODY_BYTES`], so chunked bodies with no
+/// declared length cannot bypass the limit.
+fn declared_length_exceeds(content_length: Option<&str>, cap: usize) -> bool {
+    content_length
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(|len| len > cap as u64)
+        .unwrap_or(false)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum AuthError {
     MissingHeader,
@@ -87,7 +107,20 @@ pub async fn auth_middleware(
         .map(|s| s.to_string());
 
     let (parts, body) = req.into_parts();
-    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+
+    // Reject an oversized body before buffering it. The Content-Length check is the cheap
+    // pre-read guard; the capped `to_bytes` is the authoritative limit for bodies that lie about
+    // or omit their length. Either way, the daemon never buffers more than MAX_AUTH_BODY_BYTES
+    // for an unauthenticated request.
+    let declared_len = parts
+        .headers
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok());
+    if declared_length_exceeds(declared_len, MAX_AUTH_BODY_BYTES) {
+        return error_response(ErrorCode::InvalidRequestError, "Request body too large");
+    }
+
+    let body_bytes = match axum::body::to_bytes(body, MAX_AUTH_BODY_BYTES).await {
         Ok(b) => b,
         Err(e) => {
             return error_response(
@@ -182,5 +215,26 @@ mod tests {
             validate_auth(Some(&header), key, b"body-b"),
             Err(AuthError::HmacMismatch),
         );
+    }
+
+    #[test]
+    fn declared_length_over_cap_is_rejected() {
+        assert!(declared_length_exceeds(Some("1048577"), MAX_AUTH_BODY_BYTES));
+        assert!(declared_length_exceeds(Some("9999999999"), MAX_AUTH_BODY_BYTES));
+    }
+
+    #[test]
+    fn declared_length_at_or_under_cap_is_allowed() {
+        assert!(!declared_length_exceeds(Some("1048576"), MAX_AUTH_BODY_BYTES));
+        assert!(!declared_length_exceeds(Some("0"), MAX_AUTH_BODY_BYTES));
+        assert!(!declared_length_exceeds(Some("512"), MAX_AUTH_BODY_BYTES));
+    }
+
+    #[test]
+    fn absent_or_garbage_length_defers_to_streaming_cap() {
+        // No pre-read rejection — the capped to_bytes read is the real limit.
+        assert!(!declared_length_exceeds(None, MAX_AUTH_BODY_BYTES));
+        assert!(!declared_length_exceeds(Some("not-a-number"), MAX_AUTH_BODY_BYTES));
+        assert!(!declared_length_exceeds(Some(""), MAX_AUTH_BODY_BYTES));
     }
 }

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -267,6 +267,9 @@ async fn main() -> Result<()> {
             "/api/channel-exists",
             post(handlers::channel_exists::channel_exists),
         )
+        // Defense-in-depth body cap covering every route, including the two unsigned endpoints
+        // that never reach the auth middleware's own capped read.
+        .layer(axum::extract::DefaultBodyLimit::max(auth::MAX_AUTH_BODY_BYTES))
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -806,25 +806,13 @@ impl StableChannelManager {
                 serde_json::json!({ "tlv": stable_channels::constants::STABLE_CHANNEL_TLV_TYPE, "payment_id": payment_id.clone() }),
             );
             let raw = raw.to_string();
-            if let Some(envelope) = crate::messages::parse_envelope(&raw) {
-                if crate::messages::is_trade_v1(&envelope) {
-                    if let Some(pid) = payment_id.as_deref() {
-                        if let Err(e) = self.db.record_settlement(pid, "trade") {
-                            tracing::error!(
-                                "[stable] record_settlement (inbound trade) failed: {}",
-                                e
-                            );
-                            stable_channels::audit::audit_event(
-                                "DB_WRITE_FAILED",
-                                serde_json::json!({ "op": "record_settlement", "kind": "trade", "payment_id": pid, "error": e.to_string() }),
-                            );
-                        }
-                    }
-                }
+            if let Some(_envelope) = crate::messages::parse_envelope(&raw) {
                 // An envelope is a control message, even when its inner type is unknown or
                 // malformed. Let the trade handler audit/drop it; never reinterpret it as a
-                // stability payment.
-                self.handle_trade_message(&raw, amount_msat, ldk, btc_price)
+                // stability payment. The trade settlement is recorded INSIDE the handler, only
+                // after the signature verifies — a forged or unsigned envelope from any peer no
+                // longer writes a settlement row before it is authenticated.
+                self.handle_trade_message(&raw, payment_id.as_deref(), amount_msat, ldk, btc_price)
                     .await;
             } else if rec.value.as_ref() == [1u8] {
                 if let Some(pid) = payment_id.as_deref() {
@@ -2320,6 +2308,7 @@ impl StableChannelManager {
     pub async fn handle_trade_message(
         &mut self,
         raw: &str,
+        payment_id: Option<&str>,
         amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
@@ -2412,6 +2401,19 @@ impl StableChannelManager {
             "TRADE_SIGNATURE_VALID",
             serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
         );
+
+        // Verify-then-write: the settlement row is recorded only now that the envelope's
+        // signature is verified against the channel counterparty. An unauthenticated peer's
+        // forged TLV is dropped above without ever touching the settlements table.
+        if let Some(pid) = payment_id {
+            if let Err(e) = self.db.record_settlement(pid, "trade") {
+                tracing::error!("[stable] record_settlement (inbound trade) failed: {}", e);
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({ "op": "record_settlement", "kind": "trade", "payment_id": pid, "error": e.to_string() }),
+                );
+            }
+        }
 
         // Replay protection: reject a signed trade with a stale `ts`; ts==0 means an un-upgraded wallet (no timestamp yet) — accepted until all wallets sign one.
         const TRADE_SIG_WINDOW_SECS: u64 = 300;
@@ -4140,7 +4142,7 @@ mod tests {
             payload.quote_price.unwrap_or(lsp_price),
         )
         .unwrap();
-        mgr.handle_trade_message(envelope, Some(fee_msat), ldk, lsp_price)
+        mgr.handle_trade_message(envelope, None, Some(fee_msat), ldk, lsp_price)
             .await;
     }
 
@@ -4388,6 +4390,7 @@ mod tests {
 
         mgr.handle_trade_message(
             &env,
+            None,
             Some(1),
             &fake as &dyn LdkServerCalls,
             100_000.0,

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -109,8 +109,30 @@ fn mirror_event_at(
     // so concurrent calls can interleave into corrupt lines.
     let mut line = log_line.to_string();
     line.push('\n');
+    rotate_if_oversize(path);
     let mut file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
     file.write_all(line.as_bytes())
+}
+
+/// Cap on the live audit log before it rotates. The file grows one line per event and events can
+/// be driven by any Lightning peer (inbound TLVs), so without a bound the disk fills — which stops
+/// the daemon and its stability payments. One previous generation is kept (`<path>.1`), so on-disk
+/// audit history is bounded to roughly 2× this figure.
+const AUDIT_LOG_MAX_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Rotate `path` to `<path>.1` when it reaches the size cap, replacing any prior `.1`. Best-effort:
+/// any error leaves the current file in place so logging simply continues appending. The rename is
+/// atomic on a single filesystem; a couple of lines may land in the pre-rotation file if another
+/// thread appends between the size check and the rename, which is harmless.
+fn rotate_if_oversize(path: &std::path::Path) {
+    let over = std::fs::metadata(path)
+        .map(|meta| meta.len() >= AUDIT_LOG_MAX_BYTES)
+        .unwrap_or(false);
+    if over {
+        let mut rotated = path.as_os_str().to_owned();
+        rotated.push(".1");
+        let _ = std::fs::rename(path, std::path::PathBuf::from(rotated));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Two internet-reachable resource-exhaustion vectors on the LSP daemon.

H1 — unauthenticated memory DoS via the REST body. auth_middleware read the entire request body with to_bytes(body, usize::MAX) BEFORE checking X-Auth, and axum's default extractor limit does not apply to a manual read. Any client on the public /api/* proxy could POST a multi-GB body and OOM-kill the daemon (halting stability payments). Now: reject on an oversized Content-Length before buffering, hard-cap the streaming read at MAX_AUTH_BODY_BYTES (1 MiB) so chunked/undeclared bodies can't bypass it, and add a router-wide DefaultBodyLimit covering the two unsigned routes that never reach the auth read.

H2 — keysend control-plane amplification + disk-fill. Any Lightning peer can keysend 1-msat TLV-13377331 garbage; each message drove a ListChannels gRPC call, a settlements DB insert, and audit lines under the global manager mutex, serializing the stability engine and growing on-disk state unbounded. Now:
  - Fixed-window rate limit (20/s) on stable-TLV processing, before any gRPC/DB/audit work; the drop itself is audited once per window.
  - Verify-then-write: the trade settlement row is recorded only after the envelope signature verifies against the channel counterparty, so a forged TLV no longer writes a settlement pre-authentication.
  - Size-based audit-log rotation (50 MiB, one kept generation) so the append-only log cannot fill the disk.

LSP suite 140 passing (+4 new); wallet lib 154 passing (shared audit.rs).


Claude-Session: https://claude.ai/code/session_01ED5K6AG9FVeLhrxQbTyKrM