### PR TITLE
Add durable, signed LSP trade rejections(TRADE_REJECTED_V1)

### DIFF
--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -258,6 +258,24 @@ async fn dispatch(
             let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
             let mut settlement_handled = false;
             if let Some(payment_id) = payment_id.as_deref() {
+                match state.db.mark_trade_response_delivered(
+                    payment_id,
+                    crate::stable_manager::StableChannelManager::unix_time_secs(),
+                ) {
+                    Ok(true) => settlement_handled = true,
+                    Ok(false) => {}
+                    Err(error) => {
+                        stable_channels::audit::audit_event(
+                            "DB_WRITE_FAILED",
+                            serde_json::json!({
+                                "op": "mark_trade_response_delivered",
+                                "payment_id": payment_id,
+                                "error": error.to_string(),
+                            }),
+                        );
+                        return DispatchOutcome::Reconnect;
+                    }
+                }
                 let known_settlement = state
                     .db
                     .settlement_exists(payment_id)
@@ -302,6 +320,22 @@ async fn dispatch(
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
             let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            if let Some(payment_id) = payment_id.as_deref() {
+                if let Err(error) = state.db.mark_trade_response_failed(
+                    payment_id,
+                    crate::stable_manager::StableChannelManager::unix_time_secs(),
+                ) {
+                    stable_channels::audit::audit_event(
+                        "DB_WRITE_FAILED",
+                        serde_json::json!({
+                            "op": "mark_trade_response_failed",
+                            "payment_id": payment_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                    return DispatchOutcome::Reconnect;
+                }
+            }
             let rollback = payment_id
                 .as_deref()
                 .and_then(|payment_id| mgr.handle_failed_stability_payment(payment_id));

--- a/server/stable-channels-lsp/src/main.rs
+++ b/server/stable-channels-lsp/src/main.rs
@@ -12,6 +12,7 @@ mod stability_tick;
 mod stable_manager;
 mod state;
 mod tls;
+mod trade_response_retry;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -179,6 +180,7 @@ async fn main() -> Result<()> {
     event_loop::spawn(state.clone());
     stability_tick::spawn(state.clone());
     observability::spawn(state.clone());
+    trade_response_retry::spawn(state.clone());
 
     let router = Router::new()
         .route("/GetNodeInfo", post(handlers::proxy::get_node_info))

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -21,6 +21,9 @@ pub struct TradePayload {
     pub channel_id: Option<String>,
     #[serde(default)]
     pub user_channel_id: Option<String>,
+    /// Desktop correlation id. Omitted by legacy Android/iOS clients.
+    #[serde(default)]
+    pub trade_id: Option<String>,
     pub expected_usd: f64,
     /// Wallet BTC/USD quote. The LSP uses it only for slippage and fee validation.
     #[serde(default)]
@@ -58,6 +61,53 @@ pub fn build_sync_payload(
         "sync_version": sync_version,
     })
     .to_string()
+}
+
+/// Build the correlated acceptance returned for a desktop trade. Ordinary and legacy syncs use
+/// `build_sync_payload`, which intentionally omits all correlation fields.
+#[allow(clippy::too_many_arguments)]
+pub fn build_trade_sync_payload(
+    channel_id: &str,
+    user_channel_id: &str,
+    expected_usd: f64,
+    backing_sats: u64,
+    sync_version: u64,
+    trade_id: &str,
+    trade_payment_id: &str,
+    request_hash: &str,
+) -> String {
+    serde_json::json!({
+        "type": stable_channels::constants::SYNC_MESSAGE_TYPE,
+        "channel_id": channel_id,
+        "user_channel_id": user_channel_id,
+        "expected_usd": expected_usd,
+        "backing_sats": backing_sats,
+        "sync_version": sync_version,
+        "trade_id": trade_id,
+        "trade_payment_id": trade_payment_id,
+        "request_hash": request_hash,
+    })
+    .to_string()
+}
+
+pub fn build_trade_rejected_payload(
+    channel_id: &str,
+    trade_id: &str,
+    trade_payment_id: &str,
+    request_hash: &str,
+    reason_code: stable_channels::trade::TradeRejectionReason,
+    decided_at: u64,
+) -> String {
+    serde_json::to_string(&stable_channels::trade::TradeRejectedV1 {
+        kind: stable_channels::constants::TRADE_REJECTED_MESSAGE_TYPE.to_owned(),
+        channel_id: channel_id.to_owned(),
+        trade_id: trade_id.to_owned(),
+        trade_payment_id: trade_payment_id.to_owned(),
+        request_hash: request_hash.to_owned(),
+        reason_code,
+        decided_at,
+    })
+    .unwrap_or_default()
 }
 
 /// Wrap a signed payload string + signature into the envelope JSON string.
@@ -153,6 +203,7 @@ mod tests {
             Some("189476124653200987495269098788434301048")
         );
         assert_eq!(t.expected_usd, 12.5);
+        assert_eq!(t.trade_id, None);
         assert_eq!(t.quote_price, None);
     }
 
@@ -179,9 +230,41 @@ mod tests {
     #[test]
     fn register_push_bytes_are_canonical_and_deterministic() {
         let a = register_push_signed_bytes("nodehex", "tok:en", 1717000000);
-        let expected = r#"{"type":"REGISTER_PUSH_V1","node_id":"nodehex","token":"tok:en","ts":1717000000}"#;
+        let expected =
+            r#"{"type":"REGISTER_PUSH_V1","node_id":"nodehex","token":"tok:en","ts":1717000000}"#;
         assert_eq!(String::from_utf8(a.clone()).unwrap(), expected);
         let b = register_push_signed_bytes("nodehex", "tok:en", 1717000000);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn correlated_acceptance_contains_all_correlation_fields() {
+        let id = "0123456789abcdef".repeat(4);
+        let hash = "fedcba9876543210".repeat(4);
+        let payload =
+            build_trade_sync_payload(&"a".repeat(64), "7", 25.0, 31_250, 4, &id, &id, &hash);
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["trade_id"], id);
+        assert_eq!(value["trade_payment_id"], id);
+        assert_eq!(value["request_hash"], hash);
+    }
+
+    #[test]
+    fn rejection_has_only_protocol_fields() {
+        let id = "0123456789abcdef".repeat(4);
+        let hash = "fedcba9876543210".repeat(4);
+        let payload = build_trade_rejected_payload(
+            &"a".repeat(64),
+            &id,
+            &id,
+            &hash,
+            stable_channels::trade::TradeRejectionReason::InsufficientCapacity,
+            1786310000,
+        );
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["type"], "TRADE_REJECTED_V1");
+        assert_eq!(value["reason_code"], "insufficient_capacity");
+        assert_eq!(value["decided_at"], 1786310000_u64);
+        assert_eq!(value.as_object().unwrap().len(), 7);
     }
 }

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -14,13 +14,14 @@ use ldk_server_client::ldk_server_grpc::api::{
     SpontaneousSendResponse, VerifySignatureRequest, VerifySignatureResponse,
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
-use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord};
+use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord, PaymentStatus};
 use stable_channels::constants::{
     MAX_TRADE_QUOTE_DEVIATION_PERCENT, SIGNED_STABILITY_TLV_TYPE,
     STABILITY_PAYMENT_AUTH_TTL_SECS,
 };
-use stable_channels::db::{Database, InboundStabilityRegistration};
+use stable_channels::db::{Database, InboundStabilityRegistration, PendingTradeResponse};
 use stable_channels::stable::StabilityPaymentDirection;
+use stable_channels::trade::TradeRejectionReason;
 use stable_channels::types::{Bitcoin, StableChannel, USD};
 use tracing::{error, info};
 
@@ -93,6 +94,30 @@ fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
     // signed trades, plus one sat for whole-sat rounding, while still rejecting material underpay.
     ((expected_msat as f64 * MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0).ceil() as u64)
         .max(1000)
+}
+
+fn trade_reduction_exhausts_backing(
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    new_expected_usd: f64,
+    price: f64,
+) -> bool {
+    if new_expected_usd >= current_expected_usd || new_expected_usd == 0.0 || price <= 0.0 {
+        return false;
+    }
+    let old_target = current_expected_usd / price * 100_000_000.0;
+    let new_target = new_expected_usd / price * 100_000_000.0;
+    if !old_target.is_finite()
+        || !new_target.is_finite()
+        || old_target < 0.0
+        || new_target < 0.0
+        || old_target >= u64::MAX as f64
+        || new_target >= u64::MAX as f64
+    {
+        return false;
+    }
+    (old_target.floor() as u64).saturating_sub(new_target.floor() as u64)
+        >= current_backing_sats
 }
 
 /// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
@@ -229,6 +254,206 @@ pub struct EditOutcome {
 impl StableChannelManager {
     pub fn data_dir(&self) -> &std::path::Path {
         &self.data_dir
+    }
+
+    pub(crate) fn unix_time_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .min(i64::MAX as u64) as i64
+    }
+
+    async fn send_pending_trade_response(
+        db: &Database,
+        ldk: &dyn LdkServerCalls,
+        response: &PendingTradeResponse,
+    ) {
+        let now = Self::unix_time_secs();
+        match db.reserve_trade_response_attempt(
+            &response.inbound_payment_id,
+            response.attempts,
+            now,
+        ) {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_WRITE_FAILED",
+                    serde_json::json!({
+                        "op": "reserve_trade_response_attempt",
+                        "trade_payment_id": response.inbound_payment_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        }
+        let send = ldk
+            .spontaneous_send(SpontaneousSendRequest {
+                amount_msat: 1,
+                node_id: response.counterparty.clone(),
+                route_parameters: None,
+                custom_tlvs: vec![CustomTlvRecord {
+                    type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
+                    value: response.response_envelope.clone().into_bytes().into(),
+                }],
+            })
+            .await;
+        match send {
+            Ok(sent) if !sent.payment_id.is_empty() => {
+                match db.mark_trade_response_in_flight(
+                    &response.inbound_payment_id,
+                    &sent.payment_id,
+                ) {
+                    Ok(true) => stable_channels::audit::audit_event(
+                        "TRADE_RESPONSE_SENT",
+                        serde_json::json!({
+                            "trade_payment_id": response.inbound_payment_id,
+                            "response_payment_id": sent.payment_id,
+                            "attempt": response.attempts.saturating_add(1),
+                        }),
+                    ),
+                    Ok(false) | Err(_) => stable_channels::audit::audit_event(
+                        "TRADE_RESPONSE_PAYMENT_ID_PERSIST_FAILED",
+                        serde_json::json!({
+                            "trade_payment_id": response.inbound_payment_id,
+                            "response_payment_id": sent.payment_id,
+                        }),
+                    ),
+                }
+            }
+            result => stable_channels::audit::audit_event(
+                "TRADE_RESPONSE_SEND_FAILED",
+                serde_json::json!({
+                    "trade_payment_id": response.inbound_payment_id,
+                    "attempt": response.attempts.saturating_add(1),
+                    "error": result.err().map(|error| error.to_string()),
+                }),
+            ),
+        }
+    }
+
+    /// Reconcile uncertain sends, expire 14-day obligations, prune 30-day response bytes, and
+    /// deliver all currently due decisions. Every send is reserved durably first.
+    pub async fn retry_pending_trade_responses(db: &Database, ldk: &dyn LdkServerCalls) {
+        let in_flight = db
+            .in_flight_trade_response_payment_ids()
+            .unwrap_or_default();
+        for payment_id in in_flight {
+            match ldk
+                .get_payment_details(GetPaymentDetailsRequest {
+                    payment_id: payment_id.clone(),
+                })
+                .await
+                .ok()
+                .and_then(|response| response.payment)
+                .map(|payment| payment.status)
+            {
+                Some(status) if status == PaymentStatus::Succeeded as i32 => {
+                    let _ = db.mark_trade_response_delivered(
+                        &payment_id,
+                        Self::unix_time_secs(),
+                    );
+                }
+                Some(status) if status == PaymentStatus::Failed as i32 => {
+                    let _ = db.mark_trade_response_failed(&payment_id, Self::unix_time_secs());
+                }
+                _ => {}
+            }
+        }
+        let now = Self::unix_time_secs();
+        let _ = db.abandon_expired_trade_responses(now);
+        let _ = db.prune_trade_response_details(now);
+        let responses = match db.due_trade_responses(now, 32) {
+            Ok(responses) => responses,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "DB_READ_FAILED",
+                    serde_json::json!({
+                        "op": "due_trade_responses",
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        for response in responses {
+            Self::send_pending_trade_response(db, ldk, &response).await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn reject_correlated_trade(
+        &self,
+        ldk: &dyn LdkServerCalls,
+        inbound_payment_id: &str,
+        trade_id: &str,
+        request_hash: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        counterparty: &str,
+        reason: TradeRejectionReason,
+    ) {
+        let decided_at = Self::unix_time_secs();
+        let payload = crate::messages::build_trade_rejected_payload(
+            channel_id,
+            trade_id,
+            inbound_payment_id,
+            request_hash,
+            reason,
+            decided_at as u64,
+        );
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_REJECTION_SIGN_FAILED",
+                    serde_json::json!({
+                        "trade_id": trade_id,
+                        "reason_code": reason.as_str(),
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let envelope = crate::messages::build_envelope(payload, signature);
+        match self.db.persist_trade_rejection(
+            inbound_payment_id,
+            trade_id,
+            request_hash,
+            channel_id,
+            user_channel_id,
+            counterparty,
+            reason.as_str(),
+            decided_at,
+            &envelope,
+        ) {
+            Ok(true) => stable_channels::audit::audit_event(
+                "TRADE_REJECTION_QUEUED",
+                serde_json::json!({
+                    "trade_id": trade_id,
+                    "trade_payment_id": inbound_payment_id,
+                    "request_hash": request_hash,
+                    "reason_code": reason.as_str(),
+                }),
+            ),
+            Ok(false) => {}
+            Err(error) => stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({
+                    "op": "persist_trade_rejection",
+                    "trade_id": trade_id,
+                    "error": error.to_string(),
+                }),
+            ),
+        }
     }
 
     /// Consume an asynchronous failure for an outbound stability payment. The database performs
@@ -812,7 +1037,13 @@ impl StableChannelManager {
                 // stability payment. The trade settlement is recorded INSIDE the handler, only
                 // after the signature verifies — a forged or unsigned envelope from any peer no
                 // longer writes a settlement row before it is authenticated.
-                self.handle_trade_message(&raw, payment_id.as_deref(), amount_msat, ldk, btc_price)
+                self.handle_trade_payment(
+                    &raw,
+                    payment_id.as_deref(),
+                    amount_msat,
+                    ldk,
+                    btc_price,
+                )
                     .await;
             } else if rec.value.as_ref() == [1u8] {
                 if let Some(pid) = payment_id.as_deref() {
@@ -2305,10 +2536,10 @@ impl StableChannelManager {
 
     /// Parse a TRADE_V1 envelope, verify it against the channel counterparty, validate against
     /// balance, and apply the new USD target. Drops (with an audit line) on any failure.
-    pub async fn handle_trade_message(
+    pub async fn handle_trade_payment(
         &mut self,
         raw: &str,
-        payment_id: Option<&str>,
+        inbound_payment_id: Option<&str>,
         amount_msat: Option<u64>,
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
@@ -2328,7 +2559,9 @@ impl StableChannelManager {
             );
             return;
         }
-        if payload.expected_usd < 0.0 || !payload.expected_usd.is_finite() {
+        if payload.trade_id.is_none()
+            && (payload.expected_usd < 0.0 || !payload.expected_usd.is_finite())
+        {
             stable_channels::audit::audit_event(
                 "TRADE_INVALID_AMOUNT",
                 serde_json::json!({ "expected_usd": payload.expected_usd, "user_channel_id": payload.user_channel_id.clone() }),
@@ -2356,20 +2589,14 @@ impl StableChannelManager {
                 return;
             }
         };
-        // channel_id is authoritative when present; user_channel_id is the fallback.
-        let chan = channels.into_iter().find(|c| {
-            if let Some(cid) = payload.channel_id.as_deref() {
-                if c.channel_id == cid {
-                    return true;
-                }
-            }
-            if let Some(ucid) = payload.user_channel_id.as_deref() {
-                let want = parse_user_channel_id(ucid);
-                if want.is_some() && want == parse_user_channel_id(&c.user_channel_id) {
-                    return true;
-                }
-            }
-            false
+        // channel_id is authoritative when present; only requests that omit it may use the
+        // legacy node-local user_channel_id fallback.
+        let chan = channels.into_iter().find(|c| match payload.channel_id.as_deref() {
+            Some(channel_id) => c.channel_id == channel_id,
+            None => payload.user_channel_id.as_deref().is_some_and(|user_channel_id| {
+                let wanted = parse_user_channel_id(user_channel_id);
+                wanted.is_some() && wanted == parse_user_channel_id(&c.user_channel_id)
+            }),
         });
         let Some(chan) = chan else {
             stable_channels::audit::audit_event(
@@ -2405,7 +2632,7 @@ impl StableChannelManager {
         // Verify-then-write: the settlement row is recorded only now that the envelope's
         // signature is verified against the channel counterparty. An unauthenticated peer's
         // forged TLV is dropped above without ever touching the settlements table.
-        if let Some(pid) = payment_id {
+        if let Some(pid) = inbound_payment_id {
             if let Err(e) = self.db.record_settlement(pid, "trade") {
                 tracing::error!("[stable] record_settlement (inbound trade) failed: {}", e);
                 stable_channels::audit::audit_event(
@@ -2413,6 +2640,268 @@ impl StableChannelManager {
                     serde_json::json!({ "op": "record_settlement", "kind": "trade", "payment_id": pid, "error": e.to_string() }),
                 );
             }
+        }
+
+        // A trade id opts into durable correlated results. Legacy mobile-shaped requests continue
+        // through the original silent-rejection / ordinary-SYNC path below.
+        if let Some(trade_id) = payload.trade_id.as_deref() {
+            if !stable_channels::trade::is_trade_id(trade_id)
+                || !payload
+                    .channel_id
+                    .as_deref()
+                    .is_some_and(stable_channels::trade::is_channel_id)
+            {
+                stable_channels::audit::audit_event(
+                    "TRADE_CORRELATION_INVALID",
+                    serde_json::json!({ "channel_id": chan.channel_id }),
+                );
+                return;
+            }
+            let Some(inbound_payment_id) = inbound_payment_id
+                .filter(|payment_id| stable_channels::trade::is_payment_id(payment_id))
+            else {
+                stable_channels::audit::audit_event(
+                    "TRADE_PAYMENT_UNATTRIBUTABLE",
+                    serde_json::json!({ "channel_id": chan.channel_id }),
+                );
+                return;
+            };
+            let Some(received_msat) = amount_msat else {
+                stable_channels::audit::audit_event(
+                    "TRADE_PAYMENT_UNATTRIBUTABLE",
+                    serde_json::json!({ "channel_id": chan.channel_id }),
+                );
+                return;
+            };
+            let request_hash = stable_channels::trade::request_hash(envelope.payload.as_bytes());
+            let now = Self::unix_time_secs();
+
+            match self.db.trade_decision_by_payment(inbound_payment_id) {
+                Ok(Some(decision)) => {
+                    if decision.trade_id == trade_id && decision.request_hash == request_hash {
+                        let _ = self.db.requeue_exact_trade_response(
+                            inbound_payment_id,
+                            trade_id,
+                            &request_hash,
+                            now,
+                        );
+                    }
+                    return;
+                }
+                Ok(None) => {}
+                Err(_) => {
+                    self.reject_correlated_trade(
+                        ldk,
+                        inbound_payment_id,
+                        trade_id,
+                        &request_hash,
+                        &chan.channel_id,
+                        &chan.user_channel_id,
+                        &chan.counterparty_node_id,
+                        TradeRejectionReason::InternalFailure,
+                    )
+                    .await;
+                    return;
+                }
+            }
+            match self.db.trade_decision_by_trade_id(trade_id) {
+                Ok(Some(_)) => {
+                    stable_channels::audit::audit_event(
+                        "TRADE_ID_REUSED",
+                        serde_json::json!({ "trade_id": trade_id }),
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(_) => {
+                    self.reject_correlated_trade(
+                        ldk,
+                        inbound_payment_id,
+                        trade_id,
+                        &request_hash,
+                        &chan.channel_id,
+                        &chan.user_channel_id,
+                        &chan.counterparty_node_id,
+                        TradeRejectionReason::InternalFailure,
+                    )
+                    .await;
+                    return;
+                }
+            }
+
+            macro_rules! reject_correlated {
+                ($reason:expr) => {{
+                    self.reject_correlated_trade(
+                        ldk,
+                        inbound_payment_id,
+                        trade_id,
+                        &request_hash,
+                        &chan.channel_id,
+                        &chan.user_channel_id,
+                        &chan.counterparty_node_id,
+                        $reason,
+                    )
+                    .await;
+                    return;
+                }};
+            }
+
+            if !payload.expected_usd.is_finite() || payload.expected_usd < 0.0 {
+                reject_correlated!(TradeRejectionReason::InvalidAmount);
+            }
+            let timestamp_valid = payload.ts != 0
+                && now >= 0
+                && (now as u64).abs_diff(payload.ts)
+                    <= stable_channels::constants::TRADE_RESULT_TIMEOUT_SECS;
+            if !timestamp_valid {
+                reject_correlated!(TradeRejectionReason::StaleRequest);
+            }
+            let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
+                reject_correlated!(TradeRejectionReason::InternalFailure);
+            };
+            let Some(current) = self
+                .stable_channels
+                .iter()
+                .find(|channel| channel.user_channel_id == target_uid)
+                .cloned()
+            else {
+                reject_correlated!(TradeRejectionReason::InternalFailure);
+            };
+            let new_expected =
+                stable_channels::stable::normalize_trade_expected_usd(payload.expected_usd);
+            if stable_channels::trade::target_matches(current.expected_usd.0, new_expected) {
+                reject_correlated!(TradeRejectionReason::InvalidAmount);
+            }
+            let Some(quote_price) = payload.quote_price else {
+                reject_correlated!(TradeRejectionReason::InvalidQuote);
+            };
+            if !quote_price.is_finite()
+                || quote_price <= 0.0
+                || !btc_price.is_finite()
+                || btc_price <= 0.0
+            {
+                reject_correlated!(TradeRejectionReason::InvalidQuote);
+            }
+            let Some(expected_fee_msat) = expected_trade_fee_msat(
+                current.expected_usd.0,
+                new_expected,
+                quote_price,
+            ) else {
+                reject_correlated!(TradeRejectionReason::InvalidFee);
+            };
+            let tolerance_msat = trade_fee_tolerance_msat(expected_fee_msat, true);
+            if received_msat.abs_diff(expected_fee_msat) > tolerance_msat {
+                reject_correlated!(TradeRejectionReason::InvalidFee);
+            }
+            let quote_deviation_percent =
+                ((quote_price - btc_price) / btc_price * 100.0).abs();
+            if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
+                reject_correlated!(TradeRejectionReason::QuoteDeviation);
+            }
+            let (our_sats, their_sats) = channel_peer_balances(&chan);
+            let receiver_usd = USD::from_bitcoin(Bitcoin::from_sats(their_sats), btc_price).0;
+            if new_expected > receiver_usd {
+                reject_correlated!(TradeRejectionReason::InsufficientCapacity);
+            }
+
+            let mut updated = current.clone();
+            updated.stable_provider_btc = Bitcoin::from_sats(our_sats);
+            updated.stable_receiver_btc = Bitcoin::from_sats(their_sats);
+            updated.stable_provider_usd =
+                USD::from_bitcoin(updated.stable_provider_btc, btc_price);
+            updated.stable_receiver_usd =
+                USD::from_bitcoin(updated.stable_receiver_btc, btc_price);
+            updated.latest_price = btc_price;
+            if !stable_channels::stable::apply_trade(&mut updated, new_expected, btc_price) {
+                let reason = if new_expected < current.expected_usd.0
+                    && (new_expected == 0.0
+                        || trade_reduction_exhausts_backing(
+                            current.backing_sats,
+                            current.expected_usd.0,
+                            new_expected,
+                            btc_price,
+                        ))
+                {
+                    TradeRejectionReason::SettlementRequired
+                } else {
+                    TradeRejectionReason::UnsafeAllocation
+                };
+                reject_correlated!(reason);
+            }
+            let sync_version = match self
+                .db
+                .candidate_sync_version(&format!("{}", target_uid))
+            {
+                Ok(version) => version,
+                Err(_) => reject_correlated!(TradeRejectionReason::InternalFailure),
+            };
+            let response_user_channel_id = payload
+                .user_channel_id
+                .as_deref()
+                .unwrap_or(&chan.user_channel_id);
+            let acceptance_payload = crate::messages::build_trade_sync_payload(
+                &chan.channel_id,
+                response_user_channel_id,
+                updated.expected_usd.0,
+                updated.backing_sats,
+                sync_version,
+                trade_id,
+                inbound_payment_id,
+                &request_hash,
+            );
+            let signature = match ldk
+                .sign_message(SignMessageRequest {
+                    message: acceptance_payload.as_bytes().to_vec().into(),
+                })
+                .await
+            {
+                Ok(response) => response.signature,
+                Err(_) => reject_correlated!(TradeRejectionReason::InternalFailure),
+            };
+            let response_envelope =
+                crate::messages::build_envelope(acceptance_payload, signature);
+            let native_sats = their_sats.saturating_sub(updated.backing_sats);
+            match self.db.persist_trade_acceptance(
+                inbound_payment_id,
+                trade_id,
+                &request_hash,
+                &chan.channel_id,
+                &format!("{}", target_uid),
+                &chan.counterparty_node_id,
+                updated.expected_usd.0,
+                updated.backing_sats,
+                native_sats,
+                sync_version,
+                now,
+                &response_envelope,
+            ) {
+                Ok(true) => {
+                    updated.native_sats = native_sats;
+                    updated.native_channel_btc = Bitcoin::from_sats(native_sats);
+                    if let Some(in_memory) = self
+                        .stable_channels
+                        .iter_mut()
+                        .find(|channel| channel.user_channel_id == target_uid)
+                    {
+                        *in_memory = updated.clone();
+                    }
+                    stable_channels::audit::audit_event(
+                        "TRADE_ACCEPTED",
+                        serde_json::json!({
+                            "trade_id": trade_id,
+                            "trade_payment_id": inbound_payment_id,
+                            "request_hash": request_hash,
+                            "expected_usd": updated.expected_usd.0,
+                            "backing_sats": updated.backing_sats,
+                            "sync_version": sync_version,
+                        }),
+                    );
+                }
+                Ok(false) | Err(_) => {
+                    reject_correlated!(TradeRejectionReason::InternalFailure);
+                }
+            }
+            return;
         }
 
         // Replay protection: reject a signed trade with a stale `ts`; ts==0 means an un-upgraded wallet (no timestamp yet) — accepted until all wallets sign one.
@@ -2637,6 +3126,26 @@ impl StableChannelManager {
         if !sent {
             self.startup_sync_pending.insert(target_uid);
         }
+    }
+
+    /// Compatibility/test entry point. Production passes the actual inbound LDK payment id above.
+    pub async fn handle_trade_message(
+        &mut self,
+        raw: &str,
+        inbound_payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let synthetic_payment_id = stable_channels::trade::request_hash(raw.as_bytes());
+        self.handle_trade_payment(
+            raw,
+            inbound_payment_id.or(Some(&synthetic_payment_id)),
+            amount_msat,
+            ldk,
+            btc_price,
+        )
+        .await;
     }
 }
 
@@ -4109,6 +4618,147 @@ mod tests {
         serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
     }
 
+    fn correlated_trade_envelope(
+        channel_id: &str,
+        user_channel_id: &str,
+        trade_id: &str,
+        expected_usd: f64,
+        quote_price: f64,
+    ) -> String {
+        let payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "channel_id": channel_id,
+            "user_channel_id": user_channel_id,
+            "trade_id": trade_id,
+            "expected_usd": expected_usd,
+            "quote_price": quote_price,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
+    }
+
+    fn correlated_trade_envelope_at(
+        trade_id: &str,
+        expected_usd: f64,
+        quote_price: Option<f64>,
+        ts: u64,
+    ) -> String {
+        let payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "channel_id": CHANNEL_ID_HEX,
+            "user_channel_id": USER_CHANNEL_ID_DECIMAL,
+            "trade_id": trade_id,
+            "expected_usd": expected_usd,
+            "quote_price": quote_price,
+            "ts": ts,
+        })
+        .to_string();
+        serde_json::json!({ "payload": payload, "signature": "wallet-sig" }).to_string()
+    }
+
+    fn correlated_rejection_context(
+        expected_usd: f64,
+        backing_sats: u64,
+        receiver_sats: u64,
+    ) -> (StableChannelManager, FakeLdkServer) {
+        let mut manager = make_manager();
+        let channel_value_sats = receiver_sats.saturating_add(100_000);
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            channel_value_sats,
+            100_000_000,
+            true,
+        )]);
+        let uid = USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap();
+        seed_channel(
+            &mut manager,
+            uid,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            expected_usd,
+            backing_sats,
+            receiver_sats.saturating_sub(backing_sats),
+            receiver_sats,
+            100_000.0,
+        );
+        manager
+            .db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                expected_usd,
+                backing_sats,
+                receiver_sats.saturating_sub(backing_sats),
+                None,
+            )
+            .unwrap();
+        (manager, fake)
+    }
+
+    async fn correlated_rejection_reason(
+        manager: &mut StableChannelManager,
+        fake: &FakeLdkServer,
+        envelope: &str,
+        payment_id: &str,
+        amount_msat: u64,
+        lsp_price: f64,
+    ) -> TradeRejectionReason {
+        let before = manager.stable_channels.first().map(|channel| {
+            (channel.expected_usd.0, channel.backing_sats, channel.native_sats)
+        });
+        let durable_before = manager
+            .db
+            .load_channel(USER_CHANNEL_ID_DECIMAL)
+            .unwrap()
+            .map(|channel| {
+                (
+                    channel.expected_usd,
+                    channel.backing_sats,
+                    channel.native_sats,
+                )
+            });
+        manager
+            .handle_trade_payment(
+                envelope,
+                Some(payment_id),
+                Some(amount_msat),
+                fake,
+                lsp_price,
+            )
+            .await;
+        let after = manager.stable_channels.first().map(|channel| {
+            (channel.expected_usd.0, channel.backing_sats, channel.native_sats)
+        });
+        assert_eq!(after, before, "rejection must not mutate in-memory allocation");
+        assert_eq!(
+            manager
+                .db
+                .load_channel(USER_CHANNEL_ID_DECIMAL)
+                .unwrap()
+                .map(|channel| {
+                    (
+                        channel.expected_usd,
+                        channel.backing_sats,
+                        channel.native_sats,
+                    )
+                }),
+            durable_before,
+            "rejection must not mutate durable channel allocation",
+        );
+        StableChannelManager::retry_pending_trade_responses(manager.db.as_ref(), fake).await;
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert_eq!(sends[0].amount_msat, 1);
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let response = crate::messages::parse_envelope(raw).unwrap();
+        serde_json::from_str::<stable_channels::trade::TradeRejectedV1>(&response.payload)
+            .unwrap()
+            .reason_code
+    }
+
     fn test_unix_now() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -4172,6 +4822,432 @@ mod tests {
         assert_eq!(wallet_fee_msat, 113_000);
         assert_eq!(reconstructed, 114_000);
         assert!(wallet_fee_msat.abs_diff(reconstructed) <= trade_fee_tolerance_msat(reconstructed, true));
+    }
+
+    #[tokio::test]
+    async fn correlated_acceptance_is_atomic_idempotent_and_contains_request_hash() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000,
+            true,
+        )]);
+        let uid = USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap();
+        seed_channel(
+            &mut mgr,
+            uid,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            50.0,
+            50_000,
+            50_000,
+            100_000,
+            100_000.0,
+        );
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                50.0,
+                50_000,
+                50_000,
+                None,
+            )
+            .unwrap();
+        let trade_id = "b".repeat(64);
+        let payment_id = "c".repeat(64);
+        let envelope = correlated_trade_envelope(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            &trade_id,
+            60.0,
+            100_000.0,
+        );
+        let signed = crate::messages::parse_envelope(&envelope).unwrap();
+        let request_hash = stable_channels::trade::request_hash(signed.payload.as_bytes());
+        let fee = expected_trade_fee_msat(50.0, 60.0, 100_000.0).unwrap();
+
+        mgr.handle_trade_payment(
+            &envelope,
+            Some(&payment_id),
+            Some(fee),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 60.0);
+        assert_eq!(mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(), Some(1));
+        assert!(mgr
+            .db
+            .trade_decision_by_payment(&payment_id)
+            .unwrap()
+            .is_some());
+
+        mgr.handle_trade_payment(
+            &envelope,
+            Some(&payment_id),
+            Some(fee),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        assert_eq!(mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(), Some(1));
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        assert_eq!(sends[0].amount_msat, 1);
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let response = crate::messages::parse_envelope(raw).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&response.payload).unwrap();
+        assert_eq!(value["type"], "SYNC_V1");
+        assert_eq!(value["trade_id"], trade_id);
+        assert_eq!(value["trade_payment_id"], payment_id);
+        assert_eq!(value["request_hash"], request_hash);
+        assert_eq!(value["expected_usd"], 60.0);
+    }
+
+    #[tokio::test]
+    async fn trade_response_retry_reconciles_uncertain_send_from_ldk_state() {
+        let manager = make_manager();
+        let fake = FakeLdkServer::new(vec![]);
+        let now = StableChannelManager::unix_time_secs();
+        manager
+            .db
+            .persist_trade_rejection(
+                &"7".repeat(64),
+                &"8".repeat(64),
+                &"9".repeat(64),
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                COUNTERPARTY_HEX,
+                TradeRejectionReason::InternalFailure.as_str(),
+                now,
+                "signed-rejection",
+            )
+            .unwrap();
+
+        StableChannelManager::retry_pending_trade_responses(manager.db.as_ref(), &fake).await;
+        assert_eq!(
+            manager
+                .db
+                .in_flight_trade_response_payment_ids()
+                .unwrap(),
+            vec!["fake-payment-id".to_string()]
+        );
+        fake.payments.lock().unwrap().push(GrpcPayment {
+            id: "fake-payment-id".to_string(),
+            status: PaymentStatus::Succeeded as i32,
+            ..Default::default()
+        });
+        StableChannelManager::retry_pending_trade_responses(manager.db.as_ref(), &fake).await;
+        assert!(manager
+            .db
+            .in_flight_trade_response_payment_ids()
+            .unwrap()
+            .is_empty());
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn authenticated_correlated_rejection_leaves_allocation_unchanged() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000,
+            true,
+        )]);
+        let uid = USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap();
+        seed_channel(
+            &mut mgr,
+            uid,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            50.0,
+            50_000,
+            50_000,
+            100_000,
+            100_000.0,
+        );
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                50.0,
+                50_000,
+                50_000,
+                None,
+            )
+            .unwrap();
+        let trade_id = "d".repeat(64);
+        let payment_id = "e".repeat(64);
+        let envelope = correlated_trade_envelope(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            &trade_id,
+            60.0,
+            100_000.0,
+        );
+        mgr.handle_trade_payment(&envelope, Some(&payment_id), Some(1), &fake, 100_000.0)
+            .await;
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
+        assert_eq!(mgr.db.load_channel(USER_CHANNEL_ID_DECIMAL).unwrap().unwrap().expected_usd, 50.0);
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 1);
+        let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+        let response = crate::messages::parse_envelope(raw).unwrap();
+        let rejection: stable_channels::trade::TradeRejectedV1 =
+            serde_json::from_str(&response.payload).unwrap();
+        assert_eq!(rejection.reason_code, TradeRejectionReason::InvalidFee);
+        assert_eq!(rejection.trade_payment_id, payment_id);
+    }
+
+    #[tokio::test]
+    async fn every_authenticated_correlated_rejection_keeps_allocation_unchanged() {
+        let trade_id = "5".repeat(64);
+        let payment_id = "6".repeat(64);
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            50.0,
+            Some(100_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
+                .await,
+            TradeRejectionReason::InvalidAmount
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            60.0,
+            Some(100_000.0),
+            test_unix_now() - stable_channels::constants::TRADE_RESULT_TIMEOUT_SECS - 1,
+        );
+        assert_eq!(
+            correlated_rejection_reason(
+                &mut manager,
+                &fake,
+                &envelope,
+                &payment_id,
+                expected_trade_fee_msat(50.0, 60.0, 100_000.0).unwrap(),
+                100_000.0,
+            )
+            .await,
+            TradeRejectionReason::StaleRequest
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            60.0,
+            Some(100_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
+                .await,
+            TradeRejectionReason::InvalidFee
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            60.0,
+            Some(-1.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
+                .await,
+            TradeRejectionReason::InvalidQuote
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            60.0,
+            Some(90_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(
+                &mut manager,
+                &fake,
+                &envelope,
+                &payment_id,
+                expected_trade_fee_msat(50.0, 60.0, 90_000.0).unwrap(),
+                100_000.0,
+            )
+            .await,
+            TradeRejectionReason::QuoteDeviation
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            110.0,
+            Some(100_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(
+                &mut manager,
+                &fake,
+                &envelope,
+                &payment_id,
+                expected_trade_fee_msat(50.0, 110.0, 100_000.0).unwrap(),
+                100_000.0,
+            )
+            .await,
+            TradeRejectionReason::InsufficientCapacity
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(100.0, 100_000, 200_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            0.0,
+            Some(90_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(
+                &mut manager,
+                &fake,
+                &envelope,
+                &payment_id,
+                expected_trade_fee_msat(100.0, 0.0, 90_000.0).unwrap(),
+                90_000.0,
+            )
+            .await,
+            TradeRejectionReason::SettlementRequired
+        );
+
+        let (mut manager, fake) = correlated_rejection_context(10.0, 49_000, 50_000);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            20.0,
+            Some(100_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(
+                &mut manager,
+                &fake,
+                &envelope,
+                &payment_id,
+                expected_trade_fee_msat(10.0, 20.0, 100_000.0).unwrap(),
+                100_000.0,
+            )
+            .await,
+            TradeRejectionReason::UnsafeAllocation
+        );
+
+        let mut manager = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            200_000,
+            100_000_000,
+            true,
+        )]);
+        let envelope = correlated_trade_envelope_at(
+            &trade_id,
+            20.0,
+            Some(100_000.0),
+            test_unix_now(),
+        );
+        assert_eq!(
+            correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
+                .await,
+            TradeRejectionReason::InternalFailure
+        );
+    }
+
+    #[tokio::test]
+    async fn correlated_invalid_signature_receives_no_decision_or_response() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000,
+            true,
+        )])
+        .with_verify_failure();
+        let trade_id = "1".repeat(64);
+        let payment_id = "2".repeat(64);
+        let envelope = correlated_trade_envelope(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            &trade_id,
+            60.0,
+            100_000.0,
+        );
+        mgr.handle_trade_payment(
+            &envelope,
+            Some(&payment_id),
+            Some(100_000),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        assert!(mgr
+            .db
+            .trade_decision_by_payment(&payment_id)
+            .unwrap()
+            .is_none());
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        assert!(fake.sends.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn correlated_unknown_explicit_channel_does_not_fall_back_or_respond() {
+        let mut mgr = make_manager();
+        let fake = FakeLdkServer::new(vec![make_channel(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            300_000,
+            100_000,
+            true,
+        )]);
+        let trade_id = "3".repeat(64);
+        let payment_id = "4".repeat(64);
+        let envelope = correlated_trade_envelope(
+            &"f".repeat(64),
+            USER_CHANNEL_ID_DECIMAL,
+            &trade_id,
+            60.0,
+            100_000.0,
+        );
+        mgr.handle_trade_payment(
+            &envelope,
+            Some(&payment_id),
+            Some(100_000),
+            &fake,
+            100_000.0,
+        )
+        .await;
+        assert!(fake.verify_calls.lock().unwrap().is_empty());
+        assert!(mgr
+            .db
+            .trade_decision_by_payment(&payment_id)
+            .unwrap()
+            .is_none());
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        assert!(fake.sends.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/server/stable-channels-lsp/src/trade_response_retry.rs
+++ b/server/stable-channels-lsp/src/trade_response_retry.rs
@@ -1,0 +1,21 @@
+//! Durable accepted/rejected trade-result delivery worker.
+
+use std::time::Duration;
+
+use crate::stable_manager::LdkServerCalls;
+use crate::state::AppState;
+
+pub fn spawn(state: AppState) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(1));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            crate::stable_manager::StableChannelManager::retry_pending_trade_responses(
+                state.db.as_ref(),
+                state.ldk_server.as_ref() as &dyn LdkServerCalls,
+            )
+            .await;
+        }
+    });
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -20,6 +20,9 @@ pub const TRADE_MESSAGE_TYPE: &str = "TRADE_V1";
 /// Sync message type identifier (LSP → user expected_usd sync after stable deductions)
 pub const SYNC_MESSAGE_TYPE: &str = "SYNC_V1";
 
+/// Signed rejection message returned for correlated desktop trades.
+pub const TRADE_REJECTED_MESSAGE_TYPE: &str = "TRADE_REJECTED_V1";
+
 /// Signed stability-payment message type identifier.
 pub const STABILITY_PAYMENT_MESSAGE_TYPE: &str = "STABILITY_PAYMENT_V1";
 
@@ -80,6 +83,15 @@ pub const BALANCE_UPDATE_INTERVAL_SECS: u64 = 30;
 /// Stability check interval (in seconds)
 pub const STABILITY_CHECK_INTERVAL_SECS: u64 = 60;
 
+/// A correlated trade becomes locally uncertain after this long, but remains late-resolvable.
+pub const TRADE_RESULT_TIMEOUT_SECS: u64 = 15 * 60;
+
+/// The LSP retries durable result delivery throughout this window.
+pub const TRADE_RESPONSE_RETRY_WINDOW_SECS: u64 = 14 * 24 * 60 * 60;
+
+/// Detailed signed response bytes may be pruned after this retention period.
+pub const TRADE_RESPONSE_DETAIL_RETENTION_SECS: u64 = 30 * 24 * 60 * 60;
+
 // ============================================================================
 // BUSINESS LOGIC CONSTANTS
 // ============================================================================
@@ -112,9 +124,7 @@ pub const AUTO_SWEEP_MIN_SATS: u64 = 10_000;
 pub const STABLE_CHANNEL_TRADE_FEE_RATE: f64 = 0.01;
 
 /// Maximum difference between the wallet's signed trade quote and the LSP's local price.
-///
-/// The wallet also uses this bound to reject near-capacity trades that the LSP could not support
-/// at the lowest price permitted by the quote check.
+/// Enforced by the LSP; the wallet accepts an explicit rejection if their trusted prices differ.
 pub const MAX_TRADE_QUOTE_DEVIATION_PERCENT: f64 = 0.5;
 
 /// LDK channel-config defaults for outbound forwarding fees.

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,6 +7,7 @@
 
 use chrono::{Duration as ChronoDuration, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Result as SqliteResult};
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -90,6 +91,109 @@ pub fn is_stale_inbound_stability_allocation(err: &rusqlite::Error) -> bool {
 /// Database file name
 pub const DB_FILENAME: &str = "stablechannels.db";
 
+const CREATE_TRADE_DECISIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS trade_decisions (
+        inbound_payment_id TEXT PRIMARY KEY,
+        trade_id TEXT NOT NULL UNIQUE,
+        request_hash TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        user_channel_id TEXT NOT NULL,
+        counterparty TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        reason_code TEXT,
+        expected_usd REAL,
+        backing_sats INTEGER,
+        sync_version INTEGER,
+        decided_at INTEGER NOT NULL,
+        response_envelope TEXT,
+        response_payment_id TEXT,
+        response_status TEXT NOT NULL DEFAULT 'pending',
+        response_attempts INTEGER NOT NULL DEFAULT 0,
+        next_response_attempt_at INTEGER NOT NULL,
+        delivery_deadline INTEGER NOT NULL,
+        delivered_at INTEGER,
+        details_pruned_at INTEGER
+    )";
+
+const CREATE_TRADE_DECISIONS_DUE_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_trade_decisions_response_due
+     ON trade_decisions(response_status, next_response_attempt_at)";
+
+fn trade_decision_columns(conn: &Connection) -> SqliteResult<HashSet<String>> {
+    let mut stmt = conn.prepare("PRAGMA table_info(trade_decisions)")?;
+    let columns = stmt.query_map([], |row| row.get(1))?.collect();
+    columns
+}
+
+fn init_trade_decisions_schema(conn: &mut Connection) -> SqliteResult<()> {
+    let exists: bool = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'trade_decisions'
+         )",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        conn.execute(CREATE_TRADE_DECISIONS_TABLE, [])?;
+        conn.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+        return Ok(());
+    }
+
+    let columns = trade_decision_columns(conn)?;
+    let current_columns = [
+        "inbound_payment_id", "trade_id", "request_hash", "channel_id",
+        "user_channel_id", "counterparty", "outcome", "reason_code",
+        "expected_usd", "backing_sats", "sync_version", "decided_at",
+        "response_envelope", "response_payment_id", "response_status",
+        "response_attempts", "next_response_attempt_at", "delivery_deadline",
+        "delivered_at", "details_pruned_at",
+    ];
+    if current_columns.iter().all(|column| columns.contains(*column)) {
+        conn.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+        return Ok(());
+    }
+
+    // An earlier correlated-trade prototype used this table name with an incompatible shape.
+    // Rebuild it transactionally: its already-sent responses remain terminal dedup tombstones,
+    // while new decisions use the request hash and retry lifecycle required by the protocol.
+    let legacy_columns = [
+        "inbound_payment_id", "trade_id", "channel_id", "user_channel_id",
+        "counterparty", "outcome", "reason_code", "expected_usd", "backing_sats",
+        "sync_version", "response_envelope", "response_payment_id", "response_status",
+        "response_attempts", "next_response_attempt_at", "created_at", "resolved_at",
+    ];
+    if let Some(missing) = legacy_columns.iter().find(|column| !columns.contains(**column)) {
+        return Err(rusqlite::Error::InvalidColumnName(format!(
+            "unsupported trade_decisions schema: missing {missing}"
+        )));
+    }
+
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    tx.execute("ALTER TABLE trade_decisions RENAME TO trade_decisions_legacy_v1", [])?;
+    tx.execute(CREATE_TRADE_DECISIONS_TABLE, [])?;
+    tx.execute(
+        "INSERT INTO trade_decisions (
+            inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
+            counterparty, outcome, reason_code, expected_usd, backing_sats, sync_version,
+            decided_at, response_envelope, response_payment_id, response_status,
+            response_attempts, next_response_attempt_at, delivery_deadline, delivered_at
+         )
+         SELECT inbound_payment_id, COALESCE(NULLIF(trade_id, ''), inbound_payment_id),
+            inbound_payment_id, channel_id, user_channel_id, counterparty, outcome,
+            reason_code, expected_usd, backing_sats, sync_version, created_at,
+            response_envelope, response_payment_id,
+            CASE WHEN response_status IN ('succeeded', 'delivered')
+                 THEN 'delivered' ELSE 'abandoned' END,
+            response_attempts, next_response_attempt_at, created_at,
+            CASE WHEN response_status IN ('succeeded', 'delivered')
+                 THEN COALESCE(resolved_at, created_at) ELSE NULL END
+         FROM trade_decisions_legacy_v1",
+        [],
+    )?;
+    tx.execute("DROP TABLE trade_decisions_legacy_v1", [])?;
+    tx.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+    tx.commit()
+}
+
 /// Thread-safe database handle
 #[derive(Clone)]
 pub struct Database {
@@ -112,13 +216,57 @@ pub fn forward_fingerprint(
     )
 }
 
-/// A still-pending trade recoverable after a restart (the in-memory pending-trade map is empty on launch).
+/// An unresolved or historically resolved trade addressable by protocol correlation fields.
+#[derive(Debug, Clone, PartialEq)]
 pub struct PendingTradeRow {
     pub id: i64,
+    pub channel_id: String,
+    pub trade_id: Option<String>,
+    pub payment_id: Option<String>,
+    pub request_hash: Option<String>,
+    pub fee_msat: u64,
     pub new_expected_usd: f64,
     pub btc_price: f64,
     pub new_backing_sats: Option<u64>,
     pub action: String,
+    pub status: String,
+}
+
+fn pending_trade_from_row(row: &rusqlite::Row<'_>) -> SqliteResult<PendingTradeRow> {
+    Ok(PendingTradeRow {
+        id: row.get(0)?,
+        channel_id: row.get(1)?,
+        trade_id: row.get(2)?,
+        payment_id: row.get(3)?,
+        request_hash: row.get(4)?,
+        fee_msat: row.get::<_, i64>(5)?.max(0) as u64,
+        new_expected_usd: row.get(6)?,
+        btc_price: row.get(7)?,
+        new_backing_sats: row.get::<_, Option<i64>>(8)?.map(|value| value.max(0) as u64),
+        action: row.get(9)?,
+        status: row.get(10)?,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TradeDecisionIdentity {
+    pub inbound_payment_id: String,
+    pub trade_id: String,
+    pub request_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingTradeResponse {
+    pub inbound_payment_id: String,
+    pub counterparty: String,
+    pub response_envelope: String,
+    pub attempts: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CorrelatedTradeAcceptance {
+    pub trade_resolved: bool,
+    pub allocation_applied: bool,
 }
 
 fn finish_transaction<T>(conn: &Connection, result: SqliteResult<T>) -> SqliteResult<T> {
@@ -170,7 +318,7 @@ impl Database {
 
     /// Initialize database schema
     fn init_schema(&self) -> SqliteResult<()> {
-        let conn = self.conn.lock().unwrap();
+        let mut conn = self.conn.lock().unwrap();
 
         // Channels table - stores channel settings
         conn.execute(
@@ -219,6 +367,31 @@ impl Database {
         // Exact allocation signed in TRADE_V1. NULL identifies trades written by older wallets,
         // which still need the legacy price-derived recovery path.
         let _ = conn.execute("ALTER TABLE trades ADD COLUMN new_backing_sats INTEGER", []);
+
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN trade_id TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN request_hash TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN request_payload TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN fee_msat INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN fee_status TEXT NOT NULL DEFAULT 'legacy'",
+            [],
+        );
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN failure_code TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN expires_at INTEGER", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN resolved_at INTEGER", []);
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_trade_id
+             ON trades(trade_id) WHERE trade_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trades_unresolved_channel
+             ON trades(channel_id, status)",
+            [],
+        )?;
 
         // Migration: Add stable_sats column to channels table if missing
         // stable_sats tracks the BTC backing the stable portion (excludes native BTC)
@@ -444,6 +617,8 @@ impl Database {
              ON inbound_stability_settlements(state, updated_at)",
             [],
         )?;
+
+        init_trade_decisions_schema(&mut conn)?;
 
         // Forwarded-payment dedup: tracks fingerprints of forwards already audited (live or backfilled)
         conn.execute(
@@ -831,6 +1006,246 @@ impl Database {
         Ok(version as u64)
     }
 
+    pub fn candidate_sync_version(&self, user_channel_id: &str) -> SqliteResult<u64> {
+        let conn = self.conn.lock().unwrap();
+        let current: i64 = conn.query_row(
+            "SELECT sync_version FROM channels WHERE user_channel_id = ?1",
+            params![user_channel_id],
+            |row| row.get(0),
+        )?;
+        current
+            .checked_add(1)
+            .filter(|version| *version > 0)
+            .map(|version| version as u64)
+            .ok_or(rusqlite::Error::IntegralValueOutOfRange(0, current))
+    }
+
+    pub fn trade_decision_by_payment(
+        &self,
+        inbound_payment_id: &str,
+    ) -> SqliteResult<Option<TradeDecisionIdentity>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT inbound_payment_id, trade_id, request_hash
+             FROM trade_decisions WHERE inbound_payment_id = ?1",
+            params![inbound_payment_id],
+            |row| Ok(TradeDecisionIdentity {
+                inbound_payment_id: row.get(0)?,
+                trade_id: row.get(1)?,
+                request_hash: row.get(2)?,
+            }),
+        ).optional()
+    }
+
+    pub fn trade_decision_by_trade_id(
+        &self,
+        trade_id: &str,
+    ) -> SqliteResult<Option<TradeDecisionIdentity>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT inbound_payment_id, trade_id, request_hash
+             FROM trade_decisions WHERE trade_id = ?1",
+            params![trade_id],
+            |row| Ok(TradeDecisionIdentity {
+                inbound_payment_id: row.get(0)?,
+                trade_id: row.get(1)?,
+                request_hash: row.get(2)?,
+            }),
+        ).optional()
+    }
+
+    pub fn requeue_exact_trade_response(
+        &self,
+        inbound_payment_id: &str,
+        trade_id: &str,
+        request_hash: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions
+             SET response_status = 'pending', response_payment_id = NULL,
+                 next_response_attempt_at = ?4
+             WHERE inbound_payment_id = ?1 AND trade_id = ?2 AND request_hash = ?3
+               AND response_envelope IS NOT NULL AND delivery_deadline > ?4",
+            params![inbound_payment_id, trade_id, request_hash, now],
+        )?;
+        Ok(updated == 1)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn persist_trade_rejection(
+        &self,
+        inbound_payment_id: &str,
+        trade_id: &str,
+        request_hash: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        counterparty: &str,
+        reason_code: &str,
+        decided_at: i64,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        let deadline = decided_at.saturating_add(
+            crate::constants::TRADE_RESPONSE_RETRY_WINDOW_SECS.min(i64::MAX as u64) as i64,
+        );
+        let conn = self.conn.lock().unwrap();
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO trade_decisions (
+                inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
+                counterparty, outcome, reason_code, decided_at, response_envelope,
+                next_response_attempt_at, delivery_deadline
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'rejected', ?7, ?8, ?9, ?8, ?10)",
+            params![inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
+                counterparty, reason_code, decided_at, response_envelope, deadline],
+        )?;
+        Ok(inserted == 1)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn persist_trade_acceptance(
+        &self,
+        inbound_payment_id: &str,
+        trade_id: &str,
+        request_hash: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        counterparty: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        sync_version: u64,
+        decided_at: i64,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        if !expected_usd.is_finite() || expected_usd < 0.0
+            || backing_sats > i64::MAX as u64 || native_sats > i64::MAX as u64
+            || sync_version == 0 || sync_version > i64::MAX as u64 {
+            return Ok(false);
+        }
+        let deadline = decided_at.saturating_add(
+            crate::constants::TRADE_RESPONSE_RETRY_WINDOW_SECS.min(i64::MAX as u64) as i64,
+        );
+        let previous_version = sync_version as i64 - 1;
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let duplicate: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM trade_decisions
+             WHERE inbound_payment_id = ?1 OR trade_id = ?2)",
+            params![inbound_payment_id, trade_id], |row| row.get(0),
+        )?;
+        if duplicate { tx.commit()?; return Ok(false); }
+        let updated = tx.execute(
+            "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
+             native_sats = ?4, sync_version = ?5, updated_at = strftime('%s', 'now'),
+             closed_at = NULL WHERE user_channel_id = ?6 AND sync_version = ?7",
+            params![channel_id, expected_usd, backing_sats as i64, native_sats as i64,
+                sync_version as i64, user_channel_id, previous_version],
+        )?;
+        if updated != 1 { tx.rollback()?; return Ok(false); }
+        tx.execute(
+            "INSERT INTO trade_decisions (inbound_payment_id, trade_id, request_hash,
+             channel_id, user_channel_id, counterparty, outcome, expected_usd, backing_sats,
+             sync_version, decided_at, response_envelope, next_response_attempt_at,
+             delivery_deadline) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'accepted', ?7, ?8,
+             ?9, ?10, ?11, ?10, ?12)",
+            params![inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
+                counterparty, expected_usd, backing_sats as i64, sync_version as i64,
+                decided_at, response_envelope, deadline],
+        )?;
+        tx.commit()?;
+        Ok(true)
+    }
+
+    pub fn due_trade_responses(&self, now: i64, limit: usize) -> SqliteResult<Vec<PendingTradeResponse>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT inbound_payment_id, counterparty, response_envelope, response_attempts
+             FROM trade_decisions WHERE response_status = 'pending'
+             AND next_response_attempt_at <= ?1 AND delivery_deadline > ?1
+             AND response_envelope IS NOT NULL ORDER BY next_response_attempt_at, decided_at LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![now, limit as i64], |row| Ok(PendingTradeResponse {
+            inbound_payment_id: row.get(0)?, counterparty: row.get(1)?,
+            response_envelope: row.get(2)?, attempts: row.get::<_, i64>(3)?.max(0) as u32,
+        }))?;
+        rows.collect()
+    }
+
+    fn trade_response_delay_secs(attempt: u32) -> i64 {
+        let exponent = attempt.saturating_sub(1).min(10);
+        5_i64.saturating_mul(1_i64 << exponent).min(60 * 60)
+    }
+
+    pub fn reserve_trade_response_attempt(&self, inbound_payment_id: &str,
+        expected_attempts: u32, now: i64) -> SqliteResult<bool> {
+        let next_attempt = expected_attempts.saturating_add(1);
+        let next_at = now.saturating_add(Self::trade_response_delay_secs(next_attempt));
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE trade_decisions SET response_attempts = ?2, next_response_attempt_at = ?3
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'
+             AND response_attempts = ?4 AND next_response_attempt_at <= ?5
+             AND delivery_deadline > ?5 AND response_envelope IS NOT NULL",
+            params![inbound_payment_id, next_attempt, next_at, expected_attempts, now],
+        )?;
+        Ok(updated == 1)
+    }
+
+    pub fn mark_trade_response_in_flight(&self, inbound_payment_id: &str,
+        response_payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trade_decisions SET response_status = 'in_flight', response_payment_id = ?2
+             WHERE inbound_payment_id = ?1 AND response_status = 'pending'",
+            params![inbound_payment_id, response_payment_id],
+        )? == 1)
+    }
+
+    pub fn in_flight_trade_response_payment_ids(&self) -> SqliteResult<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT response_payment_id FROM trade_decisions
+             WHERE response_status = 'in_flight' AND response_payment_id IS NOT NULL")?;
+        let payment_ids = stmt.query_map([], |row| row.get(0))?.collect();
+        payment_ids
+    }
+
+    pub fn mark_trade_response_delivered(&self, response_payment_id: &str, now: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trade_decisions SET response_status = 'delivered',
+             delivered_at = COALESCE(delivered_at, ?2)
+             WHERE response_payment_id = ?1 AND response_status <> 'delivered'",
+            params![response_payment_id, now],
+        )? > 0)
+    }
+
+    pub fn mark_trade_response_failed(&self, response_payment_id: &str, now: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trade_decisions SET response_status = 'pending', response_payment_id = NULL,
+             next_response_attempt_at = MAX(next_response_attempt_at, ?2)
+             WHERE response_payment_id = ?1 AND response_status = 'in_flight'",
+            params![response_payment_id, now],
+        )? > 0)
+    }
+
+    pub fn abandon_expired_trade_responses(&self, now: i64) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("UPDATE trade_decisions SET response_status = 'abandoned'
+             WHERE response_status IN ('pending', 'in_flight') AND delivery_deadline <= ?1", params![now])
+    }
+
+    pub fn prune_trade_response_details(&self, now: i64) -> SqliteResult<usize> {
+        let cutoff = now.saturating_sub(
+            crate::constants::TRADE_RESPONSE_DETAIL_RETENTION_SECS.min(i64::MAX as u64) as i64,
+        );
+        let conn = self.conn.lock().unwrap();
+        conn.execute("UPDATE trade_decisions SET response_envelope = NULL, details_pruned_at = ?1
+             WHERE response_status IN ('delivered', 'abandoned') AND decided_at <= ?2
+             AND response_envelope IS NOT NULL", params![now, cutoff])
+    }
+
     /// Apply a signed inbound SYNC_V1 allocation only when its version is newer.
     /// The version and allocation share one SQLite statement, so a crash cannot
     /// persist one without the other. Returns false for stale/replayed versions.
@@ -1204,6 +1619,52 @@ impl Database {
         Ok(conn.last_insert_rowid())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_prepared_trade(&self, channel_id: &str, trade_id: &str,
+        request_hash: &str, request_payload: &str, action: &str, amount_usd: f64,
+        amount_btc: f64, btc_price: f64, fee_usd: f64, fee_msat: u64,
+        new_expected_usd: f64, new_backing_sats: u64, expires_at: i64) -> SqliteResult<i64> {
+        if !crate::trade::is_channel_id(channel_id) || !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_request_hash(request_hash)
+            || crate::trade::request_hash(request_payload.as_bytes()) != request_hash
+            || fee_msat > i64::MAX as u64 || new_backing_sats > i64::MAX as u64
+            || !new_expected_usd.is_finite() || new_expected_usd < 0.0 {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO trades (channel_id, trade_id, request_hash, request_payload, action,
+             amount_usd, amount_btc, btc_price, fee_usd, fee_msat, fee_status, new_expected_usd,
+             new_backing_sats, status, expires_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8,
+             ?9, ?10, 'sending', ?11, ?12, 'sending', ?13)",
+            params![channel_id, trade_id, request_hash, request_payload, action, amount_usd,
+                amount_btc, btc_price, fee_usd, fee_msat as i64, new_expected_usd,
+                new_backing_sats as i64, expires_at],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn attach_trade_payment_id(&self, trade_db_id: i64, payment_id: &str) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(payment_id) { return Ok(false); }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute("UPDATE trades SET payment_id = ?2, fee_status = 'pending',
+             status = 'awaiting_result' WHERE id = ?1 AND payment_id IS NULL AND status = 'sending'",
+            params![trade_db_id, payment_id])? == 1)
+    }
+
+    pub fn mark_trade_send_failed(&self, trade_db_id: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute("UPDATE trades SET status = 'payment_failed', fee_status = 'failed',
+             failure_code = 'payment_failed', resolved_at = strftime('%s', 'now')
+             WHERE id = ?1 AND status = 'sending'", params![trade_db_id])? == 1)
+    }
+
+    pub fn mark_trade_fee_paid(&self, payment_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute("UPDATE trades SET fee_status = 'paid' WHERE payment_id = ?1
+             AND status IN ('sending', 'awaiting_result', 'outcome_unknown')", params![payment_id])? == 1)
+    }
+
     /// Look up a still-pending trade by its payment_id, for restart recovery. Only returns rows
     /// that have either an exact allocation or a non-zero legacy target.
     pub fn get_pending_trade_by_payment_id(
@@ -1212,20 +1673,13 @@ impl Database {
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
-             WHERE payment_id = ?1 AND status = 'pending'
+            "SELECT id, channel_id, trade_id, payment_id, request_hash, fee_msat,
+                    new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
+             WHERE payment_id = ?1 AND status IN ('pending', 'sending', 'awaiting_result', 'outcome_unknown')
                AND (new_backing_sats IS NOT NULL OR new_expected_usd > 0.0)
              ORDER BY id DESC LIMIT 1",
             params![payment_id],
-            |row| {
-                Ok(PendingTradeRow {
-                    id: row.get(0)?,
-                    new_expected_usd: row.get(1)?,
-                    btc_price: row.get(2)?,
-                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
-                    action: row.get(4)?,
-                })
-            },
+            pending_trade_from_row,
         )
         .optional()
     }
@@ -1238,22 +1692,162 @@ impl Database {
     ) -> SqliteResult<Option<PendingTradeRow>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, new_expected_usd, btc_price, new_backing_sats, action FROM trades
-             WHERE status = 'pending'
+            "SELECT id, channel_id, trade_id, payment_id, request_hash, fee_msat,
+                    new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
+             WHERE status = 'pending' AND trade_id IS NULL
                AND ABS(new_expected_usd - ?1) <= 0.000000001
              ORDER BY id DESC LIMIT 1",
             params![new_expected_usd],
-            |row| {
-                Ok(PendingTradeRow {
-                    id: row.get(0)?,
-                    new_expected_usd: row.get(1)?,
-                    btc_price: row.get(2)?,
-                    new_backing_sats: row.get::<_, Option<i64>>(3)?.map(|v| v.max(0) as u64),
-                    action: row.get(4)?,
-                })
-            },
+            pending_trade_from_row,
         )
         .optional()
+    }
+
+    pub fn get_trade_by_correlation(&self, trade_id: &str, trade_payment_id: &str,
+        request_hash: &str) -> SqliteResult<Option<PendingTradeRow>> {
+        if !crate::trade::is_trade_id(trade_id) || !crate::trade::is_payment_id(trade_payment_id)
+            || !crate::trade::is_request_hash(request_hash) { return Ok(None); }
+        let conn = self.conn.lock().unwrap();
+        conn.query_row("SELECT id, channel_id, trade_id, payment_id, request_hash, fee_msat,
+             new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
+             WHERE trade_id = ?1 AND request_hash = ?2 AND (payment_id IS NULL OR payment_id = ?3)
+             LIMIT 1", params![trade_id, request_hash, trade_payment_id], pending_trade_from_row).optional()
+    }
+
+    pub fn mark_trade_rejected(&self, trade_db_id: i64, trade_payment_id: &str,
+        reason_code: &str, decided_at: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute("UPDATE trades SET status = 'rejected', fee_status = 'paid',
+             failure_code = ?3, payment_id = COALESCE(payment_id, ?2), resolved_at = ?4
+             WHERE id = ?1 AND status IN ('sending', 'awaiting_result', 'outcome_unknown')
+             AND (payment_id IS NULL OR payment_id = ?2)",
+            params![trade_db_id, trade_payment_id, reason_code, decided_at])? == 1)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_correlated_trade_acceptance(&self, user_channel_id: &str, sync_version: u64,
+        expected_usd: f64, backing_sats: u64, native_sats: u64, trade_db_id: i64,
+        trade_payment_id: &str) -> SqliteResult<CorrelatedTradeAcceptance> {
+        let none = CorrelatedTradeAcceptance { trade_resolved: false, allocation_applied: false };
+        if sync_version == 0 || sync_version > i64::MAX as u64 || !expected_usd.is_finite()
+            || expected_usd < 0.0 || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64 { return Ok(none); }
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let trade: Option<(f64, Option<String>, String, Option<String>)> = tx.query_row(
+            "SELECT new_expected_usd, payment_id, status, trade_id FROM trades WHERE id = ?1",
+            params![trade_db_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        ).optional()?;
+        let Some((requested_usd, stored_payment_id, status, correlated_trade_id)) = trade else {
+            tx.commit()?;
+            return Ok(none);
+        };
+        if !crate::trade::target_matches(requested_usd, expected_usd)
+            || stored_payment_id.as_deref().is_some_and(|stored| stored != trade_payment_id) {
+            tx.commit()?; return Ok(none);
+        }
+        let unresolved = matches!(status.as_str(), "sending" | "awaiting_result" | "outcome_unknown");
+        let (current_version, before_expected, before_backing, before_native):
+            (i64, f64, i64, i64) = tx.query_row(
+                "SELECT sync_version, expected_usd, stable_sats, native_sats FROM channels
+                 WHERE user_channel_id = ?1",
+                params![user_channel_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )?;
+        let allocation_applied = unresolved && current_version < sync_version as i64 && tx.execute(
+            "UPDATE channels SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
+             sync_version = ?4, updated_at = strftime('%s', 'now')
+             WHERE user_channel_id = ?5 AND sync_version < ?4",
+            params![expected_usd, backing_sats as i64, native_sats as i64,
+                sync_version as i64, user_channel_id])? == 1;
+        let trade_resolved = unresolved && tx.execute(
+            "UPDATE trades SET status = 'accepted', fee_status = 'paid',
+             payment_id = COALESCE(payment_id, ?2), resolved_at = strftime('%s', 'now')
+             WHERE id = ?1 AND status IN ('sending', 'awaiting_result', 'outcome_unknown')",
+            params![trade_db_id, trade_payment_id])? == 1;
+        let ledger_mirror = if allocation_applied {
+            let draft = LedgerEventDraft {
+                event_type: "SYNC_V1_APPLIED".to_owned(),
+                category: "stability".to_owned(),
+                severity: "info".to_owned(),
+                status: "completed".to_owned(),
+                source: "signed_sync".to_owned(),
+                completeness: LedgerCompleteness::Observed,
+                occurred_at_ms: Utc::now().timestamp_millis(),
+                dedup_key: Some(format!(
+                    "signed-sync:sync-v1:{user_channel_id}:{sync_version}"
+                )),
+                before: Some(AccountingSnapshot {
+                    expected_usd: Some(before_expected),
+                    backing_sats: u64::try_from(before_backing).ok(),
+                    native_sats: u64::try_from(before_native).ok(),
+                    live_receiver_sats: u64::try_from(
+                        before_backing.saturating_add(before_native),
+                    ).ok(),
+                    ..Default::default()
+                }),
+                after: Some(AccountingSnapshot {
+                    expected_usd: Some(expected_usd),
+                    backing_sats: Some(backing_sats),
+                    native_sats: Some(native_sats),
+                    live_receiver_sats: Some(backing_sats.saturating_add(native_sats)),
+                    ..Default::default()
+                }),
+                detail: serde_json::json!({
+                    "user_channel_id": user_channel_id,
+                    "sync_version": sync_version,
+                    "trade_id": correlated_trade_id,
+                    "trade_db_id": trade_db_id,
+                    "new_expected_usd": expected_usd,
+                    "new_backing_sats": backing_sats,
+                    "new_native_sats": native_sats,
+                    "live_receiver_sats": backing_sats.saturating_add(native_sats),
+                }),
+                refs: vec![LedgerRef::new("user_channel_id", user_channel_id)],
+            };
+            let outcome = ledger::append_on_connection(&tx, &draft)?;
+            Some((draft, outcome))
+        } else {
+            None
+        };
+        tx.commit()?;
+        if let Some((draft, outcome)) = ledger_mirror {
+            if outcome.inserted {
+                crate::audit::mirror_committed_ledger_event(&draft, outcome.event_id);
+            }
+        }
+        Ok(CorrelatedTradeAcceptance { trade_resolved, allocation_applied })
+    }
+
+    pub fn mark_trade_payment_failed(&self, payment_id: &str) -> SqliteResult<Option<PendingTradeRow>> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let trade = tx.query_row("SELECT id, channel_id, trade_id, payment_id, request_hash,
+             fee_msat, new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
+             WHERE payment_id = ?1 AND status IN ('pending', 'sending', 'awaiting_result', 'outcome_unknown')
+             ORDER BY id DESC LIMIT 1", params![payment_id], pending_trade_from_row).optional()?;
+        if let Some(trade) = trade.as_ref() {
+            tx.execute("UPDATE trades SET status = 'payment_failed', fee_status = 'failed',
+                 failure_code = 'payment_failed', resolved_at = strftime('%s', 'now') WHERE id = ?1",
+                params![trade.id])?;
+        }
+        tx.commit()?;
+        Ok(trade)
+    }
+
+    pub fn mark_unresolved_trades_unknown(&self, now: i64) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("UPDATE trades SET status = 'outcome_unknown'
+             WHERE status IN ('sending', 'awaiting_result') AND expires_at IS NOT NULL
+             AND expires_at <= ?1", params![now])
+    }
+
+    pub fn has_unresolved_trade_for_channel(&self, channel_id: &str) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row("SELECT EXISTS(SELECT 1 FROM trades WHERE channel_id = ?1
+             AND status IN ('sending', 'awaiting_result', 'outcome_unknown'))",
+            params![channel_id], |row| row.get(0))
     }
 
     /// Whether this payment id belongs to any trade, including one already completed by an
@@ -1283,7 +1877,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, channel_id, action, amount_usd, amount_btc, btc_price, fee_usd,
-                    payment_id, status, created_at
+                    payment_id, status, created_at, failure_code
              FROM trades
              ORDER BY id DESC
              LIMIT ?1",
@@ -1301,6 +1895,7 @@ impl Database {
                 payment_id: row.get(7)?,
                 status: row.get(8)?,
                 created_at: row.get(9)?,
+                failure_code: row.get(10)?,
             })
         })?;
 
