### PR TITLE
authenticate and amount-bind stability settlements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitcoin = "0.32"
 ureq = { version = "2.10.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rand = "0.9"
 retry = "1.3"
 futures = "0.3"
 async-trait = "0.1"
@@ -67,7 +68,6 @@ long_description = "A self-custodial bitcoin wallet with USD stability."
 tempfile = "3"
 electrsd = { version = "0.36.1", features = ["legacy", "esplora_a33e97e1", "corepc-node_27_2"] }
 electrum-client = "0.24.0"
-rand = "0.9"
 
 [workspace]
 members = [
@@ -82,5 +82,4 @@ members = [
 # macOS / Linux builds.
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
-
 

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -15,8 +15,12 @@ use ldk_server_client::ldk_server_grpc::api::{
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
 use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
-use stable_channels::constants::MAX_TRADE_QUOTE_DEVIATION_PERCENT;
-use stable_channels::db::Database;
+use stable_channels::constants::{
+    MAX_TRADE_QUOTE_DEVIATION_PERCENT, SIGNED_STABILITY_TLV_TYPE,
+    STABILITY_PAYMENT_AUTH_TTL_SECS,
+};
+use stable_channels::db::{Database, InboundStabilityRegistration};
+use stable_channels::stable::StabilityPaymentDirection;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
 
@@ -762,6 +766,23 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
+        if let Some(record) = custom_records
+            .iter()
+            .find(|record| record.type_num == SIGNED_STABILITY_TLV_TYPE)
+        {
+            self.handle_signed_stability_payment(
+                record,
+                payment_id.as_deref(),
+                amount_msat,
+                ldk,
+                btc_price,
+            )
+            .await;
+            // A malformed signed record must never downgrade to the unsigned marker included for
+            // older mobile clients.
+            return;
+        }
+
         for rec in &custom_records {
             if rec.type_num != stable_channels::constants::STABLE_CHANNEL_TLV_TYPE {
                 continue;
@@ -805,7 +826,7 @@ impl StableChannelManager {
                 // stability payment.
                 self.handle_trade_message(&raw, amount_msat, ldk, btc_price)
                     .await;
-            } else {
+            } else if rec.value.as_ref() == [1u8] {
                 if let Some(pid) = payment_id.as_deref() {
                     if let Err(e) = self.db.record_settlement(pid, "stability") {
                         tracing::error!("[stable] record_settlement (inbound stability) failed: {}", e);
@@ -821,6 +842,15 @@ impl StableChannelManager {
                 // user's payment as an unreconciled spend and deduct expected_usd.
                 self.reconcile_incoming_stability(payment_id.as_deref(), amount_msat, ldk, btc_price)
                     .await;
+            } else {
+                stable_channels::audit::audit_event(
+                    "LEGACY_STABILITY_MARKER_INVALID",
+                    serde_json::json!({
+                        "payment_id": payment_id,
+                        "amount_msat": amount_msat,
+                        "payload_len": rec.value.len(),
+                    }),
+                );
             }
             return;
         }
@@ -829,6 +859,491 @@ impl StableChannelManager {
             "PAYMENT_RECEIVED",
             serde_json::json!({ "payment_id": payment_id, "amount_msat": amount_msat }),
         );
+    }
+
+    async fn handle_signed_stability_payment(
+        &mut self,
+        record: &CustomTlvRecord,
+        payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        if record.value.len()
+            > stable_channels::constants::MAX_SIGNED_STABILITY_TLV_VALUE_BYTES
+        {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "reason": "oversize",
+                    "payload_len": record.value.len(),
+                }),
+            );
+            return;
+        }
+        let Ok(raw) = std::str::from_utf8(record.value.as_ref()) else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                serde_json::json!({ "payment_id": payment_id, "reason": "utf8" }),
+            );
+            return;
+        };
+        let Some(envelope) = stable_channels::stable::parse_stability_signed_envelope(raw) else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                serde_json::json!({ "payment_id": payment_id, "reason": "envelope" }),
+            );
+            return;
+        };
+        let Some(payload) =
+            stable_channels::stable::parse_stability_payment_payload(&envelope.payload)
+        else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                serde_json::json!({ "payment_id": payment_id, "reason": "fields" }),
+            );
+            return;
+        };
+        let (Some(payment_id), Some(received_msat)) = (payment_id, amount_msat) else {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_BINDING_INVALID",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "amount_msat": amount_msat,
+                    "reason": "missing_payment_details",
+                }),
+            );
+            return;
+        };
+        if payload.direction != StabilityPaymentDirection::UserToLsp {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_BINDING_INVALID",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "reason": "direction",
+                }),
+            );
+            return;
+        }
+        if payload.amount_msat != received_msat {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_AMOUNT_MISMATCH",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "signed_amount_msat": payload.amount_msat,
+                    "received_amount_msat": received_msat,
+                }),
+            );
+            return;
+        }
+        let registration = match self.db.register_inbound_stability_settlement(
+            &payload.settlement_id,
+            payment_id,
+            &payload.channel_id,
+            payload.amount_msat,
+            "user_to_lsp",
+            raw,
+        ) {
+            Ok(registration) => registration,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_REPLAY_CONFLICT",
+                    serde_json::json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        if registration == InboundStabilityRegistration::Applied {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_REPLAY_IGNORED",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                }),
+            );
+            return;
+        }
+        if registration == InboundStabilityRegistration::Invalid {
+            return;
+        }
+
+        let invalidate = |reason: &str| {
+            let _ = self.db.finish_inbound_stability_settlement(
+                &payload.settlement_id,
+                "invalid",
+                Some(reason),
+            );
+        };
+        let received_at = match self
+            .db
+            .inbound_stability_settlement_received_at(&payload.settlement_id)
+        {
+            Ok(Some(received_at)) => received_at,
+            Ok(None) => return,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({
+                        "op": "inbound_stability_settlement_received_at",
+                        "settlement_id": payload.settlement_id,
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        // Evaluate expiry at the durable first-receipt time. A transient failure may be retried
+        // later without turning an on-time, already-settled Lightning payment into an invalid one.
+        if !stable_channels::stable::stability_payment_is_fresh(&payload, received_at) {
+            invalidate("expired");
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_EXPIRED",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "created_at": payload.created_at,
+                    "expires_at": payload.expires_at,
+                    "received_at": received_at,
+                }),
+            );
+            return;
+        }
+
+        let channels = match ldk.list_channels(ListChannelsRequest {}).await {
+            Ok(response) => response.channels,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_CHANNEL_LOOKUP_FAILED",
+                    serde_json::json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let Some(channel) = channels
+            .iter()
+            .find(|channel| channel.channel_id.eq_ignore_ascii_case(&payload.channel_id))
+            .cloned()
+        else {
+            invalidate("channel");
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_CHANNEL_MISMATCH",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "channel_id": payload.channel_id,
+                }),
+            );
+            return;
+        };
+        let Some(user_channel_id) = parse_user_channel_id(&channel.user_channel_id) else {
+            invalidate("user_channel_id");
+            return;
+        };
+        let canonical_user_channel_id = format!("{}", user_channel_id);
+        let Some(idx) = self
+            .stable_channels
+            .iter()
+            .position(|stable| stable.user_channel_id == user_channel_id)
+        else {
+            let known_stable_channel = match self
+                .db
+                .get_active_user_channel_id_by_channel_id(&payload.channel_id)
+            {
+                Ok(channel_id) => channel_id.is_some(),
+                Err(error) => {
+                    stable_channels::audit::audit_event(
+                        "DB_READ_FAILED",
+                        serde_json::json!({
+                            "op": "get_active_user_channel_id_by_channel_id",
+                            "settlement_id": payload.settlement_id,
+                            "payment_id": payment_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                    return;
+                }
+            };
+            if !known_stable_channel {
+                invalidate("channel_not_stable");
+            }
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_CHANNEL_UNAVAILABLE",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "channel_id": payload.channel_id,
+                    "will_retry": known_stable_channel,
+                }),
+            );
+            return;
+        };
+        let signature_valid = match ldk
+            .verify_signature(VerifySignatureRequest {
+                message: envelope.payload.as_bytes().to_vec().into(),
+                signature: envelope.signature,
+                public_key: channel.counterparty_node_id.clone(),
+            })
+            .await
+        {
+            Ok(response) => response.valid,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_SIGNATURE_CHECK_FAILED",
+                    serde_json::json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        if !signature_valid {
+            invalidate("signature");
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_SIGNATURE_INVALID",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "channel_id": payload.channel_id,
+                }),
+            );
+            return;
+        }
+        if payload.expected_usd.to_bits()
+            != self.stable_channels[idx].expected_usd.0.to_bits()
+        {
+            // The signed amount and local equilibrium bound the economic transition. A target
+            // difference between independent peers is useful telemetry, but is not a reason to
+            // discard an already-settled authenticated payment.
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_STATE_DIVERGENCE",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                    "signed_expected_usd": payload.expected_usd,
+                    "local_expected_usd": self.stable_channels[idx].expected_usd.0,
+                }),
+            );
+        }
+        if btc_price <= 0.0 {
+            stable_channels::audit::audit_event(
+                "STABILITY_PAYMENT_PRICE_UNAVAILABLE",
+                serde_json::json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_id": payment_id,
+                }),
+            );
+            return;
+        }
+
+        let (_, their_sats) = channel_peer_balances(&channel);
+        let amount_sats = received_msat / 1000;
+        let mut allocation_expected_usd = self.stable_channels[idx].expected_usd.0;
+        let mut backing_before = self.stable_channels[idx].backing_sats;
+        let Some(mut backing_after) =
+            stable_channels::stable::backing_after_user_to_lsp_stability(
+                backing_before,
+                allocation_expected_usd,
+                btc_price,
+                amount_sats,
+                their_sats,
+            )
+        else {
+            invalidate("allocation");
+            return;
+        };
+        let mut native_after = their_sats.saturating_sub(backing_after);
+        let amount_usd = amount_sats as f64
+            / stable_channels::constants::SATS_IN_BTC as f64
+            * btc_price;
+        let persist = |backing_sats_before, backing_sats_after, native_sats_after| {
+            self.db.record_signed_stability_payment_and_update_allocation(
+                payment_id,
+                &payload.settlement_id,
+                received_msat,
+                Some(amount_usd),
+                Some(btc_price),
+                &canonical_user_channel_id,
+                backing_sats_before,
+                backing_sats_after,
+                native_sats_after,
+            )
+        };
+        let persisted = match persist(backing_before, backing_after, native_after) {
+            Err(ref error)
+                if stable_channels::db::is_stale_inbound_stability_allocation(error) =>
+            {
+                let durable = match self.db.load_channel(&canonical_user_channel_id) {
+                    Ok(Some(channel)) => channel,
+                    Ok(None) => return,
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            serde_json::json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_id": payment_id,
+                                "stage": "reload_after_stale_allocation",
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return;
+                    }
+                };
+                let Some(reloaded_backing_after) =
+                    stable_channels::stable::backing_after_user_to_lsp_stability(
+                        durable.backing_sats,
+                        durable.expected_usd,
+                        btc_price,
+                        amount_sats,
+                        their_sats,
+                    )
+                else {
+                    return;
+                };
+                allocation_expected_usd = durable.expected_usd;
+                backing_before = durable.backing_sats;
+                backing_after = reloaded_backing_after;
+                native_after = their_sats.saturating_sub(backing_after);
+                match persist(backing_before, backing_after, native_after) {
+                    Ok(persisted) => persisted,
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            serde_json::json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_id": payment_id,
+                                "stage": "retry_after_stale_allocation",
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return;
+                    }
+                }
+            }
+            Err(ref error) if stable_channels::db::is_missing_channel_row(error) => {
+                if let Err(error) = self.db.save_channel(
+                    &payload.channel_id,
+                    &canonical_user_channel_id,
+                    allocation_expected_usd,
+                    backing_before,
+                    their_sats.saturating_sub(backing_before),
+                    self.stable_channels[idx].note.as_deref(),
+                ) {
+                    stable_channels::audit::audit_event(
+                        "STABILITY_PAYMENT_PERSIST_FAILED",
+                        serde_json::json!({
+                            "settlement_id": payload.settlement_id,
+                            "payment_id": payment_id,
+                            "stage": "canonicalize_channel_row",
+                            "error": error.to_string(),
+                        }),
+                    );
+                    return;
+                }
+                match persist(backing_before, backing_after, native_after) {
+                    Ok(persisted) => persisted,
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            serde_json::json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_id": payment_id,
+                                "stage": "retry_after_channel_canonicalization",
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return;
+                    }
+                }
+            }
+            Ok(persisted) => persisted,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "STABILITY_PAYMENT_PERSIST_FAILED",
+                    serde_json::json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_id": payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        if persisted.is_new {
+            let stable = &mut self.stable_channels[idx];
+            stable.expected_usd = USD::from_f64(allocation_expected_usd);
+            stable.latest_price = btc_price;
+            stable.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            stable.stable_receiver_usd = USD::from_bitcoin(stable.stable_receiver_btc, btc_price);
+            stable.backing_sats = backing_after;
+            stable.native_sats = native_after;
+            stable_channels::stable::recompute_native(stable);
+            self.spend_debounce.remove(&stable.user_channel_id);
+        }
+        stable_channels::audit::audit_event(
+            "STABILITY_PAYMENT_V1_APPLIED",
+            serde_json::json!({
+                "settlement_id": payload.settlement_id,
+                "payment_id": payment_id,
+                "channel_id": payload.channel_id,
+                "amount_msat": received_msat,
+                "backing_sats_before": backing_before,
+                "backing_sats_after": backing_after,
+                "native_sats_after": native_after,
+                "is_new": persisted.is_new,
+            }),
+        );
+    }
+
+    async fn retry_pending_signed_stability(
+        &mut self,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        if !btc_price.is_finite() || btc_price <= 0.0 {
+            return;
+        }
+        let pending = match self.db.pending_inbound_stability_settlements(32) {
+            Ok(pending) => pending,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({
+                        "op": "pending_inbound_stability_settlements",
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        for settlement in pending {
+            let record = CustomTlvRecord {
+                type_num: SIGNED_STABILITY_TLV_TYPE,
+                value: settlement.envelope.into_bytes().into(),
+            };
+            self.handle_signed_stability_payment(
+                &record,
+                Some(&settlement.payment_id),
+                Some(settlement.amount_msat),
+                ldk,
+                btc_price,
+            )
+            .await;
+        }
     }
 
     /// Settle the books for an inbound stability payment (user above par paid the LSP).
@@ -918,15 +1433,24 @@ impl StableChannelManager {
         // 1 sat of drift, not erase the entire above-par surplus and reclassify it as the
         // user's own native BTC. Floor at equilibrium so a (rounding) overpayment cannot
         // drive backing below the peg; clamp to the live balance so backing never exceeds it.
-        let equilibrium = ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
-        let settled_backing = if sc.backing_sats > equilibrium {
-            sc.backing_sats.saturating_sub(amount_sats).max(equilibrium)
-        } else {
-            // At or below the peg there was no above-par surplus to settle on this receive
-            // path; never inflate backing toward equilibrium on an unexpected payment.
-            sc.backing_sats
+        let Some(settled_backing) = stable_channels::stable::backing_after_user_to_lsp_stability(
+            sc.backing_sats,
+            sc.expected_usd.0,
+            btc_price,
+            amount_sats,
+            their_sats,
+        ) else {
+            stable_channels::audit::audit_event(
+                "STABILITY_RECEIVE_UNATTRIBUTED",
+                serde_json::json!({
+                    "payment_id": payment_id,
+                    "amount_msat": amount_msat,
+                    "reason": "invalid_allocation_inputs",
+                }),
+            );
+            return;
         };
-        sc.backing_sats = settled_backing.min(their_sats);
+        sc.backing_sats = settled_backing;
         sc.native_sats = their_sats.saturating_sub(sc.backing_sats);
         stable_channels::stable::recompute_native(sc);
         // The drop is settled; make sure the backstop forgets any ticks it counted.
@@ -966,6 +1490,9 @@ impl StableChannelManager {
         push: &std::sync::Arc<tokio::sync::Mutex<crate::push::PushService>>,
         btc_price: f64,
     ) {
+        // LDK Server's event stream is not replayable. Finish any receive that was durably
+        // registered before a transient channel/signature/DB failure.
+        self.retry_pending_signed_stability(ldk, btc_price).await;
         if btc_price <= 0.0 {
             return;
         }
@@ -1118,15 +1645,100 @@ impl StableChannelManager {
 
             if c.is_usable {
                 if is_receiver_below_expected {
+                    let settlement_id = stable_channels::stable::new_stability_settlement_id();
+                    let created_at = now.max(0) as u64;
+                    let expires_at = created_at.saturating_add(STABILITY_PAYMENT_AUTH_TTL_SECS);
+                    let payload = match stable_channels::stable::build_stability_payment_payload(
+                        &settlement_id,
+                        &c.channel_id,
+                        amount_msat,
+                        StabilityPaymentDirection::LspToUser,
+                        sc.expected_usd.0,
+                        created_at,
+                        expires_at,
+                    ) {
+                        Ok(payload) => payload,
+                        Err(error) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_SERIALIZE_FAILED",
+                                serde_json::json!({
+                                    "channel_id": c.channel_id,
+                                    "user_channel_id": format!("{}", sc.user_channel_id),
+                                    "settlement_id": settlement_id,
+                                    "amount_msat": amount_msat,
+                                    "error": error.to_string(),
+                                }),
+                            );
+                            continue;
+                        }
+                    };
+                    let signature = match ldk
+                        .sign_message(SignMessageRequest {
+                            message: payload.as_bytes().to_vec().into(),
+                        })
+                        .await
+                    {
+                        Ok(response) if !response.signature.is_empty() => response.signature,
+                        Ok(_) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_SIGN_FAILED",
+                                serde_json::json!({
+                                    "channel_id": c.channel_id,
+                                    "user_channel_id": format!("{}", sc.user_channel_id),
+                                    "settlement_id": settlement_id,
+                                    "reason": "empty_signature",
+                                }),
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_SIGN_FAILED",
+                                serde_json::json!({
+                                    "channel_id": c.channel_id,
+                                    "user_channel_id": format!("{}", sc.user_channel_id),
+                                    "settlement_id": settlement_id,
+                                    "error": error.to_string(),
+                                }),
+                            );
+                            continue;
+                        }
+                    };
+                    let envelope = match stable_channels::stable::build_stability_signed_envelope(
+                        payload,
+                        signature,
+                    ) {
+                        Ok(envelope) => envelope,
+                        Err(error) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_SERIALIZE_FAILED",
+                                serde_json::json!({
+                                    "channel_id": c.channel_id,
+                                    "user_channel_id": format!("{}", sc.user_channel_id),
+                                    "settlement_id": settlement_id,
+                                    "stage": "envelope",
+                                    "error": error.to_string(),
+                                }),
+                            );
+                            continue;
+                        }
+                    };
                     let send_req = SpontaneousSendRequest {
                         amount_msat,
                         node_id: sc.counterparty.to_string(),
                         route_parameters: None,
-                        // Tag as a stability payment so receiving clients can identify it.
-                        custom_tlvs: vec![CustomTlvRecord {
-                            type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
-                            value: vec![1u8].into(),
-                        }],
+                        // Keep the marker during the mobile rollout. Upgraded receivers must
+                        // prefer and validate the signed record whenever both are present.
+                        custom_tlvs: vec![
+                            CustomTlvRecord {
+                                type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                                value: vec![1u8].into(),
+                            },
+                            CustomTlvRecord {
+                                type_num: SIGNED_STABILITY_TLV_TYPE,
+                                value: envelope.into_bytes().into(),
+                            },
+                        ],
                     };
                     let channel_id_clone = c.channel_id.clone();
                     let user_channel_id_clone = c.user_channel_id.clone();
@@ -1140,6 +1752,17 @@ impl StableChannelManager {
                     let counterparty_for_db = sc.counterparty.to_string();
                     match ldk.spontaneous_send(send_req).await {
                         Ok(resp) => {
+                            stable_channels::audit::audit_event(
+                                "STABILITY_PAYMENT_V1_SENT",
+                                serde_json::json!({
+                                    "payment_id": resp.payment_id,
+                                    "settlement_id": settlement_id,
+                                    "channel_id": channel_id_clone,
+                                    "user_channel_id": user_channel_id_clone,
+                                    "amount_msat": amount_msat,
+                                    "direction": "lsp_to_user",
+                                }),
+                            );
                             let persisted = if resp.payment_id.is_empty() {
                                 false
                             } else {
@@ -2128,6 +2751,7 @@ mod tests {
         pub verify_should_pass: bool,
         pub signature: String,
         pub sign_calls: StdMutex<Vec<Vec<u8>>>,
+        pub verify_calls: StdMutex<Vec<VerifySignatureRequest>>,
         pub forwarded: StdMutex<Vec<GrpcForwardedPayment>>,
         pub forward_next_page_token: StdMutex<Option<PageToken>>,
         pub forward_calls: AtomicUsize,
@@ -2145,6 +2769,7 @@ mod tests {
                 verify_should_pass: true,
                 signature: "fake-sig".to_string(),
                 sign_calls: StdMutex::new(Vec::new()),
+                verify_calls: StdMutex::new(Vec::new()),
                 forwarded: StdMutex::new(Vec::new()),
                 forward_next_page_token: StdMutex::new(None),
                 forward_calls: AtomicUsize::new(0),
@@ -2207,8 +2832,9 @@ mod tests {
         }
         async fn verify_signature(
             &self,
-            _req: VerifySignatureRequest,
+            req: VerifySignatureRequest,
         ) -> Result<VerifySignatureResponse, LdkServerError> {
+            self.verify_calls.lock().unwrap().push(req);
             Ok(VerifySignatureResponse {
                 valid: self.verify_should_pass,
             })
@@ -2972,6 +3598,32 @@ mod tests {
         assert_eq!(sends.len(), 1, "expected one stability payment");
         assert_eq!(sends[0].node_id, COUNTERPARTY_HEX);
         assert!(sends[0].amount_msat > 0);
+        assert_eq!(sends[0].custom_tlvs.len(), 2);
+        assert_eq!(
+            sends[0].custom_tlvs[0].type_num,
+            stable_channels::constants::STABLE_CHANNEL_TLV_TYPE
+        );
+        assert_eq!(sends[0].custom_tlvs[0].value.as_ref(), [1u8]);
+        assert_eq!(
+            sends[0].custom_tlvs[1].type_num,
+            stable_channels::constants::SIGNED_STABILITY_TLV_TYPE
+        );
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[1].value.as_ref()).unwrap();
+        let envelope = stable_channels::stable::parse_stability_signed_envelope(raw).unwrap();
+        let payload =
+            stable_channels::stable::parse_stability_payment_payload(&envelope.payload).unwrap();
+        assert_eq!(payload.channel_id, CHANNEL_ID_HEX);
+        assert_eq!(payload.amount_msat, sends[0].amount_msat);
+        assert_eq!(
+            payload.direction,
+            stable_channels::stable::StabilityPaymentDirection::LspToUser
+        );
+        assert_eq!(payload.expected_usd, 50.0);
+        assert_eq!(envelope.signature, "fake-sig");
+        assert_eq!(
+            fake_drift.sign_calls.lock().unwrap().as_slice(),
+            [envelope.payload.as_bytes()]
+        );
         assert!(mgr.stable_channels[0].last_stability_payment > 0,
             "cooldown timestamp should be set");
     }
@@ -4460,6 +5112,503 @@ mod tests {
             type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
             value: vec![1u8].into(),
         }
+    }
+
+    fn signed_stability_record(
+        settlement_id: &str,
+        channel_id: &str,
+        amount_msat: u64,
+        direction: stable_channels::stable::StabilityPaymentDirection,
+        expected_usd: f64,
+    ) -> CustomTlvRecord {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let payload = stable_channels::stable::build_stability_payment_payload(
+            settlement_id,
+            channel_id,
+            amount_msat,
+            direction,
+            expected_usd,
+            now,
+            now + STABILITY_PAYMENT_AUTH_TTL_SECS,
+        )
+        .unwrap();
+        let envelope = stable_channels::stable::build_stability_signed_envelope(
+            payload,
+            "signed-by-test-peer".to_owned(),
+        )
+        .unwrap();
+        CustomTlvRecord {
+            type_num: stable_channels::constants::SIGNED_STABILITY_TLV_TYPE,
+            value: envelope.into_bytes().into(),
+        }
+    }
+
+    async fn manager_at_par_for_signed_stability() -> StableChannelManager {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )]);
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        mgr
+    }
+
+    #[tokio::test]
+    async fn signed_stability_payment_is_bound_to_amount_and_applied_once() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "11".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![stability_marker(), record.clone()],
+            Some("signed-payment-1".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_091);
+        assert_eq!(mgr.stable_channels[0].native_sats, 40_000);
+        assert!(mgr
+            .db
+            .load_channel(USER_CHANNEL_ID_DECIMAL)
+            .unwrap()
+            .is_some());
+        let verify_calls = fake.verify_calls.lock().unwrap();
+        assert_eq!(verify_calls.len(), 1);
+        assert_eq!(verify_calls[0].public_key, COUNTERPARTY_HEX);
+        let envelope = stable_channels::stable::parse_stability_signed_envelope(
+            std::str::from_utf8(record.value.as_ref()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(verify_calls[0].message.as_ref(), envelope.payload.as_bytes());
+        drop(verify_calls);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("applied")
+        );
+
+        mgr.handle_payment_received(
+            vec![stability_marker(), record],
+            Some("signed-payment-1".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(
+            mgr.stable_channels[0].backing_sats, 9_091,
+            "replaying the event must not apply the amount twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stability_uses_local_state_when_peer_expected_usd_differs() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "66".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.5,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-divergent-target".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 10.0);
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_091);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("applied"),
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stability_recovers_once_from_durable_backing_cas_conflict() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                10.0,
+                9_999,
+                40_001,
+                None,
+            )
+            .unwrap();
+        let settlement_id = "77".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-stale-allocation".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_090);
+        assert_eq!(
+            mgr.db
+                .load_channel(USER_CHANNEL_ID_DECIMAL)
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            9_090,
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stability_migrates_a_legacy_noncanonical_channel_row() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let legacy_user_channel_id = format!(
+            "{:032x}",
+            USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap()
+        );
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                &legacy_user_channel_id,
+                10.0,
+                10_000,
+                40_000,
+                None,
+            )
+            .unwrap();
+        assert!(mgr.db.load_channel(USER_CHANNEL_ID_DECIMAL).unwrap().is_none());
+
+        let settlement_id = "99".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-legacy-channel-row".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+
+        assert_eq!(
+            mgr.db
+                .load_channel(USER_CHANNEL_ID_DECIMAL)
+                .unwrap()
+                .unwrap()
+                .backing_sats,
+            9_091,
+        );
+        assert!(mgr
+            .db
+            .load_channel(&legacy_user_channel_id)
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn signed_stability_invalidates_an_untracked_channel_instead_of_retrying_forever() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = make_manager();
+        let settlement_id = "88".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            1_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_001_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-untracked-channel".to_owned()),
+            Some(1_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("invalid"),
+        );
+        assert!(mgr
+            .db
+            .pending_inbound_stability_settlements(32)
+            .unwrap()
+            .is_empty());
+        assert!(fake.verify_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn signed_stability_payment_rejects_amount_mismatch() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "22".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            51_000_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![stability_marker(), record],
+            Some("signed-payment-wrong-amount".to_owned()),
+            Some(1_000_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stability_payment_is_bound_to_the_claimed_channel() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "55".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            &"aa".repeat(32),
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-wrong-channel".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("invalid")
+        );
+        assert!(fake.verify_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn signed_stability_payment_retries_from_durable_inbox() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "44".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )]);
+
+        // The event is durably registered, but cannot be accounted without a trusted price.
+        mgr.handle_payment_received(
+            vec![record],
+            Some("signed-payment-retry".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            0.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("pending")
+        );
+
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
+        ));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 9_091);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("applied")
+        );
+    }
+
+    #[tokio::test]
+    async fn signed_stability_payment_rejects_invalid_signature_without_legacy_fallback() {
+        let _guard = AUDIT_TEST_GUARD.lock().unwrap();
+        let mut mgr = manager_at_par_for_signed_stability().await;
+        let settlement_id = "33".repeat(32);
+        let record = signed_stability_record(
+            &settlement_id,
+            CHANNEL_ID_HEX,
+            909_000,
+            stable_channels::stable::StabilityPaymentDirection::UserToLsp,
+            10.0,
+        );
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
+        )])
+        .with_verify_failure();
+
+        mgr.handle_payment_received(
+            vec![stability_marker(), record],
+            Some("signed-payment-bad-signature".to_owned()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
+        assert_eq!(
+            mgr.db
+                .inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("invalid")
+        );
     }
 
     #[tokio::test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,11 +8,20 @@ pub const SATS_IN_BTC: u64 = 100_000_000;
 /// Custom TLV type for stable channel messages
 pub const STABLE_CHANNEL_TLV_TYPE: u64 = 13377331;
 
+/// Authenticated metadata for a stability-payment keysend.
+pub const SIGNED_STABILITY_TLV_TYPE: u64 = 13377333;
+
+/// Maximum signed stability metadata accepted before parsing.
+pub const MAX_SIGNED_STABILITY_TLV_VALUE_BYTES: usize = 8 * 1024;
+
 /// Trade message type identifier
 pub const TRADE_MESSAGE_TYPE: &str = "TRADE_V1";
 
 /// Sync message type identifier (LSP → user expected_usd sync after stable deductions)
 pub const SYNC_MESSAGE_TYPE: &str = "SYNC_V1";
+
+/// Signed stability-payment message type identifier.
+pub const STABILITY_PAYMENT_MESSAGE_TYPE: &str = "STABILITY_PAYMENT_V1";
 
 // ============================================================================
 // DEFAULT CONFIGURATION VALUES
@@ -84,6 +93,12 @@ pub const STABILITY_THRESHOLD_USD: f64 = 0.25; // minimum $0.25 drift to trigger
 
 /// Minimum seconds between stability payments on the same channel (cooldown)
 pub const STABILITY_PAYMENT_COOLDOWN_SECS: u64 = 120;
+
+/// Maximum lifetime of a newly-created stability settlement authorization.
+pub const STABILITY_PAYMENT_AUTH_TTL_SECS: u64 = 14 * 24 * 60 * 60;
+
+/// Small allowance for peers whose system clocks are not perfectly aligned.
+pub const STABILITY_PAYMENT_CLOCK_SKEW_SECS: u64 = 60;
 
 /// Minimum USD amount to display in UI
 pub const MIN_DISPLAY_USD: f64 = 2.0;

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,6 +28,22 @@ pub struct PaymentPersistence {
     pub clamped: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InboundStabilityRegistration {
+    New,
+    Pending,
+    Applied,
+    Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingInboundStabilitySettlement {
+    pub settlement_id: String,
+    pub payment_id: String,
+    pub amount_msat: u64,
+    pub envelope: String,
+}
+
 /// Result of consuming a failed outbound stability settlement.
 #[derive(Debug, Clone, PartialEq)]
 pub struct StabilityRollback {
@@ -57,6 +73,18 @@ pub struct StabilityPaymentRollback {
 /// can recreate the row and retry.
 pub fn is_missing_channel_row(err: &rusqlite::Error) -> bool {
     matches!(err, rusqlite::Error::QueryReturnedNoRows)
+}
+
+const STALE_INBOUND_STABILITY_ALLOCATION: &str = "stale inbound stability allocation";
+
+/// Returns true when an authenticated settlement raced with a newer durable backing allocation.
+/// Callers may reload that allocation and retry the same inbox transition once.
+pub fn is_stale_inbound_stability_allocation(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::InvalidParameterName(message)
+            if message == STALE_INBOUND_STABILITY_ALLOCATION
+    )
 }
 
 /// Database file name
@@ -392,6 +420,30 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN outcome TEXT NOT NULL DEFAULT 'pending'",
             [],
         );
+
+        // Authenticated stability-payment inbox. The settlement id prevents the same signed
+        // authorization being reused with another keysend, while payment_id makes LDK event
+        // replay idempotent. The raw envelope is retained for audit and conflict detection.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS inbound_stability_settlements (
+                settlement_id TEXT PRIMARY KEY,
+                payment_id TEXT NOT NULL UNIQUE,
+                channel_id TEXT NOT NULL,
+                amount_msat INTEGER NOT NULL,
+                direction TEXT NOT NULL,
+                envelope TEXT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'pending',
+                reason TEXT,
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_inbound_stability_settlements_state
+             ON inbound_stability_settlements(state, updated_at)",
+            [],
+        )?;
 
         // Forwarded-payment dedup: tracks fingerprints of forwards already audited (live or backfilled)
         conn.execute(
@@ -1017,6 +1069,23 @@ impl Database {
         } else {
             Ok(None)
         }
+    }
+
+    /// Resolve user_channel_id only when the channel is currently tracked as active.
+    pub fn get_active_user_channel_id_by_channel_id(
+        &self,
+        channel_id: &str,
+    ) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let user_channel_id: Option<Option<String>> = conn
+            .query_row(
+                "SELECT user_channel_id FROM channels
+                 WHERE channel_id = ?1 AND closed_at IS NULL",
+                params![channel_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(user_channel_id.flatten())
     }
 
     /// Load channel settings by user_channel_id (stable across splices)
@@ -2074,10 +2143,116 @@ impl Database {
         user_channel_id: Option<&str>,
         backing_delta_sats: Option<i64>,
     ) -> SqliteResult<PaymentPersistence> {
+        self.record_payment_and_update_allocation_inner(
+            payment_id,
+            payment_type,
+            direction,
+            amount_msat,
+            amount_usd,
+            btc_price,
+            status,
+            user_channel_id,
+            backing_delta_sats,
+            None,
+            None,
+        )
+    }
+
+    /// Atomically record an authenticated inbound stability payment, apply its complete local
+    /// allocation transition, classify the payment, and consume its settlement id.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_signed_stability_payment_and_update_allocation(
+        &self,
+        payment_id: &str,
+        settlement_id: &str,
+        amount_msat: u64,
+        amount_usd: Option<f64>,
+        btc_price: Option<f64>,
+        user_channel_id: &str,
+        backing_sats_before: u64,
+        backing_sats_after: u64,
+        native_sats_after: u64,
+    ) -> SqliteResult<PaymentPersistence> {
+        if amount_msat > i64::MAX as u64
+            || backing_sats_before > i64::MAX as u64
+            || backing_sats_after > i64::MAX as u64
+            || native_sats_after > i64::MAX as u64
+        {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "stability allocation exceeds sqlite range".to_string(),
+            ));
+        }
+        self.record_payment_and_update_allocation_inner(
+            Some(payment_id),
+            "stability",
+            "received",
+            amount_msat,
+            amount_usd,
+            btc_price,
+            "completed",
+            Some(user_channel_id),
+            None,
+            Some((
+                backing_sats_before,
+                backing_sats_after,
+                native_sats_after,
+            )),
+            Some(settlement_id),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_payment_and_update_allocation_inner(
+        &self,
+        payment_id: Option<&str>,
+        payment_type: &str,
+        direction: &str,
+        amount_msat: u64,
+        amount_usd: Option<f64>,
+        btc_price: Option<f64>,
+        status: &str,
+        user_channel_id: Option<&str>,
+        backing_delta_sats: Option<i64>,
+        absolute_allocation: Option<(u64, u64, u64)>,
+        inbound_settlement_id: Option<&str>,
+    ) -> SqliteResult<PaymentPersistence> {
         let conn = self.conn.lock().unwrap();
         conn.execute_batch("BEGIN IMMEDIATE")?;
         let mut mirror = None;
         let result: SqliteResult<PaymentPersistence> = (|| {
+            if let Some(settlement_id) = inbound_settlement_id {
+                let pid = payment_id.ok_or_else(|| {
+                    rusqlite::Error::InvalidParameterName(
+                        "payment_id required for stability settlement".to_string(),
+                    )
+                })?;
+                let registered: (String, i64, String) = conn.query_row(
+                    "SELECT payment_id, amount_msat, state
+                     FROM inbound_stability_settlements WHERE settlement_id = ?1",
+                    params![settlement_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )?;
+                if registered.0 != pid || registered.1 != amount_msat as i64 {
+                    return Err(rusqlite::Error::InvalidParameterName(
+                        "stability settlement does not match its inbox record".to_string(),
+                    ));
+                }
+                match registered.2.as_str() {
+                    "pending" => {}
+                    "applied" => {
+                        return Ok(PaymentPersistence {
+                            is_new: false,
+                            new_backing: None,
+                            clamped: false,
+                        });
+                    }
+                    _ => {
+                        return Err(rusqlite::Error::InvalidParameterName(
+                            "stability settlement is not pending".to_string(),
+                        ));
+                    }
+                }
+            }
             // Dedup check inside the transaction to prevent cross-process TOCTOU
             if let Some(pid) = payment_id {
                 let exists: Option<i64> = conn
@@ -2088,6 +2263,11 @@ impl Database {
                     )
                     .optional()?;
                 if exists.is_some() {
+                    if inbound_settlement_id.is_some() {
+                        return Err(rusqlite::Error::InvalidParameterName(
+                            "stability payment id was already classified elsewhere".to_string(),
+                        ));
+                    }
                     return Ok(PaymentPersistence {
                         is_new: false,
                         new_backing: None,
@@ -2105,9 +2285,41 @@ impl Database {
             )?;
             let payment_row_id = conn.last_insert_rowid();
             let mut new_backing = None;
+            let mut new_native = None;
             let mut clamped = false;
             let mut channel_before: Option<(f64, i64, i64)> = None;
-            if let Some(delta) = backing_delta_sats {
+            if let Some((backing_before, backing_after, native_after)) = absolute_allocation {
+                let ucid = user_channel_id.ok_or_else(|| {
+                    rusqlite::Error::InvalidParameterName(
+                        "user_channel_id required for allocation update".to_string(),
+                    )
+                })?;
+                channel_before = conn
+                    .query_row(
+                        "SELECT expected_usd, stable_sats, native_sats
+                         FROM channels WHERE user_channel_id = ?1",
+                        params![ucid],
+                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    )
+                    .optional()?;
+                let current = channel_before
+                    .as_ref()
+                    .ok_or(rusqlite::Error::QueryReturnedNoRows)?;
+                if current.1 != backing_before as i64 {
+                    return Err(rusqlite::Error::InvalidParameterName(
+                        STALE_INBOUND_STABILITY_ALLOCATION.to_string(),
+                    ));
+                }
+                conn.execute(
+                    "UPDATE channels
+                     SET stable_sats = ?1, native_sats = ?2,
+                         updated_at = strftime('%s', 'now')
+                     WHERE user_channel_id = ?3",
+                    params![backing_after as i64, native_after as i64, ucid],
+                )?;
+                new_backing = Some(backing_after as i64);
+                new_native = Some(native_after as i64);
+            } else if let Some(delta) = backing_delta_sats {
                 // user_channel_id must be set when a backing update is requested.
                 let ucid = user_channel_id.ok_or_else(|| {
                     rusqlite::Error::InvalidParameterName(
@@ -2136,6 +2348,36 @@ impl Database {
                 )?;
                 new_backing = Some(updated);
             }
+            if let Some(settlement_id) = inbound_settlement_id {
+                let pid = payment_id.ok_or_else(|| {
+                    rusqlite::Error::InvalidParameterName(
+                        "payment_id required for stability settlement".to_string(),
+                    )
+                })?;
+                let ucid = user_channel_id.ok_or_else(|| {
+                    rusqlite::Error::InvalidParameterName(
+                        "user_channel_id required for stability settlement".to_string(),
+                    )
+                })?;
+                conn.execute(
+                    "INSERT OR IGNORE INTO settlement_payments
+                        (payment_id, kind, user_channel_id, outcome)
+                     VALUES (?1, 'stability', ?2, 'succeeded')",
+                    params![pid, ucid],
+                )?;
+                let consumed = conn.execute(
+                    "UPDATE inbound_stability_settlements
+                     SET state = 'applied', reason = NULL,
+                         updated_at = strftime('%s', 'now')
+                     WHERE settlement_id = ?1 AND payment_id = ?2 AND state = 'pending'",
+                    params![settlement_id, pid],
+                )?;
+                if consumed != 1 {
+                    return Err(rusqlite::Error::InvalidParameterName(
+                        "stability settlement inbox transition failed".to_string(),
+                    ));
+                }
+            }
             let after_backing = new_backing.and_then(|value| u64::try_from(value).ok());
             let before_snapshot = channel_before.map(|(expected, backing, native)| AccountingSnapshot {
                 expected_usd: Some(expected),
@@ -2150,10 +2392,16 @@ impl Database {
             let after_snapshot = before_snapshot.as_ref().map(|before| AccountingSnapshot {
                 expected_usd: before.expected_usd,
                 backing_sats: after_backing.or(before.backing_sats),
-                native_sats: before.native_sats,
+                native_sats: new_native
+                    .and_then(|value| u64::try_from(value).ok())
+                    .or(before.native_sats),
                 live_receiver_sats: after_backing
                     .or(before.backing_sats)
-                    .zip(before.native_sats)
+                    .zip(
+                        new_native
+                            .and_then(|value| u64::try_from(value).ok())
+                            .or(before.native_sats),
+                    )
                     .map(|(backing, native)| backing.saturating_add(native)),
                 btc_price,
                 amount_msat: Some(amount_msat),
@@ -2197,7 +2445,9 @@ impl Database {
                     "user_channel_id": user_channel_id,
                     "backing_delta_sats": backing_delta_sats,
                     "new_backing_sats": new_backing,
+                    "new_native_sats": new_native,
                     "clamped": clamped,
+                    "settlement_id": inbound_settlement_id,
                 }),
                 refs,
             };
@@ -2597,6 +2847,178 @@ impl Database {
             params![payment_id, kind, user_channel_id],
         )?;
         Ok(())
+    }
+
+    /// Durably register signed stability metadata before changing channel accounting.
+    /// Replays must match the original payment and complete signed envelope exactly.
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_inbound_stability_settlement(
+        &self,
+        settlement_id: &str,
+        payment_id: &str,
+        channel_id: &str,
+        amount_msat: u64,
+        direction: &str,
+        envelope: &str,
+    ) -> SqliteResult<InboundStabilityRegistration> {
+        if settlement_id.is_empty()
+            || payment_id.is_empty()
+            || channel_id.is_empty()
+            || direction.is_empty()
+            || envelope.is_empty()
+            || amount_msat == 0
+            || amount_msat > i64::MAX as u64
+        {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "invalid inbound stability settlement".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().unwrap();
+        // Terminal rows are replay tombstones only until their signed authorization is guaranteed
+        // to be expired. Prune them opportunistically so paid one-sat garbage cannot grow the
+        // inbox forever, while pending work remains durable.
+        let terminal_retention_secs = crate::constants::STABILITY_PAYMENT_AUTH_TTL_SECS
+            .saturating_add(crate::constants::STABILITY_PAYMENT_CLOCK_SKEW_SECS);
+        conn.execute(
+            "DELETE FROM inbound_stability_settlements
+             WHERE state IN ('applied', 'invalid')
+               AND updated_at < strftime('%s', 'now') - ?1",
+            params![i64::try_from(terminal_retention_secs).unwrap_or(i64::MAX)],
+        )?;
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO inbound_stability_settlements
+                (settlement_id, payment_id, channel_id, amount_msat, direction, envelope)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                settlement_id,
+                payment_id,
+                channel_id,
+                amount_msat as i64,
+                direction,
+                envelope,
+            ],
+        )?;
+        let existing: (String, String, i64, String, String, String) = conn.query_row(
+            "SELECT payment_id, channel_id, amount_msat, direction, envelope, state
+             FROM inbound_stability_settlements WHERE settlement_id = ?1",
+            params![settlement_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )?;
+        if existing.0 != payment_id
+            || existing.1 != channel_id
+            || existing.2 != amount_msat as i64
+            || existing.3 != direction
+            || existing.4 != envelope
+        {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "conflicting inbound stability settlement replay".to_string(),
+            ));
+        }
+        if inserted == 1 {
+            return Ok(InboundStabilityRegistration::New);
+        }
+        match existing.5.as_str() {
+            "pending" => Ok(InboundStabilityRegistration::Pending),
+            "applied" => Ok(InboundStabilityRegistration::Applied),
+            "invalid" => Ok(InboundStabilityRegistration::Invalid),
+            _ => Err(rusqlite::Error::InvalidQuery),
+        }
+    }
+
+    pub fn finish_inbound_stability_settlement(
+        &self,
+        settlement_id: &str,
+        state: &str,
+        reason: Option<&str>,
+    ) -> SqliteResult<()> {
+        if !matches!(state, "applied" | "invalid") {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "invalid inbound stability settlement state".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE inbound_stability_settlements
+             SET state = ?2, reason = ?3, updated_at = strftime('%s', 'now')
+             WHERE settlement_id = ?1 AND state = 'pending'",
+            params![settlement_id, state, reason],
+        )?;
+        Ok(())
+    }
+
+    #[doc(hidden)]
+    pub fn inbound_stability_settlement_state(
+        &self,
+        settlement_id: &str,
+    ) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT state FROM inbound_stability_settlements WHERE settlement_id = ?1",
+            params![settlement_id],
+            |row| row.get(0),
+        )
+        .optional()
+    }
+
+    pub fn inbound_stability_settlement_received_at(
+        &self,
+        settlement_id: &str,
+    ) -> SqliteResult<Option<u64>> {
+        let conn = self.conn.lock().unwrap();
+        let created_at: Option<i64> = conn
+            .query_row(
+                "SELECT created_at FROM inbound_stability_settlements
+                 WHERE settlement_id = ?1",
+                params![settlement_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        created_at
+            .map(|value| {
+                u64::try_from(value).map_err(|_| {
+                    rusqlite::Error::IntegralValueOutOfRange(0, value)
+                })
+            })
+            .transpose()
+    }
+
+    pub fn pending_inbound_stability_settlements(
+        &self,
+        limit: usize,
+    ) -> SqliteResult<Vec<PendingInboundStabilitySettlement>> {
+        let limit = i64::try_from(limit.max(1)).unwrap_or(i64::MAX);
+        let conn = self.conn.lock().unwrap();
+        let mut statement = conn.prepare(
+            "SELECT settlement_id, payment_id, amount_msat, envelope
+             FROM inbound_stability_settlements
+             WHERE state = 'pending'
+             ORDER BY created_at ASC, settlement_id ASC
+             LIMIT ?1",
+        )?;
+        let settlements = statement
+            .query_map(params![limit], |row| {
+                let amount_msat: i64 = row.get(2)?;
+                let amount_msat = u64::try_from(amount_msat).map_err(|_| {
+                    rusqlite::Error::IntegralValueOutOfRange(2, amount_msat)
+                })?;
+                Ok(PendingInboundStabilitySettlement {
+                    settlement_id: row.get(0)?,
+                    payment_id: row.get(1)?,
+                    amount_msat,
+                    envelope: row.get(3)?,
+                })
+            })?
+            .collect();
+        settlements
     }
 
     /// Record the reversible allocation transition, optimistic channel state, and ledger event in
@@ -3159,6 +3581,177 @@ pub struct DailyPriceRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inbound_stability_registration_detects_replays_and_conflicts() {
+        let db = Database::open_in_memory().unwrap();
+        let settlement_id = "11".repeat(32);
+        let channel_id = "22".repeat(32);
+        assert_eq!(
+            db.register_inbound_stability_settlement(
+                &settlement_id,
+                "payment-1",
+                &channel_id,
+                909_000,
+                "user_to_lsp",
+                "signed-envelope",
+            )
+            .unwrap(),
+            InboundStabilityRegistration::New
+        );
+        assert_eq!(
+            db.register_inbound_stability_settlement(
+                &settlement_id,
+                "payment-1",
+                &channel_id,
+                909_000,
+                "user_to_lsp",
+                "signed-envelope",
+            )
+            .unwrap(),
+            InboundStabilityRegistration::Pending
+        );
+        assert_eq!(
+            db.pending_inbound_stability_settlements(10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(db
+            .register_inbound_stability_settlement(
+                &settlement_id,
+                "payment-2",
+                &channel_id,
+                909_000,
+                "user_to_lsp",
+                "signed-envelope",
+            )
+            .is_err());
+
+        db.finish_inbound_stability_settlement(&settlement_id, "invalid", Some("signature"))
+            .unwrap();
+        assert_eq!(
+            db.inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("invalid")
+        );
+        assert!(db
+            .pending_inbound_stability_settlements(10)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn inbound_stability_registration_prunes_only_expired_terminal_tombstones() {
+        let db = Database::open_in_memory().unwrap();
+        let old_settlement_id = "11".repeat(32);
+        let channel_id = "22".repeat(32);
+        db.register_inbound_stability_settlement(
+            &old_settlement_id,
+            "payment-old",
+            &channel_id,
+            1_000,
+            "user_to_lsp",
+            "old-envelope",
+        )
+        .unwrap();
+        db.finish_inbound_stability_settlement(&old_settlement_id, "invalid", Some("test"))
+            .unwrap();
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE inbound_stability_settlements SET updated_at = 0
+                 WHERE settlement_id = ?1",
+                params![old_settlement_id],
+            )
+            .unwrap();
+
+        let new_settlement_id = "33".repeat(32);
+        db.register_inbound_stability_settlement(
+            &new_settlement_id,
+            "payment-new",
+            &channel_id,
+            1_000,
+            "user_to_lsp",
+            "new-envelope",
+        )
+        .unwrap();
+
+        assert_eq!(
+            db.inbound_stability_settlement_state(&old_settlement_id)
+                .unwrap(),
+            None,
+        );
+        assert_eq!(
+            db.inbound_stability_settlement_state(&new_settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("pending"),
+        );
+    }
+
+    #[test]
+    fn signed_stability_payment_updates_allocation_once_atomically() {
+        let db = Database::open_in_memory().unwrap();
+        let settlement_id = "11".repeat(32);
+        let channel_id = "22".repeat(32);
+        db.save_channel(&channel_id, "42", 10.0, 10_000, 40_000, None)
+            .unwrap();
+        db.register_inbound_stability_settlement(
+            &settlement_id,
+            "payment-1",
+            &channel_id,
+            909_000,
+            "user_to_lsp",
+            "signed-envelope",
+        )
+        .unwrap();
+
+        let first = db
+            .record_signed_stability_payment_and_update_allocation(
+                "payment-1",
+                &settlement_id,
+                909_000,
+                Some(0.9999),
+                Some(110_000.0),
+                "42",
+                10_000,
+                9_091,
+                40_000,
+            )
+            .unwrap();
+        assert!(first.is_new);
+        let channel = db.load_channel("42").unwrap().unwrap();
+        assert_eq!(channel.backing_sats, 9_091);
+        assert_eq!(channel.native_sats, 40_000);
+        assert_eq!(
+            db.inbound_stability_settlement_state(&settlement_id)
+                .unwrap()
+                .as_deref(),
+            Some("applied")
+        );
+
+        let replay = db
+            .record_signed_stability_payment_and_update_allocation(
+                "payment-1",
+                &settlement_id,
+                909_000,
+                Some(0.9999),
+                Some(110_000.0),
+                "42",
+                10_000,
+                9_091,
+                40_000,
+            )
+            .unwrap();
+        assert!(!replay.is_new);
+        assert_eq!(
+            db.load_channel("42").unwrap().unwrap().backing_sats,
+            9_091
+        );
+    }
 
     #[test]
     fn test_open_in_memory() {
@@ -4116,7 +4709,19 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         db.save_channel("chan_x", "42", 0.0, 0, 0, None).unwrap();
         assert_eq!(db.get_user_channel_id_by_channel_id("chan_x").unwrap(), Some("42".to_string()));
+        assert_eq!(
+            db.get_active_user_channel_id_by_channel_id("chan_x").unwrap(),
+            Some("42".to_string())
+        );
         assert_eq!(db.get_user_channel_id_by_channel_id("missing").unwrap(), None);
+        assert_eq!(db.get_active_user_channel_id_by_channel_id("missing").unwrap(), None);
+
+        db.mark_channel_closed("42").unwrap();
+        assert_eq!(
+            db.get_user_channel_id_by_channel_id("chan_x").unwrap(),
+            Some("42".to_string())
+        );
+        assert_eq!(db.get_active_user_channel_id_by_channel_id("chan_x").unwrap(), None);
     }
 
     #[test]

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -1,11 +1,14 @@
 use crate::audit::audit_event;
 use crate::constants::{
-    MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_PAYMENT_COOLDOWN_SECS, STABILITY_THRESHOLD_PERCENT,
-    STABILITY_THRESHOLD_USD,
+    MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_PAYMENT_AUTH_TTL_SECS,
+    STABILITY_PAYMENT_CLOCK_SKEW_SECS, STABILITY_PAYMENT_COOLDOWN_SECS,
+    STABILITY_PAYMENT_MESSAGE_TYPE, STABILITY_THRESHOLD_PERCENT, STABILITY_THRESHOLD_USD,
 };
 use crate::price_feeds::{get_cached_price, get_fresh_cached_price_no_fetch};
 use crate::types::{Bitcoin, StableChannel, USD};
 use ldk_node::Node;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
 use ureq::Agent;
@@ -431,7 +434,10 @@ pub fn trade_backing_after_delta(
     if current_expected_usd < 0.01 && current_backing_sats == 0 {
         backing_sats = normalize_backing_sats(receiver_sats, backing_sats, new_expected_usd, price);
     }
-    (backing_sats <= receiver_sats).then_some(backing_sats)
+    // Zero is also used by stability checks to mean "legacy/uninitialized backing". Persisting
+    // that sentinel for a live target would make the next check rebuild the full target at the
+    // latest price and erase the drift this delta calculation is designed to preserve.
+    (backing_sats > 0 && backing_sats <= receiver_sats).then_some(backing_sats)
 }
 
 fn allocation_drift_is_actionable(
@@ -605,12 +611,178 @@ pub fn update_balances<'update_balance_lifetime>(
 /// Information about a stability payment that was sent
 #[derive(Debug, Clone)]
 pub struct StabilityPaymentInfo {
+    pub settlement_id: String,
     pub payment_id: String,
     pub amount_msat: u64,
     pub counterparty: String,
     pub btc_price: f64,
     pub backing_sats_before: u64,
     pub backing_sats_after: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StabilityPaymentDirection {
+    UserToLsp,
+    LspToUser,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StabilityPaymentPayload {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub settlement_id: String,
+    pub channel_id: String,
+    pub amount_msat: u64,
+    pub direction: StabilityPaymentDirection,
+    pub expected_usd: f64,
+    pub created_at: u64,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StabilitySignedEnvelope {
+    pub payload: String,
+    pub signature: String,
+}
+
+pub fn new_stability_settlement_id() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn is_lower_hex_32(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_stability_payment_payload(
+    settlement_id: &str,
+    channel_id: &str,
+    amount_msat: u64,
+    direction: StabilityPaymentDirection,
+    expected_usd: f64,
+    created_at: u64,
+    expires_at: u64,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&StabilityPaymentPayload {
+        kind: STABILITY_PAYMENT_MESSAGE_TYPE.to_owned(),
+        settlement_id: settlement_id.to_owned(),
+        channel_id: channel_id.to_owned(),
+        amount_msat,
+        direction,
+        expected_usd,
+        created_at,
+        expires_at,
+    })
+}
+
+pub fn build_stability_signed_envelope(
+    payload: String,
+    signature: String,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&StabilitySignedEnvelope { payload, signature })
+}
+
+pub fn parse_stability_signed_envelope(raw: &str) -> Option<StabilitySignedEnvelope> {
+    serde_json::from_str(raw).ok()
+}
+
+pub fn parse_stability_payment_payload(payload: &str) -> Option<StabilityPaymentPayload> {
+    let payment: StabilityPaymentPayload = serde_json::from_str(payload).ok()?;
+    if payment.kind != STABILITY_PAYMENT_MESSAGE_TYPE
+        || !is_lower_hex_32(&payment.settlement_id)
+        || !is_lower_hex_32(&payment.channel_id)
+        || payment.amount_msat == 0
+        || !payment.amount_msat.is_multiple_of(1000)
+        || !payment.expected_usd.is_finite()
+        || payment.expected_usd < 0.0
+        || payment.created_at > payment.expires_at
+        || payment.expires_at.saturating_sub(payment.created_at)
+            > STABILITY_PAYMENT_AUTH_TTL_SECS
+    {
+        return None;
+    }
+    Some(payment)
+}
+
+pub fn stability_payment_is_fresh(payment: &StabilityPaymentPayload, now: u64) -> bool {
+    payment.created_at <= now.saturating_add(STABILITY_PAYMENT_CLOCK_SKEW_SECS)
+        && now <= payment.expires_at.saturating_add(STABILITY_PAYMENT_CLOCK_SKEW_SECS)
+}
+
+/// Apply a wallet-to-LSP stability payment to the LSP's local allocation.
+///
+/// The paid sats are authoritative, but PR #231's local-equilibrium floor remains in force: a
+/// payment may settle an above-par surplus, never manufacture a below-par claim at the LSP's
+/// price. The final live-balance clamp preserves the allocation invariant.
+pub fn backing_after_user_to_lsp_stability(
+    current_backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+    amount_sats: u64,
+    live_receiver_sats: u64,
+) -> Option<u64> {
+    if !expected_usd.is_finite()
+        || expected_usd < 0.0
+        || !price.is_finite()
+        || price <= 0.0
+        || amount_sats == 0
+    {
+        return None;
+    }
+    let equilibrium_f = expected_usd / price * SATS_IN_BTC as f64;
+    if !equilibrium_f.is_finite() || equilibrium_f >= u64::MAX as f64 {
+        return None;
+    }
+    let equilibrium = equilibrium_f.floor() as u64;
+    let settled = if current_backing_sats > equilibrium {
+        current_backing_sats
+            .saturating_sub(amount_sats)
+            .max(equilibrium)
+    } else {
+        current_backing_sats
+    };
+    Some(settled.min(live_receiver_sats))
+}
+
+/// Apply an LSP-to-wallet stability payment to the wallet's local allocation.
+///
+/// The received sats move backing only toward the wallet's equilibrium at its own price. Any
+/// overpayment remains native, and an already above-par allocation is never reduced by an incoming
+/// payment. This lets peers safely retain independent price feeds without comparing `f64` state
+/// bit-for-bit.
+pub fn backing_after_lsp_to_user_stability(
+    current_backing_sats: u64,
+    expected_usd: f64,
+    price: f64,
+    amount_sats: u64,
+    live_receiver_sats: u64,
+) -> Option<u64> {
+    if !expected_usd.is_finite()
+        || expected_usd < 0.0
+        || !price.is_finite()
+        || price <= 0.0
+        || amount_sats == 0
+        || current_backing_sats > live_receiver_sats
+    {
+        return None;
+    }
+    let equilibrium_f = expected_usd / price * SATS_IN_BTC as f64;
+    if !equilibrium_f.is_finite() || equilibrium_f >= u64::MAX as f64 {
+        return None;
+    }
+    let equilibrium = (equilibrium_f.floor() as u64).min(live_receiver_sats);
+    if current_backing_sats >= equilibrium {
+        return Some(current_backing_sats);
+    }
+    current_backing_sats
+        .checked_add(amount_sats)
+        .map(|backing| backing.min(equilibrium))
 }
 
 /// Check and enforce stability for a channel.
@@ -804,12 +976,69 @@ pub fn check_stability(
         return None;
     }
 
-    let amt = USD::to_msats(dollars_from_par, sc.latest_price);
+    // Stable allocations are sat-denominated. Send and sign the same exact whole-sat value that
+    // both peers can apply to backing without fractional-sat ambiguity.
+    let amt = (USD::to_msats(dollars_from_par, sc.latest_price) / 1000) * 1000;
+    if amt == 0 {
+        return None;
+    }
+    let settlement_id = new_stability_settlement_id();
+    let created_at = now.max(0) as u64;
+    let expires_at = created_at.saturating_add(STABILITY_PAYMENT_AUTH_TTL_SECS);
+    let payload = match build_stability_payment_payload(
+        &settlement_id,
+        &sc.channel_id.to_string(),
+        amt,
+        StabilityPaymentDirection::UserToLsp,
+        sc.expected_usd.0,
+        created_at,
+        expires_at,
+    ) {
+        Ok(payload) => payload,
+        Err(error) => {
+            audit_event(
+                "STABILITY_PAYMENT_SERIALIZE_FAILED",
+                json!({
+                    "user_channel_id": format!("{}", sc.user_channel_id),
+                    "settlement_id": settlement_id,
+                    "amount_msat": amt,
+                    "error": error.to_string(),
+                }),
+            );
+            return None;
+        }
+    };
+    let signature = node.sign_message(payload.as_bytes());
+    let signed_envelope = match build_stability_signed_envelope(payload, signature) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            audit_event(
+                "STABILITY_PAYMENT_SERIALIZE_FAILED",
+                json!({
+                    "user_channel_id": format!("{}", sc.user_channel_id),
+                    "settlement_id": settlement_id,
+                    "amount_msat": amt,
+                    "stage": "envelope",
+                    "error": error.to_string(),
+                }),
+            );
+            return None;
+        }
+    };
     let marker = ldk_node::CustomTlvRecord {
         type_num: crate::constants::STABLE_CHANNEL_TLV_TYPE,
         value: vec![1u8],
     };
-    match node.spontaneous_payment().send_with_custom_tlvs(amt, sc.counterparty, None, vec![marker]) {
+    let signed_record = ldk_node::CustomTlvRecord {
+        type_num: crate::constants::SIGNED_STABILITY_TLV_TYPE,
+        value: signed_envelope.into_bytes(),
+    };
+    match node.spontaneous_payment().send_with_custom_tlvs(
+        amt,
+        sc.counterparty,
+        None,
+        vec![marker, signed_record],
+    ) {
         Ok(payment_id) => {
             sc.payment_made = true;
             sc.last_stability_payment = now;
@@ -825,6 +1054,7 @@ pub fn check_stability(
             let payment_id_str = payment_id.to_string();
             let counterparty_str = sc.counterparty.to_string();
             Some(StabilityPaymentInfo {
+                settlement_id,
                 payment_id: payment_id_str,
                 amount_msat: amt,
                 counterparty: counterparty_str,
@@ -850,6 +1080,124 @@ pub fn check_stability(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signed_stability_payload_round_trips_and_enforces_expiry() {
+        let settlement_id = "11".repeat(32);
+        let channel_id = "22".repeat(32);
+        let payload = build_stability_payment_payload(
+            &settlement_id,
+            &channel_id,
+            909_000,
+            StabilityPaymentDirection::UserToLsp,
+            10.0,
+            1_000,
+            1_000 + STABILITY_PAYMENT_AUTH_TTL_SECS,
+        )
+        .unwrap();
+        let parsed = parse_stability_payment_payload(&payload).unwrap();
+        assert_eq!(parsed.settlement_id, settlement_id);
+        assert_eq!(parsed.channel_id, channel_id);
+        assert_eq!(parsed.amount_msat, 909_000);
+        assert_eq!(parsed.direction, StabilityPaymentDirection::UserToLsp);
+        assert!(stability_payment_is_fresh(&parsed, 1_300));
+        assert!(!stability_payment_is_fresh(
+            &parsed,
+            parsed.expires_at + STABILITY_PAYMENT_CLOCK_SKEW_SECS + 1
+        ));
+
+        let envelope = build_stability_signed_envelope(payload.clone(), "signature".to_owned())
+            .unwrap();
+        let parsed_envelope = parse_stability_signed_envelope(&envelope).unwrap();
+        assert_eq!(parsed_envelope.payload, payload);
+        assert_eq!(parsed_envelope.signature, "signature");
+    }
+
+    #[test]
+    fn signed_stability_payload_rejects_non_sat_and_invalid_identifiers() {
+        let valid_id = "aa".repeat(32);
+        let valid_channel = "22".repeat(32);
+        let non_sat = build_stability_payment_payload(
+            &valid_id,
+            &valid_channel,
+            1_001,
+            StabilityPaymentDirection::LspToUser,
+            10.0,
+            1_000,
+            1_100,
+        )
+        .unwrap();
+        assert!(parse_stability_payment_payload(&non_sat).is_none());
+
+        let uppercase_id = build_stability_payment_payload(
+            &valid_id.to_uppercase(),
+            &valid_channel,
+            1_000,
+            StabilityPaymentDirection::LspToUser,
+            10.0,
+            1_000,
+            1_100,
+        )
+        .unwrap();
+        assert!(parse_stability_payment_payload(&uppercase_id).is_none());
+
+        let excessive_lifetime = build_stability_payment_payload(
+            &valid_id,
+            &valid_channel,
+            1_000,
+            StabilityPaymentDirection::LspToUser,
+            10.0,
+            1_000,
+            1_001 + STABILITY_PAYMENT_AUTH_TTL_SECS,
+        )
+        .unwrap();
+        assert!(parse_stability_payment_payload(&excessive_lifetime).is_none());
+    }
+
+    #[test]
+    fn user_to_lsp_settlement_is_amount_bound_and_keeps_pr231_floor() {
+        assert_eq!(
+            backing_after_user_to_lsp_stability(10_000, 10.0, 110_000.0, 1, 49_999),
+            Some(9_999)
+        );
+        assert_eq!(
+            backing_after_user_to_lsp_stability(10_000, 10.0, 110_000.0, 909, 49_091),
+            Some(9_091)
+        );
+        // An oversized marker/payment cannot push backing below the LSP's local equilibrium.
+        assert_eq!(
+            backing_after_user_to_lsp_stability(10_000, 10.0, 110_000.0, 5_000, 45_000),
+            Some(9_090)
+        );
+        // If already below the local equilibrium, receiving money does not erase that drift.
+        assert_eq!(
+            backing_after_user_to_lsp_stability(9_000, 10.0, 110_000.0, 909, 49_091),
+            Some(9_000)
+        );
+    }
+
+    #[test]
+    fn lsp_to_user_settlement_uses_local_equilibrium_and_keeps_excess_native() {
+        assert_eq!(
+            backing_after_lsp_to_user_stability(9_000, 10.0, 100_000.0, 1_000, 50_000),
+            Some(10_000),
+        );
+        assert_eq!(
+            backing_after_lsp_to_user_stability(9_000, 10.0, 100_000.0, 5_000, 50_000),
+            Some(10_000),
+            "an overpayment cannot create backing above the local target",
+        );
+        assert_eq!(
+            backing_after_lsp_to_user_stability(10_000, 10.0, 110_000.0, 1_000, 50_000),
+            Some(10_000),
+            "an incoming payment cannot reduce an existing above-par allocation",
+        );
+        assert_eq!(
+            backing_after_lsp_to_user_stability(10_001, 10.0, 100_000.0, 1_000, 10_000),
+            None,
+            "a stale over-capacity allocation must be reconciled before settlement",
+        );
+    }
 
     #[test]
     fn only_pending_outbound_lightning_blocks_capacity_repair() {
@@ -1394,6 +1742,24 @@ mod tests {
         assert_eq!(sc.expected_usd.0, 100.0);
         assert_eq!(sc.backing_sats, 10);
         assert_eq!(sc.native_sats, 199_990);
+    }
+
+    #[test]
+    fn nonzero_trade_target_cannot_use_the_uninitialized_zero_backing_sentinel() {
+        // At the local price this reduction consumes the final 500 backing sats while leaving a
+        // live $0.50 target. Accepting it would let check_stability rebuild 500 sats and erase the
+        // existing below-par drift.
+        assert_eq!(
+            trade_backing_after_delta(10_000, 500, 1.0, 0.5, 100_000.0),
+            None,
+        );
+
+        let mut sc = test_sc(1.0, 100_000.0, 10_000);
+        sc.backing_sats = 500;
+        sc.native_sats = 9_500;
+        assert!(!apply_trade(&mut sc, 0.5, 100_000.0));
+        assert_eq!(sc.expected_usd.0, 1.0);
+        assert_eq!(sc.backing_sats, 500);
     }
 
     #[test]

--- a/src/user.rs
+++ b/src/user.rs
@@ -25,7 +25,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use stable_channels::audit::*;
 use stable_channels::constants::*;
-use stable_channels::db::{self, DailyPriceRecord, Database, PaymentRecord, TradeRecord};
+use stable_channels::db::{
+    self, DailyPriceRecord, Database, InboundStabilityRegistration, PaymentRecord, TradeRecord,
+};
 use stable_channels::historical_prices::get_seed_prices;
 use stable_channels::price_feeds::{get_cached_price_no_fetch, get_fresh_cached_price_no_fetch};
 use stable_channels::stable;
@@ -192,6 +194,13 @@ enum LocalTradeAllocationError {
     TargetExceedsSafeCapacity,
     SettlementRequired,
     UnsafeAllocation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SignedStabilityHandling {
+    Applied,
+    Invalid,
+    Retry,
 }
 
 struct BackupSnapshotDir {
@@ -2104,6 +2113,437 @@ impl UserApp {
         }
     }
 
+    fn handle_signed_stability_payment_received(
+        &mut self,
+        record: &ldk_node::CustomTlvRecord,
+        amount_msat: u64,
+        payment_hash: &str,
+        ack: &mut bool,
+    ) -> SignedStabilityHandling {
+        if record.value.len() > MAX_SIGNED_STABILITY_TLV_VALUE_BYTES {
+            audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                json!({
+                    "payment_hash": payment_hash,
+                    "reason": "oversize",
+                    "payload_len": record.value.len(),
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+        let Ok(raw) = std::str::from_utf8(record.value.as_ref()) else {
+            audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                json!({ "payment_hash": payment_hash, "reason": "utf8" }),
+            );
+            return SignedStabilityHandling::Invalid;
+        };
+        let Some(envelope) = stable::parse_stability_signed_envelope(raw) else {
+            audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                json!({ "payment_hash": payment_hash, "reason": "envelope" }),
+            );
+            return SignedStabilityHandling::Invalid;
+        };
+        let Some(payload) = stable::parse_stability_payment_payload(&envelope.payload) else {
+            audit_event(
+                "STABILITY_PAYMENT_PAYLOAD_INVALID",
+                json!({ "payment_hash": payment_hash, "reason": "fields" }),
+            );
+            return SignedStabilityHandling::Invalid;
+        };
+        let registration = match self.db.register_inbound_stability_settlement(
+            &payload.settlement_id,
+            payment_hash,
+            &payload.channel_id,
+            payload.amount_msat,
+            "lsp_to_user",
+            raw,
+        ) {
+            Ok(registration) => registration,
+            Err(error) => {
+                audit_event(
+                    "STABILITY_PAYMENT_REPLAY_CONFLICT",
+                    json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_hash": payment_hash,
+                        "error": error.to_string(),
+                    }),
+                );
+                return SignedStabilityHandling::Invalid;
+            }
+        };
+        if registration == InboundStabilityRegistration::Applied {
+            audit_event(
+                "STABILITY_PAYMENT_REPLAY_IGNORED",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                }),
+            );
+            return SignedStabilityHandling::Applied;
+        }
+        if registration == InboundStabilityRegistration::Invalid {
+            return SignedStabilityHandling::Invalid;
+        }
+
+        let invalidate = |reason: &str| {
+            let _ = self.db.finish_inbound_stability_settlement(
+                &payload.settlement_id,
+                "invalid",
+                Some(reason),
+            );
+        };
+        if payload.direction != stable::StabilityPaymentDirection::LspToUser {
+            invalidate("direction");
+            audit_event(
+                "STABILITY_PAYMENT_BINDING_INVALID",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "reason": "direction",
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+        if payload.amount_msat != amount_msat {
+            invalidate("amount");
+            audit_event(
+                "STABILITY_PAYMENT_AMOUNT_MISMATCH",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "signed_amount_msat": payload.amount_msat,
+                    "received_amount_msat": amount_msat,
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+        let received_at = match self
+            .db
+            .inbound_stability_settlement_received_at(&payload.settlement_id)
+        {
+            Ok(Some(received_at)) => received_at,
+            Ok(None) => {
+                *ack = false;
+                return SignedStabilityHandling::Retry;
+            }
+            Err(error) => {
+                *ack = false;
+                audit_event(
+                    "DB_READ_FAILED",
+                    json!({
+                        "op": "inbound_stability_settlement_received_at",
+                        "settlement_id": payload.settlement_id,
+                        "payment_hash": payment_hash,
+                        "error": error.to_string(),
+                    }),
+                );
+                return SignedStabilityHandling::Retry;
+            }
+        };
+        if !stable::stability_payment_is_fresh(&payload, received_at) {
+            invalidate("expired");
+            audit_event(
+                "STABILITY_PAYMENT_EXPIRED",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "created_at": payload.created_at,
+                    "expires_at": payload.expires_at,
+                    "received_at": received_at,
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+
+        let (counterparty, wallet_channel_id, local_expected_usd) = {
+            let sc = self.stable_channel.lock().unwrap();
+            (
+                sc.counterparty,
+                sc.channel_id.to_string(),
+                sc.expected_usd.0,
+            )
+        };
+        if payload.channel_id != wallet_channel_id {
+            invalidate("channel");
+            audit_event(
+                "STABILITY_PAYMENT_CHANNEL_MISMATCH",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "signed_channel_id": payload.channel_id,
+                    "wallet_channel_id": wallet_channel_id,
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+        if !self.node.verify_signature(
+            envelope.payload.as_bytes(),
+            &envelope.signature,
+            &counterparty,
+        ) {
+            invalidate("signature");
+            audit_event(
+                "STABILITY_PAYMENT_SIGNATURE_INVALID",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "channel_id": payload.channel_id,
+                }),
+            );
+            return SignedStabilityHandling::Invalid;
+        }
+        if payload.expected_usd.to_bits() != local_expected_usd.to_bits() {
+            // expected_usd is independently maintained between SYNCs. The authenticated amount
+            // and the wallet's local equilibrium determine the safe transition; retain the peer
+            // value only as divergence telemetry.
+            audit_event(
+                "STABILITY_PAYMENT_STATE_DIVERGENCE",
+                json!({
+                    "settlement_id": payload.settlement_id,
+                    "payment_hash": payment_hash,
+                    "signed_expected_usd": payload.expected_usd,
+                    "local_expected_usd": local_expected_usd,
+                }),
+            );
+        }
+
+        let amount_sats = amount_msat / 1000;
+        let (
+            price,
+            user_channel_id,
+            live_receiver_sats,
+            mut backing_before,
+            mut backing_after,
+            mut native_after,
+        ) = {
+            let mut sc = self.stable_channel.lock().unwrap();
+            update_balances(&self.node, &mut sc);
+            if !sc.latest_price.is_finite() || sc.latest_price <= 0.0 {
+                *ack = false;
+                audit_event(
+                    "STABILITY_PAYMENT_PRICE_UNAVAILABLE",
+                    json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_hash": payment_hash,
+                    }),
+                );
+                return SignedStabilityHandling::Retry;
+            }
+            let Some(backing_after) = stable::backing_after_lsp_to_user_stability(
+                sc.backing_sats,
+                sc.expected_usd.0,
+                sc.latest_price,
+                amount_sats,
+                sc.stable_receiver_btc.sats,
+            ) else {
+                invalidate("allocation_capacity");
+                audit_event(
+                    "STABILITY_PAYMENT_ALLOCATION_INVALID",
+                    json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_hash": payment_hash,
+                        "backing_sats": sc.backing_sats,
+                        "amount_sats": amount_sats,
+                        "live_receiver_sats": sc.stable_receiver_btc.sats,
+                    }),
+                );
+                return SignedStabilityHandling::Invalid;
+            };
+            (
+                sc.latest_price,
+                format!("{}", sc.user_channel_id),
+                sc.stable_receiver_btc.sats,
+                sc.backing_sats,
+                backing_after,
+                sc.stable_receiver_btc.sats.saturating_sub(backing_after),
+            )
+        };
+        let amount_usd = (price > 0.0)
+            .then(|| amount_sats as f64 / SATS_IN_BTC as f64 * price);
+        let persist = |backing_sats_before, backing_sats_after, native_sats_after| {
+            self.db.record_signed_stability_payment_and_update_allocation(
+                payment_hash,
+                &payload.settlement_id,
+                amount_msat,
+                amount_usd,
+                (price > 0.0).then_some(price),
+                &user_channel_id,
+                backing_sats_before,
+                backing_sats_after,
+                native_sats_after,
+            )
+        };
+        let mut reloaded_expected_usd = None;
+        let persisted = match persist(backing_before, backing_after, native_after) {
+            Err(ref error) if db::is_stale_inbound_stability_allocation(error) => {
+                let durable = match self.db.load_channel(&user_channel_id) {
+                    Ok(Some(channel)) => channel,
+                    Ok(None) => {
+                        *ack = false;
+                        return SignedStabilityHandling::Retry;
+                    }
+                    Err(error) => {
+                        *ack = false;
+                        audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_hash": payment_hash,
+                                "stage": "reload_after_stale_allocation",
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return SignedStabilityHandling::Retry;
+                    }
+                };
+                let Some(reloaded_backing_after) =
+                    stable::backing_after_lsp_to_user_stability(
+                        durable.backing_sats,
+                        durable.expected_usd,
+                        price,
+                        amount_sats,
+                        live_receiver_sats,
+                    )
+                else {
+                    *ack = false;
+                    audit_event(
+                        "STABILITY_PAYMENT_ALLOCATION_RETRY_DEFERRED",
+                        json!({
+                            "settlement_id": payload.settlement_id,
+                            "payment_hash": payment_hash,
+                            "durable_backing_sats": durable.backing_sats,
+                            "live_receiver_sats": live_receiver_sats,
+                        }),
+                    );
+                    return SignedStabilityHandling::Retry;
+                };
+                backing_before = durable.backing_sats;
+                backing_after = reloaded_backing_after;
+                native_after = live_receiver_sats.saturating_sub(backing_after);
+                reloaded_expected_usd = Some(durable.expected_usd);
+                match persist(backing_before, backing_after, native_after) {
+                    Ok(persisted) => persisted,
+                    Err(error) => {
+                        *ack = false;
+                        audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_hash": payment_hash,
+                                "stage": "retry_after_stale_allocation",
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return SignedStabilityHandling::Retry;
+                    }
+                }
+            }
+            Err(ref error) if db::is_missing_channel_row(error) => {
+                self.save_channel_settings();
+                match persist(backing_before, backing_after, native_after) {
+                    Ok(persisted) => persisted,
+                    Err(error) => {
+                        *ack = false;
+                        audit_event(
+                            "STABILITY_PAYMENT_PERSIST_FAILED",
+                            json!({
+                                "settlement_id": payload.settlement_id,
+                                "payment_hash": payment_hash,
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return SignedStabilityHandling::Retry;
+                    }
+                }
+            }
+            Ok(persisted) => persisted,
+            Err(error) => {
+                *ack = false;
+                audit_event(
+                    "STABILITY_PAYMENT_PERSIST_FAILED",
+                    json!({
+                        "settlement_id": payload.settlement_id,
+                        "payment_hash": payment_hash,
+                        "error": error.to_string(),
+                    }),
+                );
+                return SignedStabilityHandling::Retry;
+            }
+        };
+        if persisted.is_new {
+            let mut sc = self.stable_channel.lock().unwrap();
+            update_balances(&self.node, &mut sc);
+            if let Some(expected_usd) = reloaded_expected_usd {
+                sc.expected_usd = USD::from_f64(expected_usd);
+            }
+            sc.backing_sats = backing_after;
+            sc.native_sats = native_after;
+            stable::recompute_native(&mut sc);
+        }
+        self.update_balances();
+        audit_event(
+            "STABILITY_PAYMENT_V1_APPLIED",
+            json!({
+                "settlement_id": payload.settlement_id,
+                "payment_hash": payment_hash,
+                "channel_id": payload.channel_id,
+                "amount_msat": amount_msat,
+                "backing_sats_before": backing_before,
+                "backing_sats_after": backing_after,
+                "native_sats_after": native_after,
+                "is_new": persisted.is_new,
+            }),
+        );
+        SignedStabilityHandling::Applied
+    }
+
+    fn record_untrusted_signed_stability_as_lightning(
+        &mut self,
+        payment_hash: &str,
+        amount_msat: u64,
+        ack: &mut bool,
+    ) {
+        if amount_msat < 1000 {
+            return;
+        }
+        let price = self.stable_channel.lock().unwrap().latest_price;
+        let amount_usd = (price > 0.0)
+            .then(|| amount_msat as f64 / 1000.0 / SATS_IN_BTC as f64 * price);
+        match self.db.record_payment_and_maybe_update_backing(
+            Some(payment_hash),
+            "lightning",
+            "received",
+            amount_msat,
+            amount_usd,
+            (price > 0.0).then_some(price),
+            "completed",
+            None,
+            None,
+        ) {
+            Ok(_) => {
+                let mut sc = self.stable_channel.lock().unwrap();
+                update_balances(&self.node, &mut sc);
+                stable::recompute_native(&mut sc);
+                drop(sc);
+                self.save_channel_settings_preserving_backing();
+                self.update_balances();
+            }
+            Err(error) => {
+                *ack = false;
+                audit_event(
+                    "PAYMENT_PERSIST_FAILED",
+                    json!({
+                        "payment_hash": payment_hash,
+                        "reason": "invalid_signed_stability",
+                        "error": error.to_string(),
+                    }),
+                );
+            }
+        }
+    }
+
     /// Save user's stable channel to database
     fn save_channel_settings(&self) {
         let sc = self.stable_channel.lock().unwrap();
@@ -2842,8 +3282,31 @@ impl UserApp {
                 } => {
                     let payment_hash_str = format!("{payment_hash}");
 
+                    let signed_stability = custom_records
+                        .iter()
+                        .find(|record| record.type_num == SIGNED_STABILITY_TLV_TYPE)
+                        .map(|record| {
+                            self.handle_signed_stability_payment_received(
+                                record,
+                                amount_msat,
+                                &payment_hash_str,
+                                &mut ack,
+                            )
+                        });
+                    let handled_signed_stability = signed_stability.is_some();
+                    if signed_stability == Some(SignedStabilityHandling::Invalid) {
+                        self.record_untrusted_signed_stability_as_lightning(
+                            &payment_hash_str,
+                            amount_msat,
+                            &mut ack,
+                        );
+                    }
+
                     // Check for SYNC_V1 message from LSP (expected_usd synchronization)
-                    let handled_sync = 'sync: {
+                    let handled_sync = if handled_signed_stability {
+                        false
+                    } else {
+                        'sync: {
                         for tlv in &custom_records {
                             if tlv.type_num != STABLE_CHANNEL_TLV_TYPE {
                                 continue;
@@ -3058,9 +3521,14 @@ impl UserApp {
                             break 'sync true;
                         }
                         false
+                        }
                     };
 
-                    if handled_sync {
+                    if handled_signed_stability {
+                        // Signed stability metadata takes precedence over the compatibility marker.
+                        // Invalid signed records are recorded as ordinary Lightning receipts and
+                        // can never downgrade to unsigned stability accounting.
+                    } else if handled_sync {
                         // Sync message: update balances but don't record as a normal payment
                         {
                             let mut sc = self.stable_channel.lock().unwrap();
@@ -3071,6 +3539,19 @@ impl UserApp {
                         let has_stable_control_message = custom_records.iter().any(|tlv| {
                             tlv.type_num == STABLE_CHANNEL_TLV_TYPE && tlv.value.as_slice() != [1u8]
                         });
+                        let has_legacy_stability_marker = custom_records.iter().any(|tlv| {
+                            tlv.type_num == STABLE_CHANNEL_TLV_TYPE
+                                && tlv.value.as_slice() == [1u8]
+                        });
+                        if has_legacy_stability_marker {
+                            audit_event(
+                                "LEGACY_STABILITY_MARKER_UNAUTHENTICATED",
+                                json!({
+                                    "payment_hash": payment_hash_str,
+                                    "amount_msat": amount_msat,
+                                }),
+                            );
+                        }
                         if has_stable_control_message || amount_msat < 1000 {
                             audit_event(
                                 "PAYMENT_RECEIVED_IGNORED",
@@ -3085,11 +3566,7 @@ impl UserApp {
                                 }),
                             );
                         } else {
-                            let is_stability_payment = custom_records.iter().any(|tlv| {
-                                tlv.type_num == STABLE_CHANNEL_TLV_TYPE
-                                    && tlv.value.as_slice() == [1u8]
-                            });
-                            let (amount_usd, btc_price, payment_type, user_channel_id_str) = {
+                            let (amount_usd, btc_price) = {
                                 let sc = self.stable_channel.lock().unwrap();
                                 let price = sc.latest_price;
                                 let usd = if price > 0.0 {
@@ -3097,69 +3574,27 @@ impl UserApp {
                                 } else {
                                     None
                                 };
-                                let ptype = if is_stability_payment {
-                                    "stability"
-                                } else {
-                                    "lightning"
-                                };
-                                let ucid = format!("{}", sc.user_channel_id);
-                                (
-                                    usd,
-                                    if price > 0.0 { Some(price) } else { None },
-                                    ptype,
-                                    ucid,
-                                )
+                                (usd, if price > 0.0 { Some(price) } else { None })
                             };
-                            let backing_delta =
-                                is_stability_payment.then(|| (amount_msat / 1000) as i64);
-                            // Atomically insert payment and update backing in one transaction.
-                            // is_new=true → inserted, is_new=false → duplicate → acknowledge.
-                            // Err → transient failure, do not acknowledge so LDK re-delivers.
-                            let record = || {
-                                self.db.record_payment_and_maybe_update_backing(
-                                    Some(&payment_hash_str),
-                                    payment_type,
-                                    "received",
-                                    amount_msat,
-                                    amount_usd,
-                                    btc_price,
-                                    "completed",
-                                    is_stability_payment.then(|| user_channel_id_str.as_str()),
-                                    backing_delta,
-                                )
-                            };
-                            let db_result = match record() {
-                                Err(ref e) if db::is_missing_channel_row(e) => {
-                                    // The channels row is gone (nothing else recreates
-                                    // it) — recreate it from in-memory state and retry
-                                    // once so this event can't permanently block the
-                                    // queue.
-                                    audit_event(
-                                        "PAYMENT_CHANNEL_ROW_MISSING",
-                                        json!({
-                                            "payment_hash": payment_hash_str,
-                                            "user_channel_id": user_channel_id_str,
-                                        }),
-                                    );
-                                    self.save_channel_settings();
-                                    record()
-                                }
-                                other => other,
-                            };
+                            // Desktop backing changes only through authenticated stability
+                            // metadata. A legacy marker is retained for migration diagnostics but
+                            // its settled value is ordinary Lightning.
+                            let db_result = self.db.record_payment_and_maybe_update_backing(
+                                Some(&payment_hash_str),
+                                "lightning",
+                                "received",
+                                amount_msat,
+                                amount_usd,
+                                btc_price,
+                                "completed",
+                                None,
+                                None,
+                            );
                             match db_result {
                                 Ok(persisted) => {
                                     {
                                         let mut sc = self.stable_channel.lock().unwrap();
                                         update_balances(&self.node, &mut sc);
-                                        if persisted.is_new && is_stability_payment {
-                                            // Sync memory from the authoritative DB value
-                                            // committed in the transaction, not by
-                                            // re-applying the delta — the sc mutex was
-                                            // dropped across the transaction.
-                                            if let Some(new_backing) = persisted.new_backing {
-                                                sc.backing_sats = new_backing.max(0) as u64;
-                                            }
-                                        }
                                         stable::reconcile_incoming(&mut sc);
                                     }
                                     if persisted.clamped {
@@ -3167,7 +3602,7 @@ impl UserApp {
                                             "PAYMENT_BACKING_CLAMPED",
                                             json!({
                                                 "payment_hash": payment_hash_str,
-                                                "backing_delta_sats": backing_delta,
+                                                "backing_delta_sats": null,
                                                 "new_backing_sats": persisted.new_backing,
                                             }),
                                         );
@@ -10647,13 +11082,13 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     })
 }
 
-fn trade_reduction_underflows_backing(
+fn trade_reduction_exhausts_backing(
     current_backing_sats: u64,
     current_expected_usd: f64,
     new_expected_usd: f64,
     current_price: f64,
 ) -> bool {
-    if new_expected_usd >= current_expected_usd {
+    if new_expected_usd >= current_expected_usd || new_expected_usd == 0.0 {
         return false;
     }
     let current_target = current_expected_usd / current_price * SATS_IN_BTC as f64;
@@ -10666,7 +11101,7 @@ fn trade_reduction_underflows_backing(
         return false;
     }
     let reduction = (current_target.floor() as u64).saturating_sub(new_target.floor() as u64);
-    reduction > current_backing_sats
+    reduction >= current_backing_sats
 }
 
 /// Calculate the allocation the wallet must persist before it sends the trade fee.
@@ -10696,16 +11131,53 @@ fn local_trade_backing_sats(
     if new_expected_usd > receiver_usd {
         return Err(LocalTradeAllocationError::TargetExceedsCapacity);
     }
+    // The LSP measures quote deviation against its own price. These are therefore the exact local
+    // price endpoints that can still pass its symmetric deviation check.
+    let quote_deviation = MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0;
+    let minimum_permitted_lsp_price = current_price / (1.0 + quote_deviation);
+    let maximum_permitted_lsp_price = current_price / (1.0 - quote_deviation);
     if new_expected_usd > current_expected_usd {
-        // The LSP accepts a signed quote up to this deviation from its own price. Use the exact
-        // inverse of that check so every permitted lower LSP price still supports this target.
-        let minimum_permitted_lsp_price =
-            current_price / (1.0 + MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0);
+        // Every permitted lower LSP price must still support an increased target.
         let conservative_receiver_usd =
             post_fee_receiver_sats as f64 / SATS_IN_BTC as f64
                 * minimum_permitted_lsp_price;
         if new_expected_usd > conservative_receiver_usd {
             return Err(LocalTradeAllocationError::TargetExceedsSafeCapacity);
+        }
+    } else {
+        // Reductions and exits can underflow backing or cross the actionable-drift gate at either
+        // edge of the accepted quote range. Validate both before paying the non-refundable fee.
+        for permitted_lsp_price in [
+            minimum_permitted_lsp_price,
+            maximum_permitted_lsp_price,
+        ] {
+            let permitted_receiver_usd =
+                post_fee_receiver_sats as f64 / SATS_IN_BTC as f64 * permitted_lsp_price;
+            if new_expected_usd > permitted_receiver_usd {
+                return Err(LocalTradeAllocationError::TargetExceedsSafeCapacity);
+            }
+            if stable::trade_backing_after_delta(
+                post_fee_receiver_sats,
+                current_backing_sats,
+                current_expected_usd,
+                new_expected_usd,
+                permitted_lsp_price,
+            )
+            .is_none()
+            {
+                return Err(if new_expected_usd == 0.0
+                    || trade_reduction_exhausts_backing(
+                        current_backing_sats,
+                        current_expected_usd,
+                        new_expected_usd,
+                        permitted_lsp_price,
+                    )
+                {
+                    LocalTradeAllocationError::SettlementRequired
+                } else {
+                    LocalTradeAllocationError::UnsafeAllocation
+                });
+            }
         }
     }
     let backing_sats = stable::trade_backing_after_delta(
@@ -10716,7 +11188,7 @@ fn local_trade_backing_sats(
         current_price,
     )
     .ok_or(if new_expected_usd == 0.0
-        || trade_reduction_underflows_backing(
+        || trade_reduction_exhausts_backing(
             current_backing_sats,
             current_expected_usd,
             new_expected_usd,
@@ -10948,9 +11420,24 @@ mod tests {
             Err(LocalTradeAllocationError::SettlementRequired),
         );
         assert_eq!(
+            local_trade_backing_sats(10_000, 0, 500, 1.0, 0.5, 100_000.0),
+            Err(LocalTradeAllocationError::SettlementRequired),
+            "a live target cannot consume the final initialized backing sat",
+        );
+        assert_eq!(
             local_trade_backing_sats(100_000, 0, 0, 0.0, 99.51, 100_000.0),
             Err(LocalTradeAllocationError::TargetExceedsSafeCapacity),
             "the preflight reserves the full permitted quote-deviation band",
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 0, 501, 1.0, 0.5, 100_000.0),
+            Err(LocalTradeAllocationError::SettlementRequired),
+            "a reduction that works locally must also work at the lowest permitted LSP price",
+        );
+        assert_eq!(
+            local_trade_backing_sats(200_000, 0, 100_000, 100.0, 0.0, 100_000.0),
+            Err(LocalTradeAllocationError::SettlementRequired),
+            "a full exit must be below the stability threshold across the accepted quote range",
         );
     }
 
@@ -10966,13 +11453,18 @@ mod tests {
             Ok((199_900, 100_009)),
         );
         assert_eq!(
-            local_trade_backing_sats(200_000, 500, 100_000, 100.0, 0.0, 100_001.0),
-            Ok((199_500, 0)),
+            local_trade_backing_sats(20_000, 50, 10_000, 10.0, 0.0, 100_001.0),
+            Ok((19_950, 0)),
         );
         assert_eq!(
-            local_trade_backing_sats(200_000, 500, 100_000, 100.0, 0.009, 100_001.0),
-            Ok((199_500, 0)),
+            local_trade_backing_sats(20_000, 50, 10_000, 10.0, 0.009, 100_001.0),
+            Ok((19_950, 0)),
             "a sub-cent target follows the same guarded full-exit path",
+        );
+        assert_eq!(
+            local_trade_backing_sats(2_000, 0, 1_000, 1.0, 0.5, 100_000.0),
+            Ok((2_000, 500)),
+            "ordinary reductions remain available when both quote endpoints are safe",
         );
     }
 


### PR DESCRIPTION
  ## Problem

  Lightning authenticates the payment transport between nodes, but it does not tell our application that a custom TLV is authorized to change a specific stable channel’s accounting.

  The existing one-byte stability marker did not bind the payment’s sender, channel, amount, direction, or settlement identity. Trade and sync payloads are signed for the same reason: their application-level meaning must be authenticated separately from the Lightning payment carrying them.

  ## Solution

  This PR adds a signed stability-settlement envelope that binds:

  - Stable channel and settlement identity
  - Exact payment amount and direction
  - Expiry and replay protection

  The receiver verifies the stable counterparty’s node signature, matches the signed amount against the actual payment, and applies the settlement atomically using its own local price. Durable deduplication and retries make processing safe across crashes and transient failures. The LSP remains compatible with older mobile clients.

  This does not replace Lightning’s signatures. Lightning secures payment delivery; this signature authorizes the Stable Channels accounting instruction carried inside it.

  The PR also fixes a channel-ID representation bug that could leave valid settlements pending indefinitely, plus a trade edge case where zero backing for a non-zero target could later erase preserved stability drift.