@@ -3523,6 +4118,7 @@ pub struct TradeRecord {
     pub payment_id: Option<String>,
     pub status: String,
     pub created_at: i64,
+    pub failure_code: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -4060,6 +4656,472 @@ mod tests {
         assert_eq!(db.next_sync_version("user-channel-1").unwrap(), 2);
         assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
         assert!(db.next_sync_version("missing").is_err());
+    }
+
+    #[test]
+    fn legacy_trade_decisions_are_migrated_to_terminal_dedup_records() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(DB_FILENAME);
+        let payment_id = "11".repeat(32);
+        let trade_id = "22".repeat(32);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE trade_decisions (
+                inbound_payment_id TEXT PRIMARY KEY,
+                trade_id TEXT,
+                channel_id TEXT NOT NULL,
+                user_channel_id TEXT NOT NULL,
+                counterparty TEXT NOT NULL,
+                outcome TEXT NOT NULL,
+                reason_code TEXT,
+                explanation TEXT,
+                expected_usd REAL,
+                backing_sats INTEGER,
+                sync_version INTEGER,
+                response_envelope TEXT NOT NULL,
+                response_amount_msat INTEGER NOT NULL,
+                response_payment_id TEXT,
+                response_status TEXT NOT NULL DEFAULT 'pending',
+                response_attempts INTEGER NOT NULL DEFAULT 0,
+                next_response_attempt_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+                resolved_at INTEGER,
+                remote_user_channel_id TEXT
+             );
+             CREATE INDEX idx_trade_decisions_response_due
+                ON trade_decisions(response_status, next_response_attempt_at);",
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO trade_decisions (
+                inbound_payment_id, trade_id, channel_id, user_channel_id, counterparty,
+                outcome, expected_usd, backing_sats, sync_version, response_envelope,
+                response_amount_msat, response_payment_id, response_status,
+                response_attempts, next_response_attempt_at, created_at, resolved_at
+             ) VALUES (?1, ?2, ?3, 'user-channel', 'counterparty', 'accepted', 20.0,
+                20000, 7, 'old-signed-sync', 1, ?4, 'succeeded', 1, 101, 100, 102)",
+            params![payment_id, trade_id, "33".repeat(32), "44".repeat(32)],
+        ).unwrap();
+        drop(conn);
+
+        let db = Database::open(directory.path()).unwrap();
+        assert_eq!(db.trade_decision_by_payment(&payment_id).unwrap(), Some(TradeDecisionIdentity {
+            inbound_payment_id: payment_id.clone(),
+            trade_id: trade_id.clone(),
+            request_hash: payment_id.clone(),
+        }));
+        let conn = db.conn.lock().unwrap();
+        let (status, delivered_at): (String, Option<i64>) = conn.query_row(
+            "SELECT response_status, delivered_at FROM trade_decisions
+             WHERE inbound_payment_id = ?1",
+            params![payment_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+        assert_eq!(status, "delivered");
+        assert_eq!(delivered_at, Some(102));
+        let columns = trade_decision_columns(&conn).unwrap();
+        assert!(columns.contains("request_hash"));
+        assert!(columns.contains("delivery_deadline"));
+        assert!(!columns.contains("response_amount_msat"));
+        drop(conn);
+
+        assert!(db.persist_trade_rejection(
+            &"55".repeat(32), &"66".repeat(32), &"77".repeat(32), &"88".repeat(32),
+            "user-channel", "counterparty", "internal_failure", 200,
+            "new-signed-rejection",
+        ).unwrap());
+        drop(db);
+
+        let reopened = Database::open(directory.path()).unwrap();
+        assert_eq!(reopened.due_trade_responses(200, 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn lsp_trade_acceptance_and_decision_commit_atomically() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "11".repeat(32);
+        let trade_id = "22".repeat(32);
+        let request_hash = "33".repeat(32);
+        let payment_id = "44".repeat(32);
+        db.save_channel(&channel_id, "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER reject_trade_decision BEFORE INSERT ON trade_decisions
+                 BEGIN SELECT RAISE(ABORT, 'injected decision failure'); END;",
+            )
+            .unwrap();
+        assert!(db
+            .persist_trade_acceptance(
+                &payment_id,
+                &trade_id,
+                &request_hash,
+                &channel_id,
+                "user-channel-1",
+                "counterparty",
+                20.0,
+                20_000,
+                4_000,
+                1,
+                100,
+                "signed-sync",
+            )
+            .is_err());
+        let unchanged = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(unchanged.expected_usd, 10.0);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(0));
+        assert!(db.trade_decision_by_payment(&payment_id).unwrap().is_none());
+
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TRIGGER reject_trade_decision")
+            .unwrap();
+        assert!(db
+            .persist_trade_acceptance(
+                &payment_id,
+                &trade_id,
+                &request_hash,
+                &channel_id,
+                "user-channel-1",
+                "counterparty",
+                20.0,
+                20_000,
+                4_000,
+                1,
+                100,
+                "signed-sync",
+            )
+            .unwrap());
+        let accepted = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(accepted.expected_usd, 20.0);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(1));
+        assert!(db.trade_decision_by_payment(&payment_id).unwrap().is_some());
+        assert!(!db
+            .persist_trade_acceptance(
+                &payment_id,
+                &trade_id,
+                &request_hash,
+                &channel_id,
+                "user-channel-1",
+                "counterparty",
+                30.0,
+                30_000,
+                1_000,
+                2,
+                101,
+                "different-sync",
+            )
+            .unwrap());
+        assert_eq!(
+            db.load_channel("user-channel-1")
+                .unwrap()
+                .unwrap()
+                .expected_usd,
+            20.0
+        );
+    }
+
+    #[test]
+    fn durable_trade_response_reserves_backoff_and_stops_after_delivery() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(Database::trade_response_delay_secs(1), 5);
+        assert_eq!(Database::trade_response_delay_secs(2), 10);
+        assert_eq!(Database::trade_response_delay_secs(100), 60 * 60);
+        let payment_id = "55".repeat(32);
+        assert!(db
+            .persist_trade_rejection(
+                &payment_id,
+                &"66".repeat(32),
+                &"77".repeat(32),
+                &"88".repeat(32),
+                "user-channel-1",
+                "counterparty",
+                "insufficient_capacity",
+                100,
+                "signed-rejection",
+            )
+            .unwrap());
+        let due = db.due_trade_responses(100, 10).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].attempts, 0);
+        assert!(db.reserve_trade_response_attempt(&payment_id, 0, 100).unwrap());
+        assert!(db.due_trade_responses(104, 10).unwrap().is_empty());
+        assert_eq!(db.due_trade_responses(105, 10).unwrap()[0].attempts, 1);
+
+        assert!(db.reserve_trade_response_attempt(&payment_id, 1, 105).unwrap());
+        let response_payment_id = "99".repeat(32);
+        assert!(db
+            .mark_trade_response_in_flight(&payment_id, &response_payment_id)
+            .unwrap());
+        assert_eq!(
+            db.in_flight_trade_response_payment_ids().unwrap(),
+            vec![response_payment_id.clone()]
+        );
+        assert!(db
+            .mark_trade_response_failed(&response_payment_id, 106)
+            .unwrap());
+        assert!(db.due_trade_responses(114, 10).unwrap().is_empty());
+        assert_eq!(db.due_trade_responses(115, 10).unwrap().len(), 1);
+
+        assert!(db.reserve_trade_response_attempt(&payment_id, 2, 115).unwrap());
+        assert!(db
+            .mark_trade_response_in_flight(&payment_id, &response_payment_id)
+            .unwrap());
+        assert!(db
+            .mark_trade_response_delivered(&response_payment_id, 116)
+            .unwrap());
+        assert!(db.due_trade_responses(i64::MAX / 2, 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn trade_response_retry_survives_restart_then_abandons_and_prunes_details() {
+        let directory = tempfile::tempdir().unwrap();
+        let payment_id = "0a".repeat(32);
+        {
+            let db = Database::open(directory.path()).unwrap();
+            assert!(db
+                .persist_trade_rejection(
+                    &payment_id,
+                    &"0b".repeat(32),
+                    &"0c".repeat(32),
+                    &"0d".repeat(32),
+                    "user-channel-1",
+                    "counterparty",
+                    "internal_failure",
+                    100,
+                    "signed-rejection",
+                )
+                .unwrap());
+        }
+
+        let db = Database::open(directory.path()).unwrap();
+        assert_eq!(db.due_trade_responses(100, 10).unwrap().len(), 1);
+        let deadline = 100 + crate::constants::TRADE_RESPONSE_RETRY_WINDOW_SECS as i64;
+        assert_eq!(db.abandon_expired_trade_responses(deadline).unwrap(), 1);
+        assert!(db.due_trade_responses(deadline, 10).unwrap().is_empty());
+        assert!(db.trade_decision_by_payment(&payment_id).unwrap().is_some());
+
+        let prune_at = 100 + crate::constants::TRADE_RESPONSE_DETAIL_RETENTION_SECS as i64;
+        assert_eq!(db.prune_trade_response_details(prune_at).unwrap(), 1);
+        let envelope: Option<String> = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT response_envelope FROM trade_decisions WHERE inbound_payment_id = ?1",
+                params![payment_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(envelope, None);
+        assert!(db.trade_decision_by_payment(&payment_id).unwrap().is_some());
+    }
+
+    fn prepare_correlated_trade(
+        db: &Database,
+        channel_id: &str,
+        user_channel_id: &str,
+        trade_id: &str,
+        payment_id: &str,
+        request_hash: &str,
+    ) -> i64 {
+        let payload = "exact signed payload";
+        db.save_channel(channel_id, user_channel_id, 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let row_id = db
+            .record_prepared_trade(
+                channel_id,
+                trade_id,
+                request_hash,
+                payload,
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.1,
+                100_000,
+                20.0,
+                20_000,
+                100,
+            )
+            .unwrap();
+        assert!(db.attach_trade_payment_id(row_id, payment_id).unwrap());
+        row_id
+    }
+
+    #[test]
+    fn correlated_trade_acceptance_appends_accounting_ledger_atomically() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "a1".repeat(32);
+        let trade_id = "b1".repeat(32);
+        let payment_id = "c1".repeat(32);
+        let request_hash = crate::trade::request_hash(b"exact signed payload");
+        let row_id = prepare_correlated_trade(
+            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+        );
+
+        let result = db
+            .apply_correlated_trade_acceptance(
+                "user-channel-1", 1, 20.0, 20_000, 5_000, row_id, &payment_id,
+            )
+            .unwrap();
+        assert_eq!(result, CorrelatedTradeAcceptance {
+            trade_resolved: true,
+            allocation_applied: true,
+        });
+        let events = db
+            .list_ledger_events(&LedgerQuery {
+                identifier: Some("user-channel-1".to_owned()),
+                limit: 20,
+                ..Default::default()
+            })
+            .unwrap()
+            .events;
+        let sync = events
+            .iter()
+            .find(|event| event.event_type == "SYNC_V1_APPLIED")
+            .unwrap();
+        assert_eq!(sync.before.as_ref().unwrap().backing_sats, Some(10_000));
+        assert_eq!(sync.after.as_ref().unwrap().backing_sats, Some(20_000));
+        assert_eq!(sync.after.as_ref().unwrap().native_sats, Some(5_000));
+        assert_eq!(sync.detail["trade_id"], trade_id);
+    }
+
+    #[test]
+    fn correlated_acceptance_ledger_failure_rolls_back_trade_and_allocation() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "a2".repeat(32);
+        let trade_id = "b2".repeat(32);
+        let payment_id = "c2".repeat(32);
+        let request_hash = crate::trade::request_hash(b"exact signed payload");
+        let row_id = prepare_correlated_trade(
+            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+        );
+        db.conn.lock().unwrap().execute_batch(
+            "CREATE TRIGGER inject_correlated_sync_ledger_failure
+             BEFORE INSERT ON ledger_events
+             WHEN NEW.event_type = 'SYNC_V1_APPLIED'
+             BEGIN SELECT RAISE(ABORT, 'injected ledger failure'); END;",
+        ).unwrap();
+
+        assert!(db
+            .apply_correlated_trade_acceptance(
+                "user-channel-1", 1, 20.0, 20_000, 5_000, row_id, &payment_id,
+            )
+            .is_err());
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 10.0);
+        assert_eq!(channel.backing_sats, 10_000);
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(0));
+        assert_eq!(
+            db.get_trade_by_correlation(&trade_id, &payment_id, &request_hash)
+                .unwrap()
+                .unwrap()
+                .status,
+            "awaiting_result"
+        );
+    }
+
+    #[test]
+    fn desktop_unknown_trade_accepts_late_older_correlated_sync_without_rollback() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "aa".repeat(32);
+        let trade_id = "bb".repeat(32);
+        let payment_id = "cc".repeat(32);
+        let request_hash = crate::trade::request_hash(b"exact signed payload");
+        let row_id = prepare_correlated_trade(
+            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+        );
+        assert!(db
+            .apply_sync_if_newer("user-channel-1", 2, 30.0, 30_000, 7_000)
+            .unwrap());
+        assert_eq!(db.mark_unresolved_trades_unknown(100).unwrap(), 1);
+
+        let result = db
+            .apply_correlated_trade_acceptance(
+                "user-channel-1",
+                1,
+                20.0,
+                20_000,
+                4_000,
+                row_id,
+                &payment_id,
+            )
+            .unwrap();
+        assert!(result.trade_resolved);
+        assert!(!result.allocation_applied);
+        let current = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(db.get_sync_version("user-channel-1").unwrap(), Some(2));
+        assert_eq!(current.expected_usd, 30.0);
+        assert_eq!(
+            db.get_trade_by_correlation(&trade_id, &payment_id, &request_hash)
+                .unwrap()
+                .unwrap()
+                .status,
+            "accepted"
+        );
+    }
+
+    #[test]
+    fn rejected_trade_cannot_later_apply_a_conflicting_acceptance() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "da".repeat(32);
+        let trade_id = "db".repeat(32);
+        let payment_id = "dc".repeat(32);
+        let payload = "signed request";
+        let request_hash = crate::trade::request_hash(payload.as_bytes());
+        db.save_channel(&channel_id, "user-channel-1", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let row_id = db
+            .record_prepared_trade(
+                &channel_id,
+                &trade_id,
+                &request_hash,
+                payload,
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.1,
+                100_000,
+                20.0,
+                20_000,
+                1_000,
+            )
+            .unwrap();
+        assert!(db.attach_trade_payment_id(row_id, &payment_id).unwrap());
+        assert!(db
+            .mark_trade_rejected(
+                row_id,
+                &payment_id,
+                "insufficient_capacity",
+                100,
+            )
+            .unwrap());
+        let result = db
+            .apply_correlated_trade_acceptance(
+                "user-channel-1",
+                1,
+                20.0,
+                20_000,
+                4_000,
+                row_id,
+                &payment_id,
+            )
+            .unwrap();
+        assert_eq!(
+            result,
+            CorrelatedTradeAcceptance {
+                trade_resolved: false,
+                allocation_applied: false,
+            }
+        );
+        let channel = db.load_channel("user-channel-1").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 10.0);
+        assert_eq!(channel.backing_sats, 10_000);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod historical_prices;
 pub mod ledger;
 pub mod price_feeds;
 pub mod stable;
+pub mod trade;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ pub mod db;
 pub mod ledger;
 pub mod price_feeds;
 pub mod stable;
+pub mod trade;
 pub mod types;
 pub mod user;
 

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -1,0 +1,177 @@
+//! Wire vocabulary shared by the desktop wallet and LSP trade protocol.
+
+use bitcoin::hashes::{sha256, Hash};
+use serde::{Deserialize, Serialize};
+
+/// Authenticated trade failures. These codes are deliberately closed: the wallet never renders
+/// peer-provided prose and ignores responses containing a code it does not understand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TradeRejectionReason {
+    InvalidAmount,
+    StaleRequest,
+    InvalidFee,
+    InvalidQuote,
+    QuoteDeviation,
+    InsufficientCapacity,
+    SettlementRequired,
+    UnsafeAllocation,
+    InternalFailure,
+}
+
+impl TradeRejectionReason {
+    pub const ALL: &'static [Self] = &[
+        Self::InvalidAmount,
+        Self::StaleRequest,
+        Self::InvalidFee,
+        Self::InvalidQuote,
+        Self::QuoteDeviation,
+        Self::InsufficientCapacity,
+        Self::SettlementRequired,
+        Self::UnsafeAllocation,
+        Self::InternalFailure,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidAmount => "invalid_amount",
+            Self::StaleRequest => "stale_request",
+            Self::InvalidFee => "invalid_fee",
+            Self::InvalidQuote => "invalid_quote",
+            Self::QuoteDeviation => "quote_deviation",
+            Self::InsufficientCapacity => "insufficient_capacity",
+            Self::SettlementRequired => "settlement_required",
+            Self::UnsafeAllocation => "unsafe_allocation",
+            Self::InternalFailure => "internal_failure",
+        }
+    }
+
+    pub fn from_code(code: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|reason| reason.as_str() == code)
+    }
+
+    /// Fixed local copy for the desktop UI. No arbitrary text from the peer is displayed.
+    pub const fn user_message(self) -> &'static str {
+        match self {
+            Self::InvalidAmount => "The trade amount is invalid. Review the amount and retry.",
+            Self::StaleRequest => {
+                "The quote expired before it could be accepted. Refresh and retry."
+            }
+            Self::InvalidFee => "The trade fee was invalid. Refresh the quote before retrying.",
+            Self::InvalidQuote => "A valid market quote is required. Refresh and retry.",
+            Self::QuoteDeviation => "The market moved outside the quote range. Refresh and retry.",
+            Self::InsufficientCapacity => {
+                "The channel does not have enough capacity for this trade. Reduce the amount."
+            }
+            Self::SettlementRequired => {
+                "Settle the current stability adjustment before retrying this trade."
+            }
+            Self::UnsafeAllocation => {
+                "This trade cannot preserve the current channel allocation safely."
+            }
+            Self::InternalFailure => "The provider could not process the trade. Try again later.",
+        }
+    }
+}
+
+/// Signed LSP rejection carried inside the existing stable-channel TLV.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TradeRejectedV1 {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub channel_id: String,
+    pub trade_id: String,
+    pub trade_payment_id: String,
+    pub request_hash: String,
+    pub reason_code: TradeRejectionReason,
+    pub decided_at: u64,
+}
+
+/// Canonical identifiers used by correlated trade messages are 32 bytes of lowercase hex.
+pub fn is_canonical_32_byte_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+pub fn is_trade_id(value: &str) -> bool {
+    is_canonical_32_byte_hex(value)
+}
+
+pub fn is_payment_id(value: &str) -> bool {
+    is_canonical_32_byte_hex(value)
+}
+
+pub fn is_request_hash(value: &str) -> bool {
+    is_canonical_32_byte_hex(value)
+}
+
+pub fn is_channel_id(value: &str) -> bool {
+    is_canonical_32_byte_hex(value)
+}
+
+/// Hash the exact signed TRADE_V1 payload bytes, without parsing or reserialization.
+pub fn request_hash(payload: &[u8]) -> String {
+    sha256::Hash::hash(payload).to_string()
+}
+
+/// The USD target is the contract; correlated responses never permit partial fills.
+pub fn target_matches(requested_usd: f64, answered_usd: f64) -> bool {
+    requested_usd.is_finite()
+        && answered_usd.is_finite()
+        && (requested_usd - answered_usd).abs() <= 0.000000001
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifiers_require_exact_lowercase_hex() {
+        let valid = "0123456789abcdef".repeat(4);
+        assert!(is_trade_id(&valid));
+        assert!(is_payment_id(&valid));
+        assert!(is_request_hash(&valid));
+        assert!(!is_trade_id(&valid.to_ascii_uppercase()));
+        assert!(!is_trade_id("abcd"));
+    }
+
+    #[test]
+    fn request_hash_uses_exact_payload_bytes() {
+        let compact = br#"{"type":"TRADE_V1","expected_usd":1}"#;
+        let spaced = br#"{"type": "TRADE_V1", "expected_usd": 1}"#;
+        assert_eq!(
+            request_hash(compact),
+            "53842fe0ffc7d71ad4b6f9d0940152f9803eba24ba30de840b8967c410acbcd4"
+        );
+        assert_ne!(request_hash(compact), request_hash(spaced));
+    }
+
+    #[test]
+    fn rejection_reasons_round_trip_with_wire_codes() {
+        for reason in TradeRejectionReason::ALL {
+            assert_eq!(
+                TradeRejectionReason::from_code(reason.as_str()),
+                Some(*reason)
+            );
+            assert_eq!(
+                serde_json::to_string(reason).unwrap(),
+                format!("\"{}\"", reason.as_str())
+            );
+            assert!(!reason.user_message().is_empty());
+        }
+        assert_eq!(TradeRejectionReason::from_code("peer_text"), None);
+    }
+
+    #[test]
+    fn target_matching_is_exact_with_float_noise_tolerance() {
+        assert!(target_matches(10.0, 10.0));
+        assert!(!target_matches(10.0, 9.99));
+        assert!(!target_matches(f64::NAN, 10.0));
+    }
+}

--- a/src/user.rs
+++ b/src/user.rs
@@ -156,6 +156,7 @@ pub struct PendingTrade {
     pub btc_amount: f64,
     pub btc_sats: u64,
     pub net_amount_usd: f64,
+    pub is_full_peg: bool,
 }
 
 /// Trade payment that's been sent but not yet confirmed by LDK.
@@ -183,6 +184,9 @@ struct IncomingSync {
     expected_usd: f64,
     backing_sats: u64,
     sync_version: u64,
+    trade_id: Option<String>,
+    trade_payment_id: Option<String>,
+    request_hash: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -191,7 +195,6 @@ enum LocalTradeAllocationError {
     LiveBalanceUnavailable,
     FeeExceedsBalance,
     TargetExceedsCapacity,
-    TargetExceedsSafeCapacity,
     SettlementRequired,
     UnsafeAllocation,
 }
@@ -681,6 +684,12 @@ impl UserApp {
         // Initialize SQLite database
         let db =
             Database::open(&data_dir).map_err(|e| format!("Failed to open database: {}", e))?;
+        let startup_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .min(i64::MAX as u64) as i64;
+        let _ = db.mark_unresolved_trades_unknown(startup_now);
 
         let mut app = Self {
             node: Arc::clone(&node),
@@ -1939,7 +1948,9 @@ impl UserApp {
         fee_usd: f64,
         trade_action: &str,
         trade_price: f64,
-    ) -> Option<(PaymentId, u64)> {
+        amount_usd: f64,
+        amount_btc: f64,
+    ) -> Option<(PaymentId, u64, i64)> {
         let new_expected_usd = stable::normalize_trade_expected_usd(new_expected_usd);
         // The fee is a direct keysend amount. Account for its whole-sat channel impact before
         // deriving the wallet's post-settlement allocation.
@@ -2000,10 +2011,6 @@ impl UserApp {
                     LocalTradeAllocationError::TargetExceedsCapacity => {
                         "The trade target exceeds the wallet's local channel capacity.".to_string()
                     }
-                    LocalTradeAllocationError::TargetExceedsSafeCapacity => {
-                        "The trade target is too close to the channel limit for independent price feeds. Reduce the amount and retry."
-                            .to_string()
-                    }
                     LocalTradeAllocationError::InvalidValues => {
                         "A trusted local price is required before trading.".to_string()
                     }
@@ -2029,10 +2036,23 @@ impl UserApp {
             }
         };
 
+        if self
+            .db
+            .has_unresolved_trade_for_channel(&channel_id_str)
+            .unwrap_or(true)
+        {
+            self.trade_error =
+                "A previous trade on this channel is still awaiting its authoritative result."
+                    .to_string();
+            self.status_message = self.trade_error.clone();
+            return None;
+        }
+
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
+        let trade_id = hex::encode(rand::random::<[u8; 32]>());
 
         // The quote is signed as the user's slippage bound and fee input. backing_sats remains
         // local state; a peer-supplied allocation must never become authoritative.
@@ -2040,6 +2060,7 @@ impl UserApp {
             "type": TRADE_MESSAGE_TYPE,
             "channel_id": channel_id_str,
             "user_channel_id": user_channel_id_str,
+            "trade_id": trade_id,
             "expected_usd": new_expected_usd,
             "quote_price": trade_price,
             "ts": ts,
@@ -2047,6 +2068,7 @@ impl UserApp {
 
         // Serialize payload and sign it with the node's key
         let payload_str = payload.to_string();
+        let request_hash = stable_channels::trade::request_hash(payload_str.as_bytes());
         let signature = self.node.sign_message(payload_str.as_bytes());
 
         // Envelope we actually send over the wire:
@@ -2057,6 +2079,37 @@ impl UserApp {
         });
 
         let signed_str = signed_msg.to_string();
+
+        let expires_at = ts
+            .saturating_add(TRADE_RESULT_TIMEOUT_SECS)
+            .min(i64::MAX as u64) as i64;
+        let trade_db_id = match self.db.record_prepared_trade(
+            &channel_id_str,
+            &trade_id,
+            &request_hash,
+            &payload_str,
+            trade_action,
+            amount_usd,
+            amount_btc,
+            trade_price,
+            fee_usd,
+            amt_msat,
+            new_expected_usd,
+            backing_sats,
+            expires_at,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                self.trade_error =
+                    "The trade intent could not be saved, so no fee was sent.".to_string();
+                self.status_message = self.trade_error.clone();
+                audit_event(
+                    "TRADE_INTENT_PERSIST_FAILED",
+                    json!({ "trade_id": trade_id, "error": error.to_string() }),
+                );
+                return None;
+            }
+        };
 
         // Build custom TLV record
         let custom_tlv = ldk_node::CustomTlvRecord {
@@ -2074,12 +2127,28 @@ impl UserApp {
                 // Don't apply_trade yet — wait for PaymentSuccessful event.
                 // Store pending info so we can finalize or revert later.
                 let payment_id_str = format!("{payment_id}");
+                if !self
+                    .db
+                    .attach_trade_payment_id(trade_db_id, &payment_id_str)
+                    .unwrap_or(false)
+                {
+                    audit_event(
+                        "TRADE_PAYMENT_ID_PERSIST_FAILED",
+                        json!({
+                            "trade_db_id": trade_db_id,
+                            "trade_id": trade_id,
+                            "payment_id": payment_id_str,
+                        }),
+                    );
+                }
 
                 self.status_message = format!("Order pending (fee: ${:.2})", fee_usd,);
                 audit_event(
                     "TRADE_MESSAGE_SENT",
                     json!({
                         "payment_id": payment_id_str,
+                        "trade_id": trade_id,
+                        "request_hash": request_hash,
                         "user_channel_id": user_channel_id_str,
                         "action": trade_action,
                         "old_expected_usd": old_expected_usd,
@@ -2094,15 +2163,17 @@ impl UserApp {
                     }),
                 );
 
-                Some((payment_id, backing_sats))
+                Some((payment_id, backing_sats, trade_db_id))
             }
             Err(e) => {
+                let _ = self.db.mark_trade_send_failed(trade_db_id);
                 self.status_message = format!("Failed to send order: {}", e);
                 self.trade_error = self.status_message.clone();
                 audit_event(
                     "TRADE_MESSAGE_FAILED",
                     json!({
                         "user_channel_id": user_channel_id_str,
+                        "trade_id": trade_id,
                         "action": trade_action,
                         "new_expected_usd": new_expected_usd,
                         "error": format!("{e}"),
@@ -2735,44 +2806,6 @@ impl UserApp {
         }
     }
 
-    /// Record a trade in the database. Returns the DB row id (0 on error).
-    fn record_trade(
-        &self,
-        action: &str,
-        amount_usd: f64,
-        amount_btc: f64,
-        btc_price: f64,
-        fee_usd: f64,
-        new_expected_usd: f64,
-        new_backing_sats: Option<u64>,
-        payment_id: Option<&str>,
-        status: &str,
-    ) -> i64 {
-        let user_channel_id_str = {
-            let sc = self.stable_channel.lock().unwrap();
-            format!("{}", sc.user_channel_id)
-        };
-
-        match self.db.record_trade(
-            &user_channel_id_str,
-            action,
-            amount_usd,
-            amount_btc,
-            btc_price,
-            fee_usd,
-            new_expected_usd,
-            new_backing_sats,
-            payment_id,
-            status,
-        ) {
-            Ok(id) => id,
-            Err(e) => {
-                eprintln!("Failed to record trade: {}", e);
-                0
-            }
-        }
-    }
-
     fn send_stable_message(&mut self) {
         let amt = 1;
         let custom_str = self.stable_message.clone();
@@ -3302,225 +3335,314 @@ impl UserApp {
                         );
                     }
 
-                    // Check for SYNC_V1 message from LSP (expected_usd synchronization)
+                    // Check for an authenticated trade result or ordinary SYNC_V1 from the LSP.
                     let handled_sync = if handled_signed_stability {
                         false
                     } else {
                         'sync: {
-                        for tlv in &custom_records {
-                            if tlv.type_num != STABLE_CHANNEL_TLV_TYPE {
-                                continue;
-                            }
-                            let raw = match String::from_utf8(tlv.value.clone()) {
-                                Ok(s) => s,
-                                Err(_) => continue,
-                            };
-                            let envelope: serde_json::Value = match serde_json::from_str(&raw) {
-                                Ok(v) => v,
-                                Err(_) => continue,
-                            };
-                            let payload_str = match envelope.get("payload").and_then(|v| v.as_str())
-                            {
-                                Some(s) => s,
-                                None => continue,
-                            };
-                            let signature = match envelope.get("signature").and_then(|v| v.as_str())
-                            {
-                                Some(s) => s,
-                                None => continue,
-                            };
-                            let payload: serde_json::Value = match serde_json::from_str(payload_str)
-                            {
-                                Ok(v) => v,
-                                Err(_) => continue,
-                            };
-                            if payload.get("type").and_then(|v| v.as_str())
-                                != Some(SYNC_MESSAGE_TYPE)
-                            {
-                                continue;
-                            }
-                            // Verify signature against LSP (counterparty)
-                            let counterparty = {
-                                let sc = self.stable_channel.lock().unwrap();
-                                sc.counterparty
-                            };
-                            let sig_ok = self.node.verify_signature(
-                                payload_str.as_bytes(),
-                                signature,
-                                &counterparty,
-                            );
-                            if !sig_ok {
-                                audit_event(
-                                    "SYNC_V1_SIGNATURE_INVALID",
-                                    json!({
-                                        "payment_hash": &payment_hash_str,
-                                    }),
-                                );
-                                continue;
-                            }
-                            let Some(sync) = parse_incoming_sync(&payload) else {
-                                audit_event(
-                                    "SYNC_V1_PAYLOAD_INVALID",
-                                    json!({ "payment_hash": &payment_hash_str }),
-                                );
-                                break 'sync true;
-                            };
-
-                            let mut sc = self.stable_channel.lock().unwrap();
-                            let wallet_channel_id = sc.channel_id.to_string();
-                            if sync.channel_id != wallet_channel_id {
-                                audit_event(
-                                    "SYNC_V1_CHANNEL_MISMATCH",
-                                    json!({
-                                        "payment_hash": &payment_hash_str,
-                                        "payload_channel_id": sync.channel_id.clone(),
-                                        "wallet_channel_id": wallet_channel_id,
-                                        "sync_version": sync.sync_version,
-                                    }),
-                                );
-                                break 'sync true;
-                            }
-
-                            stable::update_balances(&self.node, &mut sc);
-                            let price = sc.latest_price;
-                            let old_expected = sc.expected_usd.0;
-                            let live_receiver_sats = sc.stable_receiver_btc.sats;
-                            let pending_trade = match self
-                                .db
-                                .get_pending_trade_by_expected_usd(sync.expected_usd)
-                            {
-                                Ok(trade) => trade,
-                                Err(e) => {
-                                    audit_event(
-                                        "DB_READ_FAILED",
-                                        json!({
-                                            "op": "get_pending_trade_by_expected_usd",
-                                            "payment_hash": &payment_hash_str,
-                                            "error": e.to_string(),
-                                        }),
-                                    );
-                                    ack = false;
-                                    break 'sync true;
+                            for tlv in &custom_records {
+                                if tlv.type_num != STABLE_CHANNEL_TLV_TYPE {
+                                    continue;
                                 }
-                            };
-                            let local_backing_sats = match local_sync_backing_sats(
-                                &sync,
-                                live_receiver_sats,
-                                price,
-                                old_expected,
-                                sc.backing_sats,
-                                pending_trade.as_ref(),
-                            ) {
-                                Ok(backing_sats) => backing_sats,
-                                Err(reason) => {
-                                    audit_event(
-                                        "SYNC_V1_ALLOCATION_REJECTED",
-                                        json!({
-                                            "payment_hash": &payment_hash_str,
-                                            "reason": reason,
-                                            "expected_usd": sync.expected_usd,
-                                            "peer_backing_sats": sync.backing_sats,
-                                            "live_receiver_sats": live_receiver_sats,
-                                            "btc_price": price,
-                                            "sync_version": sync.sync_version,
-                                        }),
-                                    );
-                                    break 'sync true;
+                                let Ok(raw) = std::str::from_utf8(&tlv.value) else {
+                                    continue;
+                                };
+                                let Ok(envelope) = serde_json::from_str::<serde_json::Value>(raw)
+                                else {
+                                    continue;
+                                };
+                                let Some(payload_str) =
+                                    envelope.get("payload").and_then(|value| value.as_str())
+                                else {
+                                    continue;
+                                };
+                                let Some(signature) =
+                                    envelope.get("signature").and_then(|value| value.as_str())
+                                else {
+                                    continue;
+                                };
+                                let Ok(payload) =
+                                    serde_json::from_str::<serde_json::Value>(payload_str)
+                                else {
+                                    continue;
+                                };
+                                let kind = payload.get("type").and_then(|value| value.as_str());
+                                if kind != Some(SYNC_MESSAGE_TYPE)
+                                    && kind != Some(TRADE_REJECTED_MESSAGE_TYPE)
+                                {
+                                    continue;
                                 }
-                            };
-                            if local_backing_sats != sync.backing_sats {
-                                audit_event(
-                                    "SYNC_V1_ALLOCATION_DIVERGENCE",
-                                    json!({
-                                        "payment_hash": &payment_hash_str,
-                                        "peer_backing_sats": sync.backing_sats,
-                                        "local_backing_sats": local_backing_sats,
-                                        "sync_version": sync.sync_version,
-                                    }),
-                                );
-                            }
-                            let native_sats =
-                                live_receiver_sats.saturating_sub(local_backing_sats);
-                            let user_channel_id = format!("{}", sc.user_channel_id);
-                            match self.db.apply_sync_if_newer_and_complete_trade(
-                                &user_channel_id,
-                                sync.sync_version,
-                                sync.expected_usd,
-                                local_backing_sats,
-                                native_sats,
-                                pending_trade.as_ref().map(|trade| trade.id),
-                            ) {
-                                Ok(true) => {
-                                    stable::apply_trade_allocation(
-                                        &mut sc,
-                                        sync.expected_usd,
-                                        local_backing_sats,
-                                    );
+
+                                let counterparty = self.stable_channel.lock().unwrap().counterparty;
+                                if !self.node.verify_signature(
+                                    payload_str.as_bytes(),
+                                    signature,
+                                    &counterparty,
+                                ) {
                                     audit_event(
-                                        "SYNC_V1_APPLIED",
-                                        json!({
-                                            "old_expected_usd": old_expected,
-                                            "new_expected_usd": sync.expected_usd,
-                                            "backing_sats": local_backing_sats,
-                                            "peer_backing_sats": sync.backing_sats,
-                                            "sync_version": sync.sync_version,
-                                            "live_receiver_sats": live_receiver_sats,
-                                            "btc_price": price,
-                                            "payment_hash": &payment_hash_str,
-                                        }),
+                                        "TRADE_RESULT_SIGNATURE_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str, "type": kind }),
                                     );
-                                    drop(sc);
-                                    if let Some(trade) = pending_trade {
-                                        self.pending_trade_payments
-                                            .retain(|_, pending| pending.trade_db_id != trade.id);
+                                    continue;
+                                }
+
+                                if kind == Some(TRADE_REJECTED_MESSAGE_TYPE) {
+                                    let Some(rejection) = parse_trade_rejection(payload_str) else {
                                         audit_event(
-                                            "TRADE_ACCEPTED_BY_LSP",
+                                            "TRADE_REJECTED_V1_PAYLOAD_INVALID",
+                                            json!({ "payment_hash": &payment_hash_str }),
+                                        );
+                                        break 'sync true;
+                                    };
+                                    let wallet_channel_id =
+                                        self.stable_channel.lock().unwrap().channel_id.to_string();
+                                    if amount_msat != 1
+                                        || rejection.channel_id != wallet_channel_id
+                                    {
+                                        audit_event(
+                                            "TRADE_REJECTED_V1_CONTEXT_INVALID",
+                                            json!({ "payment_hash": &payment_hash_str }),
+                                        );
+                                        break 'sync true;
+                                    }
+                                    let trade = match self.db.get_trade_by_correlation(
+                                        &rejection.trade_id,
+                                        &rejection.trade_payment_id,
+                                        &rejection.request_hash,
+                                    ) {
+                                        Ok(Some(trade)) if trade.channel_id == rejection.channel_id => trade,
+                                        Ok(_) => {
+                                            audit_event(
+                                                "TRADE_REJECTED_V1_UNMATCHED",
+                                                json!({ "payment_hash": &payment_hash_str }),
+                                            );
+                                            break 'sync true;
+                                        }
+                                        Err(error) => {
+                                            audit_event(
+                                                "DB_READ_FAILED",
+                                                json!({ "op": "get_trade_by_correlation", "error": error.to_string() }),
+                                            );
+                                            ack = false;
+                                            break 'sync true;
+                                        }
+                                    };
+                                    match self.db.mark_trade_rejected(
+                                        trade.id,
+                                        &rejection.trade_payment_id,
+                                        rejection.reason_code.as_str(),
+                                        rejection.decided_at as i64,
+                                    ) {
+                                        Ok(true) => {
+                                            self.pending_trade_payments.retain(|_, pending| {
+                                                pending.trade_db_id != trade.id
+                                            });
+                                            self.status_message =
+                                                rejection.reason_code.user_message().to_string();
+                                            self.show_toast("Trade rejected", "X");
+                                            audit_event(
+                                                "TRADE_REJECTED_BY_LSP",
+                                                json!({
+                                                    "trade_id": rejection.trade_id,
+                                                    "reason_code": rejection.reason_code.as_str(),
+                                                    "decided_at": rejection.decided_at,
+                                                }),
+                                            );
+                                        }
+                                        Ok(false) => {}
+                                        Err(error) => {
+                                            audit_event(
+                                                "DB_WRITE_FAILED",
+                                                json!({ "op": "mark_trade_rejected", "error": error.to_string() }),
+                                            );
+                                            ack = false;
+                                        }
+                                    }
+                                    break 'sync true;
+                                }
+
+                                let Some(sync) = parse_incoming_sync(&payload) else {
+                                    audit_event(
+                                        "SYNC_V1_PAYLOAD_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str }),
+                                    );
+                                    break 'sync true;
+                                };
+                                let correlation = sync
+                                    .trade_id
+                                    .as_deref()
+                                    .zip(sync.trade_payment_id.as_deref())
+                                    .zip(sync.request_hash.as_deref())
+                                    .map(|((trade_id, payment_id), request_hash)| {
+                                        (trade_id, payment_id, request_hash)
+                                    });
+                                if correlation.is_some() && amount_msat != 1 {
+                                    audit_event(
+                                        "SYNC_V1_CORRELATED_AMOUNT_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str, "amount_msat": amount_msat }),
+                                    );
+                                    break 'sync true;
+                                }
+
+                                let mut sc = self.stable_channel.lock().unwrap();
+                                let wallet_channel_id = sc.channel_id.to_string();
+                                if sync.channel_id != wallet_channel_id {
+                                    audit_event(
+                                        "SYNC_V1_CHANNEL_MISMATCH",
+                                        json!({
+                                            "payment_hash": &payment_hash_str,
+                                            "payload_channel_id": sync.channel_id,
+                                            "wallet_channel_id": wallet_channel_id,
+                                            "sync_version": sync.sync_version,
+                                        }),
+                                    );
+                                    break 'sync true;
+                                }
+
+                                let pending_trade = match correlation {
+                                    Some((trade_id, payment_id, request_hash)) => self
+                                        .db
+                                        .get_trade_by_correlation(
+                                            trade_id,
+                                            payment_id,
+                                            request_hash,
+                                        ),
+                                    None => self
+                                        .db
+                                        .get_pending_trade_by_expected_usd(sync.expected_usd),
+                                };
+                                let pending_trade = match pending_trade {
+                                    Ok(trade) => trade,
+                                    Err(error) => {
+                                        audit_event(
+                                            "DB_READ_FAILED",
+                                            json!({ "op": "find_trade_for_sync", "error": error.to_string() }),
+                                        );
+                                        ack = false;
+                                        break 'sync true;
+                                    }
+                                };
+                                if correlation.is_some()
+                                    && !pending_trade.as_ref().is_some_and(|trade| {
+                                        trade.channel_id == sync.channel_id
+                                            && stable_channels::trade::target_matches(
+                                                trade.new_expected_usd,
+                                                sync.expected_usd,
+                                            )
+                                    })
+                                {
+                                    audit_event(
+                                        "SYNC_V1_CORRELATION_INVALID",
+                                        json!({ "payment_hash": &payment_hash_str }),
+                                    );
+                                    break 'sync true;
+                                }
+
+                                stable::update_balances(&self.node, &mut sc);
+                                let price = sc.latest_price;
+                                let old_expected = sc.expected_usd.0;
+                                let live_receiver_sats = sc.stable_receiver_btc.sats;
+                                let local_backing_sats = match local_sync_backing_sats(
+                                    &sync,
+                                    live_receiver_sats,
+                                    price,
+                                    old_expected,
+                                    sc.backing_sats,
+                                    pending_trade.as_ref(),
+                                ) {
+                                    Ok(backing_sats) => backing_sats,
+                                    Err(reason) => {
+                                        audit_event(
+                                            "SYNC_V1_ALLOCATION_REJECTED",
+                                            json!({ "payment_hash": &payment_hash_str, "reason": reason }),
+                                        );
+                                        // A correlated result can arrive while another outbound
+                                        // HTLC temporarily lowers live capacity. Keep the local
+                                        // LDK event queued for retry instead of consuming it after
+                                        // the LSP has already observed successful delivery.
+                                        if correlation.is_some() {
+                                            ack = false;
+                                        }
+                                        break 'sync true;
+                                    }
+                                };
+                                let native_sats =
+                                    live_receiver_sats.saturating_sub(local_backing_sats);
+                                let user_channel_id = format!("{}", sc.user_channel_id);
+
+                                let persistence = if let Some((_, payment_id, _)) = correlation {
+                                    self.db
+                                        .apply_correlated_trade_acceptance(
+                                            &user_channel_id,
+                                            sync.sync_version,
+                                            sync.expected_usd,
+                                            local_backing_sats,
+                                            native_sats,
+                                            pending_trade.as_ref().unwrap().id,
+                                            payment_id,
+                                        )
+                                        .map(|result| {
+                                            (result.allocation_applied, result.trade_resolved)
+                                        })
+                                } else {
+                                    self.db
+                                        .apply_sync_if_newer_and_complete_trade(
+                                            &user_channel_id,
+                                            sync.sync_version,
+                                            sync.expected_usd,
+                                            local_backing_sats,
+                                            native_sats,
+                                            pending_trade.as_ref().map(|trade| trade.id),
+                                        )
+                                        .map(|applied| (applied, applied && pending_trade.is_some()))
+                                };
+                                match persistence {
+                                    Ok((allocation_applied, trade_resolved)) => {
+                                        if allocation_applied {
+                                            stable::apply_trade_allocation(
+                                                &mut sc,
+                                                sync.expected_usd,
+                                                local_backing_sats,
+                                            );
+                                        }
+                                        drop(sc);
+                                        if trade_resolved {
+                                            let trade = pending_trade.as_ref().unwrap();
+                                            self.pending_trade_payments.retain(|_, pending| {
+                                                pending.trade_db_id != trade.id
+                                            });
+                                            let verb = if trade.action == "buy" {
+                                                "USD → BTC"
+                                            } else {
+                                                "BTC → USD"
+                                            };
+                                            self.show_toast(
+                                                &format!("{} order confirmed", verb),
+                                                "OK",
+                                            );
+                                        }
+                                        audit_event(
+                                            "SYNC_V1_PROCESSED",
                                             json!({
-                                                "trade_id": trade.id,
-                                                "action": trade.action,
-                                                "expected_usd": sync.expected_usd,
-                                                "backing_sats": local_backing_sats,
                                                 "sync_version": sync.sync_version,
+                                                "allocation_applied": allocation_applied,
+                                                "trade_resolved": trade_resolved,
+                                                "local_backing_sats": local_backing_sats,
+                                                "peer_backing_sats": sync.backing_sats,
                                             }),
                                         );
-                                        let verb = if trade.action == "buy" {
-                                            "USD → BTC"
-                                        } else {
-                                            "BTC → USD"
-                                        };
-                                        self.show_toast(
-                                            &format!("{} order confirmed", verb),
-                                            "OK",
+                                    }
+                                    Err(error) => {
+                                        audit_event(
+                                            "DB_WRITE_FAILED",
+                                            json!({ "op": "apply_trade_sync", "error": error.to_string() }),
                                         );
+                                        ack = false;
                                     }
                                 }
-                                Ok(false) => {
-                                    audit_event(
-                                        "SYNC_V1_REPLAY_REJECTED",
-                                        json!({
-                                            "payment_hash": &payment_hash_str,
-                                            "user_channel_id": user_channel_id,
-                                            "sync_version": sync.sync_version,
-                                        }),
-                                    );
-                                }
-                                Err(e) => {
-                                    audit_event(
-                                        "DB_WRITE_FAILED",
-                                        json!({
-                                            "op": "apply_sync_if_newer",
-                                            "payment_hash": &payment_hash_str,
-                                            "user_channel_id": user_channel_id,
-                                            "sync_version": sync.sync_version,
-                                            "error": e.to_string(),
-                                        }),
-                                    );
-                                    ack = false;
-                                }
+                                break 'sync true;
                             }
-                            break 'sync true;
-                        }
-                        false
+                            false
                         }
                     };
 
@@ -3663,6 +3785,15 @@ impl UserApp {
                     ..
                 } => {
                     let payment_hash_str = format!("{payment_hash}");
+                    if let Some(pid) = payment_id {
+                        if let Err(error) = self.db.mark_trade_fee_paid(&format!("{pid}")) {
+                            ack = false;
+                            audit_event(
+                                "TRADE_FEE_STATUS_PERSIST_FAILED",
+                                json!({ "payment_id": format!("{pid}"), "error": error.to_string() }),
+                            );
+                        }
+                    }
 
                     // Payment success proves that the fee reached the LSP, not that it accepted the
                     // trade. Keep it pending until the LSP's signed SYNC_V1 arrives.
@@ -3803,40 +3934,47 @@ impl UserApp {
                     }
 
                     if !handled_stability_failure {
-                        // Check if this is a pending trade payment
-                        let mut pending_trade =
-                            payment_id.and_then(|pid| self.pending_trade_payments.remove(&pid));
-                        if pending_trade.is_none() {
-                            if let Some(pid) = payment_id {
-                                match self.db.get_pending_trade_by_payment_id(&format!("{pid}")) {
-                                    Ok(Some(row)) => {
-                                        pending_trade = Some(PendingTradePayment {
-                                            new_expected_usd: row.new_expected_usd,
-                                            backing_sats: row.new_backing_sats,
-                                            trade_db_id: row.id,
-                                            action: row.action,
-                                        });
+                        let mut is_trade_payment = false;
+                        let pending_trade = if let Some(pid) = payment_id {
+                            self.pending_trade_payments.remove(&pid);
+                            match self.db.mark_trade_payment_failed(&format!("{pid}")) {
+                                Ok(Some(row)) => {
+                                    is_trade_payment = true;
+                                    Some(PendingTradePayment {
+                                        new_expected_usd: row.new_expected_usd,
+                                        backing_sats: row.new_backing_sats,
+                                        trade_db_id: row.id,
+                                        action: row.action,
+                                    })
+                                }
+                                Ok(None) => match self.db.is_trade_payment(&format!("{pid}")) {
+                                    Ok(found) => {
+                                        is_trade_payment = found;
+                                        None
                                     }
-                                    Ok(None) => {}
-                                    Err(e) => {
+                                    Err(error) => {
                                         ack = false;
                                         audit_event(
                                             "TRADE_PAYMENT_CLASSIFICATION_FAILED",
-                                            json!({
-                                                "payment_id": format!("{pid}"),
-                                                "context": "payment_failed",
-                                                "error": e.to_string(),
-                                            }),
+                                            json!({ "payment_id": format!("{pid}"), "error": error.to_string() }),
                                         );
+                                        None
                                     }
+                                },
+                                Err(error) => {
+                                    ack = false;
+                                    audit_event(
+                                        "TRADE_PAYMENT_FAILURE_PERSIST_FAILED",
+                                        json!({ "payment_id": format!("{pid}"), "error": error.to_string() }),
+                                    );
+                                    None
                                 }
                             }
-                        }
+                        } else {
+                            None
+                        };
 
                         if let Some(trade) = pending_trade {
-                            // Trade payment failed — mark as failed, don't apply trade
-                            let _ = self.db.update_trade_status(trade.trade_db_id, "failed");
-
                             audit_event(
                                 "TRADE_FAILED",
                                 json!({
@@ -3854,7 +3992,7 @@ impl UserApp {
                             };
                             self.status_message = format!("{} order failed: {:?}", verb, reason);
                             self.show_toast(&format!("{} order failed", verb), "X");
-                        } else if ack {
+                        } else if !is_trade_payment && ack {
                             // Check if this is a pending outgoing payment
                             let pending =
                                 payment_id.and_then(|pid| self.pending_payments.remove(&pid));
@@ -5700,13 +5838,14 @@ impl UserApp {
             let spendable_onchain_sats = balances.spendable_onchain_balance_sats;
 
             // Get balance info
-            let (btc_price, last_update, expected_usd, backing_sats) = {
+            let (btc_price, last_update, expected_usd, backing_sats, receiver_sats) = {
                 let sc = self.stable_channel.lock().unwrap();
                 (
                     sc.latest_price,
                     sc.timestamp,
                     sc.expected_usd.0,
                     sc.backing_sats,
+                    sc.stable_receiver_btc.sats,
                 )
             };
 
@@ -5751,6 +5890,17 @@ impl UserApp {
                 expected_usd,
                 btc_price,
             );
+            let (_, receiver_native_sats, _) =
+                channel_balance_split(receiver_sats, backing_sats, expected_usd, btc_price);
+            let buy_available_usd = floor_usd_cents(stabilized_usd) as f64 / 100.0;
+            let sell_available_usd = max_sell_trade_usd_cents(
+                receiver_sats,
+                receiver_native_sats,
+                backing_sats,
+                expected_usd,
+                btc_price,
+            ) as f64
+                / 100.0;
 
             // Header row: "Total Balance" (click to toggle USD↔BTC) + refresh button
             ui.horizontal(|ui| {
@@ -5928,6 +6078,17 @@ impl UserApp {
                 let base_x_local = rect.width() * synth_ratio;
                 let base_x = rect.min.x + base_x_local;
                 let min_trade_usd = 1.0_f64;
+                let max_buy_drag_offset = if bar_total_usd > 0.0 {
+                    ((buy_available_usd / bar_total_usd) as f32 * rect.width()).min(base_x_local)
+                } else {
+                    0.0
+                };
+                let max_sell_drag_offset = if bar_total_usd > 0.0 {
+                    ((sell_available_usd / bar_total_usd) as f32 * rect.width())
+                        .min(rect.width() - base_x_local)
+                } else {
+                    0.0
+                };
 
                 // Begin drag if pointer started near the thumb.
                 if response.drag_started() {
@@ -5943,7 +6104,7 @@ impl UserApp {
                 if response.dragged() && self.bar_slider_dragging {
                     self.bar_slider_drag_offset = (self.bar_slider_drag_offset
                         + response.drag_delta().x)
-                        .clamp(-base_x_local, rect.width() - base_x_local);
+                        .clamp(-max_buy_drag_offset, max_sell_drag_offset);
                 }
 
                 if response.drag_stopped() && self.bar_slider_dragging {
@@ -5956,7 +6117,7 @@ impl UserApp {
                     if trade_usd >= min_trade_usd {
                         if self.bar_slider_drag_offset > 0.0 {
                             // Drag right → SELL native BTC, grow USD position.
-                            let clamped = trade_usd.min(native_usd).max(0.0);
+                            let clamped = trade_usd.min(sell_available_usd).max(0.0);
                             if clamped >= min_trade_usd {
                                 self.trade_amount_input = format!("{:.2}", clamped);
                                 self.trade_error.clear();
@@ -5965,7 +6126,7 @@ impl UserApp {
                             }
                         } else {
                             // Drag left → BUY BTC, shrink USD position.
-                            let clamped = trade_usd.min(stabilized_usd).max(0.0);
+                            let clamped = trade_usd.min(buy_available_usd).max(0.0);
                             if clamped >= min_trade_usd {
                                 self.trade_amount_input = format!("{:.2}", clamped);
                                 self.trade_error.clear();
@@ -6143,7 +6304,7 @@ impl UserApp {
                                 let native_btc = native_sats as f64 / 100_000_000.0;
                                 format!("{} BTC", Self::format_btc_spaced(native_btc))
                             } else {
-                                Self::format_price(native_usd)
+                                Self::format_price(floor_usd_cents(native_usd) as f64 / 100.0)
                             };
                             ui.label(
                                 RichText::new(native_text)
@@ -7144,6 +7305,11 @@ impl UserApp {
                     .add(make_action_btn("USD → BTC", theme::IOS_ORANGE))
                     .clicked()
                 {
+                    self.trade_amount_input.clear();
+                    self.trade_error.clear();
+                    self.pending_trade = None;
+                    self.show_confirm_trade = false;
+                    self.trade_success = None;
                     self.show_buy_modal = true;
                     self.modal_opened_at = std::time::Instant::now();
                 }
@@ -7152,6 +7318,11 @@ impl UserApp {
                     .add(make_action_btn("BTC → USD", theme::IOS_RED))
                     .clicked()
                 {
+                    self.trade_amount_input.clear();
+                    self.trade_error.clear();
+                    self.pending_trade = None;
+                    self.show_confirm_trade = false;
+                    self.trade_success = None;
                     self.show_sell_modal = true;
                     self.modal_opened_at = std::time::Instant::now();
                 }
@@ -7815,9 +7986,15 @@ impl UserApp {
                                     );
 
                                     let (status_label, status_color) = match trade.status.as_str() {
-                                        "completed" => ("Confirmed", theme::SUCCESS),
-                                        "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
-                                        "failed" => ("Failed", theme::DANGER_HOVER),
+                                        "completed" | "accepted" => ("Confirmed", theme::SUCCESS),
+                                        "pending" | "sending" | "awaiting_result" => {
+                                            ("Pending", Color32::from_rgb(234, 179, 8))
+                                        }
+                                        "outcome_unknown" => ("Unknown", theme::WARNING),
+                                        "rejected" => ("Rejected", theme::DANGER_HOVER),
+                                        "failed" | "payment_failed" => {
+                                            ("Failed", theme::DANGER_HOVER)
+                                        }
                                         _ => (&*trade.status, Color32::DARK_GRAY),
                                     };
                                     let (badge_rect, _) = ui.allocate_exact_size(
@@ -8177,6 +8354,14 @@ impl UserApp {
                     });
                     ui.add_space(2.0);
                 };
+                let wrapped_row = |ui: &mut egui::Ui, label: &str, value: &str| {
+                    ui.label(RichText::new(label).size(12.0).color(Color32::GRAY));
+                    ui.add(
+                        egui::Label::new(RichText::new(value).size(12.0).color(Color32::BLACK))
+                            .wrap(),
+                    );
+                    ui.add_space(6.0);
+                };
 
                 let action = if trade.action == "buy" {
                     "USD → BTC"
@@ -8194,9 +8379,13 @@ impl UserApp {
                 row(ui, "BTC Price", &Self::format_price(trade.btc_price));
 
                 let (status_label, status_color) = match trade.status.as_str() {
-                    "completed" => ("Confirmed", theme::SUCCESS),
-                    "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
-                    "failed" => ("Failed", theme::DANGER_HOVER),
+                    "completed" | "accepted" => ("Confirmed", theme::SUCCESS),
+                    "pending" | "sending" | "awaiting_result" => {
+                        ("Pending", Color32::from_rgb(234, 179, 8))
+                    }
+                    "outcome_unknown" => ("Unknown", theme::WARNING),
+                    "rejected" => ("Rejected", theme::DANGER_HOVER),
+                    "failed" | "payment_failed" => ("Failed", theme::DANGER_HOVER),
                     _ => (&*trade.status, Color32::DARK_GRAY),
                 };
                 ui.horizontal(|ui| {
@@ -8214,6 +8403,23 @@ impl UserApp {
                     });
                 });
                 ui.add_space(2.0);
+
+                if trade.status == "rejected" {
+                    if let Some(message) = trade
+                        .failure_code
+                        .as_deref()
+                        .and_then(stable_channels::trade::TradeRejectionReason::from_code)
+                        .map(|reason| reason.user_message())
+                    {
+                        wrapped_row(ui, "Reason", message);
+                    }
+                } else if trade.status == "outcome_unknown" {
+                    wrapped_row(
+                        ui,
+                        "Result",
+                        "Still awaiting the provider; another trade is blocked.",
+                    );
+                }
 
                 row(ui, "Date", &Self::format_timestamp(trade.created_at));
 
@@ -9258,9 +9464,10 @@ impl UserApp {
             if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
                 if amount_cents > 0 {
                     let amount = amount_cents as f64 / 100.0;
+                    let net_amount = amount - Self::stable_trade_fee(amount);
                     let btc_price = get_cached_price_no_fetch();
                     if btc_price > 0.0 {
-                        let btc = amount / btc_price;
+                        let btc = net_amount / btc_price;
                         ui.add_space(4.0);
                         ui.label(
                             RichText::new(format!("\u{2248} {:.8} BTC", btc))
@@ -9339,6 +9546,7 @@ impl UserApp {
                         btc_amount,
                         btc_sats,
                         net_amount_usd: net_amount,
+                        is_full_peg: false,
                     });
                     self.show_confirm_trade = true;
                     self.trade_error.clear();
@@ -9581,7 +9789,7 @@ impl UserApp {
         // Show the native allocation valued in USD. A price quote changes its value, not which
         // sats belong to it.
         let btc_price = get_cached_price_no_fetch();
-        let native_sats = {
+        let (live_receiver_sats, native_sats, current_backing_sats, current_expected_usd) = {
             let sc = self.stable_channel.lock().unwrap();
             let (_, native_sats, _) = channel_balance_split(
                 sc.stable_receiver_btc.sats,
@@ -9589,16 +9797,27 @@ impl UserApp {
                 sc.expected_usd.0,
                 btc_price,
             );
-            native_sats
+            (
+                sc.stable_receiver_btc.sats,
+                native_sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+            )
         };
-        // A hard spending limit must never be formatted upward. Otherwise an exact displayed
-        // maximum can exceed the underlying sats by a fraction of a cent.
-        let available_btc_usd_cents =
-            floor_usd_cents(native_sats as f64 / SATS_IN_BTC as f64 * btc_price);
+        // Native BTC can be worth more than the channel's remaining stable-target capacity when
+        // the current backing has drifted below its USD target. Show the largest cent-denominated
+        // order that passes the same post-fee allocation check used when the order is submitted.
+        let available_btc_usd_cents = max_sell_trade_usd_cents(
+            live_receiver_sats,
+            native_sats,
+            current_backing_sats,
+            current_expected_usd,
+            btc_price,
+        );
         let available_btc_usd = available_btc_usd_cents as f64 / 100.0;
         ui.label(
             RichText::new(format!(
-                "Available: {}",
+                "Available to convert: {}",
                 Self::format_price(available_btc_usd)
             ))
             .size(14.0)
@@ -9685,13 +9904,13 @@ impl UserApp {
             if let Some(amount_cents) = parse_trade_usd_cents(&self.trade_amount_input) {
                 let amount = amount_cents as f64 / 100.0;
                 // Validate user has enough BTC to sell
-                if amount_cents > available_btc_usd_cents {
+                if btc_price < 1.0 || !btc_price.is_finite() {
+                    self.trade_error = "Invalid price".to_string();
+                } else if amount_cents > available_btc_usd_cents {
                     self.trade_error = format!(
-                        "Insufficient BTC. You have {} available.",
+                        "Amount exceeds tradable channel capacity. Maximum is {}.",
                         Self::format_price(available_btc_usd)
                     );
-                } else if btc_price < 1.0 || !btc_price.is_finite() {
-                    self.trade_error = "Invalid price".to_string();
                 } else {
                     // Calculate trade details
                     let fee_usd = Self::stable_trade_fee(amount);
@@ -9711,6 +9930,7 @@ impl UserApp {
                         btc_amount,
                         btc_sats,
                         net_amount_usd: net_amount,
+                        is_full_peg: amount_cents == available_btc_usd_cents,
                     });
                     self.show_confirm_trade = true;
                     self.trade_error.clear();
@@ -9764,6 +9984,7 @@ impl UserApp {
         let btc_amount = trade.btc_amount;
         let btc_sats = trade.btc_sats;
         let net_amount = trade.net_amount_usd;
+        let is_full_peg = trade.is_full_peg;
 
         // Header
         ui.label(
@@ -9858,6 +10079,20 @@ impl UserApp {
                     });
                 });
             });
+
+        if is_full_peg {
+            ui.add_space(12.0);
+            ui.add(
+                egui::Label::new(
+                    RichText::new(
+                        "This trade may be rejected by the LSP if the price changes, and the trade fee will not be refunded.",
+                    )
+                    .size(12.0)
+                    .color(theme::WARNING),
+                )
+                .wrap(),
+            );
+        }
 
         let confirmation_blocked = !self.trade_error.is_empty();
         if confirmation_blocked {
@@ -10188,21 +10423,15 @@ impl UserApp {
         } else {
             0.0
         };
-        if let Some((payment_id, backing_sats)) =
-            self.send_trade(new_expected_usd, fee_usd, "buy", btc_price)
+        if let Some((payment_id, backing_sats, trade_db_id)) = self.send_trade(
+            new_expected_usd,
+            fee_usd,
+            "buy",
+            btc_price,
+            amount_usd,
+            btc_amount,
+        )
         {
-            let payment_id_str = format!("{payment_id}");
-            let trade_db_id = self.record_trade(
-                "buy",
-                amount_usd,
-                btc_amount,
-                btc_price,
-                fee_usd,
-                new_expected_usd,
-                Some(backing_sats),
-                Some(&payment_id_str),
-                "pending",
-            );
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
@@ -10252,21 +10481,15 @@ impl UserApp {
         let new_expected_usd = current_expected_usd + net_amount;
 
         let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
-        if let Some((payment_id, backing_sats)) =
-            self.send_trade(new_expected_usd, fee_usd, "sell", btc_price)
+        if let Some((payment_id, backing_sats, trade_db_id)) = self.send_trade(
+            new_expected_usd,
+            fee_usd,
+            "sell",
+            btc_price,
+            amount_usd,
+            btc_amount,
+        )
         {
-            let payment_id_str = format!("{payment_id}");
-            let trade_db_id = self.record_trade(
-                "sell",
-                amount_usd,
-                btc_amount,
-                btc_price,
-                fee_usd,
-                new_expected_usd,
-                Some(backing_sats),
-                Some(&payment_id_str),
-                "pending",
-            );
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
@@ -10592,6 +10815,12 @@ impl App for UserApp {
         self.start_background_if_needed();
 
         if self.balance_last_update.elapsed() >= Duration::from_secs(2) {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                .min(i64::MAX as u64) as i64;
+            let _ = self.db.mark_unresolved_trades_unknown(now);
             self.update_balances();
             self.balance_last_update = std::time::Instant::now();
         }
@@ -11058,10 +11287,10 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
         return None;
     }
     let channel_id = payload.get("channel_id")?.as_str()?;
-    if channel_id.len() != 64 || !channel_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    if !stable_channels::trade::is_channel_id(channel_id) {
         return None;
     }
-    let channel_id = channel_id.to_ascii_lowercase();
+    let channel_id = channel_id.to_string();
     let expected_usd =
         stable::normalize_trade_expected_usd(payload.get("expected_usd")?.as_f64()?);
     let backing_sats = payload.get("backing_sats")?.as_u64()?;
@@ -11074,12 +11303,58 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
     {
         return None;
     }
+    let correlation = match (
+        payload.get("trade_id"),
+        payload.get("trade_payment_id"),
+        payload.get("request_hash"),
+    ) {
+        (None, None, None) => None,
+        (Some(trade_id), Some(payment_id), Some(request_hash)) => {
+            let trade_id = trade_id.as_str()?;
+            let payment_id = payment_id.as_str()?;
+            let request_hash = request_hash.as_str()?;
+            if !stable_channels::trade::is_trade_id(trade_id)
+                || !stable_channels::trade::is_payment_id(payment_id)
+                || !stable_channels::trade::is_request_hash(request_hash)
+            {
+                return None;
+            }
+            Some((
+                trade_id.to_string(),
+                payment_id.to_string(),
+                request_hash.to_string(),
+            ))
+        }
+        _ => return None,
+    };
+    let (trade_id, trade_payment_id, request_hash) = correlation
+        .map(|(trade_id, payment_id, request_hash)| {
+            (Some(trade_id), Some(payment_id), Some(request_hash))
+        })
+        .unwrap_or((None, None, None));
     Some(IncomingSync {
         channel_id,
         expected_usd,
         backing_sats,
         sync_version,
+        trade_id,
+        trade_payment_id,
+        request_hash,
     })
+}
+
+fn parse_trade_rejection(payload: &str) -> Option<stable_channels::trade::TradeRejectedV1> {
+    let rejection: stable_channels::trade::TradeRejectedV1 = serde_json::from_str(payload).ok()?;
+    if rejection.kind != TRADE_REJECTED_MESSAGE_TYPE
+        || !stable_channels::trade::is_channel_id(&rejection.channel_id)
+        || !stable_channels::trade::is_trade_id(&rejection.trade_id)
+        || !stable_channels::trade::is_payment_id(&rejection.trade_payment_id)
+        || !stable_channels::trade::is_request_hash(&rejection.request_hash)
+        || rejection.decided_at > i64::MAX as u64
+    {
+        return None;
+    }
+    Some(rejection)
 }
 
 fn trade_reduction_exhausts_backing(
@@ -11131,55 +11406,6 @@ fn local_trade_backing_sats(
     if new_expected_usd > receiver_usd {
         return Err(LocalTradeAllocationError::TargetExceedsCapacity);
     }
-    // The LSP measures quote deviation against its own price. These are therefore the exact local
-    // price endpoints that can still pass its symmetric deviation check.
-    let quote_deviation = MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0;
-    let minimum_permitted_lsp_price = current_price / (1.0 + quote_deviation);
-    let maximum_permitted_lsp_price = current_price / (1.0 - quote_deviation);
-    if new_expected_usd > current_expected_usd {
-        // Every permitted lower LSP price must still support an increased target.
-        let conservative_receiver_usd =
-            post_fee_receiver_sats as f64 / SATS_IN_BTC as f64
-                * minimum_permitted_lsp_price;
-        if new_expected_usd > conservative_receiver_usd {
-            return Err(LocalTradeAllocationError::TargetExceedsSafeCapacity);
-        }
-    } else {
-        // Reductions and exits can underflow backing or cross the actionable-drift gate at either
-        // edge of the accepted quote range. Validate both before paying the non-refundable fee.
-        for permitted_lsp_price in [
-            minimum_permitted_lsp_price,
-            maximum_permitted_lsp_price,
-        ] {
-            let permitted_receiver_usd =
-                post_fee_receiver_sats as f64 / SATS_IN_BTC as f64 * permitted_lsp_price;
-            if new_expected_usd > permitted_receiver_usd {
-                return Err(LocalTradeAllocationError::TargetExceedsSafeCapacity);
-            }
-            if stable::trade_backing_after_delta(
-                post_fee_receiver_sats,
-                current_backing_sats,
-                current_expected_usd,
-                new_expected_usd,
-                permitted_lsp_price,
-            )
-            .is_none()
-            {
-                return Err(if new_expected_usd == 0.0
-                    || trade_reduction_exhausts_backing(
-                        current_backing_sats,
-                        current_expected_usd,
-                        new_expected_usd,
-                        permitted_lsp_price,
-                    )
-                {
-                    LocalTradeAllocationError::SettlementRequired
-                } else {
-                    LocalTradeAllocationError::UnsafeAllocation
-                });
-            }
-        }
-    }
     let backing_sats = stable::trade_backing_after_delta(
         post_fee_receiver_sats,
         current_backing_sats,
@@ -11200,6 +11426,55 @@ fn local_trade_backing_sats(
         LocalTradeAllocationError::UnsafeAllocation
     })?;
     Ok((post_fee_receiver_sats, backing_sats))
+}
+
+/// Largest whole-cent BTC-to-USD order that fits both the native sat allocation and the wallet's
+/// post-fee channel allocation. The predicate is monotonic for an increasing stable target, so a
+/// binary search keeps this cheap even for large channels.
+fn max_sell_trade_usd_cents(
+    live_receiver_sats: u64,
+    native_sats: u64,
+    current_backing_sats: u64,
+    current_expected_usd: f64,
+    current_price: f64,
+) -> u64 {
+    if native_sats == 0
+        || !current_expected_usd.is_finite()
+        || current_expected_usd < 0.0
+        || !current_price.is_finite()
+        || current_price <= 0.0
+    {
+        return 0;
+    }
+
+    let mut low = 0_u64;
+    let mut high = floor_usd_cents(native_sats as f64 / SATS_IN_BTC as f64 * current_price);
+    while low < high {
+        let distance = high - low;
+        let cents = low + distance / 2 + distance % 2;
+        let amount_usd = cents as f64 / 100.0;
+        let fee_usd = amount_usd * STABLE_CHANNEL_TRADE_FEE_RATE;
+        let fee_sats = (fee_usd / current_price * SATS_IN_BTC as f64) as u64;
+        let new_expected_usd = current_expected_usd + amount_usd - fee_usd;
+        let fits_native = sats_for_usd_cents(cents, current_price)
+            .is_some_and(|required_sats| required_sats <= native_sats);
+        let fits_allocation = fits_native
+            && local_trade_backing_sats(
+                live_receiver_sats,
+                fee_sats,
+                current_backing_sats,
+                current_expected_usd,
+                new_expected_usd,
+                current_price,
+            )
+            .is_ok();
+        if fits_allocation {
+            low = cents;
+        } else {
+            high = cents - 1;
+        }
+    }
+    low
 }
 
 /// Derive the allocation this wallet will commit for an authenticated sync. The peer's
@@ -11315,8 +11590,9 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 mod tests {
     use super::{
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        local_sync_backing_sats, local_trade_backing_sats, parse_incoming_sync,
-        parse_trade_usd_cents, restrict_secret_file_permissions, sats_for_usd_cents,
+        local_sync_backing_sats, local_trade_backing_sats, max_sell_trade_usd_cents,
+        parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
+        restrict_secret_file_permissions, sats_for_usd_cents,
         splice_in_overlap_sats, splice_reconcile_action, write_secret_file, IncomingSync,
         LocalTradeAllocationError, PendingSplice, SpliceReconcileAction, UserApp,
     };
@@ -11348,6 +11624,36 @@ mod tests {
 
         assert_eq!(available_cents, 1_060);
         assert!(required_sats <= native_sats);
+    }
+
+    #[test]
+    fn sell_limit_accounts_for_stable_target_drift_and_trade_fee() {
+        // Production-shaped state: the native bucket is worth $7.70, but the backing is worth
+        // about $0.21 less than its $25.407 target. Only $7.50 can become a safe new target.
+        assert_eq!(
+            max_sell_trade_usd_cents(51_984, 12_174, 39_810, 25.407, 63_304.40),
+            750,
+        );
+        assert_eq!(
+            max_sell_trade_usd_cents(51_984, 12_174, 39_810, 25.407, 63_321.94),
+            751,
+        );
+        assert_eq!(
+            max_sell_trade_usd_cents(51_984, 12_174, 39_810, 25.407, 63_425.91),
+            756,
+        );
+    }
+
+    #[test]
+    fn sell_limit_allows_the_full_native_value_when_the_target_is_fully_backed() {
+        assert_eq!(
+            max_sell_trade_usd_cents(150_000, 50_000, 100_000, 100.0, 100_000.0),
+            5_000,
+        );
+        assert_eq!(
+            max_sell_trade_usd_cents(150_000, 50_000, 100_000, 100.0, f64::NAN),
+            0,
+        );
     }
 
     #[test]
@@ -11426,18 +11732,18 @@ mod tests {
         );
         assert_eq!(
             local_trade_backing_sats(100_000, 0, 0, 0.0, 99.51, 100_000.0),
-            Err(LocalTradeAllocationError::TargetExceedsSafeCapacity),
-            "the preflight reserves the full permitted quote-deviation band",
+            Ok((100_000, 99_510)),
+            "the LSP may reject a near-capacity target priced outside its safe capacity",
         );
         assert_eq!(
             local_trade_backing_sats(200_000, 0, 501, 1.0, 0.5, 100_000.0),
-            Err(LocalTradeAllocationError::SettlementRequired),
-            "a reduction that works locally must also work at the lowest permitted LSP price",
+            Ok((200_000, 1)),
+            "the wallet validates reductions only at its own trusted price",
         );
         assert_eq!(
             local_trade_backing_sats(200_000, 0, 100_000, 100.0, 0.0, 100_000.0),
-            Err(LocalTradeAllocationError::SettlementRequired),
-            "a full exit must be below the stability threshold across the accepted quote range",
+            Ok((200_000, 0)),
+            "the wallet validates a full exit only at its own trusted price",
         );
     }
 
@@ -11446,7 +11752,7 @@ mod tests {
         assert_eq!(
             local_trade_backing_sats(100_000, 0, 0, 0.0, 99.50, 100_000.0),
             Ok((100_000, 99_500)),
-            "a target below the conservative cross-feed limit remains available",
+            "a locally safe near-capacity target remains available",
         );
         assert_eq!(
             local_trade_backing_sats(200_000, 100, 100_000, 100.0, 100.01, 110_000.0),
@@ -11464,7 +11770,7 @@ mod tests {
         assert_eq!(
             local_trade_backing_sats(2_000, 0, 1_000, 1.0, 0.5, 100_000.0),
             Ok((2_000, 500)),
-            "ordinary reductions remain available when both quote endpoints are safe",
+            "ordinary reductions remain available when locally safe",
         );
     }
 
@@ -11475,6 +11781,9 @@ mod tests {
             expected_usd: 60.0,
             backing_sats: 99_999,
             sync_version: 1,
+            trade_id: None,
+            trade_payment_id: None,
+            request_hash: None,
         };
         assert_eq!(
             local_sync_backing_sats(&sync, 100_000, 100_000.0, 0.0, 0, None),
@@ -11502,15 +11811,37 @@ mod tests {
 
         let pending = PendingTradeRow {
             id: 1,
+            channel_id: "00".repeat(32),
+            trade_id: None,
+            payment_id: None,
+            request_hash: None,
+            fee_msat: 0,
             new_expected_usd: 60.0,
             btc_price: 100_500.0,
             new_backing_sats: Some(59_701),
             action: "sell".to_owned(),
+            status: "pending".to_owned(),
         };
         assert_eq!(
             local_sync_backing_sats(&sync, 100_000, 0.0, 50.0, 50_000, Some(&pending)),
             Ok(59_701),
             "a trade acknowledgment uses the wallet's stored trade-time allocation",
+        );
+        let temporarily_over_capacity = PendingTradeRow {
+            new_backing_sats: Some(100_001),
+            ..pending
+        };
+        assert_eq!(
+            local_sync_backing_sats(
+                &sync,
+                100_000,
+                0.0,
+                50.0,
+                50_000,
+                Some(&temporarily_over_capacity),
+            ),
+            Err("stored trade allocation exceeds the live balance"),
+            "a correlated result must be retried while live capacity is temporarily reduced",
         );
 
         let over_capacity = IncomingSync {
@@ -11664,6 +11995,9 @@ mod tests {
                 expected_usd: 25.0,
                 backing_sats: 31_250,
                 sync_version: 4,
+                trade_id: None,
+                trade_payment_id: None,
+                request_hash: None,
             })
         );
 
@@ -11699,6 +12033,52 @@ mod tests {
             "sync_version": 5,
         });
         assert_eq!(parse_incoming_sync(&malformed_channel), None);
+    }
+
+    #[test]
+    fn correlated_sync_requires_all_strict_identifiers() {
+        let identifier = "ab".repeat(32);
+        let mut payload = serde_json::json!({
+            "type": "SYNC_V1",
+            "channel_id": identifier,
+            "expected_usd": 25.0,
+            "backing_sats": 31_250,
+            "sync_version": 4,
+            "trade_id": identifier,
+            "trade_payment_id": identifier,
+            "request_hash": identifier,
+        });
+        assert!(parse_incoming_sync(&payload).unwrap().trade_id.is_some());
+        payload.as_object_mut().unwrap().remove("request_hash");
+        assert_eq!(parse_incoming_sync(&payload), None);
+        payload["request_hash"] = serde_json::json!("AB".repeat(32));
+        assert_eq!(parse_incoming_sync(&payload), None);
+    }
+
+    #[test]
+    fn rejection_parser_is_closed_and_strict() {
+        let identifier = "cd".repeat(32);
+        let payload = serde_json::json!({
+            "type": "TRADE_REJECTED_V1",
+            "channel_id": identifier,
+            "trade_id": identifier,
+            "trade_payment_id": identifier,
+            "request_hash": identifier,
+            "reason_code": "insufficient_capacity",
+            "decided_at": 1_786_310_000u64,
+        });
+        assert_eq!(
+            parse_trade_rejection(&payload.to_string())
+                .unwrap()
+                .reason_code,
+            stable_channels::trade::TradeRejectionReason::InsufficientCapacity
+        );
+        let mut unknown_reason = payload.clone();
+        unknown_reason["reason_code"] = serde_json::json!("peer_text");
+        assert_eq!(parse_trade_rejection(&unknown_reason.to_string()), None);
+        let mut extra = payload;
+        extra["message"] = serde_json::json!("render me");
+        assert_eq!(parse_trade_rejection(&extra.to_string()), None);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

  When the LSP rejected a trade, the wallet received no result and could remain pending indefinitely.

  ## Solution

  - Return signed acceptance or rejection results.
  - Persist decisions and retry lost responses.
  - Safely deduplicate repeated trade requests.
  - Keep rejected trades from changing channel state.
  - Also removed the +-0.5% check on the wallet side, and added a warning for full peg trade that trade fees is non-refundable 