### PR TITLE
add durable two-phase trade confirmation

### DIFF
--- a/server/lsp-server-gui/src/ui/payments.rs
+++ b/server/lsp-server-gui/src/ui/payments.rs
@@ -561,7 +561,12 @@ fn render_payment_details_dialog(ctx: &Context, app: &mut LspServerApp) {
 									.as_ref()
 									.map(|k| format_payment_kind(k))
 									.unwrap_or_else(|| "Unknown".to_string());
-								ui.label(payment_type);
+								let settlement_kind = app
+									.state
+									.settlement_kinds
+									.as_ref()
+									.and_then(|kinds| kinds.get(&payment.id).copied());
+								ui.label(payment_type_label_str(&payment_type, settlement_kind));
 								ui.end_row();
 
 								// Amount (unit-aware, pre-formatted above)

--- a/server/stable-channels-lsp/Cargo.toml
+++ b/server/stable-channels-lsp/Cargo.toml
@@ -13,6 +13,7 @@ ldk-server-client = { git = "https://github.com/lightningdevkit/ldk-server", rev
 # module path. The rev must match the root Cargo.toml.
 ldk-node          = { git = "https://github.com/lightningdevkit/ldk-node", rev = "47dad6d909af0fbb53e76d07740c04df5abdde3b" }
 hex               = "0.4"
+rand              = "0.9"
 
 # Async trait support for &dyn LdkServerCalls (stable Rust async-fn-in-trait
 # does not yet support trait objects).

--- a/server/stable-channels-lsp/src/event_loop.rs
+++ b/server/stable-channels-lsp/src/event_loop.rs
@@ -51,7 +51,7 @@ async fn run(state: AppState) {
             Ok(s) => {
                 backoff = Duration::from_secs(1);
                 s
-            },
+            }
             Err(e) => {
                 if gap_correlation_id.is_none() {
                     let correlation_id = format!("event-stream-gap-{}", now_millis());
@@ -77,7 +77,7 @@ async fn run(state: AppState) {
                 tokio::time::sleep(backoff).await;
                 backoff = std::cmp::min(backoff * 2, Duration::from_secs(60));
                 continue;
-            },
+            }
         };
         info!("[event_loop] subscribed");
         stable_channels::audit::audit_event(
@@ -106,7 +106,8 @@ async fn run(state: AppState) {
             let counts = crate::backfill::reconcile_event_history(
                 state.ldk_server.as_ref(),
                 state.db.as_ref(),
-            ).await;
+            )
+            .await;
             let reconciliation_complete =
                 counts.failed_scopes == 0 && counts.incomplete_scopes == 0;
             stable_channels::audit::audit_event(
@@ -165,7 +166,7 @@ async fn dispatch(
         Err(e) => {
             warn!("[event_loop] item error: {}", e);
             return DispatchOutcome::Reconnect;
-        },
+        }
     };
     let btc_price = stable_channels::price_feeds::get_fresh_cached_price_no_fetch();
     let mut mgr = state.stable_manager.lock().await;
@@ -222,13 +223,21 @@ async fn dispatch(
                     ),
                 );
             }
-        },
+        }
         Some(EventVariant::PaymentReceived(e)) => {
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
-            mgr.handle_payment_received(e.custom_records, payment_id, amount_msat, ldk, btc_price)
-                .await;
-        },
+            let settled_at = e.payment.as_ref().map(|p| p.latest_update_timestamp);
+            mgr.handle_payment_received_at(
+                e.custom_records,
+                payment_id,
+                amount_msat,
+                settled_at,
+                ldk,
+                btc_price,
+            )
+            .await;
+        }
         Some(EventVariant::PaymentForwarded(e)) => {
             if let Some(fp) = e.forwarded_payment {
                 // ForwardedPayment now carries per-HTLC locators; take the first of each list as the representative channel/node.
@@ -237,7 +246,8 @@ async fn dispatch(
                 let prev_channel_id = prev.map(|h| h.channel_id.clone()).unwrap_or_default();
                 let next_channel_id = next.map(|h| h.channel_id.clone()).unwrap_or_default();
                 mgr.handle_payment_forwarded(
-                    prev.and_then(|h| h.user_channel_id.clone()).unwrap_or_default(),
+                    prev.and_then(|h| h.user_channel_id.clone())
+                        .unwrap_or_default(),
                     next.and_then(|h| h.user_channel_id.clone()),
                     prev_channel_id,
                     next_channel_id,
@@ -250,12 +260,18 @@ async fn dispatch(
                 )
                 .await;
             }
-        },
+        }
         Some(EventVariant::PaymentSuccessful(e)) => {
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
-            let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            let direction = e.payment.as_ref().map(|p| {
+                if p.direction == 1 {
+                    "outbound"
+                } else {
+                    "inbound"
+                }
+            });
             let mut settlement_handled = false;
             if let Some(payment_id) = payment_id.as_deref() {
                 match state.db.mark_trade_response_delivered(
@@ -276,11 +292,7 @@ async fn dispatch(
                         return DispatchOutcome::Reconnect;
                     }
                 }
-                let known_settlement = state
-                    .db
-                    .settlement_exists(payment_id)
-                    .ok()
-                    .unwrap_or(false);
+                let known_settlement = state.db.settlement_exists(payment_id).ok().unwrap_or(false);
                 match state.db.mark_settlement_succeeded(
                     payment_id,
                     amount_msat,
@@ -289,7 +301,7 @@ async fn dispatch(
                 ) {
                     Ok(true) => settlement_handled = true,
                     Ok(false) if known_settlement => settlement_handled = true,
-                    Ok(false) => {},
+                    Ok(false) => {}
                     Err(error) => {
                         stable_channels::audit::audit_event(
                             "DB_WRITE_FAILED",
@@ -300,7 +312,7 @@ async fn dispatch(
                             }),
                         );
                         return DispatchOutcome::Reconnect;
-                    },
+                    }
                 }
             }
             if !settlement_handled {
@@ -314,12 +326,18 @@ async fn dispatch(
                     }),
                 );
             }
-        },
+        }
         Some(EventVariant::PaymentFailed(e)) => {
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
             let fee_paid_msat = e.payment.as_ref().and_then(|p| p.fee_paid_msat);
-            let direction = e.payment.as_ref().map(|p| if p.direction == 1 { "outbound" } else { "inbound" });
+            let direction = e.payment.as_ref().map(|p| {
+                if p.direction == 1 {
+                    "outbound"
+                } else {
+                    "inbound"
+                }
+            });
             if let Some(payment_id) = payment_id.as_deref() {
                 if let Err(error) = state.db.mark_trade_response_failed(
                     payment_id,
@@ -343,7 +361,8 @@ async fn dispatch(
                 .as_ref()
                 .map(|rollback| rollback.user_channel_id.clone())
                 .or_else(|| {
-                    payment_id.as_deref()
+                    payment_id
+                        .as_deref()
                         .and_then(|pid| state.db.get_settlement_channel(pid).ok().flatten())
                 });
             stable_channels::audit::audit_event(
@@ -357,7 +376,7 @@ async fn dispatch(
                     "stability_rollback_applied": rollback.map(|rollback| rollback.applied),
                 }),
             );
-        },
+        }
         Some(EventVariant::PaymentClaimable(e)) => {
             let payment_id = e.payment.as_ref().map(|p| p.id.clone());
             let amount_msat = e.payment.as_ref().and_then(|p| p.amount_msat);
@@ -366,8 +385,8 @@ async fn dispatch(
                 "PAYMENT_CLAIMABLE",
                 claimable_audit_data(payment_id.as_deref(), amount_msat, has_custom_records),
             );
-        },
-        _ => {},
+        }
+        _ => {}
     }
     DispatchOutcome::Continue
 }

--- a/server/stable-channels-lsp/src/messages.rs
+++ b/server/stable-channels-lsp/src/messages.rs
@@ -24,13 +24,61 @@ pub struct TradePayload {
     /// Desktop correlation id. Omitted by legacy Android/iOS clients.
     #[serde(default)]
     pub trade_id: Option<String>,
+    /// Missing means the legacy fee-first path. Upgraded desktop uses propose/execute/cancel.
+    #[serde(default)]
+    pub phase: Option<String>,
     pub expected_usd: f64,
     /// Wallet BTC/USD quote. The LSP uses it only for slippage and fee validation.
     #[serde(default)]
     pub quote_price: Option<f64>,
+    #[serde(default)]
+    pub base_sync_version: Option<u64>,
+    #[serde(default)]
+    pub replaces_trade_id: Option<String>,
+    #[serde(default)]
+    pub proposal_payment_id: Option<String>,
+    #[serde(default)]
+    pub proposal_hash: Option<String>,
+    #[serde(default)]
+    pub confirmation_id: Option<String>,
+    #[serde(default)]
+    pub fee_msat: Option<u64>,
     /// Unix seconds the wallet signed at; 0 if absent (un-upgraded wallet). Drives replay freshness.
     #[serde(default)]
     pub ts: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_confirm_trade_payload(
+    channel_id: &str,
+    user_channel_id: &str,
+    trade_id: &str,
+    proposal_payment_id: &str,
+    proposal_hash: &str,
+    confirmation_id: &str,
+    expected_usd: f64,
+    quote_price: f64,
+    fee_msat: u64,
+    base_sync_version: u64,
+    confirmed_at: u64,
+    expires_at: u64,
+) -> String {
+    serde_json::to_string(&stable_channels::trade::ConfirmTradeV1 {
+        kind: stable_channels::constants::CONFIRM_TRADE_MESSAGE_TYPE.to_owned(),
+        channel_id: channel_id.to_owned(),
+        user_channel_id: user_channel_id.to_owned(),
+        trade_id: trade_id.to_owned(),
+        proposal_payment_id: proposal_payment_id.to_owned(),
+        proposal_hash: proposal_hash.to_owned(),
+        confirmation_id: confirmation_id.to_owned(),
+        expected_usd,
+        quote_price,
+        fee_msat,
+        base_sync_version,
+        confirmed_at,
+        expires_at,
+    })
+    .unwrap_or_default()
 }
 
 /// RegisterPush signed body. Field declaration order IS the canonical serialization order;
@@ -266,5 +314,37 @@ mod tests {
         assert_eq!(value["reason_code"], "insufficient_capacity");
         assert_eq!(value["decided_at"], 1786310000_u64);
         assert_eq!(value.as_object().unwrap().len(), 7);
+    }
+
+    #[test]
+    fn upgraded_phases_and_confirmation_round_trip() {
+        let id = "11".repeat(32);
+        let proposal = format!(
+            r#"{{"type":"TRADE_V1","phase":"propose","channel_id":"{}","trade_id":"{}","expected_usd":12.5,"quote_price":100000.0,"base_sync_version":3,"ts":10}}"#,
+            "22".repeat(32),
+            id
+        );
+        let parsed = parse_trade_payload(&proposal).unwrap();
+        assert_eq!(parsed.phase.as_deref(), Some("propose"));
+        assert_eq!(parsed.base_sync_version, Some(3));
+
+        let payload = build_confirm_trade_payload(
+            &"22".repeat(32),
+            "7",
+            &id,
+            &"33".repeat(32),
+            &"44".repeat(32),
+            &"55".repeat(32),
+            12.5,
+            100_000.0,
+            1_000,
+            3,
+            100,
+            160,
+        );
+        let confirmation: stable_channels::trade::ConfirmTradeV1 =
+            serde_json::from_str(&payload).unwrap();
+        assert!(confirmation.has_valid_shape());
+        assert_eq!(confirmation.fee_msat, 1_000);
     }
 }

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -9,15 +9,14 @@ use ldk_server_client::error::LdkServerError;
 use ldk_server_client::ldk_server_grpc::api::{
     GetBalancesRequest, GetBalancesResponse, GetPaymentDetailsRequest, GetPaymentDetailsResponse,
     ListChannelsRequest, ListChannelsResponse, ListForwardedPaymentsRequest,
-    ListForwardedPaymentsResponse, ListPeersRequest, ListPeersResponse, ListPaymentsRequest,
-    ListPaymentsResponse, SignMessageRequest, SignMessageResponse, SpontaneousSendRequest,
+    ListForwardedPaymentsResponse, ListPaymentsRequest, ListPaymentsResponse, ListPeersRequest,
+    ListPeersResponse, SignMessageRequest, SignMessageResponse, SpontaneousSendRequest,
     SpontaneousSendResponse, VerifySignatureRequest, VerifySignatureResponse,
 };
 use ldk_server_client::ldk_server_grpc::events::ChannelStateChangeReason;
 use ldk_server_client::ldk_server_grpc::types::{Channel, CustomTlvRecord, PaymentStatus};
 use stable_channels::constants::{
-    MAX_TRADE_QUOTE_DEVIATION_PERCENT, SIGNED_STABILITY_TLV_TYPE,
-    STABILITY_PAYMENT_AUTH_TTL_SECS,
+    MAX_TRADE_QUOTE_DEVIATION_PERCENT, SIGNED_STABILITY_TLV_TYPE, STABILITY_PAYMENT_AUTH_TTL_SECS,
 };
 use stable_channels::db::{Database, InboundStabilityRegistration, PendingTradeResponse};
 use stable_channels::stable::StabilityPaymentDirection;
@@ -44,6 +43,22 @@ fn splice_balance_change(before_sats: u64, after_sats: u64) -> (&'static str, u6
     } else {
         ("unchanged", 0)
     }
+}
+
+fn durable_trade_response_is_sync(response_envelope: &str) -> bool {
+    crate::messages::parse_envelope(response_envelope)
+        .and_then(|envelope| serde_json::from_str::<serde_json::Value>(&envelope.payload).ok())
+        .and_then(|payload| {
+            payload
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .map(|kind| kind == stable_channels::constants::SYNC_MESSAGE_TYPE)
+        })
+        .unwrap_or(false)
+}
+
+fn stability_mutation_allowed<T, E>(reservation: &Result<Option<T>, E>) -> bool {
+    matches!(reservation, Ok(None))
 }
 
 /// Reproduce the wallet's trade-fee calculation from the allocation transition. Buys reduce the
@@ -92,8 +107,7 @@ fn trade_fee_tolerance_msat(expected_msat: u64, has_signed_quote: bool) -> u64 {
 
     // Transitional legacy wallets did not sign their quote. Admit the same maximum price skew as
     // signed trades, plus one sat for whole-sat rounding, while still rejecting material underpay.
-    ((expected_msat as f64 * MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0).ceil() as u64)
-        .max(1000)
+    ((expected_msat as f64 * MAX_TRADE_QUOTE_DEVIATION_PERCENT / 100.0).ceil() as u64).max(1000)
 }
 
 fn trade_reduction_exhausts_backing(
@@ -116,8 +130,7 @@ fn trade_reduction_exhausts_backing(
     {
         return false;
     }
-    (old_target.floor() as u64).saturating_sub(new_target.floor() as u64)
-        >= current_backing_sats
+    (old_target.floor() as u64).saturating_sub(new_target.floor() as u64) >= current_backing_sats
 }
 
 /// Tiny trait of the gRPC methods the manager calls, so run_tick and handlers can be unit-tested with a fake.
@@ -209,10 +222,7 @@ impl LdkServerCalls for LdkServerClient {
     ) -> Result<GetBalancesResponse, LdkServerError> {
         LdkServerClient::get_balances(self, req).await
     }
-    async fn list_peers(
-        &self,
-        req: ListPeersRequest,
-    ) -> Result<ListPeersResponse, LdkServerError> {
+    async fn list_peers(&self, req: ListPeersRequest) -> Result<ListPeersResponse, LdkServerError> {
         LdkServerClient::list_peers(self, req).await
     }
     async fn list_payments(
@@ -269,6 +279,7 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         response: &PendingTradeResponse,
     ) {
+        let is_sync = durable_trade_response_is_sync(&response.response_envelope);
         let now = Self::unix_time_secs();
         match db.reserve_trade_response_attempt(
             &response.inbound_payment_id,
@@ -302,18 +313,37 @@ impl StableChannelManager {
             .await;
         match send {
             Ok(sent) if !sent.payment_id.is_empty() => {
-                match db.mark_trade_response_in_flight(
-                    &response.inbound_payment_id,
-                    &sent.payment_id,
-                ) {
-                    Ok(true) => stable_channels::audit::audit_event(
-                        "TRADE_RESPONSE_SENT",
-                        serde_json::json!({
-                            "trade_payment_id": response.inbound_payment_id,
-                            "response_payment_id": sent.payment_id,
-                            "attempt": response.attempts.saturating_add(1),
-                        }),
-                    ),
+                match db
+                    .mark_trade_response_in_flight(&response.inbound_payment_id, &sent.payment_id)
+                {
+                    Ok(true) => {
+                        if is_sync {
+                            if let Err(error) = db.record_settlement(&sent.payment_id, "sync") {
+                                tracing::error!(
+                                    "[stable] record_settlement (durable trade sync) failed: {}",
+                                    error
+                                );
+                                stable_channels::audit::audit_event(
+                                    "DB_WRITE_FAILED",
+                                    serde_json::json!({
+                                        "op": "record_settlement",
+                                        "kind": "sync",
+                                        "payment_id": sent.payment_id,
+                                        "trade_payment_id": response.inbound_payment_id,
+                                        "error": error.to_string(),
+                                    }),
+                                );
+                            }
+                        }
+                        stable_channels::audit::audit_event(
+                            "TRADE_RESPONSE_SENT",
+                            serde_json::json!({
+                                "trade_payment_id": response.inbound_payment_id,
+                                "response_payment_id": sent.payment_id,
+                                "attempt": response.attempts.saturating_add(1),
+                            }),
+                        );
+                    }
                     Ok(false) | Err(_) => stable_channels::audit::audit_event(
                         "TRADE_RESPONSE_PAYMENT_ID_PERSIST_FAILED",
                         serde_json::json!({
@@ -351,10 +381,7 @@ impl StableChannelManager {
                 .map(|payment| payment.status)
             {
                 Some(status) if status == PaymentStatus::Succeeded as i32 => {
-                    let _ = db.mark_trade_response_delivered(
-                        &payment_id,
-                        Self::unix_time_secs(),
-                    );
+                    let _ = db.mark_trade_response_delivered(&payment_id, Self::unix_time_secs());
                 }
                 Some(status) if status == PaymentStatus::Failed as i32 => {
                     let _ = db.mark_trade_response_failed(&payment_id, Self::unix_time_secs());
@@ -454,6 +481,570 @@ impl StableChannelManager {
                 }),
             ),
         }
+    }
+
+    async fn reject_reserved_trade(
+        &self,
+        ldk: &dyn LdkServerCalls,
+        trade_id: &str,
+        payment_id: &str,
+        request_hash: &str,
+        channel_id: &str,
+        reason: TradeRejectionReason,
+    ) {
+        let decided_at = Self::unix_time_secs();
+        let payload = crate::messages::build_trade_rejected_payload(
+            channel_id,
+            trade_id,
+            payment_id,
+            request_hash,
+            reason,
+            decided_at.max(0) as u64,
+        );
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(error) => {
+                stable_channels::audit::audit_event(
+                    "TRADE_REJECTION_SIGN_FAILED",
+                    serde_json::json!({
+                        "trade_id": trade_id,
+                        "reason_code": reason.as_str(),
+                        "error": error.to_string(),
+                    }),
+                );
+                return;
+            }
+        };
+        let envelope = crate::messages::build_envelope(payload, signature);
+        match self.db.reject_trade_reservation(
+            trade_id,
+            payment_id,
+            request_hash,
+            reason.as_str(),
+            decided_at,
+            &envelope,
+        ) {
+            Ok(true) => stable_channels::audit::audit_event(
+                "TRADE_REJECTION_QUEUED",
+                serde_json::json!({
+                    "trade_id": trade_id,
+                    "trade_payment_id": payment_id,
+                    "request_hash": request_hash,
+                    "reason_code": reason.as_str(),
+                }),
+            ),
+            Ok(false) => {}
+            Err(error) => stable_channels::audit::audit_event(
+                "DB_WRITE_FAILED",
+                serde_json::json!({
+                    "op": "reject_trade_reservation",
+                    "trade_id": trade_id,
+                    "error": error.to_string(),
+                }),
+            ),
+        }
+    }
+
+    async fn handle_trade_proposal(
+        &mut self,
+        payload: &crate::messages::TradePayload,
+        envelope: &crate::messages::SignedEnvelope,
+        chan: &Channel,
+        inbound_payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
+        let Some(trade_id) = payload
+            .trade_id
+            .as_deref()
+            .filter(|value| stable_channels::trade::is_trade_id(value))
+        else {
+            return;
+        };
+        let Some(proposal_payment_id) =
+            inbound_payment_id.filter(|value| stable_channels::trade::is_payment_id(value))
+        else {
+            return;
+        };
+        let proposal_hash = stable_channels::trade::request_hash(envelope.payload.as_bytes());
+        if let Ok(Some(existing)) = self.db.trade_reservation_by_trade_id(trade_id) {
+            if existing.proposal_payment_id == proposal_payment_id
+                && existing.proposal_hash == proposal_hash
+                && existing.outcome == "reserved"
+            {
+                let _ = self.db.requeue_exact_trade_response(
+                    &existing.proposal_payment_id,
+                    trade_id,
+                    &proposal_hash,
+                    Self::unix_time_secs(),
+                );
+            }
+            return;
+        }
+
+        macro_rules! reject_proposal {
+            ($reason:expr) => {{
+                self.reject_correlated_trade(
+                    ldk,
+                    proposal_payment_id,
+                    trade_id,
+                    &proposal_hash,
+                    &chan.channel_id,
+                    &chan.user_channel_id,
+                    &chan.counterparty_node_id,
+                    $reason,
+                )
+                .await;
+                return;
+            }};
+        }
+
+        let Some(peer_user_channel_id) = payload
+            .user_channel_id
+            .as_deref()
+            .filter(|value| stable_channels::trade::is_user_channel_id(value))
+        else {
+            reject_proposal!(TradeRejectionReason::InvalidConfirmation);
+        };
+        if amount_msat != Some(1)
+            || payload.channel_id.as_deref() != Some(chan.channel_id.as_str())
+            || payload.proposal_payment_id.is_some()
+            || payload.proposal_hash.is_some()
+            || payload.confirmation_id.is_some()
+            || payload.fee_msat.is_some()
+        {
+            reject_proposal!(TradeRejectionReason::InvalidConfirmation);
+        }
+        let Some(base_sync_version) = payload.base_sync_version else {
+            reject_proposal!(TradeRejectionReason::StaleState);
+        };
+        if payload
+            .replaces_trade_id
+            .as_deref()
+            .is_some_and(|value| !stable_channels::trade::is_trade_id(value))
+        {
+            reject_proposal!(TradeRejectionReason::InvalidConfirmation);
+        }
+        let now = Self::unix_time_secs();
+        if payload.ts == 0
+            || now < 0
+            || (now as u64).abs_diff(payload.ts) > 300
+            || !payload.expected_usd.is_finite()
+            || payload.expected_usd < 0.0
+        {
+            reject_proposal!(TradeRejectionReason::StaleRequest);
+        }
+        if let Ok(Some(active_trade_id)) = self.db.active_trade_reservation(&chan.channel_id, now) {
+            if payload.replaces_trade_id.as_deref() != Some(active_trade_id.as_str()) {
+                reject_proposal!(TradeRejectionReason::ChannelBusy);
+            }
+        } else if payload.replaces_trade_id.is_some() {
+            reject_proposal!(TradeRejectionReason::StaleState);
+        }
+        let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
+            reject_proposal!(TradeRejectionReason::InternalFailure);
+        };
+        let Some(current) = self
+            .stable_channels
+            .iter()
+            .find(|channel| channel.user_channel_id == target_uid)
+            .cloned()
+        else {
+            reject_proposal!(TradeRejectionReason::InternalFailure);
+        };
+        let current_version = match self.db.candidate_sync_version(&chan.user_channel_id) {
+            Ok(candidate) => candidate.saturating_sub(1),
+            Err(_) => reject_proposal!(TradeRejectionReason::InternalFailure),
+        };
+        if base_sync_version != current_version {
+            reject_proposal!(TradeRejectionReason::StaleState);
+        }
+        match self.db.load_channel(&chan.user_channel_id) {
+            Ok(Some(durable))
+                if stable_channels::trade::target_matches(
+                    durable.expected_usd,
+                    current.expected_usd.0,
+                ) && durable.backing_sats == current.backing_sats => {}
+            Ok(Some(_)) => reject_proposal!(TradeRejectionReason::StaleState),
+            _ => reject_proposal!(TradeRejectionReason::InternalFailure),
+        }
+        let new_expected =
+            stable_channels::stable::normalize_trade_expected_usd(payload.expected_usd);
+        if stable_channels::trade::target_matches(current.expected_usd.0, new_expected) {
+            reject_proposal!(TradeRejectionReason::InvalidAmount);
+        }
+        let Some(wallet_quote) = payload.quote_price else {
+            reject_proposal!(TradeRejectionReason::InvalidQuote);
+        };
+        if !wallet_quote.is_finite()
+            || wallet_quote <= 0.0
+            || !btc_price.is_finite()
+            || btc_price <= 0.0
+        {
+            reject_proposal!(TradeRejectionReason::InvalidQuote);
+        }
+        let quote_deviation_percent = ((wallet_quote - btc_price) / btc_price * 100.0).abs();
+        if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
+            reject_proposal!(TradeRejectionReason::QuoteDeviation);
+        }
+        let Some(fee_msat) =
+            expected_trade_fee_msat(current.expected_usd.0, new_expected, btc_price)
+        else {
+            reject_proposal!(TradeRejectionReason::InvalidFee);
+        };
+        let (our_sats, their_sats) = channel_peer_balances(chan);
+        let projected_receiver_sats = their_sats.saturating_sub(fee_msat / 1000);
+        let receiver_usd =
+            USD::from_bitcoin(Bitcoin::from_sats(projected_receiver_sats), btc_price).0;
+        if new_expected > receiver_usd {
+            reject_proposal!(TradeRejectionReason::InsufficientCapacity);
+        }
+        let mut reserved = current.clone();
+        reserved.stable_provider_btc = Bitcoin::from_sats(our_sats.saturating_add(fee_msat / 1000));
+        reserved.stable_receiver_btc = Bitcoin::from_sats(projected_receiver_sats);
+        reserved.stable_provider_usd = USD::from_bitcoin(reserved.stable_provider_btc, btc_price);
+        reserved.stable_receiver_usd = USD::from_bitcoin(reserved.stable_receiver_btc, btc_price);
+        reserved.latest_price = btc_price;
+        if !stable_channels::stable::apply_trade(&mut reserved, new_expected, btc_price) {
+            let reason = if new_expected < current.expected_usd.0
+                && (new_expected == 0.0
+                    || trade_reduction_exhausts_backing(
+                        current.backing_sats,
+                        current.expected_usd.0,
+                        new_expected,
+                        btc_price,
+                    )) {
+                TradeRejectionReason::SettlementRequired
+            } else {
+                TradeRejectionReason::UnsafeAllocation
+            };
+            reject_proposal!(reason);
+        }
+        let native_sats = projected_receiver_sats.saturating_sub(reserved.backing_sats);
+        let confirmation_id = hex::encode(rand::random::<[u8; 32]>());
+        let confirmed_at = now.max(0) as u64;
+        let expires_at =
+            confirmed_at.saturating_add(stable_channels::constants::TRADE_CONFIRMATION_TTL_SECS);
+        let confirmation_payload = crate::messages::build_confirm_trade_payload(
+            &chan.channel_id,
+            peer_user_channel_id,
+            trade_id,
+            proposal_payment_id,
+            &proposal_hash,
+            &confirmation_id,
+            reserved.expected_usd.0,
+            btc_price,
+            fee_msat,
+            base_sync_version,
+            confirmed_at,
+            expires_at,
+        );
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: confirmation_payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(_) => reject_proposal!(TradeRejectionReason::InternalFailure),
+        };
+        let confirmation_envelope =
+            crate::messages::build_envelope(confirmation_payload, signature);
+        match self.db.reserve_trade_proposal(
+            proposal_payment_id,
+            trade_id,
+            &proposal_hash,
+            &chan.channel_id,
+            &chan.user_channel_id,
+            peer_user_channel_id,
+            &chan.counterparty_node_id,
+            &confirmation_id,
+            reserved.expected_usd.0,
+            reserved.backing_sats,
+            native_sats,
+            btc_price,
+            fee_msat,
+            base_sync_version,
+            now,
+            expires_at.min(i64::MAX as u64) as i64,
+            payload.replaces_trade_id.as_deref(),
+            &confirmation_envelope,
+        ) {
+            Ok(true) => stable_channels::audit::audit_event(
+                "TRADE_RESERVED",
+                serde_json::json!({
+                    "trade_id": trade_id,
+                    "proposal_payment_id": proposal_payment_id,
+                    "proposal_hash": proposal_hash,
+                    "confirmation_id": confirmation_id,
+                    "fee_msat": fee_msat,
+                    "expires_at": expires_at,
+                }),
+            ),
+            Ok(false) => reject_proposal!(TradeRejectionReason::StaleState),
+            Err(_) => reject_proposal!(TradeRejectionReason::InternalFailure),
+        }
+    }
+
+    async fn handle_trade_execution(
+        &mut self,
+        payload: &crate::messages::TradePayload,
+        envelope: &crate::messages::SignedEnvelope,
+        chan: &Channel,
+        inbound_payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        settled_at: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+    ) {
+        let Some(trade_id) = payload
+            .trade_id
+            .as_deref()
+            .filter(|value| stable_channels::trade::is_trade_id(value))
+        else {
+            return;
+        };
+        let Some(execution_payment_id) =
+            inbound_payment_id.filter(|value| stable_channels::trade::is_payment_id(value))
+        else {
+            return;
+        };
+        let execution_hash = stable_channels::trade::request_hash(envelope.payload.as_bytes());
+        let Ok(Some(reservation)) = self.db.trade_reservation_by_trade_id(trade_id) else {
+            self.reject_correlated_trade(
+                ldk,
+                execution_payment_id,
+                trade_id,
+                &execution_hash,
+                &chan.channel_id,
+                &chan.user_channel_id,
+                &chan.counterparty_node_id,
+                TradeRejectionReason::InvalidConfirmation,
+            )
+            .await;
+            return;
+        };
+        let settled_at = settled_at
+            .unwrap_or_else(|| Self::unix_time_secs().max(0) as u64)
+            .min(i64::MAX as u64) as i64;
+        if reservation.outcome == "accepted"
+            && reservation.execution_payment_id.as_deref() == Some(execution_payment_id)
+            && reservation.execution_hash.as_deref() == Some(execution_hash.as_str())
+        {
+            let _ = self.db.requeue_exact_trade_response(
+                &reservation.proposal_payment_id,
+                trade_id,
+                &execution_hash,
+                Self::unix_time_secs(),
+            );
+            return;
+        }
+        if !matches!(reservation.outcome.as_str(), "reserved" | "expired") {
+            return;
+        }
+        let valid = amount_msat == Some(reservation.fee_msat)
+            && payload.fee_msat == Some(reservation.fee_msat)
+            && payload.channel_id.as_deref() == Some(reservation.channel_id.as_str())
+            && payload.user_channel_id.as_deref()
+                == Some(reservation.peer_user_channel_id.as_str())
+            && payload.proposal_payment_id.as_deref()
+                == Some(reservation.proposal_payment_id.as_str())
+            && payload.proposal_hash.as_deref() == Some(reservation.proposal_hash.as_str())
+            && payload.confirmation_id.as_deref() == Some(reservation.confirmation_id.as_str())
+            && stable_channels::trade::target_matches(
+                payload.expected_usd,
+                reservation.expected_usd,
+            )
+            && payload
+                .quote_price
+                .is_some_and(|price| price.to_bits() == reservation.quote_price.to_bits())
+            && payload.ts != 0;
+        if !valid {
+            self.reject_reserved_trade(
+                ldk,
+                trade_id,
+                execution_payment_id,
+                &execution_hash,
+                &reservation.channel_id,
+                TradeRejectionReason::InvalidConfirmation,
+            )
+            .await;
+            return;
+        }
+        if settled_at > reservation.expires_at {
+            self.reject_reserved_trade(
+                ldk,
+                trade_id,
+                execution_payment_id,
+                &execution_hash,
+                &reservation.channel_id,
+                TradeRejectionReason::ConfirmationExpired,
+            )
+            .await;
+            return;
+        }
+        let acceptance_payload = crate::messages::build_trade_sync_payload(
+            &reservation.channel_id,
+            &reservation.peer_user_channel_id,
+            reservation.expected_usd,
+            reservation.backing_sats,
+            reservation.sync_version,
+            trade_id,
+            execution_payment_id,
+            &execution_hash,
+        );
+        let signature = match ldk
+            .sign_message(SignMessageRequest {
+                message: acceptance_payload.as_bytes().to_vec().into(),
+            })
+            .await
+        {
+            Ok(response) => response.signature,
+            Err(_) => {
+                self.reject_reserved_trade(
+                    ldk,
+                    trade_id,
+                    execution_payment_id,
+                    &execution_hash,
+                    &reservation.channel_id,
+                    TradeRejectionReason::InternalFailure,
+                )
+                .await;
+                return;
+            }
+        };
+        let response_envelope = crate::messages::build_envelope(acceptance_payload, signature);
+        let decided_at = Self::unix_time_secs();
+        match self.db.execute_trade_reservation(
+            trade_id,
+            &reservation.confirmation_id,
+            execution_payment_id,
+            &execution_hash,
+            settled_at,
+            decided_at,
+            &response_envelope,
+        ) {
+            Ok(true) => {
+                let committed = self
+                    .db
+                    .load_channel(&reservation.user_channel_id)
+                    .ok()
+                    .flatten();
+                if let Some(target_uid) = parse_user_channel_id(&reservation.user_channel_id) {
+                    if let Some(in_memory) = self
+                        .stable_channels
+                        .iter_mut()
+                        .find(|channel| channel.user_channel_id == target_uid)
+                    {
+                        let expected_usd = committed
+                            .as_ref()
+                            .map(|row| row.expected_usd)
+                            .unwrap_or(reservation.expected_usd);
+                        let backing_sats = committed
+                            .as_ref()
+                            .map(|row| row.backing_sats)
+                            .unwrap_or(reservation.backing_sats);
+                        let native_sats = committed
+                            .as_ref()
+                            .map(|row| row.native_sats)
+                            .unwrap_or(reservation.native_sats);
+                        in_memory.expected_usd = USD(expected_usd);
+                        in_memory.backing_sats = backing_sats;
+                        in_memory.native_sats = native_sats;
+                        in_memory.native_channel_btc = Bitcoin::from_sats(native_sats);
+                    }
+                }
+                stable_channels::audit::audit_event(
+                    "TRADE_ACCEPTED",
+                    serde_json::json!({
+                        "trade_id": trade_id,
+                        "trade_payment_id": execution_payment_id,
+                        "request_hash": execution_hash,
+                        "expected_usd": reservation.expected_usd,
+                        "backing_sats": reservation.backing_sats,
+                        "sync_version": reservation.sync_version,
+                    }),
+                );
+            }
+            Ok(false) => {
+                self.reject_reserved_trade(
+                    ldk,
+                    trade_id,
+                    execution_payment_id,
+                    &execution_hash,
+                    &reservation.channel_id,
+                    TradeRejectionReason::StaleState,
+                )
+                .await;
+            }
+            Err(_) => {
+                self.reject_reserved_trade(
+                    ldk,
+                    trade_id,
+                    execution_payment_id,
+                    &execution_hash,
+                    &reservation.channel_id,
+                    TradeRejectionReason::InternalFailure,
+                )
+                .await;
+            }
+        }
+    }
+
+    async fn handle_trade_cancellation(
+        &mut self,
+        payload: &crate::messages::TradePayload,
+        envelope: &crate::messages::SignedEnvelope,
+        chan: &Channel,
+        inbound_payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+    ) {
+        let (Some(trade_id), Some(cancel_payment_id)) =
+            (payload.trade_id.as_deref(), inbound_payment_id)
+        else {
+            return;
+        };
+        if amount_msat != Some(1)
+            || !stable_channels::trade::is_trade_id(trade_id)
+            || !stable_channels::trade::is_payment_id(cancel_payment_id)
+            || payload
+                .confirmation_id
+                .as_deref()
+                .is_some_and(|value| !stable_channels::trade::is_confirmation_id(value))
+        {
+            return;
+        }
+        let Ok(Some(reservation)) = self.db.trade_reservation_by_trade_id(trade_id) else {
+            return;
+        };
+        if reservation.outcome != "reserved"
+            || reservation.channel_id != chan.channel_id
+            || payload
+                .confirmation_id
+                .as_deref()
+                .is_some_and(|value| reservation.confirmation_id != value)
+            || payload.proposal_payment_id.as_deref()
+                != Some(reservation.proposal_payment_id.as_str())
+            || payload.proposal_hash.as_deref() != Some(reservation.proposal_hash.as_str())
+        {
+            return;
+        }
+        let request_hash = stable_channels::trade::request_hash(envelope.payload.as_bytes());
+        self.reject_reserved_trade(
+            ldk,
+            trade_id,
+            cancel_payment_id,
+            &request_hash,
+            &reservation.channel_id,
+            TradeRejectionReason::ClientCancelled,
+        )
+        .await;
     }
 
     /// Consume an asynchronous failure for an outbound stability payment. The database performs
@@ -648,7 +1239,10 @@ impl StableChannelManager {
 
         EditOutcome {
             ok: true,
-            status: format!("Set expected_usd={} on channel {}", expected_usd_f, channel_id),
+            status: format!(
+                "Set expected_usd={} on channel {}",
+                expected_usd_f, channel_id
+            ),
         }
     }
 
@@ -677,7 +1271,8 @@ impl StableChannelManager {
         if let Err(e) = self.db.mark_channel_closed(&user_channel_id) {
             tracing::error!(
                 "[stable] handle_channel_closed: db.mark_channel_closed failed for {}: {}",
-                user_channel_id, e
+                user_channel_id,
+                e
             );
             stable_channels::audit::audit_event(
                 "DB_WRITE_FAILED",
@@ -698,11 +1293,7 @@ impl StableChannelManager {
     }
 
     /// Rebuild the in-memory stable-channel list at startup from sqlite joined with the live snapshot, dropping vanished channels.
-    pub async fn reconcile_from_grpc(
-        &mut self,
-        ldk: &dyn LdkServerCalls,
-        btc_price: f64,
-    ) {
+    pub async fn reconcile_from_grpc(&mut self, ldk: &dyn LdkServerCalls, btc_price: f64) {
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
             Ok(r) => r.channels,
             Err(e) => {
@@ -752,7 +1343,8 @@ impl StableChannelManager {
                 if let Err(e) = self.db.mark_channel_closed(&record.user_channel_id) {
                     tracing::error!(
                         "[stable] reconcile: db.mark_channel_closed({}) failed: {}",
-                        record.user_channel_id, e
+                        record.user_channel_id,
+                        e
                     );
                     stable_channels::audit::audit_event(
                         "DB_WRITE_FAILED",
@@ -889,12 +1481,7 @@ impl StableChannelManager {
             .iter()
             .any(|sc| sc.user_channel_id == target_uid)
         {
-            self.handle_channel_ready_splice(
-                target_uid,
-                funding_txo.as_deref(),
-                ldk,
-                btc_price,
-            )
+            self.handle_channel_ready_splice(target_uid, funding_txo.as_deref(), ldk, btc_price)
                 .await;
             return;
         }
@@ -902,10 +1489,7 @@ impl StableChannelManager {
         let channels = match ldk.list_channels(ListChannelsRequest {}).await {
             Ok(r) => r.channels,
             Err(e) => {
-                tracing::error!(
-                    "[stable] handle_channel_ready: list_channels failed: {}",
-                    e
-                );
+                tracing::error!("[stable] handle_channel_ready: list_channels failed: {}", e);
                 stable_channels::audit::audit_event(
                     "LDK_CALL_FAILED",
                     serde_json::json!({ "op": "list_channels", "context": "handle_channel_ready", "user_channel_id": user_channel_id, "channel_id": channel_id, "error": e.to_string() }),
@@ -991,6 +1575,26 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
+        self.handle_payment_received_at(
+            custom_records,
+            payment_id,
+            amount_msat,
+            None,
+            ldk,
+            btc_price,
+        )
+        .await;
+    }
+
+    pub async fn handle_payment_received_at(
+        &mut self,
+        custom_records: Vec<CustomTlvRecord>,
+        payment_id: Option<String>,
+        amount_msat: Option<u64>,
+        settled_at: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
         if let Some(record) = custom_records
             .iter()
             .find(|record| record.type_num == SIGNED_STABILITY_TLV_TYPE)
@@ -1037,18 +1641,22 @@ impl StableChannelManager {
                 // stability payment. The trade settlement is recorded INSIDE the handler, only
                 // after the signature verifies — a forged or unsigned envelope from any peer no
                 // longer writes a settlement row before it is authenticated.
-                self.handle_trade_payment(
+                self.handle_trade_payment_at(
                     &raw,
                     payment_id.as_deref(),
                     amount_msat,
+                    settled_at,
                     ldk,
                     btc_price,
                 )
-                    .await;
+                .await;
             } else if rec.value.as_ref() == [1u8] {
                 if let Some(pid) = payment_id.as_deref() {
                     if let Err(e) = self.db.record_settlement(pid, "stability") {
-                        tracing::error!("[stable] record_settlement (inbound stability) failed: {}", e);
+                        tracing::error!(
+                            "[stable] record_settlement (inbound stability) failed: {}",
+                            e
+                        );
                         stable_channels::audit::audit_event(
                             "DB_WRITE_FAILED",
                             serde_json::json!({ "op": "record_settlement", "kind": "stability", "payment_id": pid, "error": e.to_string() }),
@@ -1059,8 +1667,13 @@ impl StableChannelManager {
                 // books NOW: with stale backing_sats the channel still reads above par
                 // (double-charge risk) and the balance-truth backstop would misread the
                 // user's payment as an unreconciled spend and deduct expected_usd.
-                self.reconcile_incoming_stability(payment_id.as_deref(), amount_msat, ldk, btc_price)
-                    .await;
+                self.reconcile_incoming_stability(
+                    payment_id.as_deref(),
+                    amount_msat,
+                    ldk,
+                    btc_price,
+                )
+                .await;
             } else {
                 stable_channels::audit::audit_event(
                     "LEGACY_STABILITY_MARKER_INVALID",
@@ -1088,9 +1701,7 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
-        if record.value.len()
-            > stable_channels::constants::MAX_SIGNED_STABILITY_TLV_VALUE_BYTES
-        {
+        if record.value.len() > stable_channels::constants::MAX_SIGNED_STABILITY_TLV_VALUE_BYTES {
             stable_channels::audit::audit_event(
                 "STABILITY_PAYMENT_PAYLOAD_INVALID",
                 serde_json::json!({
@@ -1342,9 +1953,7 @@ impl StableChannelManager {
             );
             return;
         }
-        if payload.expected_usd.to_bits()
-            != self.stable_channels[idx].expected_usd.0.to_bits()
-        {
+        if payload.expected_usd.to_bits() != self.stable_channels[idx].expected_usd.0.to_bits() {
             // The signed amount and local equilibrium bound the economic transition. A target
             // difference between independent peers is useful telemetry, but is not a reason to
             // discard an already-settled authenticated payment.
@@ -1373,39 +1982,35 @@ impl StableChannelManager {
         let amount_sats = received_msat / 1000;
         let mut allocation_expected_usd = self.stable_channels[idx].expected_usd.0;
         let mut backing_before = self.stable_channels[idx].backing_sats;
-        let Some(mut backing_after) =
-            stable_channels::stable::backing_after_user_to_lsp_stability(
-                backing_before,
-                allocation_expected_usd,
-                btc_price,
-                amount_sats,
-                their_sats,
-            )
-        else {
+        let Some(mut backing_after) = stable_channels::stable::backing_after_user_to_lsp_stability(
+            backing_before,
+            allocation_expected_usd,
+            btc_price,
+            amount_sats,
+            their_sats,
+        ) else {
             invalidate("allocation");
             return;
         };
         let mut native_after = their_sats.saturating_sub(backing_after);
-        let amount_usd = amount_sats as f64
-            / stable_channels::constants::SATS_IN_BTC as f64
-            * btc_price;
+        let amount_usd =
+            amount_sats as f64 / stable_channels::constants::SATS_IN_BTC as f64 * btc_price;
         let persist = |backing_sats_before, backing_sats_after, native_sats_after| {
-            self.db.record_signed_stability_payment_and_update_allocation(
-                payment_id,
-                &payload.settlement_id,
-                received_msat,
-                Some(amount_usd),
-                Some(btc_price),
-                &canonical_user_channel_id,
-                backing_sats_before,
-                backing_sats_after,
-                native_sats_after,
-            )
+            self.db
+                .record_signed_stability_payment_and_update_allocation(
+                    payment_id,
+                    &payload.settlement_id,
+                    received_msat,
+                    Some(amount_usd),
+                    Some(btc_price),
+                    &canonical_user_channel_id,
+                    backing_sats_before,
+                    backing_sats_after,
+                    native_sats_after,
+                )
         };
         let persisted = match persist(backing_before, backing_after, native_after) {
-            Err(ref error)
-                if stable_channels::db::is_stale_inbound_stability_allocation(error) =>
-            {
+            Err(ref error) if stable_channels::db::is_stale_inbound_stability_allocation(error) => {
                 let durable = match self.db.load_channel(&canonical_user_channel_id) {
                     Ok(Some(channel)) => channel,
                     Ok(None) => return,
@@ -1528,11 +2133,7 @@ impl StableChannelManager {
         );
     }
 
-    async fn retry_pending_signed_stability(
-        &mut self,
-        ldk: &dyn LdkServerCalls,
-        btc_price: f64,
-    ) {
+    async fn retry_pending_signed_stability(&mut self, ldk: &dyn LdkServerCalls, btc_price: f64) {
         if !btc_price.is_finite() || btc_price <= 0.0 {
             return;
         }
@@ -1614,9 +2215,10 @@ impl StableChannelManager {
             if sc.expected_usd.0 < 0.01 {
                 continue;
             }
-            let Some(c) = channels.iter().find(|c| {
-                parse_user_channel_id(&c.user_channel_id) == Some(sc.user_channel_id)
-            }) else {
+            let Some(c) = channels
+                .iter()
+                .find(|c| parse_user_channel_id(&c.user_channel_id) == Some(sc.user_channel_id))
+            else {
                 continue;
             };
             let (_, their_sats) = channel_peer_balances(c);
@@ -1734,6 +2336,7 @@ impl StableChannelManager {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs() as i64;
+        let _ = self.db.expire_trade_reservations(now);
 
         let percent_threshold = stable_channels::constants::STABILITY_THRESHOLD_PERCENT;
         let dollar_threshold = stable_channels::constants::STABILITY_THRESHOLD_USD;
@@ -1747,7 +2350,25 @@ impl StableChannelManager {
             if sc.expected_usd.0 < 0.01 {
                 continue;
             }
-            let Some(c) = by_user_channel_id.get(&sc.user_channel_id) else { continue; };
+            let Some(c) = by_user_channel_id.get(&sc.user_channel_id) else {
+                continue;
+            };
+            // The confirmed allocation and fee are locked for the short review window.
+            let reservation = self.db.active_trade_reservation(&c.channel_id, now);
+            if !stability_mutation_allowed(&reservation) {
+                if let Err(error) = reservation {
+                    stable_channels::audit::audit_event(
+                        "DB_READ_FAILED",
+                        serde_json::json!({
+                            "op": "active_trade_reservation",
+                            "context": "stability_tick",
+                            "channel_id": c.channel_id,
+                            "error": error.to_string(),
+                        }),
+                    );
+                }
+                continue;
+            }
 
             let (our_sats, their_sats) = channel_peer_balances(c);
             sc.stable_provider_btc = Bitcoin::from_sats(our_sats);
@@ -1816,14 +2437,25 @@ impl StableChannelManager {
             let percent_from_par = (((stable_usd_value - target) / target) * 100.0).abs();
             let dollars_from_par = (stable_usd_value - target).abs();
 
-            if percent_from_par < percent_threshold
-                || dollars_from_par < dollar_threshold
-            {
+            if percent_from_par < percent_threshold || dollars_from_par < dollar_threshold {
                 continue;
             }
             if sc.risk_level > stable_channels::constants::MAX_RISK_LEVEL {
-                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
-                if stability_should_log(&lo, "high_risk", lv, stable_usd_value, target, dollar_threshold, percent_threshold, false) {
+                let (lo, lv) = self
+                    .stability_throttle
+                    .get(&sc.user_channel_id)
+                    .cloned()
+                    .unwrap_or_default();
+                if stability_should_log(
+                    &lo,
+                    "high_risk",
+                    lv,
+                    stable_usd_value,
+                    target,
+                    dollar_threshold,
+                    percent_threshold,
+                    false,
+                ) {
                     stable_channels::audit::audit_event(
                         "STABILITY_SKIP_HIGH_RISK",
                         serde_json::json!({
@@ -1832,13 +2464,29 @@ impl StableChannelManager {
                             "risk_level": sc.risk_level,
                         }),
                     );
-                    self.stability_throttle.insert(sc.user_channel_id, ("high_risk".to_string(), stable_usd_value));
+                    self.stability_throttle.insert(
+                        sc.user_channel_id,
+                        ("high_risk".to_string(), stable_usd_value),
+                    );
                 }
                 continue;
             }
             if now - sc.last_stability_payment < cooldown {
-                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
-                if stability_should_log(&lo, "cooldown", lv, stable_usd_value, target, dollar_threshold, percent_threshold, false) {
+                let (lo, lv) = self
+                    .stability_throttle
+                    .get(&sc.user_channel_id)
+                    .cloned()
+                    .unwrap_or_default();
+                if stability_should_log(
+                    &lo,
+                    "cooldown",
+                    lv,
+                    stable_usd_value,
+                    target,
+                    dollar_threshold,
+                    percent_threshold,
+                    false,
+                ) {
                     stable_channels::audit::audit_event(
                         "STABILITY_COOLDOWN",
                         serde_json::json!({
@@ -1848,7 +2496,10 @@ impl StableChannelManager {
                             "cooldown_secs": cooldown,
                         }),
                     );
-                    self.stability_throttle.insert(sc.user_channel_id, ("cooldown".to_string(), stable_usd_value));
+                    self.stability_throttle.insert(
+                        sc.user_channel_id,
+                        ("cooldown".to_string(), stable_usd_value),
+                    );
                 }
                 continue;
             }
@@ -1924,8 +2575,7 @@ impl StableChannelManager {
                         }
                     };
                     let envelope = match stable_channels::stable::build_stability_signed_envelope(
-                        payload,
-                        signature,
+                        payload, signature,
                     ) {
                         Ok(envelope) => envelope,
                         Err(error) => {
@@ -1964,8 +2614,7 @@ impl StableChannelManager {
                     let expected_usd_for_db = sc.expected_usd.0;
                     let note_for_db = sc.note.clone();
                     let backing_before = sc.backing_sats;
-                    let backing_after =
-                        ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
+                    let backing_after = ((sc.expected_usd.0 / btc_price) * 100_000_000.0) as u64;
                     let native_before = sc.native_sats;
                     let last_stability_payment_before = sc.last_stability_payment;
                     let counterparty_for_db = sc.counterparty.to_string();
@@ -2006,7 +2655,7 @@ impl StableChannelManager {
                                             serde_json::json!({ "op": "record_stability_settlement_with_rollback", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": "duplicate payment id or invalid rollback metadata" }),
                                         );
                                         false
-                                    },
+                                    }
                                     Err(e) => {
                                         tracing::error!(
                                             "[stable] record_settlement (stability) failed: {}",
@@ -2017,7 +2666,7 @@ impl StableChannelManager {
                                             serde_json::json!({ "op": "record_stability_settlement_with_rollback", "kind": "stability", "payment_id": resp.payment_id.clone(), "user_channel_id": user_channel_id_clone.clone(), "channel_id": channel_id_clone.clone(), "error": e.to_string() }),
                                         );
                                         false
-                                    },
+                                    }
                                 }
                             };
                             sc.last_stability_payment = now;
@@ -2028,14 +2677,19 @@ impl StableChannelManager {
                             }
                             self.stability_throttle.insert(
                                 sc.user_channel_id,
-                                (if persisted { "payment_sent" } else { "payment_persist_failed" }.to_string(), stable_usd_value),
+                                (
+                                    if persisted {
+                                        "payment_sent"
+                                    } else {
+                                        "payment_persist_failed"
+                                    }
+                                    .to_string(),
+                                    stable_usd_value,
+                                ),
                             );
-                        },
+                        }
                         Err(e) => {
-                            tracing::warn!(
-                                "[stable] run_tick: spontaneous_send failed: {}",
-                                e
-                            );
+                            tracing::warn!("[stable] run_tick: spontaneous_send failed: {}", e);
                             stable_channels::audit::audit_event(
                                 "STABILITY_PAYMENT_FAILED",
                                 serde_json::json!({
@@ -2045,14 +2699,30 @@ impl StableChannelManager {
                                     "error": e.to_string(),
                                 }),
                             );
-                            self.stability_throttle.insert(sc.user_channel_id, ("payment_failed".to_string(), stable_usd_value));
+                            self.stability_throttle.insert(
+                                sc.user_channel_id,
+                                ("payment_failed".to_string(), stable_usd_value),
+                            );
                             // Do not bump last_stability_payment so retry can fire.
-                        },
+                        }
                     }
                 } else {
                     // User above par: CHECK_ONLY. The LSP can only push value, not pull, so do nothing here (no cooldown bump).
-                    let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
-                    if stability_should_log(&lo, "check_only", lv, stable_usd_value, target, dollar_threshold, percent_threshold, true) {
+                    let (lo, lv) = self
+                        .stability_throttle
+                        .get(&sc.user_channel_id)
+                        .cloned()
+                        .unwrap_or_default();
+                    if stability_should_log(
+                        &lo,
+                        "check_only",
+                        lv,
+                        stable_usd_value,
+                        target,
+                        dollar_threshold,
+                        percent_threshold,
+                        true,
+                    ) {
                         stable_channels::audit::audit_event(
                             "STABILITY_CHECK_ONLY",
                             serde_json::json!({
@@ -2063,7 +2733,10 @@ impl StableChannelManager {
                                 "expected_usd": target,
                             }),
                         );
-                        self.stability_throttle.insert(sc.user_channel_id, ("check_only".to_string(), stable_usd_value));
+                        self.stability_throttle.insert(
+                            sc.user_channel_id,
+                            ("check_only".to_string(), stable_usd_value),
+                        );
                     }
                 }
             } else {
@@ -2071,8 +2744,21 @@ impl StableChannelManager {
                 p.notify(&sc.counterparty.to_string(), direction);
                 drop(p);
                 let key = format!("push_queued:{}", direction);
-                let (lo, lv) = self.stability_throttle.get(&sc.user_channel_id).cloned().unwrap_or_default();
-                if stability_should_log(&lo, &key, lv, stable_usd_value, target, dollar_threshold, percent_threshold, true) {
+                let (lo, lv) = self
+                    .stability_throttle
+                    .get(&sc.user_channel_id)
+                    .cloned()
+                    .unwrap_or_default();
+                if stability_should_log(
+                    &lo,
+                    &key,
+                    lv,
+                    stable_usd_value,
+                    target,
+                    dollar_threshold,
+                    percent_threshold,
+                    true,
+                ) {
                     stable_channels::audit::audit_event(
                         "STABILITY_PUSH_QUEUED",
                         serde_json::json!({
@@ -2084,7 +2770,8 @@ impl StableChannelManager {
                             "expected_usd": target,
                         }),
                     );
-                    self.stability_throttle.insert(sc.user_channel_id, (key, stable_usd_value));
+                    self.stability_throttle
+                        .insert(sc.user_channel_id, (key, stable_usd_value));
                 }
             }
         }
@@ -2178,10 +2865,7 @@ impl StableChannelManager {
                         "sync",
                         &format!("{}", user_channel_id),
                     ) {
-                        tracing::error!(
-                            "[stable] record_settlement (outbound sync) failed: {}",
-                            e
-                        );
+                        tracing::error!("[stable] record_settlement (outbound sync) failed: {}", e);
                         stable_channels::audit::audit_event(
                             "DB_WRITE_FAILED",
                             serde_json::json!({ "op": "record_settlement", "kind": "sync", "payment_id": resp.payment_id, "user_channel_id": format!("{}", user_channel_id), "error": e.to_string() }),
@@ -2199,7 +2883,7 @@ impl StableChannelManager {
                     }),
                 );
                 true
-            },
+            }
             Err(e) => {
                 stable_channels::audit::audit_event(
                     "SYNC_MESSAGE_FAILED",
@@ -2544,12 +3228,28 @@ impl StableChannelManager {
         ldk: &dyn LdkServerCalls,
         btc_price: f64,
     ) {
+        self.handle_trade_payment_at(raw, inbound_payment_id, amount_msat, None, ldk, btc_price)
+            .await;
+    }
+
+    async fn handle_trade_payment_at(
+        &mut self,
+        raw: &str,
+        inbound_payment_id: Option<&str>,
+        amount_msat: Option<u64>,
+        settled_at: Option<u64>,
+        ldk: &dyn LdkServerCalls,
+        btc_price: f64,
+    ) {
         let Some(envelope) = crate::messages::parse_envelope(raw) else {
             stable_channels::audit::audit_event("TRADE_PARSE_SIGNED_FAILED", serde_json::json!({}));
             return;
         };
         let Some(payload) = crate::messages::parse_trade_payload(&envelope.payload) else {
-            stable_channels::audit::audit_event("TRADE_PARSE_PAYLOAD_FAILED", serde_json::json!({}));
+            stable_channels::audit::audit_event(
+                "TRADE_PARSE_PAYLOAD_FAILED",
+                serde_json::json!({}),
+            );
             return;
         };
         if payload.kind != stable_channels::constants::TRADE_MESSAGE_TYPE {
@@ -2591,13 +3291,18 @@ impl StableChannelManager {
         };
         // channel_id is authoritative when present; only requests that omit it may use the
         // legacy node-local user_channel_id fallback.
-        let chan = channels.into_iter().find(|c| match payload.channel_id.as_deref() {
-            Some(channel_id) => c.channel_id == channel_id,
-            None => payload.user_channel_id.as_deref().is_some_and(|user_channel_id| {
-                let wanted = parse_user_channel_id(user_channel_id);
-                wanted.is_some() && wanted == parse_user_channel_id(&c.user_channel_id)
-            }),
-        });
+        let chan = channels
+            .into_iter()
+            .find(|c| match payload.channel_id.as_deref() {
+                Some(channel_id) => c.channel_id == channel_id,
+                None => payload
+                    .user_channel_id
+                    .as_deref()
+                    .is_some_and(|user_channel_id| {
+                        let wanted = parse_user_channel_id(user_channel_id);
+                        wanted.is_some() && wanted == parse_user_channel_id(&c.user_channel_id)
+                    }),
+            });
         let Some(chan) = chan else {
             stable_channels::audit::audit_event(
                 "TRADE_CHANNEL_NOT_FOUND",
@@ -2640,6 +3345,51 @@ impl StableChannelManager {
                     serde_json::json!({ "op": "record_settlement", "kind": "trade", "payment_id": pid, "error": e.to_string() }),
                 );
             }
+        }
+
+        if let Some(phase) = payload.phase.as_deref() {
+            match phase {
+                "propose" => {
+                    self.handle_trade_proposal(
+                        &payload,
+                        &envelope,
+                        &chan,
+                        inbound_payment_id,
+                        amount_msat,
+                        ldk,
+                        btc_price,
+                    )
+                    .await;
+                }
+                "execute" => {
+                    self.handle_trade_execution(
+                        &payload,
+                        &envelope,
+                        &chan,
+                        inbound_payment_id,
+                        amount_msat,
+                        settled_at,
+                        ldk,
+                    )
+                    .await;
+                }
+                "cancel" => {
+                    self.handle_trade_cancellation(
+                        &payload,
+                        &envelope,
+                        &chan,
+                        inbound_payment_id,
+                        amount_msat,
+                        ldk,
+                    )
+                    .await;
+                }
+                _ => stable_channels::audit::audit_event(
+                    "TRADE_PHASE_INVALID",
+                    serde_json::json!({ "phase": phase, "channel_id": chan.channel_id }),
+                ),
+            }
+            return;
         }
 
         // A trade id opts into durable correlated results. Legacy mobile-shaped requests continue
@@ -2782,19 +3532,16 @@ impl StableChannelManager {
             {
                 reject_correlated!(TradeRejectionReason::InvalidQuote);
             }
-            let Some(expected_fee_msat) = expected_trade_fee_msat(
-                current.expected_usd.0,
-                new_expected,
-                quote_price,
-            ) else {
+            let Some(expected_fee_msat) =
+                expected_trade_fee_msat(current.expected_usd.0, new_expected, quote_price)
+            else {
                 reject_correlated!(TradeRejectionReason::InvalidFee);
             };
             let tolerance_msat = trade_fee_tolerance_msat(expected_fee_msat, true);
             if received_msat.abs_diff(expected_fee_msat) > tolerance_msat {
                 reject_correlated!(TradeRejectionReason::InvalidFee);
             }
-            let quote_deviation_percent =
-                ((quote_price - btc_price) / btc_price * 100.0).abs();
+            let quote_deviation_percent = ((quote_price - btc_price) / btc_price * 100.0).abs();
             if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
                 reject_correlated!(TradeRejectionReason::QuoteDeviation);
             }
@@ -2807,10 +3554,8 @@ impl StableChannelManager {
             let mut updated = current.clone();
             updated.stable_provider_btc = Bitcoin::from_sats(our_sats);
             updated.stable_receiver_btc = Bitcoin::from_sats(their_sats);
-            updated.stable_provider_usd =
-                USD::from_bitcoin(updated.stable_provider_btc, btc_price);
-            updated.stable_receiver_usd =
-                USD::from_bitcoin(updated.stable_receiver_btc, btc_price);
+            updated.stable_provider_usd = USD::from_bitcoin(updated.stable_provider_btc, btc_price);
+            updated.stable_receiver_usd = USD::from_bitcoin(updated.stable_receiver_btc, btc_price);
             updated.latest_price = btc_price;
             if !stable_channels::stable::apply_trade(&mut updated, new_expected, btc_price) {
                 let reason = if new_expected < current.expected_usd.0
@@ -2820,18 +3565,14 @@ impl StableChannelManager {
                             current.expected_usd.0,
                             new_expected,
                             btc_price,
-                        ))
-                {
+                        )) {
                     TradeRejectionReason::SettlementRequired
                 } else {
                     TradeRejectionReason::UnsafeAllocation
                 };
                 reject_correlated!(reason);
             }
-            let sync_version = match self
-                .db
-                .candidate_sync_version(&format!("{}", target_uid))
-            {
+            let sync_version = match self.db.candidate_sync_version(&format!("{}", target_uid)) {
                 Ok(version) => version,
                 Err(_) => reject_correlated!(TradeRejectionReason::InternalFailure),
             };
@@ -2858,8 +3599,7 @@ impl StableChannelManager {
                 Ok(response) => response.signature,
                 Err(_) => reject_correlated!(TradeRejectionReason::InternalFailure),
             };
-            let response_envelope =
-                crate::messages::build_envelope(acceptance_payload, signature);
+            let response_envelope = crate::messages::build_envelope(acceptance_payload, signature);
             let native_sats = their_sats.saturating_sub(updated.backing_sats);
             match self.db.persist_trade_acceptance(
                 inbound_payment_id,
@@ -2921,7 +3661,10 @@ impl StableChannelManager {
         }
 
         let Some(target_uid) = parse_user_channel_id(&chan.user_channel_id) else {
-            stable_channels::audit::audit_event("TRADE_CHANNEL_UID_UNPARSEABLE", serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }));
+            stable_channels::audit::audit_event(
+                "TRADE_CHANNEL_UID_UNPARSEABLE",
+                serde_json::json!({ "channel_id": chan.channel_id.clone(), "user_channel_id": chan.user_channel_id.clone() }),
+            );
             return;
         };
         let Some(current_expected_usd) = self
@@ -2940,11 +3683,9 @@ impl StableChannelManager {
             stable_channels::stable::normalize_trade_expected_usd(payload.expected_usd);
 
         let fee_price = payload.quote_price.unwrap_or(btc_price);
-        let Some(expected_fee_msat) = expected_trade_fee_msat(
-            current_expected_usd,
-            new_expected,
-            fee_price,
-        ) else {
+        let Some(expected_fee_msat) =
+            expected_trade_fee_msat(current_expected_usd, new_expected, fee_price)
+        else {
             stable_channels::audit::audit_event(
                 "TRADE_FEE_INVALID",
                 serde_json::json!({
@@ -3005,8 +3746,7 @@ impl StableChannelManager {
 
                 // Both peers run their own price feed. Admit small observation-time differences,
                 // but reject a quote far enough away to change the economic trade materially.
-                let quote_deviation_percent =
-                    ((quote_price - btc_price) / btc_price * 100.0).abs();
+                let quote_deviation_percent = ((quote_price - btc_price) / btc_price * 100.0).abs();
                 if quote_deviation_percent > MAX_TRADE_QUOTE_DEVIATION_PERCENT {
                     stable_channels::audit::audit_event(
                         "TRADE_QUOTE_DEVIATION_EXCEEDED",
@@ -3205,13 +3945,21 @@ fn parse_user_channel_id(s: &str) -> Option<u128> {
 
 /// Whether a throttled stability event should log this tick: on outcome change, or (if tracking value) a significant value move.
 pub(crate) fn stability_should_log(
-    last_outcome: &str, outcome: &str,
-    last_value: f64, value: f64, target: f64,
-    usd_threshold: f64, pct_threshold: f64,
+    last_outcome: &str,
+    outcome: &str,
+    last_value: f64,
+    value: f64,
+    target: f64,
+    usd_threshold: f64,
+    pct_threshold: f64,
     track_value: bool,
 ) -> bool {
-    if last_outcome != outcome { return true; }
-    if !track_value { return false; }
+    if last_outcome != outcome {
+        return true;
+    }
+    if !track_value {
+        return false;
+    }
     let d = (value - last_value).abs();
     d > usd_threshold && (d / target * 100.0) > pct_threshold
 }
@@ -3245,9 +3993,9 @@ mod tests {
         ListPaymentsRequest, ListPaymentsResponse, ListPeersRequest, ListPeersResponse,
     };
     use ldk_server_client::ldk_server_grpc::types::{
-        Channel as GrpcChannel, ForwardedPayment as GrpcForwardedPayment, HtlcLocator,
-        PageToken, Payment as GrpcPayment, PaymentStatus,
-        PendingSweepBalance as GrpcPendingSweepBalance, Peer as GrpcPeer,
+        Channel as GrpcChannel, ForwardedPayment as GrpcForwardedPayment, HtlcLocator, PageToken,
+        Payment as GrpcPayment, PaymentStatus, Peer as GrpcPeer,
+        PendingSweepBalance as GrpcPendingSweepBalance,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex as StdMutex;
@@ -3297,14 +4045,26 @@ mod tests {
             self.verify_should_pass = false;
             self
         }
-        pub fn with_forwarded(self, f: Vec<GrpcForwardedPayment>) -> Self { *self.forwarded.lock().unwrap() = f; self }
+        pub fn with_forwarded(self, f: Vec<GrpcForwardedPayment>) -> Self {
+            *self.forwarded.lock().unwrap() = f;
+            self
+        }
         pub fn with_forward_cursor(self, token: PageToken) -> Self {
             *self.forward_next_page_token.lock().unwrap() = Some(token);
             self
         }
-        pub fn with_sweeps(self, s: Vec<GrpcPendingSweepBalance>) -> Self { *self.sweeps.lock().unwrap() = s; self }
-        pub fn with_peers(self, p: Vec<GrpcPeer>) -> Self { *self.peers.lock().unwrap() = p; self }
-        pub fn with_payments(self, p: Vec<GrpcPayment>) -> Self { *self.payments.lock().unwrap() = p; self }
+        pub fn with_sweeps(self, s: Vec<GrpcPendingSweepBalance>) -> Self {
+            *self.sweeps.lock().unwrap() = s;
+            self
+        }
+        pub fn with_peers(self, p: Vec<GrpcPeer>) -> Self {
+            *self.peers.lock().unwrap() = p;
+            self
+        }
+        pub fn with_payments(self, p: Vec<GrpcPayment>) -> Self {
+            *self.payments.lock().unwrap() = p;
+            self
+        }
     }
 
     #[async_trait]
@@ -3350,28 +4110,46 @@ mod tests {
                 valid: self.verify_should_pass,
             })
         }
-        async fn list_forwarded_payments(&self, _req: ListForwardedPaymentsRequest)
-            -> Result<ListForwardedPaymentsResponse, LdkServerError> {
+        async fn list_forwarded_payments(
+            &self,
+            _req: ListForwardedPaymentsRequest,
+        ) -> Result<ListForwardedPaymentsResponse, LdkServerError> {
             self.forward_calls.fetch_add(1, Ordering::SeqCst);
             Ok(ListForwardedPaymentsResponse {
                 forwarded_payments: self.forwarded.lock().unwrap().clone(),
                 next_page_token: self.forward_next_page_token.lock().unwrap().clone(),
             })
         }
-        async fn get_balances(&self, _req: GetBalancesRequest)
-            -> Result<GetBalancesResponse, LdkServerError> {
-            Ok(GetBalancesResponse { pending_balances_from_channel_closures: self.sweeps.lock().unwrap().clone(), ..Default::default() })
+        async fn get_balances(
+            &self,
+            _req: GetBalancesRequest,
+        ) -> Result<GetBalancesResponse, LdkServerError> {
+            Ok(GetBalancesResponse {
+                pending_balances_from_channel_closures: self.sweeps.lock().unwrap().clone(),
+                ..Default::default()
+            })
         }
-        async fn list_peers(&self, _req: ListPeersRequest)
-            -> Result<ListPeersResponse, LdkServerError> {
-            Ok(ListPeersResponse { peers: self.peers.lock().unwrap().clone() })
+        async fn list_peers(
+            &self,
+            _req: ListPeersRequest,
+        ) -> Result<ListPeersResponse, LdkServerError> {
+            Ok(ListPeersResponse {
+                peers: self.peers.lock().unwrap().clone(),
+            })
         }
-        async fn list_payments(&self, _req: ListPaymentsRequest)
-            -> Result<ListPaymentsResponse, LdkServerError> {
-            Ok(ListPaymentsResponse { payments: self.payments.lock().unwrap().clone(), next_page_token: None })
+        async fn list_payments(
+            &self,
+            _req: ListPaymentsRequest,
+        ) -> Result<ListPaymentsResponse, LdkServerError> {
+            Ok(ListPaymentsResponse {
+                payments: self.payments.lock().unwrap().clone(),
+                next_page_token: None,
+            })
         }
-        async fn get_payment_details(&self, req: GetPaymentDetailsRequest)
-            -> Result<GetPaymentDetailsResponse, LdkServerError> {
+        async fn get_payment_details(
+            &self,
+            req: GetPaymentDetailsRequest,
+        ) -> Result<GetPaymentDetailsResponse, LdkServerError> {
             Ok(GetPaymentDetailsResponse {
                 payment: self
                     .payments
@@ -3395,8 +4173,11 @@ mod tests {
         let peers = fake.list_peers(ListPeersRequest {}).await.unwrap().peers;
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].node_id, "02aa");
-        let fwd = fake.list_forwarded_payments(ListForwardedPaymentsRequest { page_token: None })
-            .await.unwrap().forwarded_payments;
+        let fwd = fake
+            .list_forwarded_payments(ListForwardedPaymentsRequest { page_token: None })
+            .await
+            .unwrap()
+            .forwarded_payments;
         assert!(fwd.is_empty());
     }
 
@@ -3447,16 +4228,31 @@ mod tests {
         let mut mgr = make_manager();
         // Seed an existing record so handle_channel_closed has something to remove.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), Some("note".to_string()),
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            Some("note".to_string()),
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         assert_eq!(mgr.stable_channels.len(), 1);
 
-        mgr.handle_channel_closed("".to_string(), USER_CHANNEL_ID_HEX.to_string(), None, None, 0, None);
+        mgr.handle_channel_closed(
+            "".to_string(),
+            USER_CHANNEL_ID_HEX.to_string(),
+            None,
+            None,
+            0,
+            None,
+        );
         assert_eq!(mgr.stable_channels.len(), 0);
     }
 
@@ -3464,18 +4260,27 @@ mod tests {
     async fn reconcile_drops_channels_no_longer_on_server() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), None,
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         assert_eq!(mgr.stable_channels.len(), 1);
 
         // LDK Server no longer reports the channel.
         let empty_server = FakeLdkServer::new(vec![]);
-        mgr.reconcile_from_grpc(&empty_server as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.reconcile_from_grpc(&empty_server as &dyn LdkServerCalls, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels.len(), 0);
     }
 
@@ -3483,20 +4288,33 @@ mod tests {
     async fn reconcile_refreshes_known_channel() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), None,
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // Same channel, different balance: outbound drops from 50_000 to 30_000 sats.
         let fake2 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 30_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            30_000_000,
+            true,
         )]);
-        mgr.reconcile_from_grpc(&fake2 as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.reconcile_from_grpc(&fake2 as &dyn LdkServerCalls, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels.len(), 1);
         // outbound dropped from 50_000 to 30_000 sats; receiver got 20_000 more.
         assert_eq!(mgr.stable_channels[0].stable_receiver_btc.sats, 70_000);
@@ -3521,17 +4339,34 @@ mod tests {
 
         // The live LDK Server still reports the channel.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
 
-        assert_eq!(mgr.stable_channels.len(), 1, "channel must be hydrated from db");
+        assert_eq!(
+            mgr.stable_channels.len(),
+            1,
+            "channel must be hydrated from db"
+        );
         let sc = &mgr.stable_channels[0];
         assert_eq!(sc.expected_usd.0, 25.0, "persisted expected_usd preserved");
         assert_eq!(sc.backing_sats, 40_000, "persisted backing_sats preserved");
-        assert_eq!(sc.note.as_deref(), Some("persisted"), "persisted note preserved");
-        assert_eq!(sc.counterparty.to_string(), COUNTERPARTY_HEX, "counterparty resolved from live channel");
+        assert_eq!(
+            sc.note.as_deref(),
+            Some("persisted"),
+            "persisted note preserved"
+        );
+        assert_eq!(
+            sc.counterparty.to_string(),
+            COUNTERPARTY_HEX,
+            "counterparty resolved from live channel"
+        );
         assert_eq!(
             fake.sends.lock().unwrap().len(),
             1,
@@ -3661,29 +4496,52 @@ mod tests {
     async fn reconcile_if_empty_hydrates_then_leaves_populated_untouched() {
         // Simulate the cold-start skip: empty in-memory Vec, persisted row, live channel present.
         let mut mgr = make_manager();
-        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, 25.0, 40_000, 10_000, Some("persisted")).unwrap();
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_HEX,
+                25.0,
+                40_000,
+                10_000,
+                Some("persisted"),
+            )
+            .unwrap();
         assert_eq!(mgr.stable_channels.len(), 0, "fresh manager starts empty");
 
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         // Empty vec -> self-heal repopulates from truth.
-        mgr.reconcile_if_empty(&fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.reconcile_if_empty(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels.len(), 1, "empty list is hydrated");
 
         // Populated vec -> guard skips reconcile, so a transient empty snapshot can't wipe it.
         let empty_server = FakeLdkServer::new(vec![]);
-        mgr.reconcile_if_empty(&empty_server as &dyn LdkServerCalls, 100_000.0).await;
-        assert_eq!(mgr.stable_channels.len(), 1, "populated list is left untouched");
+        mgr.reconcile_if_empty(&empty_server as &dyn LdkServerCalls, 100_000.0)
+            .await;
+        assert_eq!(
+            mgr.stable_channels.len(),
+            1,
+            "populated list is left untouched"
+        );
     }
 
     #[tokio::test]
     async fn handle_channel_ready_auto_registers_new_channel() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.handle_channel_ready(
             CHANNEL_ID_HEX.to_string(),
@@ -3691,7 +4549,8 @@ mod tests {
             None,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
         assert_eq!(mgr.stable_channels.len(), 1);
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
     }
@@ -3700,8 +4559,12 @@ mod tests {
     async fn handle_channel_ready_is_idempotent() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.handle_channel_ready(
             CHANNEL_ID_HEX.to_string(),
@@ -3709,14 +4572,16 @@ mod tests {
             None,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
         mgr.handle_channel_ready(
             CHANNEL_ID_HEX.to_string(),
             USER_CHANNEL_ID_HEX.to_string(),
             None,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
         assert_eq!(mgr.stable_channels.len(), 1);
     }
 
@@ -3724,9 +4589,24 @@ mod tests {
     async fn payment_received_trade_tlv_applies() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 8.0);
         let records = vec![CustomTlvRecord {
@@ -3757,9 +4637,20 @@ mod tests {
     async fn payment_received_no_tlv_is_noop() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![]);
-        seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            1u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            5.0,
+            5_000,
+            45_000,
+            50_000,
+            100_000.0,
+        );
 
-        mgr.handle_payment_received(vec![], None, None, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(vec![], None, None, &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // untouched
         assert!(mgr.db.list_settlements().unwrap().is_empty());
@@ -3769,16 +4660,38 @@ mod tests {
     async fn payment_received_marker_records_settlement() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let records = vec![CustomTlvRecord {
             type_num: stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
             value: vec![1u8].into(),
         }];
         let before = mgr.stable_channels[0].expected_usd.0;
-        mgr.handle_payment_received(records, Some("pay_settlement_1".to_string()), None, &fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.handle_payment_received(
+            records,
+            Some("pay_settlement_1".to_string()),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // the 1-byte marker is not an envelope, so it records stability and applies no trade
         assert_eq!(
@@ -3792,13 +4705,21 @@ mod tests {
     async fn seed_forwarded_fixture() -> (StableChannelManager, FakeLdkServer) {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), None,
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         assert_eq!(mgr.stable_channels.len(), 1);
         assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
         assert_eq!(mgr.stable_channels[0].native_sats, 40_000);
@@ -3810,8 +4731,12 @@ mod tests {
         let (mut mgr, fake) = seed_forwarded_fixture().await;
         // Forward 45k out: 40k native + 5k stable. Post-forward user side = 5_000 (LSP 95_000).
         *fake.channels.lock().unwrap() = vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )];
 
         mgr.handle_payment_forwarded(
@@ -3825,15 +4750,19 @@ mod tests {
             0,          // fee_msat
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
 
         // 5_000 overflow sats * $100k / 1e8 = $5.00 deducted: $10 -> $5.
         let exp = mgr.stable_channels[0].expected_usd.0;
-        assert!((exp - 5.0).abs() < 0.01, "expected_usd should drop to ~5.0, got {}", exp);
+        assert!(
+            (exp - 5.0).abs() < 0.01,
+            "expected_usd should drop to ~5.0, got {}",
+            exp
+        );
         // native_sats and native_channel_btc must agree after reconcile.
         assert_eq!(
-            mgr.stable_channels[0].native_channel_btc.sats,
-            mgr.stable_channels[0].native_sats,
+            mgr.stable_channels[0].native_channel_btc.sats, mgr.stable_channels[0].native_sats,
             "native_channel_btc must match native_sats after a forward",
         );
     }
@@ -3892,8 +4821,12 @@ mod tests {
         let (mut mgr, fake) = seed_forwarded_fixture().await;
         // Forward 20k out, fully covered by the 40k native buffer. Post-forward user side = 30_000 (LSP 70_000).
         *fake.channels.lock().unwrap() = vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 70_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            70_000_000,
+            true,
         )];
 
         mgr.handle_payment_forwarded(
@@ -3907,16 +4840,20 @@ mod tests {
             0,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
 
         let exp = mgr.stable_channels[0].expected_usd.0;
-        assert!((exp - 10.0).abs() < 0.01, "expected_usd must stay ~10.0, got {}", exp);
+        assert!(
+            (exp - 10.0).abs() < 0.01,
+            "expected_usd must stay ~10.0, got {}",
+            exp
+        );
         // Native buffer shrank by the spend: 40_000 - 20_000 = 20_000.
         assert_eq!(mgr.stable_channels[0].native_sats, 20_000);
         // native_sats and native_channel_btc must agree after reconcile.
         assert_eq!(
-            mgr.stable_channels[0].native_channel_btc.sats,
-            mgr.stable_channels[0].native_sats,
+            mgr.stable_channels[0].native_channel_btc.sats, mgr.stable_channels[0].native_sats,
             "native_channel_btc must match native_sats after a forward",
         );
     }
@@ -3926,8 +4863,12 @@ mod tests {
         let mut mgr = make_manager();
         // Untracked channel: a forward on an unknown channel must not panic or invent a record.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
@@ -3940,7 +4881,8 @@ mod tests {
             0,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
         assert!(mgr.stable_channels.is_empty());
     }
 
@@ -3949,10 +4891,25 @@ mod tests {
         let mut mgr = make_manager();
         // Post-forward channel snapshot: their = 5,000 sats (our 95k via outbound 95M msat).
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )]);
         // expected $10 -> backing 10,000; native 40,000; receiver 50,000 at $100k.
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
 
         // Forward 45,000 sats out: pre = 5,000 + 45,000 = 50,000, native 40,000, overflow 5,000 = $5.
         mgr.handle_payment_forwarded(
@@ -3970,7 +4927,11 @@ mod tests {
         .await;
 
         let sends = fake.sends.lock().unwrap();
-        assert_eq!(sends.len(), 1, "a SYNC should be sent after a stable deduction");
+        assert_eq!(
+            sends.len(),
+            1,
+            "a SYNC should be sent after a stable deduction"
+        );
         assert_eq!(sends[0].amount_msat, 1);
         assert_eq!(
             sends[0].custom_tlvs[0].type_num,
@@ -3982,8 +4943,12 @@ mod tests {
     async fn payment_forwarded_audit_records_both_legs() {
         let (mut mgr, fake) = seed_forwarded_fixture().await;
         *fake.channels.lock().unwrap() = vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )];
         mgr.handle_payment_forwarded(
             USER_CHANNEL_ID_DECIMAL.to_string(),
@@ -3996,7 +4961,8 @@ mod tests {
             0,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
         let page = mgr
             .db
             .list_ledger_events(&stable_channels::ledger::LedgerQuery {
@@ -4010,8 +4976,14 @@ mod tests {
             .iter()
             .find(|event| event.event_type == "PAYMENT_FORWARDED")
             .expect("PAYMENT_FORWARDED must be emitted");
-        assert_eq!(data.detail["prev_user_channel_id"], USER_CHANNEL_ID_DECIMAL, "inbound leg must be recorded");
-        assert_eq!(data.detail["next_user_channel_id"], "outbound-ucid", "outbound leg must be recorded");
+        assert_eq!(
+            data.detail["prev_user_channel_id"], USER_CHANNEL_ID_DECIMAL,
+            "inbound leg must be recorded"
+        );
+        assert_eq!(
+            data.detail["next_user_channel_id"], "outbound-ucid",
+            "outbound leg must be recorded"
+        );
         assert_eq!(data.detail["prev_node_id"], "prev-node-pubkey");
         assert_eq!(data.detail["next_node_id"], "next-node-pubkey");
     }
@@ -4020,8 +4992,12 @@ mod tests {
     async fn run_tick_skips_zero_target() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         // expected_usd defaulted to 0; tick must not attempt any send.
         mgr.handle_channel_ready(
@@ -4030,15 +5006,15 @@ mod tests {
             None,
             &fake as &dyn LdkServerCalls,
             100_000.0,
-        ).await;
+        )
+        .await;
 
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         assert!(fake.sends.lock().unwrap().is_empty());
     }
 
@@ -4046,13 +5022,21 @@ mod tests {
     async fn run_tick_skips_cooldown_active() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(10.0), None,
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         // Pretend we just paid: bump last_stability_payment to "now".
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -4062,16 +5046,19 @@ mod tests {
 
         // Force a large drift by swapping in a channel with no outbound capacity.
         let fake2 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 0, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            0,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
-        mgr.run_tick(&fake2 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake2 as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         assert!(
             fake2.sends.lock().unwrap().is_empty(),
             "cooldown should suppress send"
@@ -4083,27 +5070,38 @@ mod tests {
         let mut mgr = make_manager();
         // Channel exists, set expected_usd = 50.
         let fake_initial = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(50.0), None,
-            &fake_initial as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake_initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // Price drops 20% to 80_000 (receiver USD below 50), peer connected.
         let fake_drift = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
 
-        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0).await;
+        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
 
         let sends = fake_drift.sends.lock().unwrap();
         assert_eq!(sends.len(), 1, "expected one stability payment");
@@ -4135,34 +5133,47 @@ mod tests {
             fake_drift.sign_calls.lock().unwrap().as_slice(),
             [envelope.payload.as_bytes()]
         );
-        assert!(mgr.stable_channels[0].last_stability_payment > 0,
-            "cooldown timestamp should be set");
+        assert!(
+            mgr.stable_channels[0].last_stability_payment > 0,
+            "cooldown timestamp should be set"
+        );
     }
 
     #[tokio::test]
     async fn run_tick_send_failure_keeps_cooldown_unset() {
         let mut mgr = make_manager();
         let fake_initial = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(50.0), None,
-            &fake_initial as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake_initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         let fake_drift = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )])
         .with_send_failure();
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
 
-        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0).await;
+        mgr.run_tick(&fake_drift as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
 
         assert_eq!(
             mgr.stable_channels[0].last_stability_payment, 0,
@@ -4174,27 +5185,38 @@ mod tests {
     async fn run_tick_pushes_when_offline_and_drift_exceeds_threshold() {
         let mut mgr = make_manager();
         let fake_initial = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(50.0), None,
-            &fake_initial as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake_initial as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // Peer disconnected: is_usable=false.
         let fake_offline = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, false,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            false,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
 
-        mgr.run_tick(&fake_offline as &dyn LdkServerCalls, &push, 80_000.0).await;
+        mgr.run_tick(&fake_offline as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
 
         let sends = fake_offline.sends.lock().unwrap();
         assert!(sends.is_empty(), "must not send when peer offline");
@@ -4208,43 +5230,91 @@ mod tests {
     async fn run_tick_check_only_when_connected_and_user_above_par() {
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         // expected_usd=50 at price 100k -> backing_sats = 50_000
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // Price RISES to 120k: stable_usd_value = 50_000/1e8*120k = $60 > $50 target -> user_to_lsp.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await;
-        assert!(fake.sends.lock().unwrap().is_empty(), "LSP must NOT send when user is above par (CHECK_ONLY)");
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0)
+            .await;
+        assert!(
+            fake.sends.lock().unwrap().is_empty(),
+            "LSP must NOT send when user is above par (CHECK_ONLY)"
+        );
     }
 
     #[tokio::test]
     async fn run_tick_resets_backing_to_equilibrium_after_send() {
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         // expected_usd=50 at price 100k -> backing_sats = 50_000
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         // Price DROPS to 80k: stable_usd_value = 50_000/1e8*80k = $40 < $50 -> lsp_to_user -> send.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
 
-        assert_eq!(fake.sends.lock().unwrap().len(), 1, "should send in lsp_to_user direction");
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "should send in lsp_to_user direction"
+        );
         // backing reset to target/price = 50/80000*1e8 = 62_500 (NOT left at stale 50_000).
-        assert_eq!(mgr.stable_channels[0].backing_sats, 62_500, "backing must reset to equilibrium, preventing oscillation");
+        assert_eq!(
+            mgr.stable_channels[0].backing_sats, 62_500,
+            "backing must reset to equilibrium, preventing oscillation"
+        );
     }
 
     #[tokio::test]
@@ -4274,9 +5344,10 @@ mod tests {
             50_000_000,
             true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
 
         mgr.run_tick(&drift as &dyn LdkServerCalls, &push, 80_000.0)
             .await;
@@ -4306,16 +5377,33 @@ mod tests {
     #[tokio::test]
     async fn run_tick_skips_high_risk_channel() {
         let mut mgr = make_manager();
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 50_000, 0, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            50.0,
+            50_000,
+            0,
+            50_000,
+            100_000.0,
+        );
         mgr.stable_channels[0].risk_level = stable_channels::constants::MAX_RISK_LEVEL + 1;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Price drops 20% -> would normally pay lsp_to_user; high risk must skip.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
         assert!(
             fake.sends.lock().unwrap().is_empty(),
             "a channel above MAX_RISK_LEVEL must not trigger a stability send"
@@ -4326,27 +5414,59 @@ mod tests {
     async fn backstop_deducts_and_syncs_after_two_low_ticks() {
         let mut mgr = make_manager();
         // expected $10 -> backing 10_000; receiver 50_000 (native 40_000) at $100k.
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Live balance dropped to 5_000 (< backing 10_000): a spend the forwarded event missed.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )]);
 
         // Tick 1: debounce only.
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
-        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "tick 1 must not deduct");
-        assert!(fake.sends.lock().unwrap().is_empty(), "tick 1 must not SYNC");
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
+        assert!(
+            (mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6,
+            "tick 1 must not deduct"
+        );
+        assert!(
+            fake.sends.lock().unwrap().is_empty(),
+            "tick 1 must not SYNC"
+        );
 
         // Tick 2: act.
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         let exp = mgr.stable_channels[0].expected_usd.0;
-        assert!((exp - 5.0).abs() < 0.01, "tick 2 must deduct ~$5 (10_000-5_000 sats), got {}", exp);
+        assert!(
+            (exp - 5.0).abs() < 0.01,
+            "tick 2 must deduct ~$5 (10_000-5_000 sats), got {}",
+            exp
+        );
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1, "tick 2 must send exactly one SYNC");
-        assert_eq!(sends[0].custom_tlvs.len(), 1, "SYNC must carry exactly one stable TLV");
+        assert_eq!(
+            sends[0].custom_tlvs.len(),
+            1,
+            "SYNC must carry exactly one stable TLV"
+        );
         assert_eq!(
             sends[0].custom_tlvs[0].type_num,
             stable_channels::constants::STABLE_CHANNEL_TLV_TYPE,
@@ -4357,64 +5477,138 @@ mod tests {
     #[tokio::test]
     async fn backstop_single_tick_dip_does_not_deduct() {
         let mut mgr = make_manager();
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Tick 1: transient dip to 5_000 (in-flight outbound HTLC; outbound_capacity excludes it).
         let dip = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )]);
-        mgr.run_tick(&dip as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&dip as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         // Tick 2: balance restored to 50_000 (HTLC resolved without spending stable).
         let restored = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.run_tick(&restored as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&restored as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
 
-        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "a transient dip must not deduct");
-        assert!(restored.sends.lock().unwrap().is_empty(), "no SYNC for a transient dip");
+        assert!(
+            (mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6,
+            "a transient dip must not deduct"
+        );
+        assert!(
+            restored.sends.lock().unwrap().is_empty(),
+            "no SYNC for a transient dip"
+        );
     }
 
     #[tokio::test]
     async fn backstop_noop_when_balance_healthy() {
         let mut mgr = make_manager();
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Healthy: their 50_000 >= backing 10_000.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
-        assert!(fake.sends.lock().unwrap().is_empty(), "no backstop action when healthy");
+        assert!(
+            fake.sends.lock().unwrap().is_empty(),
+            "no backstop action when healthy"
+        );
     }
 
     #[tokio::test]
     async fn reconcile_hydrates_channel_with_decimal_user_channel_id() {
         let mut mgr = make_manager();
         // Persist a row whose user_channel_id is the realistic decimal form.
-        mgr.db.save_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 12.0, 30_000, 5_000, Some("dec")).unwrap();
+        mgr.db
+            .save_channel(
+                CHANNEL_ID_HEX,
+                USER_CHANNEL_ID_DECIMAL,
+                12.0,
+                30_000,
+                5_000,
+                Some("dec"),
+            )
+            .unwrap();
 
         // The live channel reports the SAME decimal user_channel_id (as real gRPC does).
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.reconcile_from_grpc(&fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
 
-        assert_eq!(mgr.stable_channels.len(), 1, "decimal-id channel MUST hydrate (not be dropped)");
+        assert_eq!(
+            mgr.stable_channels.len(),
+            1,
+            "decimal-id channel MUST hydrate (not be dropped)"
+        );
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 12.0);
         // The in-memory u128 must equal the decimal parse, not a hex misparse.
-        assert_eq!(mgr.stable_channels[0].user_channel_id, 189476124653200987495269098788434301048u128);
+        assert_eq!(
+            mgr.stable_channels[0].user_channel_id,
+            189476124653200987495269098788434301048u128
+        );
     }
 
     #[test]
     fn parse_user_channel_id_prefers_decimal() {
-        assert_eq!(parse_user_channel_id("189476124653200987495269098788434301048"),
-                   Some(189476124653200987495269098788434301048u128));
+        assert_eq!(
+            parse_user_channel_id("189476124653200987495269098788434301048"),
+            Some(189476124653200987495269098788434301048u128)
+        );
         // hex fallback still works for 0x-prefixed values
         assert_eq!(parse_user_channel_id("0x01"), Some(1));
     }
@@ -4466,7 +5660,9 @@ mod tests {
     async fn fake_sign_and_verify_behaviour() {
         let fake = FakeLdkServer::new(vec![]);
         let sig = fake
-            .sign_message(SignMessageRequest { message: b"hello".to_vec().into() })
+            .sign_message(SignMessageRequest {
+                message: b"hello".to_vec().into(),
+            })
             .await
             .unwrap();
         assert_eq!(sig.signature, "fake-sig");
@@ -4554,7 +5750,17 @@ mod tests {
         let mut mgr = make_manager();
         // Seed channel with backing_sats=0 so stable_usd_value = stable_receiver_usd (live balance).
         // receiver_sats=50_000 at 100k = $50; expected=50. Price drops to 80k -> $40 < $50 (20% drift).
-        seed_channel(&mut mgr, 1u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 50.0, 0, 0, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            1u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            50.0,
+            0,
+            0,
+            50_000,
+            100_000.0,
+        );
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -4563,21 +5769,29 @@ mod tests {
         mgr.stable_channels[0].last_stability_payment = now + 100;
         // Channel with 50k their side; price 80k -> drift 20% -> exceeds threshold -> hits cooldown gate.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(
-                &crate::config::PushConfig::default(),
-                mgr.data_dir(),
-            ),
-        ));
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0).await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 80_000.0)
+            .await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
-        let cd = events.iter().find(|(e, _)| e == "STABILITY_COOLDOWN")
+        let cd = events
+            .iter()
+            .find(|(e, _)| e == "STABILITY_COOLDOWN")
             .expect("STABILITY_COOLDOWN should be emitted on a cooldown-blocked tick");
-        assert!(cd.1.get("user_channel_id").is_some(), "must carry user_channel_id");
+        assert!(
+            cd.1.get("user_channel_id").is_some(),
+            "must carry user_channel_id"
+        );
         assert!(cd.1.get("channel_id").is_some(), "must carry channel_id");
     }
 
@@ -4707,7 +5921,11 @@ mod tests {
         lsp_price: f64,
     ) -> TradeRejectionReason {
         let before = manager.stable_channels.first().map(|channel| {
-            (channel.expected_usd.0, channel.backing_sats, channel.native_sats)
+            (
+                channel.expected_usd.0,
+                channel.backing_sats,
+                channel.native_sats,
+            )
         });
         let durable_before = manager
             .db
@@ -4730,9 +5948,16 @@ mod tests {
             )
             .await;
         let after = manager.stable_channels.first().map(|channel| {
-            (channel.expected_usd.0, channel.backing_sats, channel.native_sats)
+            (
+                channel.expected_usd.0,
+                channel.backing_sats,
+                channel.native_sats,
+            )
         });
-        assert_eq!(after, before, "rejection must not mutate in-memory allocation");
+        assert_eq!(
+            after, before,
+            "rejection must not mutate in-memory allocation"
+        );
         assert_eq!(
             manager
                 .db
@@ -4806,10 +6031,7 @@ mod tests {
             expected_trade_fee_msat(50.0, 99.5, 100_000.0),
             Some(500_000)
         );
-        assert_eq!(
-            expected_trade_fee_msat(50.0, 50.0, 100_000.0),
-            Some(1)
-        );
+        assert_eq!(expected_trade_fee_msat(50.0, 50.0, 100_000.0), Some(1));
         assert_eq!(trade_fee_tolerance_msat(114_000, true), 1_000);
 
         // At this boundary the wallet's original gross fee floors to 113 sats, while recovering
@@ -4821,7 +6043,10 @@ mod tests {
         let reconstructed = expected_trade_fee_msat(0.0, signed_net_target, 65_000.0).unwrap();
         assert_eq!(wallet_fee_msat, 113_000);
         assert_eq!(reconstructed, 114_000);
-        assert!(wallet_fee_msat.abs_diff(reconstructed) <= trade_fee_tolerance_msat(reconstructed, true));
+        assert!(
+            wallet_fee_msat.abs_diff(reconstructed)
+                <= trade_fee_tolerance_msat(reconstructed, true)
+        );
     }
 
     #[tokio::test]
@@ -4870,31 +6095,25 @@ mod tests {
         let request_hash = stable_channels::trade::request_hash(signed.payload.as_bytes());
         let fee = expected_trade_fee_msat(50.0, 60.0, 100_000.0).unwrap();
 
-        mgr.handle_trade_payment(
-            &envelope,
-            Some(&payment_id),
-            Some(fee),
-            &fake,
-            100_000.0,
-        )
-        .await;
+        mgr.handle_trade_payment(&envelope, Some(&payment_id), Some(fee), &fake, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 60.0);
-        assert_eq!(mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(), Some(1));
+        assert_eq!(
+            mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(),
+            Some(1)
+        );
         assert!(mgr
             .db
             .trade_decision_by_payment(&payment_id)
             .unwrap()
             .is_some());
 
-        mgr.handle_trade_payment(
-            &envelope,
-            Some(&payment_id),
-            Some(fee),
-            &fake,
-            100_000.0,
-        )
-        .await;
-        assert_eq!(mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(), Some(1));
+        mgr.handle_trade_payment(&envelope, Some(&payment_id), Some(fee), &fake, 100_000.0)
+            .await;
+        assert_eq!(
+            mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(),
+            Some(1)
+        );
         StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
@@ -4907,6 +6126,233 @@ mod tests {
         assert_eq!(value["trade_payment_id"], payment_id);
         assert_eq!(value["request_hash"], request_hash);
         assert_eq!(value["expected_usd"], 60.0);
+    }
+
+    #[tokio::test]
+    async fn swept_two_phase_trade_uses_in_time_settlement_for_execution() {
+        let (mut mgr, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
+        let trade_id = "a1".repeat(32);
+        let proposal_payment_id = "a2".repeat(32);
+        let wallet_user_channel_id = "42";
+        let proposal_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "propose",
+            "channel_id": CHANNEL_ID_HEX,
+            "user_channel_id": wallet_user_channel_id,
+            "trade_id": trade_id,
+            "expected_usd": 60.0,
+            "quote_price": 100_000.0,
+            "base_sync_version": 0,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        let proposal = serde_json::json!({
+            "payload": proposal_payload,
+            "signature": "wallet-sig",
+        })
+        .to_string();
+        mgr.handle_trade_payment(
+            &proposal,
+            Some(&proposal_payment_id),
+            Some(1),
+            &fake,
+            100_000.0,
+        )
+        .await;
+
+        let reservation = mgr
+            .db
+            .trade_reservation_by_trade_id(&trade_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reservation.outcome, "reserved");
+        assert_eq!(reservation.user_channel_id, USER_CHANNEL_ID_DECIMAL);
+        assert_eq!(reservation.peer_user_channel_id, wallet_user_channel_id);
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
+        assert_eq!(
+            mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(),
+            Some(0)
+        );
+
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        {
+            let sends = fake.sends.lock().unwrap();
+            assert_eq!(sends.len(), 1);
+            let raw = std::str::from_utf8(sends[0].custom_tlvs[0].value.as_ref()).unwrap();
+            let response = crate::messages::parse_envelope(raw).unwrap();
+            let confirmation: stable_channels::trade::ConfirmTradeV1 =
+                serde_json::from_str(&response.payload).unwrap();
+            assert_eq!(confirmation.user_channel_id, wallet_user_channel_id);
+        }
+
+        let execution_payment_id = "a3".repeat(32);
+        let execution_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "execute",
+            "channel_id": reservation.channel_id,
+            "user_channel_id": reservation.peer_user_channel_id,
+            "trade_id": reservation.trade_id,
+            "proposal_payment_id": reservation.proposal_payment_id,
+            "proposal_hash": reservation.proposal_hash,
+            "confirmation_id": reservation.confirmation_id,
+            "expected_usd": reservation.expected_usd,
+            "quote_price": reservation.quote_price,
+            "fee_msat": reservation.fee_msat,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        let execution_hash = stable_channels::trade::request_hash(execution_payload.as_bytes());
+        let execution = serde_json::json!({
+            "payload": execution_payload,
+            "signature": "wallet-sig",
+        })
+        .to_string();
+        assert_eq!(
+            mgr.db
+                .expire_trade_reservations(reservation.expires_at)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            mgr.db
+                .trade_reservation_by_trade_id(&trade_id)
+                .unwrap()
+                .unwrap()
+                .outcome,
+            "expired"
+        );
+        mgr.handle_trade_payment_at(
+            &execution,
+            Some(&execution_payment_id),
+            Some(reservation.fee_msat),
+            Some(reservation.expires_at as u64),
+            &fake,
+            120_000.0,
+        )
+        .await;
+
+        assert_eq!(mgr.stable_channels[0].expected_usd.0, 60.0);
+        assert_eq!(
+            mgr.db.get_sync_version(USER_CHANNEL_ID_DECIMAL).unwrap(),
+            Some(1)
+        );
+        let terminal = mgr
+            .db
+            .trade_reservation_by_trade_id(&trade_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(terminal.outcome, "accepted");
+        assert_eq!(
+            terminal.execution_payment_id.as_deref(),
+            Some(execution_payment_id.as_str())
+        );
+        assert_eq!(
+            terminal.execution_hash.as_deref(),
+            Some(execution_hash.as_str())
+        );
+
+        StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
+        let sends = fake.sends.lock().unwrap();
+        assert_eq!(sends.len(), 2);
+        let raw = std::str::from_utf8(sends[1].custom_tlvs[0].value.as_ref()).unwrap();
+        let response = crate::messages::parse_envelope(raw).unwrap();
+        let sync: serde_json::Value = serde_json::from_str(&response.payload).unwrap();
+        assert_eq!(sync["type"], "SYNC_V1");
+        assert_eq!(sync["user_channel_id"], wallet_user_channel_id);
+        assert_eq!(sync["trade_payment_id"], execution_payment_id);
+        assert_eq!(sync["request_hash"], execution_hash);
+        drop(sends);
+        assert!(mgr
+            .db
+            .list_settlements()
+            .unwrap()
+            .contains(&("fake-payment-id".to_string(), "sync".to_string())));
+    }
+
+    #[tokio::test]
+    async fn two_phase_full_peg_absorbs_lsp_drift_before_confirmation() {
+        let (mut mgr, fake) = correlated_rejection_context(34.8404, 55_278, 68_550);
+        let trade_id = "b1".repeat(32);
+        let proposal_payment_id = "b2".repeat(32);
+        let proposal_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "propose",
+            "channel_id": CHANNEL_ID_HEX,
+            "user_channel_id": "42",
+            "trade_id": trade_id,
+            "expected_usd": 43.1366,
+            "quote_price": 63_052.275,
+            "base_sync_version": 0,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        let proposal = serde_json::json!({
+            "payload": proposal_payload,
+            "signature": "wallet-sig",
+        })
+        .to_string();
+
+        mgr.handle_trade_payment(
+            &proposal,
+            Some(&proposal_payment_id),
+            Some(1),
+            &fake,
+            63_052.275,
+        )
+        .await;
+
+        let reservation = mgr
+            .db
+            .trade_reservation_by_trade_id(&trade_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reservation.outcome, "reserved");
+        assert_eq!(reservation.fee_msat, 132_000);
+        assert_eq!(reservation.backing_sats, 68_418);
+        assert_eq!(reservation.native_sats, 0);
+    }
+
+    #[tokio::test]
+    async fn two_phase_full_peg_absorbs_sub_cent_usd_headroom_before_sat_flooring() {
+        let (mut mgr, fake) = correlated_rejection_context(0.0, 0, 67_735);
+        let trade_id = "b3".repeat(32);
+        let proposal_payment_id = "b4".repeat(32);
+        let proposal_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "propose",
+            "channel_id": CHANNEL_ID_HEX,
+            "user_channel_id": "42",
+            "trade_id": trade_id,
+            "expected_usd": 42.2532,
+            "quote_price": 63_024.5675,
+            "base_sync_version": 0,
+            "ts": test_unix_now(),
+        })
+        .to_string();
+        let proposal = serde_json::json!({
+            "payload": proposal_payload,
+            "signature": "wallet-sig",
+        })
+        .to_string();
+
+        mgr.handle_trade_payment(
+            &proposal,
+            Some(&proposal_payment_id),
+            Some(1),
+            &fake,
+            63_024.15,
+        )
+        .await;
+
+        let reservation = mgr
+            .db
+            .trade_reservation_by_trade_id(&trade_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reservation.outcome, "reserved");
+        assert_eq!(reservation.fee_msat, 677_000);
+        assert_eq!(reservation.backing_sats, 67_058);
+        assert_eq!(reservation.native_sats, 0);
     }
 
     #[tokio::test]
@@ -4931,10 +6377,7 @@ mod tests {
 
         StableChannelManager::retry_pending_trade_responses(manager.db.as_ref(), &fake).await;
         assert_eq!(
-            manager
-                .db
-                .in_flight_trade_response_payment_ids()
-                .unwrap(),
+            manager.db.in_flight_trade_response_payment_ids().unwrap(),
             vec!["fake-payment-id".to_string()]
         );
         fake.payments.lock().unwrap().push(GrpcPayment {
@@ -4996,7 +6439,14 @@ mod tests {
         mgr.handle_trade_payment(&envelope, Some(&payment_id), Some(1), &fake, 100_000.0)
             .await;
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
-        assert_eq!(mgr.db.load_channel(USER_CHANNEL_ID_DECIMAL).unwrap().unwrap().expected_usd, 50.0);
+        assert_eq!(
+            mgr.db
+                .load_channel(USER_CHANNEL_ID_DECIMAL)
+                .unwrap()
+                .unwrap()
+                .expected_usd,
+            50.0
+        );
         StableChannelManager::retry_pending_trade_responses(mgr.db.as_ref(), &fake).await;
         let sends = fake.sends.lock().unwrap();
         assert_eq!(sends.len(), 1);
@@ -5014,12 +6464,8 @@ mod tests {
         let payment_id = "6".repeat(64);
 
         let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            50.0,
-            Some(100_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 50.0, Some(100_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
                 .await,
@@ -5047,12 +6493,8 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            60.0,
-            Some(100_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 60.0, Some(100_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
                 .await,
@@ -5060,12 +6502,7 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            60.0,
-            Some(-1.0),
-            test_unix_now(),
-        );
+        let envelope = correlated_trade_envelope_at(&trade_id, 60.0, Some(-1.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
                 .await,
@@ -5073,12 +6510,8 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            60.0,
-            Some(90_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 60.0, Some(90_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(
                 &mut manager,
@@ -5093,12 +6526,8 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(50.0, 50_000, 100_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            110.0,
-            Some(100_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 110.0, Some(100_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(
                 &mut manager,
@@ -5113,12 +6542,8 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(100.0, 100_000, 200_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            0.0,
-            Some(90_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 0.0, Some(90_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(
                 &mut manager,
@@ -5133,12 +6558,8 @@ mod tests {
         );
 
         let (mut manager, fake) = correlated_rejection_context(10.0, 49_000, 50_000);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            20.0,
-            Some(100_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 20.0, Some(100_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(
                 &mut manager,
@@ -5161,12 +6582,8 @@ mod tests {
             100_000_000,
             true,
         )]);
-        let envelope = correlated_trade_envelope_at(
-            &trade_id,
-            20.0,
-            Some(100_000.0),
-            test_unix_now(),
-        );
+        let envelope =
+            correlated_trade_envelope_at(&trade_id, 20.0, Some(100_000.0), test_unix_now());
         assert_eq!(
             correlated_rejection_reason(&mut manager, &fake, &envelope, &payment_id, 1, 100_000.0)
                 .await,
@@ -5254,18 +6671,27 @@ mod tests {
     async fn trade_applies_valid_target() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6);
     }
@@ -5294,23 +6720,11 @@ mod tests {
         );
 
         let tiny = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.01);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &tiny,
-            &fake as &dyn LdkServerCalls,
-            110_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &tiny, &fake as &dyn LdkServerCalls, 110_000.0).await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 100_009);
 
         let noop = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 100.01);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &noop,
-            &fake as &dyn LdkServerCalls,
-            90_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &noop, &fake as &dyn LdkServerCalls, 90_000.0).await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 100_009);
     }
 
@@ -5338,13 +6752,7 @@ mod tests {
         );
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 99.0);
 
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 100.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 10);
@@ -5377,13 +6785,7 @@ mod tests {
             );
             let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 0.0);
 
-            handle_trade_with_valid_fee(
-                &mut mgr,
-                &env,
-                &fake as &dyn LdkServerCalls,
-                price,
-            )
-            .await;
+            handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, price).await;
 
             if should_apply {
                 assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
@@ -5421,13 +6823,7 @@ mod tests {
         );
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 0.009);
 
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_001.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_001.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 0);
@@ -5464,14 +6860,8 @@ mod tests {
             49_950,
         );
 
-        mgr.handle_trade_message(
-            &env,
-            None,
-            Some(1),
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        mgr.handle_trade_message(&env, None, Some(1), &fake as &dyn LdkServerCalls, 100_000.0)
+            .await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 0);
@@ -5510,13 +6900,7 @@ mod tests {
             100_400.0,
             49_551,
         );
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].backing_sats, 49_750);
         assert_eq!(mgr.stable_channels[0].native_sats, 250);
@@ -5560,13 +6944,7 @@ mod tests {
             100_000.0,
             49_995,
         );
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 50.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 50_000);
@@ -5603,13 +6981,7 @@ mod tests {
             100_000.0,
             49_000,
         );
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 49.95);
         assert_eq!(mgr.stable_channels[0].backing_sats, 49_950);
@@ -5620,18 +6992,28 @@ mod tests {
     async fn trade_rejects_invalid_signature() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
-        )]).with_verify_failure();
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 3.0, 3_000, 47_000, 50_000, 100_000.0);
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
+        )])
+        .with_verify_failure();
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            3.0,
+            3_000,
+            47_000,
+            50_000,
+            100_000.0,
+        );
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 3.0).abs() < 1e-6); // unchanged
     }
@@ -5640,18 +7022,27 @@ mod tests {
     async fn trade_rejects_over_balance() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 999.0);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6); // unchanged
     }
@@ -5661,19 +7052,28 @@ mod tests {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let target = 50.001;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 0);
@@ -5685,19 +7085,28 @@ mod tests {
         let mut mgr = make_manager();
         // Live receiver side = 50_000 sats at $100k -> receiver_usd = $50.00 exactly.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         let target = 50.01;
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, target);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert_eq!(mgr.stable_channels[0].expected_usd.0, 0.0);
         assert_eq!(mgr.stable_channels[0].backing_sats, 0);
@@ -5708,16 +7117,20 @@ mod tests {
     async fn trade_channel_not_found_is_noop() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 5.0, 5_000, 45_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            5.0,
+            5_000,
+            45_000,
+            50_000,
+            100_000.0,
+        );
 
         let env = trade_envelope(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // unchanged
     }
@@ -5726,20 +7139,29 @@ mod tests {
     async fn trade_rejects_stale_ts() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         // A captured signed trade replayed a day later must be rejected (replay protection).
         let stale = test_unix_now() - 86_400;
         let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, stale);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
         assert!(
             (mgr.stable_channels[0].expected_usd.0 - 0.0).abs() < 1e-6,
@@ -5754,44 +7176,75 @@ mod tests {
         stable_channels::audit::enable_test_capture();
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
         let stale = test_unix_now() - 86_400;
         let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, stale);
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
-        let stale_ev = events.iter().find(|(e, _)| e == "TRADE_STALE")
+        let stale_ev = events
+            .iter()
+            .find(|(e, _)| e == "TRADE_STALE")
             .expect("TRADE_STALE must be emitted for a stale signed trade");
-        assert!(stale_ev.1.get("user_channel_id").is_some(), "TRADE_STALE must carry user_channel_id");
+        assert!(
+            stale_ev.1.get("user_channel_id").is_some(),
+            "TRADE_STALE must carry user_channel_id"
+        );
     }
 
     #[tokio::test]
     async fn trade_accepts_fresh_ts() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 0.0, 0, 50_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            0.0,
+            0,
+            50_000,
+            50_000,
+            100_000.0,
+        );
 
         // A trade signed just now is within the window and applies normally.
-        let env = trade_envelope_with_ts(CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, 10.0, test_unix_now());
-        handle_trade_with_valid_fee(
-            &mut mgr,
-            &env,
-            &fake as &dyn LdkServerCalls,
-            100_000.0,
-        )
-        .await;
+        let env = trade_envelope_with_ts(
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            10.0,
+            test_unix_now(),
+        );
+        handle_trade_with_valid_fee(&mut mgr, &env, &fake as &dyn LdkServerCalls, 100_000.0).await;
 
-        assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6, "a fresh signed trade must apply");
+        assert!(
+            (mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6,
+            "a fresh signed trade must apply"
+        );
     }
 
     #[test]
@@ -5806,10 +7259,25 @@ mod tests {
         let mut mgr = make_manager();
         // Post-splice snapshot: their = 5,000 (our 95k via outbound 95M msat).
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )]);
         // expected $10 -> backing 10,000; receiver was 50,000.
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
 
         mgr.handle_channel_ready(
             CHANNEL_ID_HEX.to_string(),
@@ -5822,7 +7290,11 @@ mod tests {
 
         // backing 10,000 vs new receiver 5,000 -> overflow 5,000 = $5 -> expected $5.
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6);
-        assert_eq!(fake.sends.lock().unwrap().len(), 1, "splice-out should SYNC");
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "splice-out should SYNC"
+        );
     }
 
     #[tokio::test]
@@ -5830,9 +7302,24 @@ mod tests {
         let mut mgr = make_manager();
         // Post-splice snapshot: their grew to 80,000 (our 20k via outbound 20M msat).
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 20_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            20_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
 
         mgr.handle_channel_ready(
             CHANNEL_ID_HEX.to_string(),
@@ -5844,16 +7331,35 @@ mod tests {
         .await;
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 10.0).abs() < 1e-6); // unchanged
-        assert_eq!(fake.sends.lock().unwrap().len(), 0, "splice-in must not SYNC");
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            0,
+            "splice-in must not SYNC"
+        );
     }
 
     #[tokio::test]
     async fn splice_replay_does_not_double_deduct() {
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX, 100_000, 95_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            95_000_000,
+            true,
         )]);
-        seed_channel(&mut mgr, 189476124653200987495269098788434301048u128, COUNTERPARTY_HEX, CHANNEL_ID_HEX, 10.0, 10_000, 40_000, 50_000, 100_000.0);
+        seed_channel(
+            &mut mgr,
+            189476124653200987495269098788434301048u128,
+            COUNTERPARTY_HEX,
+            CHANNEL_ID_HEX,
+            10.0,
+            10_000,
+            40_000,
+            50_000,
+            100_000.0,
+        );
 
         for _ in 0..2 {
             mgr.handle_channel_ready(
@@ -5867,7 +7373,11 @@ mod tests {
         }
 
         assert!((mgr.stable_channels[0].expected_usd.0 - 5.0).abs() < 1e-6); // deducted once, not twice
-        assert_eq!(fake.sends.lock().unwrap().len(), 1, "second pass deducts nothing, no second SYNC");
+        assert_eq!(
+            fake.sends.lock().unwrap().len(),
+            1,
+            "second pass deducts nothing, no second SYNC"
+        );
     }
 
     #[tokio::test]
@@ -5884,13 +7394,21 @@ mod tests {
 
         let mut mgr = make_manager();
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_DECIMAL, COUNTERPARTY_HEX,
-            100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_DECIMAL,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
         mgr.edit_stable_channel(
-            CHANNEL_ID_HEX, Some(7.5), None,
-            &fake as &dyn LdkServerCalls, 100_000.0,
-        ).await;
+            CHANNEL_ID_HEX,
+            Some(7.5),
+            None,
+            &fake as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
 
         let contents = std::fs::read_to_string(&path).unwrap_or_default();
         assert!(
@@ -5928,9 +7446,16 @@ mod tests {
         // open_in_memory() is #[cfg(test)]-gated in the shared crate, unreachable across this crate boundary; use the tempdir pattern from make_manager() instead.
         let dir = tempdir().unwrap();
         let db = stable_channels::db::Database::open(dir.path()).unwrap();
-        let fake = FakeLdkServer::new(vec![]).with_forwarded(vec![fwd("aa", "bb", 1000), fwd("cc", "dd", 2000)]);
-        assert_eq!(crate::backfill::backfill_forwards(&fake, &db).await.emitted, 2); // both unseen
-        assert_eq!(crate::backfill::backfill_forwards(&fake, &db).await.emitted, 0); // both now seen
+        let fake = FakeLdkServer::new(vec![])
+            .with_forwarded(vec![fwd("aa", "bb", 1000), fwd("cc", "dd", 2000)]);
+        assert_eq!(
+            crate::backfill::backfill_forwards(&fake, &db).await.emitted,
+            2
+        ); // both unseen
+        assert_eq!(
+            crate::backfill::backfill_forwards(&fake, &db).await.emitted,
+            0
+        ); // both now seen
     }
 
     #[tokio::test]
@@ -5950,10 +7475,8 @@ mod tests {
 
     #[tokio::test]
     async fn reconnect_reconstructs_channel_payment_forward_peer_and_sweep() {
-        use ldk_server_client::ldk_server_grpc::types::{
-            pending_sweep_balance, PendingBroadcast,
-        };
-        use stable_channels::ledger::{LedgerQuery, LedgerCompleteness};
+        use ldk_server_client::ldk_server_grpc::types::{pending_sweep_balance, PendingBroadcast};
+        use stable_channels::ledger::{LedgerCompleteness, LedgerQuery};
 
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let dir = tempdir().unwrap();
@@ -5985,7 +7508,10 @@ mod tests {
         }])
         .with_sweeps(vec![GrpcPendingSweepBalance {
             balance_type: Some(pending_sweep_balance::BalanceType::PendingBroadcast(
-                PendingBroadcast { channel_id: Some(CHANNEL_ID_HEX.into()), amount_satoshis: 777 },
+                PendingBroadcast {
+                    channel_id: Some(CHANNEL_ID_HEX.into()),
+                    amount_satoshis: 777,
+                },
             )),
         }]);
 
@@ -5997,18 +7523,33 @@ mod tests {
         assert_eq!(counts.sweeps, 1);
         assert_eq!(counts.failed_scopes, 0);
 
-        let page = db.list_ledger_events(&LedgerQuery {
-            completeness: Some("reconstructed".into()),
-            limit: 50,
-            ..Default::default()
-        }).unwrap();
+        let page = db
+            .list_ledger_events(&LedgerQuery {
+                completeness: Some("reconstructed".into()),
+                limit: 50,
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(page.events.len(), 5);
-        assert!(page.events.iter().all(|event| event.completeness == LedgerCompleteness::Reconstructed));
-        let payment = page.events.iter().find(|event| event.event_type == "PAYMENT_RECONSTRUCTED").unwrap();
+        assert!(page
+            .events
+            .iter()
+            .all(|event| event.completeness == LedgerCompleteness::Reconstructed));
+        let payment = page
+            .events
+            .iter()
+            .find(|event| event.event_type == "PAYMENT_RECONSTRUCTED")
+            .unwrap();
         assert_eq!(payment.status, "completed");
         assert_eq!(payment.detail["ldk_status"], "SUCCEEDED");
-        assert_eq!(payment.detail["channel_association"], "unavailable_from_ldk");
-        assert!(!payment.refs.iter().any(|reference| reference.role.contains("channel")));
+        assert_eq!(
+            payment.detail["channel_association"],
+            "unavailable_from_ldk"
+        );
+        assert!(!payment
+            .refs
+            .iter()
+            .any(|reference| reference.role.contains("channel")));
 
         let replay_counts = crate::backfill::reconcile_event_history(&fake, &db).await;
         assert_eq!(replay_counts.channels, 0);
@@ -6080,8 +7621,8 @@ mod tests {
     #[tokio::test]
     async fn sweep_reconstruction_identity_survives_unrelated_list_shifts() {
         use ldk_server_client::ldk_server_grpc::types::{
-            pending_sweep_balance, AwaitingThresholdConfirmations,
-            BroadcastAwaitingConfirmation, PendingBroadcast,
+            pending_sweep_balance, AwaitingThresholdConfirmations, BroadcastAwaitingConfirmation,
+            PendingBroadcast,
         };
 
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
@@ -6108,16 +7649,19 @@ mod tests {
                 ),
             ),
         };
-        let fake = FakeLdkServer::new(vec![])
-            .with_sweeps(vec![pending, broadcast.clone()]);
+        let fake = FakeLdkServer::new(vec![]).with_sweeps(vec![pending, broadcast.clone()]);
         assert_eq!(
-            crate::backfill::reconcile_event_history(&fake, &db).await.sweeps,
+            crate::backfill::reconcile_event_history(&fake, &db)
+                .await
+                .sweeps,
             2
         );
 
         *fake.sweeps.lock().unwrap() = vec![broadcast];
         assert_eq!(
-            crate::backfill::reconcile_event_history(&fake, &db).await.sweeps,
+            crate::backfill::reconcile_event_history(&fake, &db)
+                .await
+                .sweeps,
             0,
             "removing an earlier sweep must not make the remaining sweep look new"
         );
@@ -6136,7 +7680,9 @@ mod tests {
             ),
         }];
         assert_eq!(
-            crate::backfill::reconcile_event_history(&fake, &db).await.sweeps,
+            crate::backfill::reconcile_event_history(&fake, &db)
+                .await
+                .sweeps,
             1,
             "the same sweep changing confirmation state must remain visible"
         );
@@ -6144,22 +7690,67 @@ mod tests {
 
     #[test]
     fn should_log_on_outcome_change() {
-        assert!(stability_should_log("", "check_only", 0.0, 90.0, 90.0, 0.25, 1.0, true));
-        assert!(stability_should_log("cooldown", "check_only", 90.0, 90.0, 90.0, 0.25, 1.0, true));
+        assert!(stability_should_log(
+            "",
+            "check_only",
+            0.0,
+            90.0,
+            90.0,
+            0.25,
+            1.0,
+            true
+        ));
+        assert!(stability_should_log(
+            "cooldown",
+            "check_only",
+            90.0,
+            90.0,
+            90.0,
+            0.25,
+            1.0,
+            true
+        ));
     }
 
     #[test]
     fn should_log_on_significant_value_move_when_tracking() {
         // same outcome, move > $0.25 and > 1% -> true
-        assert!(stability_should_log("check_only", "check_only", 90.0, 92.0, 90.0, 0.25, 1.0, true));
+        assert!(stability_should_log(
+            "check_only",
+            "check_only",
+            90.0,
+            92.0,
+            90.0,
+            0.25,
+            1.0,
+            true
+        ));
         // same outcome, sub-threshold move -> false
-        assert!(!stability_should_log("check_only", "check_only", 90.0, 90.10, 90.0, 0.25, 1.0, true));
+        assert!(!stability_should_log(
+            "check_only",
+            "check_only",
+            90.0,
+            90.10,
+            90.0,
+            0.25,
+            1.0,
+            true
+        ));
     }
 
     #[test]
     fn no_value_trigger_when_not_tracking() {
         // same outcome, huge move, but track_value=false -> false
-        assert!(!stability_should_log("high_risk", "high_risk", 90.0, 200.0, 90.0, 0.25, 1.0, false));
+        assert!(!stability_should_log(
+            "high_risk",
+            "high_risk",
+            90.0,
+            200.0,
+            90.0,
+            0.25,
+            1.0,
+            false
+        ));
     }
 
     #[tokio::test]
@@ -6167,21 +7758,44 @@ mod tests {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(50.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(50.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         stable_channels::audit::enable_test_capture();
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await; // above par -> CHECK_ONLY (emit)
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0).await; // identical -> throttled
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0)
+            .await; // above par -> CHECK_ONLY (emit)
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 120_000.0)
+            .await; // identical -> throttled
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
-        let n = events.iter().filter(|(e, _)| e == "STABILITY_CHECK_ONLY").count();
+        let n = events
+            .iter()
+            .filter(|(e, _)| e == "STABILITY_CHECK_ONLY")
+            .count();
         assert_eq!(n, 1, "identical repeated ticks must emit CHECK_ONLY once");
     }
 
@@ -6243,9 +7857,10 @@ mod tests {
             100_000.0,
         )
         .await;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 100_000.0)
             .await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
@@ -6295,7 +7910,10 @@ mod tests {
             std::str::from_utf8(record.value.as_ref()).unwrap(),
         )
         .unwrap();
-        assert_eq!(verify_calls[0].message.as_ref(), envelope.payload.as_bytes());
+        assert_eq!(
+            verify_calls[0].message.as_ref(),
+            envelope.payload.as_bytes()
+        );
         drop(verify_calls);
         assert_eq!(
             mgr.db
@@ -6415,10 +8033,8 @@ mod tests {
     async fn signed_stability_migrates_a_legacy_noncanonical_channel_row() {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = manager_at_par_for_signed_stability().await;
-        let legacy_user_channel_id = format!(
-            "{:032x}",
-            USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap()
-        );
+        let legacy_user_channel_id =
+            format!("{:032x}", USER_CHANNEL_ID_DECIMAL.parse::<u128>().unwrap());
         mgr.db
             .save_channel(
                 CHANNEL_ID_HEX,
@@ -6429,7 +8045,11 @@ mod tests {
                 None,
             )
             .unwrap();
-        assert!(mgr.db.load_channel(USER_CHANNEL_ID_DECIMAL).unwrap().is_none());
+        assert!(mgr
+            .db
+            .load_channel(USER_CHANNEL_ID_DECIMAL)
+            .unwrap()
+            .is_none());
 
         let settlement_id = "99".repeat(32);
         let record = signed_stability_record(
@@ -6635,9 +8255,10 @@ mod tests {
             Some("pending")
         );
 
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0)
             .await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 9_091);
@@ -6696,21 +8317,40 @@ mod tests {
         let mut mgr = make_manager();
         // $10 target at $100k: equilibrium backing = 10_000 sats; user side 50_000 -> native 40_000.
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Snapshot balances at par (no drift at $100k, so nothing fires).
-        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
         assert_eq!(mgr.stable_channels[0].stable_receiver_btc.sats, 50_000);
 
         // Price rises to $110k: user is $1 above par and settles 909 sats to the LSP.
         // Live user side drops 50_000 -> 49_091 (our side gains).
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_909_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
         )]);
         mgr.handle_payment_received(
             vec![stability_marker()],
@@ -6725,10 +8365,19 @@ mod tests {
         // Amount-proportional: backing 10_000 minus the 909 sats actually paid = 9_091,
         // one sat above the truncated equilibrium (9_090) — that residual sat is the honest
         // rounding remainder the wallet under-paid, not stolen surplus.
-        assert_eq!(sc.backing_sats, 9_091, "backing is reduced by the settled amount");
+        assert_eq!(
+            sc.backing_sats, 9_091,
+            "backing is reduced by the settled amount"
+        );
         // Native absorbs only rounding, never the settlement: 49_091 - 9_091 = 40_000.
-        assert_eq!(sc.native_sats, 40_000, "native sats must be preserved across the settlement");
-        assert!(sc.backing_sats <= sc.stable_receiver_btc.sats, "backing may never exceed live balance");
+        assert_eq!(
+            sc.native_sats, 40_000,
+            "native sats must be preserved across the settlement"
+        );
+        assert!(
+            sc.backing_sats <= sc.stable_receiver_btc.sats,
+            "backing may never exceed live balance"
+        );
     }
 
     #[tokio::test]
@@ -6739,21 +8388,40 @@ mod tests {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
         // Snapshot at par: backing = 10_000 sats, user side = 50_000.
-        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         assert_eq!(mgr.stable_channels[0].backing_sats, 10_000);
 
         // Price rises to $110k: the honest owed amount is ~910 sats. The attacker instead
         // keysends 1 sat with the same marker. The user paying 1 sat raises the LSP's
         // outbound by 1 sat (50_000_000 -> 50_001_000), so the user side drops 50_000 -> 49_999.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_001_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_001_000,
+            true,
         )]);
         mgr.handle_payment_received(
             vec![stability_marker()],
@@ -6767,9 +8435,18 @@ mod tests {
         let sc = &mgr.stable_channels[0];
         // Only 1 sat of drift settled: 10_000 - 1 = 9_999. The surplus stays owed as backing,
         // NOT erased to the $110k equilibrium of 9_090.
-        assert_eq!(sc.backing_sats, 9_999, "a 1-sat payment settles only 1 sat of drift");
-        assert_ne!(sc.backing_sats, 9_090, "backing must NOT collapse to equilibrium for a token payment");
-        assert_eq!(sc.native_sats, 40_000, "the surplus is not reclassified as free native BTC");
+        assert_eq!(
+            sc.backing_sats, 9_999,
+            "a 1-sat payment settles only 1 sat of drift"
+        );
+        assert_ne!(
+            sc.backing_sats, 9_090,
+            "backing must NOT collapse to equilibrium for a token payment"
+        );
+        assert_eq!(
+            sc.native_sats, 40_000,
+            "the surplus is not reclassified as free native BTC"
+        );
     }
 
     #[tokio::test]
@@ -6777,29 +8454,54 @@ mod tests {
         let _guard = AUDIT_TEST_GUARD.lock().unwrap();
         let mut mgr = make_manager();
         let fake0 = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_000_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_000_000,
+            true,
         )]);
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
-        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
 
         // User settles 909 sats; books reconciled at receive.
         let fake = FakeLdkServer::new(vec![make_channel(
-            CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, 50_909_000, true,
+            CHANNEL_ID_HEX,
+            USER_CHANNEL_ID_HEX,
+            COUNTERPARTY_HEX,
+            100_000,
+            50_909_000,
+            true,
         )]);
         mgr.handle_payment_received(
-            vec![stability_marker()], Some("pay-2".to_string()), Some(909_000),
-            &fake as &dyn LdkServerCalls, 110_000.0,
-        ).await;
+            vec![stability_marker()],
+            Some("pay-2".to_string()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
         let expected_before = mgr.stable_channels[0].expected_usd.0;
 
         // Two ticks at the new price: without receive-time reconcile the backstop
         // would read the settled sats as an unreconciled spend and deduct expected_usd.
         stable_channels::audit::enable_test_capture();
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0).await;
-        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0).await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0)
+            .await;
+        mgr.run_tick(&fake as &dyn LdkServerCalls, &push, 110_000.0)
+            .await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
 
@@ -6822,34 +8524,84 @@ mod tests {
         // Two identical channels: an identical balance drop on both is unattributable.
         let mk = |outbound_msat: u64| {
             vec![
-                make_channel(CHANNEL_ID_HEX, USER_CHANNEL_ID_HEX, COUNTERPARTY_HEX, 100_000, outbound_msat, true),
-                make_channel(CHAN2_ID, UID2_HEX, COUNTERPARTY_HEX, 100_000, outbound_msat, true),
+                make_channel(
+                    CHANNEL_ID_HEX,
+                    USER_CHANNEL_ID_HEX,
+                    COUNTERPARTY_HEX,
+                    100_000,
+                    outbound_msat,
+                    true,
+                ),
+                make_channel(
+                    CHAN2_ID,
+                    UID2_HEX,
+                    COUNTERPARTY_HEX,
+                    100_000,
+                    outbound_msat,
+                    true,
+                ),
             ]
         };
         let fake0 = FakeLdkServer::new(mk(50_000_000));
-        mgr.edit_stable_channel(CHANNEL_ID_HEX, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        mgr.edit_stable_channel(CHAN2_ID, Some(10.0), None, &fake0 as &dyn LdkServerCalls, 100_000.0).await;
-        let push = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::push::PushService::new(&crate::config::PushConfig::default(), mgr.data_dir()),
-        ));
-        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0).await;
+        mgr.edit_stable_channel(
+            CHANNEL_ID_HEX,
+            Some(10.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        mgr.edit_stable_channel(
+            CHAN2_ID,
+            Some(10.0),
+            None,
+            &fake0 as &dyn LdkServerCalls,
+            100_000.0,
+        )
+        .await;
+        let push = std::sync::Arc::new(tokio::sync::Mutex::new(crate::push::PushService::new(
+            &crate::config::PushConfig::default(),
+            mgr.data_dir(),
+        )));
+        mgr.run_tick(&fake0 as &dyn LdkServerCalls, &push, 100_000.0)
+            .await;
         let backing_before: Vec<u64> = mgr.stable_channels.iter().map(|s| s.backing_sats).collect();
 
         let fake = FakeLdkServer::new(mk(50_909_000));
         stable_channels::audit::enable_test_capture();
         mgr.handle_payment_received(
-            vec![stability_marker()], Some("pay-3".to_string()), Some(909_000),
-            &fake as &dyn LdkServerCalls, 110_000.0,
-        ).await;
+            vec![stability_marker()],
+            Some("pay-3".to_string()),
+            Some(909_000),
+            &fake as &dyn LdkServerCalls,
+            110_000.0,
+        )
+        .await;
         let events = stable_channels::audit::drain_test_capture();
         stable_channels::audit::disable_test_capture();
 
         let backing_after: Vec<u64> = mgr.stable_channels.iter().map(|s| s.backing_sats).collect();
-        assert_eq!(backing_before, backing_after, "ambiguous attribution must not touch the books");
+        assert_eq!(
+            backing_before, backing_after,
+            "ambiguous attribution must not touch the books"
+        );
         assert!(
-            events.iter().any(|(e, d)| e == "STABILITY_RECEIVE_UNATTRIBUTED"
-                && d.get("candidates").and_then(|v| v.as_u64()) == Some(2)),
+            events
+                .iter()
+                .any(|(e, d)| e == "STABILITY_RECEIVE_UNATTRIBUTED"
+                    && d.get("candidates").and_then(|v| v.as_u64()) == Some(2)),
             "the miss must be audited with the candidate count"
         );
+    }
+
+    #[test]
+    fn stability_reservation_guard_fails_closed() {
+        assert!(stability_mutation_allowed(&Ok::<Option<&str>, &str>(None)));
+        assert!(!stability_mutation_allowed(&Ok::<Option<&str>, &str>(
+            Some("trade-id")
+        )));
+        assert!(!stability_mutation_allowed(&Err::<Option<&str>, &str>(
+            "database locked"
+        )));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,6 +17,9 @@ pub const MAX_SIGNED_STABILITY_TLV_VALUE_BYTES: usize = 8 * 1024;
 /// Trade message type identifier
 pub const TRADE_MESSAGE_TYPE: &str = "TRADE_V1";
 
+/// Signed LSP reservation returned for an upgraded desktop trade proposal.
+pub const CONFIRM_TRADE_MESSAGE_TYPE: &str = "CONFIRM_TRADE_V1";
+
 /// Sync message type identifier (LSP → user expected_usd sync after stable deductions)
 pub const SYNC_MESSAGE_TYPE: &str = "SYNC_V1";
 
@@ -85,6 +88,12 @@ pub const STABILITY_CHECK_INTERVAL_SECS: u64 = 60;
 
 /// A correlated trade becomes locally uncertain after this long, but remains late-resolvable.
 pub const TRADE_RESULT_TIMEOUT_SECS: u64 = 15 * 60;
+
+/// A desktop quote reservation is deliberately short lived.
+pub const TRADE_CONFIRMATION_TTL_SECS: u64 = 60;
+
+/// Do not start the fee payment when too little of the reservation remains.
+pub const TRADE_CONFIRMATION_SEND_MARGIN_SECS: u64 = 10;
 
 /// The LSP retries durable result delivery throughout this window.
 pub const TRADE_RESPONSE_RETRY_WINDOW_SECS: u64 = 14 * 24 * 60 * 60;

--- a/src/db.rs
+++ b/src/db.rs
@@ -97,6 +97,7 @@ const CREATE_TRADE_DECISIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS trade_dec
         request_hash TEXT NOT NULL,
         channel_id TEXT NOT NULL,
         user_channel_id TEXT NOT NULL,
+        peer_user_channel_id TEXT,
         counterparty TEXT NOT NULL,
         outcome TEXT NOT NULL,
         reason_code TEXT,
@@ -111,7 +112,22 @@ const CREATE_TRADE_DECISIONS_TABLE: &str = "CREATE TABLE IF NOT EXISTS trade_dec
         next_response_attempt_at INTEGER NOT NULL,
         delivery_deadline INTEGER NOT NULL,
         delivered_at INTEGER,
-        details_pruned_at INTEGER
+        details_pruned_at INTEGER,
+        phase TEXT NOT NULL DEFAULT 'legacy',
+        proposal_payment_id TEXT,
+        proposal_hash TEXT,
+        confirmation_id TEXT,
+        base_sync_version INTEGER,
+        quote_price REAL,
+        fee_msat INTEGER,
+        expires_at INTEGER,
+        execution_payment_id TEXT,
+        execution_hash TEXT,
+        settled_at INTEGER,
+        reservation_native_sats INTEGER,
+        base_expected_usd REAL,
+        base_backing_sats INTEGER,
+        base_native_sats INTEGER
     )";
 
 const CREATE_TRADE_DECISIONS_DUE_INDEX: &str =
@@ -135,20 +151,87 @@ fn init_trade_decisions_schema(conn: &mut Connection) -> SqliteResult<()> {
     if !exists {
         conn.execute(CREATE_TRADE_DECISIONS_TABLE, [])?;
         conn.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_active_channel
+             ON trade_decisions(channel_id) WHERE outcome = 'reserved'",
+            [],
+        )?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_proposal_payment
+             ON trade_decisions(proposal_payment_id) WHERE proposal_payment_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_execution_payment
+             ON trade_decisions(execution_payment_id) WHERE execution_payment_id IS NOT NULL",
+            [],
+        )?;
         return Ok(());
     }
 
     let columns = trade_decision_columns(conn)?;
     let current_columns = [
-        "inbound_payment_id", "trade_id", "request_hash", "channel_id",
-        "user_channel_id", "counterparty", "outcome", "reason_code",
-        "expected_usd", "backing_sats", "sync_version", "decided_at",
-        "response_envelope", "response_payment_id", "response_status",
-        "response_attempts", "next_response_attempt_at", "delivery_deadline",
-        "delivered_at", "details_pruned_at",
+        "inbound_payment_id",
+        "trade_id",
+        "request_hash",
+        "channel_id",
+        "user_channel_id",
+        "counterparty",
+        "outcome",
+        "reason_code",
+        "expected_usd",
+        "backing_sats",
+        "sync_version",
+        "decided_at",
+        "response_envelope",
+        "response_payment_id",
+        "response_status",
+        "response_attempts",
+        "next_response_attempt_at",
+        "delivery_deadline",
+        "delivered_at",
+        "details_pruned_at",
     ];
-    if current_columns.iter().all(|column| columns.contains(*column)) {
+    if current_columns
+        .iter()
+        .all(|column| columns.contains(*column))
+    {
+        for statement in [
+            "ALTER TABLE trade_decisions ADD COLUMN phase TEXT NOT NULL DEFAULT 'legacy'",
+            "ALTER TABLE trade_decisions ADD COLUMN peer_user_channel_id TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN proposal_payment_id TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN proposal_hash TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN confirmation_id TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN base_sync_version INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN quote_price REAL",
+            "ALTER TABLE trade_decisions ADD COLUMN fee_msat INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN expires_at INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN execution_payment_id TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN execution_hash TEXT",
+            "ALTER TABLE trade_decisions ADD COLUMN settled_at INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN reservation_native_sats INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN base_expected_usd REAL",
+            "ALTER TABLE trade_decisions ADD COLUMN base_backing_sats INTEGER",
+            "ALTER TABLE trade_decisions ADD COLUMN base_native_sats INTEGER",
+        ] {
+            let _ = conn.execute(statement, []);
+        }
         conn.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_active_channel
+             ON trade_decisions(channel_id) WHERE outcome = 'reserved'",
+            [],
+        )?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_proposal_payment
+             ON trade_decisions(proposal_payment_id) WHERE proposal_payment_id IS NOT NULL",
+            [],
+        )?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_execution_payment
+             ON trade_decisions(execution_payment_id) WHERE execution_payment_id IS NOT NULL",
+            [],
+        )?;
         return Ok(());
     }
 
@@ -156,19 +239,38 @@ fn init_trade_decisions_schema(conn: &mut Connection) -> SqliteResult<()> {
     // Rebuild it transactionally: its already-sent responses remain terminal dedup tombstones,
     // while new decisions use the request hash and retry lifecycle required by the protocol.
     let legacy_columns = [
-        "inbound_payment_id", "trade_id", "channel_id", "user_channel_id",
-        "counterparty", "outcome", "reason_code", "expected_usd", "backing_sats",
-        "sync_version", "response_envelope", "response_payment_id", "response_status",
-        "response_attempts", "next_response_attempt_at", "created_at", "resolved_at",
+        "inbound_payment_id",
+        "trade_id",
+        "channel_id",
+        "user_channel_id",
+        "counterparty",
+        "outcome",
+        "reason_code",
+        "expected_usd",
+        "backing_sats",
+        "sync_version",
+        "response_envelope",
+        "response_payment_id",
+        "response_status",
+        "response_attempts",
+        "next_response_attempt_at",
+        "created_at",
+        "resolved_at",
     ];
-    if let Some(missing) = legacy_columns.iter().find(|column| !columns.contains(**column)) {
+    if let Some(missing) = legacy_columns
+        .iter()
+        .find(|column| !columns.contains(**column))
+    {
         return Err(rusqlite::Error::InvalidColumnName(format!(
             "unsupported trade_decisions schema: missing {missing}"
         )));
     }
 
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-    tx.execute("ALTER TABLE trade_decisions RENAME TO trade_decisions_legacy_v1", [])?;
+    tx.execute(
+        "ALTER TABLE trade_decisions RENAME TO trade_decisions_legacy_v1",
+        [],
+    )?;
     tx.execute(CREATE_TRADE_DECISIONS_TABLE, [])?;
     tx.execute(
         "INSERT INTO trade_decisions (
@@ -191,6 +293,21 @@ fn init_trade_decisions_schema(conn: &mut Connection) -> SqliteResult<()> {
     )?;
     tx.execute("DROP TABLE trade_decisions_legacy_v1", [])?;
     tx.execute(CREATE_TRADE_DECISIONS_DUE_INDEX, [])?;
+    tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_active_channel
+         ON trade_decisions(channel_id) WHERE outcome = 'reserved'",
+        [],
+    )?;
+    tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_proposal_payment
+         ON trade_decisions(proposal_payment_id) WHERE proposal_payment_id IS NOT NULL",
+        [],
+    )?;
+    tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_trade_decisions_execution_payment
+         ON trade_decisions(execution_payment_id) WHERE execution_payment_id IS NOT NULL",
+        [],
+    )?;
     tx.commit()
 }
 
@@ -232,6 +349,29 @@ pub struct PendingTradeRow {
     pub status: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct WalletTradeConfirmation {
+    pub id: i64,
+    pub channel_id: String,
+    pub trade_id: String,
+    pub proposal_payment_id: String,
+    pub proposal_hash: String,
+    pub proposal_payload: Option<String>,
+    pub confirmation_id: Option<String>,
+    pub confirmation_payload: Option<String>,
+    pub confirmation_expires_at: Option<i64>,
+    pub base_sync_version: u64,
+    pub fee_msat: u64,
+    pub new_expected_usd: f64,
+    pub btc_price: f64,
+    pub new_backing_sats: Option<u64>,
+    pub action: String,
+    pub status: String,
+    pub amount_usd: f64,
+    pub amount_btc: f64,
+    pub fee_usd: f64,
+}
+
 fn pending_trade_from_row(row: &rusqlite::Row<'_>) -> SqliteResult<PendingTradeRow> {
     Ok(PendingTradeRow {
         id: row.get(0)?,
@@ -242,7 +382,9 @@ fn pending_trade_from_row(row: &rusqlite::Row<'_>) -> SqliteResult<PendingTradeR
         fee_msat: row.get::<_, i64>(5)?.max(0) as u64,
         new_expected_usd: row.get(6)?,
         btc_price: row.get(7)?,
-        new_backing_sats: row.get::<_, Option<i64>>(8)?.map(|value| value.max(0) as u64),
+        new_backing_sats: row
+            .get::<_, Option<i64>>(8)?
+            .map(|value| value.max(0) as u64),
         action: row.get(9)?,
         status: row.get(10)?,
     })
@@ -253,6 +395,31 @@ pub struct TradeDecisionIdentity {
     pub inbound_payment_id: String,
     pub trade_id: String,
     pub request_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TradeReservation {
+    pub trade_id: String,
+    pub channel_id: String,
+    /// LSP-local identifier used for durable channel state mutations.
+    pub user_channel_id: String,
+    /// Wallet-local identifier echoed in the signed confirmation and execution.
+    pub peer_user_channel_id: String,
+    pub counterparty: String,
+    pub proposal_payment_id: String,
+    pub proposal_hash: String,
+    pub confirmation_id: String,
+    pub expected_usd: f64,
+    pub backing_sats: u64,
+    pub native_sats: u64,
+    pub quote_price: f64,
+    pub fee_msat: u64,
+    pub base_sync_version: u64,
+    pub sync_version: u64,
+    pub expires_at: i64,
+    pub outcome: String,
+    pub execution_payment_id: Option<String>,
+    pub execution_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -276,12 +443,12 @@ fn finish_transaction<T>(conn: &Connection, result: SqliteResult<T>) -> SqliteRe
             Err(error) => {
                 let _ = conn.execute_batch("ROLLBACK");
                 Err(error)
-            },
+            }
         },
         Err(error) => {
             let _ = conn.execute_batch("ROLLBACK");
             Err(error)
-        },
+        }
     }
 }
 
@@ -382,6 +549,40 @@ impl Database {
         let _ = conn.execute("ALTER TABLE trades ADD COLUMN failure_code TEXT", []);
         let _ = conn.execute("ALTER TABLE trades ADD COLUMN expires_at INTEGER", []);
         let _ = conn.execute("ALTER TABLE trades ADD COLUMN resolved_at INTEGER", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN proposal_payment_id TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN proposal_hash TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN proposal_payload TEXT", []);
+        let _ = conn.execute("ALTER TABLE trades ADD COLUMN confirmation_id TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN confirmation_payload TEXT",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN confirmation_expires_at INTEGER",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN cancellation_payment_id TEXT",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN base_sync_version INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "ALTER TABLE trades ADD COLUMN execution_started INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+        let _ = conn.execute(
+            "UPDATE trades SET execution_started = 1
+             WHERE trade_id IS NOT NULL AND proposal_hash IS NULL",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_proposal_payment_id
+             ON trades(proposal_payment_id) WHERE proposal_payment_id IS NOT NULL",
+            [],
+        );
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_trade_id
              ON trades(trade_id) WHERE trade_id IS NOT NULL",
@@ -566,9 +767,9 @@ impl Database {
             "ALTER TABLE settlement_payments ADD COLUMN user_channel_id TEXT",
             [],
         ); // Ignore error if column already exists
-        // Outbound stability sends optimistically move backing to equilibrium. Persist the exact
-        // transition so a later asynchronous PaymentFailed can undo it without guessing or
-        // overwriting a newer trade/sync allocation.
+           // Outbound stability sends optimistically move backing to equilibrium. Persist the exact
+           // transition so a later asynchronous PaymentFailed can undo it without guessing or
+           // overwriting a newer trade/sync allocation.
         let _ = conn.execute(
             "ALTER TABLE settlement_payments ADD COLUMN backing_sats_before INTEGER",
             [],
@@ -753,19 +954,19 @@ impl Database {
             }
             // Try to update by user_channel_id first (handles channel_id changes from splices)
             let updated = conn.execute(
-            "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
+                "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
                                  note = ?4, user_channel_id = ?5, native_sats = ?6,
                                  closed_at = NULL,
                                  updated_at = strftime('%s', 'now')
              WHERE user_channel_id = ?5",
-            params![
-                channel_id,
-                expected_usd,
-                backing_sats as i64,
-                note,
-                user_channel_id,
-                native_sats as i64
-            ],
+                params![
+                    channel_id,
+                    expected_usd,
+                    backing_sats as i64,
+                    note,
+                    user_channel_id,
+                    native_sats as i64
+                ],
             )?;
             if updated == 0 {
                 // No existing row — insert new
@@ -796,14 +997,14 @@ impl Database {
                 completeness: LedgerCompleteness::Observed,
                 occurred_at_ms: Utc::now().timestamp_millis(),
                 dedup_key: None,
-                before: before
-                    .as_ref()
-                    .map(|(expected, backing, native, _, _, _)| AccountingSnapshot {
-                    expected_usd: Some(*expected),
-                    backing_sats: u64::try_from(*backing).ok(),
-                    native_sats: u64::try_from(*native).ok(),
-                    live_receiver_sats: u64::try_from(backing.saturating_add(*native)).ok(),
-                    ..Default::default()
+                before: before.as_ref().map(|(expected, backing, native, _, _, _)| {
+                    AccountingSnapshot {
+                        expected_usd: Some(*expected),
+                        backing_sats: u64::try_from(*backing).ok(),
+                        native_sats: u64::try_from(*native).ok(),
+                        live_receiver_sats: u64::try_from(backing.saturating_add(*native)).ok(),
+                        ..Default::default()
+                    }
                 }),
                 after: Some(AccountingSnapshot {
                     expected_usd: Some(expected_usd),
@@ -1026,15 +1227,408 @@ impl Database {
     ) -> SqliteResult<Option<TradeDecisionIdentity>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT inbound_payment_id, trade_id, request_hash
-             FROM trade_decisions WHERE inbound_payment_id = ?1",
+            "SELECT ?1, trade_id,
+                    CASE WHEN proposal_payment_id = ?1 THEN COALESCE(proposal_hash, request_hash)
+                         WHEN execution_payment_id = ?1 THEN COALESCE(execution_hash, request_hash)
+                         ELSE request_hash END
+             FROM trade_decisions WHERE inbound_payment_id = ?1
+                OR proposal_payment_id = ?1 OR execution_payment_id = ?1",
             params![inbound_payment_id],
-            |row| Ok(TradeDecisionIdentity {
-                inbound_payment_id: row.get(0)?,
-                trade_id: row.get(1)?,
-                request_hash: row.get(2)?,
-            }),
-        ).optional()
+            |row| {
+                Ok(TradeDecisionIdentity {
+                    inbound_payment_id: row.get(0)?,
+                    trade_id: row.get(1)?,
+                    request_hash: row.get(2)?,
+                })
+            },
+        )
+        .optional()
+    }
+
+    pub fn trade_reservation_by_trade_id(
+        &self,
+        trade_id: &str,
+    ) -> SqliteResult<Option<TradeReservation>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT trade_id, channel_id, user_channel_id, counterparty,
+                    proposal_payment_id, proposal_hash, confirmation_id, expected_usd,
+                    backing_sats, quote_price, fee_msat, base_sync_version, sync_version,
+                    expires_at, outcome, execution_payment_id, execution_hash,
+                    reservation_native_sats, peer_user_channel_id
+             FROM trade_decisions WHERE trade_id = ?1 AND phase = 'two_phase'",
+            params![trade_id],
+            |row| {
+                let backing = row.get::<_, i64>(8)?.max(0) as u64;
+                let expected_usd: f64 = row.get(7)?;
+                let native_sats = row.get::<_, Option<i64>>(17)?.unwrap_or_default().max(0) as u64;
+                let user_channel_id: String = row.get(2)?;
+                let peer_user_channel_id = row
+                    .get::<_, Option<String>>(18)?
+                    .unwrap_or_else(|| user_channel_id.clone());
+                Ok(TradeReservation {
+                    trade_id: row.get(0)?,
+                    channel_id: row.get(1)?,
+                    user_channel_id,
+                    peer_user_channel_id,
+                    counterparty: row.get(3)?,
+                    proposal_payment_id: row.get(4)?,
+                    proposal_hash: row.get(5)?,
+                    confirmation_id: row.get(6)?,
+                    expected_usd,
+                    backing_sats: backing,
+                    native_sats,
+                    quote_price: row.get(9)?,
+                    fee_msat: row.get::<_, i64>(10)?.max(0) as u64,
+                    base_sync_version: row.get::<_, i64>(11)?.max(0) as u64,
+                    sync_version: row.get::<_, i64>(12)?.max(0) as u64,
+                    expires_at: row.get(13)?,
+                    outcome: row.get(14)?,
+                    execution_payment_id: row.get(15)?,
+                    execution_hash: row.get(16)?,
+                })
+            },
+        )
+        .optional()
+    }
+
+    pub fn active_trade_reservation(
+        &self,
+        channel_id: &str,
+        now: i64,
+    ) -> SqliteResult<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT trade_id FROM trade_decisions
+             WHERE channel_id = ?1 AND outcome = 'reserved' AND expires_at > ?2",
+            params![channel_id, now],
+            |row| row.get(0),
+        )
+        .optional()
+    }
+
+    pub fn expire_trade_reservations(&self, now: i64) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE trade_decisions SET outcome = 'expired', reason_code = 'confirmation_expired',
+                    response_status = 'abandoned', response_payment_id = NULL
+             WHERE outcome = 'reserved' AND expires_at <= ?1",
+            params![now],
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn reserve_trade_proposal(
+        &self,
+        proposal_payment_id: &str,
+        trade_id: &str,
+        proposal_hash: &str,
+        channel_id: &str,
+        user_channel_id: &str,
+        peer_user_channel_id: &str,
+        counterparty: &str,
+        confirmation_id: &str,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        quote_price: f64,
+        fee_msat: u64,
+        base_sync_version: u64,
+        confirmed_at: i64,
+        expires_at: i64,
+        replaces_trade_id: Option<&str>,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(proposal_payment_id)
+            || !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_request_hash(proposal_hash)
+            || !crate::trade::is_channel_id(channel_id)
+            || !crate::trade::is_user_channel_id(peer_user_channel_id)
+            || !crate::trade::is_confirmation_id(confirmation_id)
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+            || !quote_price.is_finite()
+            || quote_price <= 0.0
+            || fee_msat == 0
+            || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64
+            || fee_msat > i64::MAX as u64
+            || base_sync_version >= i64::MAX as u64
+            || expires_at <= confirmed_at
+        {
+            return Ok(false);
+        }
+        let sync_version = base_sync_version + 1;
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute(
+            "UPDATE trade_decisions SET outcome = 'expired', reason_code = 'confirmation_expired',
+                    response_status = 'abandoned', response_payment_id = NULL
+             WHERE outcome = 'reserved' AND expires_at <= ?1",
+            params![confirmed_at],
+        )?;
+        let active: Option<String> = tx
+            .query_row(
+                "SELECT trade_id FROM trade_decisions
+                 WHERE channel_id = ?1 AND outcome = 'reserved'",
+                params![channel_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(active_trade_id) = active {
+            if replaces_trade_id != Some(active_trade_id.as_str()) {
+                tx.commit()?;
+                return Ok(false);
+            }
+            tx.execute(
+                "UPDATE trade_decisions SET outcome = 'cancelled', reason_code = 'client_cancelled',
+                        response_status = 'abandoned', response_payment_id = NULL
+                 WHERE trade_id = ?1 AND outcome = 'reserved'",
+                params![active_trade_id],
+            )?;
+        } else if replaces_trade_id.is_some() {
+            tx.commit()?;
+            return Ok(false);
+        }
+        let current_state: Option<(i64, f64, i64, i64)> = tx
+            .query_row(
+                "SELECT sync_version, expected_usd, stable_sats, native_sats
+                 FROM channels WHERE user_channel_id = ?1
+                 AND channel_id = ?2 AND closed_at IS NULL",
+                params![user_channel_id, channel_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+        let Some((current_version, base_expected, base_backing, base_native)) = current_state
+        else {
+            tx.rollback()?;
+            return Ok(false);
+        };
+        if current_version != base_sync_version as i64 {
+            tx.rollback()?;
+            return Ok(false);
+        }
+        let inserted = tx.execute(
+            "INSERT OR IGNORE INTO trade_decisions (
+                inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
+                counterparty, outcome, expected_usd, backing_sats, sync_version, decided_at,
+                response_envelope, response_status, next_response_attempt_at, delivery_deadline,
+                phase, proposal_payment_id, proposal_hash, confirmation_id, base_sync_version,
+                quote_price, fee_msat, expires_at, reservation_native_sats,
+                base_expected_usd, base_backing_sats, base_native_sats,
+                peer_user_channel_id
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'reserved', ?7, ?8, ?9, ?10,
+                       ?11, 'pending', ?10, ?12, 'two_phase', ?1, ?3, ?13, ?14,
+                       ?15, ?16, ?12, ?17, ?18, ?19, ?20, ?21)",
+            params![
+                proposal_payment_id,
+                trade_id,
+                proposal_hash,
+                channel_id,
+                user_channel_id,
+                counterparty,
+                expected_usd,
+                backing_sats as i64,
+                sync_version as i64,
+                confirmed_at,
+                response_envelope,
+                expires_at,
+                confirmation_id,
+                base_sync_version as i64,
+                quote_price,
+                fee_msat as i64,
+                native_sats as i64,
+                base_expected,
+                base_backing,
+                base_native,
+                peer_user_channel_id,
+            ],
+        )?;
+        if inserted != 1 {
+            tx.rollback()?;
+            return Ok(false);
+        }
+        tx.commit()?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn execute_trade_reservation(
+        &self,
+        trade_id: &str,
+        confirmation_id: &str,
+        execution_payment_id: &str,
+        execution_hash: &str,
+        settled_at: i64,
+        decided_at: i64,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_confirmation_id(confirmation_id)
+            || !crate::trade::is_payment_id(execution_payment_id)
+            || !crate::trade::is_request_hash(execution_hash)
+            || settled_at < 0
+            || decided_at < 0
+        {
+            return Ok(false);
+        }
+        let deadline = decided_at.saturating_add(
+            crate::constants::TRADE_RESPONSE_RETRY_WINDOW_SECS.min(i64::MAX as u64) as i64,
+        );
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let reservation: Option<(String, String, f64, i64, i64, i64, i64, f64, i64, i64)> = tx
+            .query_row(
+                "SELECT user_channel_id, channel_id, expected_usd, backing_sats,
+                        reservation_native_sats, base_sync_version, sync_version,
+                        base_expected_usd, base_backing_sats, base_native_sats
+                 FROM trade_decisions WHERE trade_id = ?1 AND confirmation_id = ?2
+                   AND outcome IN ('reserved', 'expired') AND expires_at >= ?3",
+                params![trade_id, confirmation_id, settled_at],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
+                        row.get(9)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((
+            user_channel_id,
+            channel_id,
+            expected_usd,
+            backing_sats,
+            reserved_native_sats,
+            base_version,
+            sync_version,
+            base_expected,
+            base_backing,
+            base_native,
+        )) = reservation
+        else {
+            tx.commit()?;
+            return Ok(false);
+        };
+        let current: Option<(f64, i64, i64)> = tx
+            .query_row(
+                "SELECT expected_usd, stable_sats, native_sats FROM channels
+             WHERE user_channel_id = ?1 AND channel_id = ?2 AND sync_version = ?3
+               AND closed_at IS NULL",
+                params![user_channel_id, channel_id, base_version],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        let Some((current_expected, current_backing, current_native)) = current else {
+            tx.commit()?;
+            return Ok(false);
+        };
+        if current_expected.to_bits() != base_expected.to_bits()
+            || current_backing != base_backing
+            || current_native < base_native
+        {
+            tx.commit()?;
+            return Ok(false);
+        }
+        let compatible_native_increase = current_native.saturating_sub(base_native);
+        let native_sats = reserved_native_sats.saturating_add(compatible_native_increase);
+        let updated = tx.execute(
+            "UPDATE channels SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
+                    sync_version = ?4, updated_at = strftime('%s', 'now')
+             WHERE user_channel_id = ?5 AND channel_id = ?6 AND sync_version = ?7
+               AND expected_usd = ?8 AND stable_sats = ?9 AND native_sats = ?10
+               AND closed_at IS NULL",
+            params![
+                expected_usd,
+                backing_sats,
+                native_sats,
+                sync_version,
+                user_channel_id,
+                channel_id,
+                base_version,
+                base_expected,
+                base_backing,
+                current_native
+            ],
+        )?;
+        if updated != 1 {
+            tx.rollback()?;
+            return Ok(false);
+        }
+        let terminal = tx.execute(
+            "UPDATE trade_decisions SET outcome = 'accepted', reason_code = NULL, request_hash = ?2,
+                    execution_payment_id = ?3, execution_hash = ?2, settled_at = ?4,
+                    decided_at = ?5, response_envelope = ?6, response_payment_id = NULL,
+                    response_status = 'pending', response_attempts = 0,
+                    next_response_attempt_at = ?5, delivery_deadline = ?7
+             WHERE trade_id = ?1 AND confirmation_id = ?8
+               AND outcome IN ('reserved', 'expired')",
+            params![
+                trade_id,
+                execution_hash,
+                execution_payment_id,
+                settled_at,
+                decided_at,
+                response_envelope,
+                deadline,
+                confirmation_id
+            ],
+        )?;
+        if terminal != 1 {
+            tx.rollback()?;
+            return Ok(false);
+        }
+        tx.commit()?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn reject_trade_reservation(
+        &self,
+        trade_id: &str,
+        execution_payment_id: &str,
+        execution_hash: &str,
+        reason_code: &str,
+        decided_at: i64,
+        response_envelope: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_payment_id(execution_payment_id)
+            || !crate::trade::is_request_hash(execution_hash)
+            || decided_at < 0
+        {
+            return Ok(false);
+        }
+        let deadline = decided_at.saturating_add(
+            crate::constants::TRADE_RESPONSE_RETRY_WINDOW_SECS.min(i64::MAX as u64) as i64,
+        );
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trade_decisions SET outcome = CASE WHEN ?4 = 'client_cancelled'
+                                                       THEN 'cancelled' ELSE 'rejected' END,
+                    reason_code = ?4, request_hash = ?3, execution_payment_id = ?2,
+                    execution_hash = ?3, decided_at = ?5, response_envelope = ?6,
+                    response_payment_id = NULL, response_status = 'pending',
+                    response_attempts = 0, next_response_attempt_at = ?5,
+                    delivery_deadline = ?7
+             WHERE trade_id = ?1 AND outcome IN ('reserved', 'expired')",
+            params![
+                trade_id,
+                execution_payment_id,
+                execution_hash,
+                reason_code,
+                decided_at,
+                response_envelope,
+                deadline
+            ],
+        )? == 1)
     }
 
     pub fn trade_decision_by_trade_id(
@@ -1046,12 +1640,15 @@ impl Database {
             "SELECT inbound_payment_id, trade_id, request_hash
              FROM trade_decisions WHERE trade_id = ?1",
             params![trade_id],
-            |row| Ok(TradeDecisionIdentity {
-                inbound_payment_id: row.get(0)?,
-                trade_id: row.get(1)?,
-                request_hash: row.get(2)?,
-            }),
-        ).optional()
+            |row| {
+                Ok(TradeDecisionIdentity {
+                    inbound_payment_id: row.get(0)?,
+                    trade_id: row.get(1)?,
+                    request_hash: row.get(2)?,
+                })
+            },
+        )
+        .optional()
     }
 
     pub fn requeue_exact_trade_response(
@@ -1067,7 +1664,8 @@ impl Database {
              SET response_status = 'pending', response_payment_id = NULL,
                  next_response_attempt_at = ?4
              WHERE inbound_payment_id = ?1 AND trade_id = ?2 AND request_hash = ?3
-               AND response_envelope IS NOT NULL AND delivery_deadline > ?4",
+               AND response_envelope IS NOT NULL AND delivery_deadline > ?4
+               AND response_status <> 'delivered'",
             params![inbound_payment_id, trade_id, request_hash, now],
         )?;
         Ok(updated == 1)
@@ -1096,8 +1694,18 @@ impl Database {
                 counterparty, outcome, reason_code, decided_at, response_envelope,
                 next_response_attempt_at, delivery_deadline
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'rejected', ?7, ?8, ?9, ?8, ?10)",
-            params![inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
-                counterparty, reason_code, decided_at, response_envelope, deadline],
+            params![
+                inbound_payment_id,
+                trade_id,
+                request_hash,
+                channel_id,
+                user_channel_id,
+                counterparty,
+                reason_code,
+                decided_at,
+                response_envelope,
+                deadline
+            ],
         )?;
         Ok(inserted == 1)
     }
@@ -1118,9 +1726,13 @@ impl Database {
         decided_at: i64,
         response_envelope: &str,
     ) -> SqliteResult<bool> {
-        if !expected_usd.is_finite() || expected_usd < 0.0
-            || backing_sats > i64::MAX as u64 || native_sats > i64::MAX as u64
-            || sync_version == 0 || sync_version > i64::MAX as u64 {
+        if !expected_usd.is_finite()
+            || expected_usd < 0.0
+            || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64
+            || sync_version == 0
+            || sync_version > i64::MAX as u64
+        {
             return Ok(false);
         }
         let deadline = decided_at.saturating_add(
@@ -1132,32 +1744,61 @@ impl Database {
         let duplicate: bool = tx.query_row(
             "SELECT EXISTS(SELECT 1 FROM trade_decisions
              WHERE inbound_payment_id = ?1 OR trade_id = ?2)",
-            params![inbound_payment_id, trade_id], |row| row.get(0),
+            params![inbound_payment_id, trade_id],
+            |row| row.get(0),
         )?;
-        if duplicate { tx.commit()?; return Ok(false); }
+        if duplicate {
+            tx.commit()?;
+            return Ok(false);
+        }
         let updated = tx.execute(
             "UPDATE channels SET channel_id = ?1, expected_usd = ?2, stable_sats = ?3,
              native_sats = ?4, sync_version = ?5, updated_at = strftime('%s', 'now'),
              closed_at = NULL WHERE user_channel_id = ?6 AND sync_version = ?7",
-            params![channel_id, expected_usd, backing_sats as i64, native_sats as i64,
-                sync_version as i64, user_channel_id, previous_version],
+            params![
+                channel_id,
+                expected_usd,
+                backing_sats as i64,
+                native_sats as i64,
+                sync_version as i64,
+                user_channel_id,
+                previous_version
+            ],
         )?;
-        if updated != 1 { tx.rollback()?; return Ok(false); }
+        if updated != 1 {
+            tx.rollback()?;
+            return Ok(false);
+        }
         tx.execute(
             "INSERT INTO trade_decisions (inbound_payment_id, trade_id, request_hash,
              channel_id, user_channel_id, counterparty, outcome, expected_usd, backing_sats,
              sync_version, decided_at, response_envelope, next_response_attempt_at,
              delivery_deadline) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'accepted', ?7, ?8,
              ?9, ?10, ?11, ?10, ?12)",
-            params![inbound_payment_id, trade_id, request_hash, channel_id, user_channel_id,
-                counterparty, expected_usd, backing_sats as i64, sync_version as i64,
-                decided_at, response_envelope, deadline],
+            params![
+                inbound_payment_id,
+                trade_id,
+                request_hash,
+                channel_id,
+                user_channel_id,
+                counterparty,
+                expected_usd,
+                backing_sats as i64,
+                sync_version as i64,
+                decided_at,
+                response_envelope,
+                deadline
+            ],
         )?;
         tx.commit()?;
         Ok(true)
     }
 
-    pub fn due_trade_responses(&self, now: i64, limit: usize) -> SqliteResult<Vec<PendingTradeResponse>> {
+    pub fn due_trade_responses(
+        &self,
+        now: i64,
+        limit: usize,
+    ) -> SqliteResult<Vec<PendingTradeResponse>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT inbound_payment_id, counterparty, response_envelope, response_attempts
@@ -1165,10 +1806,14 @@ impl Database {
              AND next_response_attempt_at <= ?1 AND delivery_deadline > ?1
              AND response_envelope IS NOT NULL ORDER BY next_response_attempt_at, decided_at LIMIT ?2",
         )?;
-        let rows = stmt.query_map(params![now, limit as i64], |row| Ok(PendingTradeResponse {
-            inbound_payment_id: row.get(0)?, counterparty: row.get(1)?,
-            response_envelope: row.get(2)?, attempts: row.get::<_, i64>(3)?.max(0) as u32,
-        }))?;
+        let rows = stmt.query_map(params![now, limit as i64], |row| {
+            Ok(PendingTradeResponse {
+                inbound_payment_id: row.get(0)?,
+                counterparty: row.get(1)?,
+                response_envelope: row.get(2)?,
+                attempts: row.get::<_, i64>(3)?.max(0) as u32,
+            })
+        })?;
         rows.collect()
     }
 
@@ -1177,8 +1822,12 @@ impl Database {
         5_i64.saturating_mul(1_i64 << exponent).min(60 * 60)
     }
 
-    pub fn reserve_trade_response_attempt(&self, inbound_payment_id: &str,
-        expected_attempts: u32, now: i64) -> SqliteResult<bool> {
+    pub fn reserve_trade_response_attempt(
+        &self,
+        inbound_payment_id: &str,
+        expected_attempts: u32,
+        now: i64,
+    ) -> SqliteResult<bool> {
         let next_attempt = expected_attempts.saturating_add(1);
         let next_at = now.saturating_add(Self::trade_response_delay_secs(next_attempt));
         let conn = self.conn.lock().unwrap();
@@ -1187,13 +1836,22 @@ impl Database {
              WHERE inbound_payment_id = ?1 AND response_status = 'pending'
              AND response_attempts = ?4 AND next_response_attempt_at <= ?5
              AND delivery_deadline > ?5 AND response_envelope IS NOT NULL",
-            params![inbound_payment_id, next_attempt, next_at, expected_attempts, now],
+            params![
+                inbound_payment_id,
+                next_attempt,
+                next_at,
+                expected_attempts,
+                now
+            ],
         )?;
         Ok(updated == 1)
     }
 
-    pub fn mark_trade_response_in_flight(&self, inbound_payment_id: &str,
-        response_payment_id: &str) -> SqliteResult<bool> {
+    pub fn mark_trade_response_in_flight(
+        &self,
+        inbound_payment_id: &str,
+        response_payment_id: &str,
+    ) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
         Ok(conn.execute(
             "UPDATE trade_decisions SET response_status = 'in_flight', response_payment_id = ?2
@@ -1204,13 +1862,19 @@ impl Database {
 
     pub fn in_flight_trade_response_payment_ids(&self) -> SqliteResult<Vec<String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT response_payment_id FROM trade_decisions
-             WHERE response_status = 'in_flight' AND response_payment_id IS NOT NULL")?;
+        let mut stmt = conn.prepare(
+            "SELECT response_payment_id FROM trade_decisions
+             WHERE response_status = 'in_flight' AND response_payment_id IS NOT NULL",
+        )?;
         let payment_ids = stmt.query_map([], |row| row.get(0))?.collect();
         payment_ids
     }
 
-    pub fn mark_trade_response_delivered(&self, response_payment_id: &str, now: i64) -> SqliteResult<bool> {
+    pub fn mark_trade_response_delivered(
+        &self,
+        response_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
         Ok(conn.execute(
             "UPDATE trade_decisions SET response_status = 'delivered',
@@ -1220,7 +1884,11 @@ impl Database {
         )? > 0)
     }
 
-    pub fn mark_trade_response_failed(&self, response_payment_id: &str, now: i64) -> SqliteResult<bool> {
+    pub fn mark_trade_response_failed(
+        &self,
+        response_payment_id: &str,
+        now: i64,
+    ) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
         Ok(conn.execute(
             "UPDATE trade_decisions SET response_status = 'pending', response_payment_id = NULL,
@@ -1232,8 +1900,11 @@ impl Database {
 
     pub fn abandon_expired_trade_responses(&self, now: i64) -> SqliteResult<usize> {
         let conn = self.conn.lock().unwrap();
-        conn.execute("UPDATE trade_decisions SET response_status = 'abandoned'
-             WHERE response_status IN ('pending', 'in_flight') AND delivery_deadline <= ?1", params![now])
+        conn.execute(
+            "UPDATE trade_decisions SET response_status = 'abandoned'
+             WHERE response_status IN ('pending', 'in_flight') AND delivery_deadline <= ?1",
+            params![now],
+        )
     }
 
     pub fn prune_trade_response_details(&self, now: i64) -> SqliteResult<usize> {
@@ -1241,9 +1912,12 @@ impl Database {
             crate::constants::TRADE_RESPONSE_DETAIL_RETENTION_SECS.min(i64::MAX as u64) as i64,
         );
         let conn = self.conn.lock().unwrap();
-        conn.execute("UPDATE trade_decisions SET response_envelope = NULL, details_pruned_at = ?1
+        conn.execute(
+            "UPDATE trade_decisions SET response_envelope = NULL, details_pruned_at = ?1
              WHERE response_status IN ('delivered', 'abandoned') AND decided_at <= ?2
-             AND response_envelope IS NOT NULL", params![now, cutoff])
+             AND response_envelope IS NOT NULL",
+            params![now, cutoff],
+        )
     }
 
     /// Apply a signed inbound SYNC_V1 allocation only when its version is newer.
@@ -1475,9 +2149,13 @@ impl Database {
     }
 
     /// Resolve user_channel_id from a (possibly closed) channel_id.
-    pub fn get_user_channel_id_by_channel_id(&self, channel_id: &str) -> SqliteResult<Option<String>> {
+    pub fn get_user_channel_id_by_channel_id(
+        &self,
+        channel_id: &str,
+    ) -> SqliteResult<Option<String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT user_channel_id FROM channels WHERE channel_id = ?1")?;
+        let mut stmt =
+            conn.prepare("SELECT user_channel_id FROM channels WHERE channel_id = ?1")?;
         let mut rows = stmt.query(params![channel_id])?;
         if let Some(row) = rows.next()? {
             Ok(row.get::<_, Option<String>>(0)?)
@@ -1612,57 +2290,374 @@ impl Database {
                                  new_expected_usd, new_backing_sats, payment_id, status)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
-                channel_id, action, amount_usd, amount_btc, btc_price, fee_usd, new_expected_usd,
-                new_backing_sats, payment_id, status
+                channel_id,
+                action,
+                amount_usd,
+                amount_btc,
+                btc_price,
+                fee_usd,
+                new_expected_usd,
+                new_backing_sats,
+                payment_id,
+                status
             ],
         )?;
         Ok(conn.last_insert_rowid())
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn record_prepared_trade(&self, channel_id: &str, trade_id: &str,
-        request_hash: &str, request_payload: &str, action: &str, amount_usd: f64,
-        amount_btc: f64, btc_price: f64, fee_usd: f64, fee_msat: u64,
-        new_expected_usd: f64, new_backing_sats: u64, expires_at: i64) -> SqliteResult<i64> {
-        if !crate::trade::is_channel_id(channel_id) || !crate::trade::is_trade_id(trade_id)
+    pub fn record_prepared_trade(
+        &self,
+        channel_id: &str,
+        trade_id: &str,
+        request_hash: &str,
+        request_payload: &str,
+        action: &str,
+        amount_usd: f64,
+        amount_btc: f64,
+        btc_price: f64,
+        fee_usd: f64,
+        fee_msat: u64,
+        new_expected_usd: f64,
+        new_backing_sats: u64,
+        expires_at: i64,
+    ) -> SqliteResult<i64> {
+        if !crate::trade::is_channel_id(channel_id)
+            || !crate::trade::is_trade_id(trade_id)
             || !crate::trade::is_request_hash(request_hash)
             || crate::trade::request_hash(request_payload.as_bytes()) != request_hash
-            || fee_msat > i64::MAX as u64 || new_backing_sats > i64::MAX as u64
-            || !new_expected_usd.is_finite() || new_expected_usd < 0.0 {
+            || fee_msat > i64::MAX as u64
+            || new_backing_sats > i64::MAX as u64
+            || !new_expected_usd.is_finite()
+            || new_expected_usd < 0.0
+        {
             return Err(rusqlite::Error::InvalidQuery);
         }
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO trades (channel_id, trade_id, request_hash, request_payload, action,
              amount_usd, amount_btc, btc_price, fee_usd, fee_msat, fee_status, new_expected_usd,
-             new_backing_sats, status, expires_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8,
-             ?9, ?10, 'sending', ?11, ?12, 'sending', ?13)",
-            params![channel_id, trade_id, request_hash, request_payload, action, amount_usd,
-                amount_btc, btc_price, fee_usd, fee_msat as i64, new_expected_usd,
-                new_backing_sats as i64, expires_at],
+             new_backing_sats, status, expires_at, execution_started)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8,
+             ?9, ?10, 'sending', ?11, ?12, 'sending', ?13, 1)",
+            params![
+                channel_id,
+                trade_id,
+                request_hash,
+                request_payload,
+                action,
+                amount_usd,
+                amount_btc,
+                btc_price,
+                fee_usd,
+                fee_msat as i64,
+                new_expected_usd,
+                new_backing_sats as i64,
+                expires_at
+            ],
         )?;
         Ok(conn.last_insert_rowid())
     }
 
-    pub fn attach_trade_payment_id(&self, trade_db_id: i64, payment_id: &str) -> SqliteResult<bool> {
-        if !crate::trade::is_payment_id(payment_id) { return Ok(false); }
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_trade_proposal(
+        &self,
+        channel_id: &str,
+        trade_id: &str,
+        proposal_hash: &str,
+        proposal_payload: &str,
+        action: &str,
+        amount_usd: f64,
+        amount_btc: f64,
+        btc_price: f64,
+        fee_usd: f64,
+        fee_msat: u64,
+        new_expected_usd: f64,
+        new_backing_sats: u64,
+        base_sync_version: u64,
+    ) -> SqliteResult<i64> {
+        if !crate::trade::is_channel_id(channel_id)
+            || !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_request_hash(proposal_hash)
+            || crate::trade::request_hash(proposal_payload.as_bytes()) != proposal_hash
+            || fee_msat == 0
+            || fee_msat > i64::MAX as u64
+            || new_backing_sats > i64::MAX as u64
+            || base_sync_version > i64::MAX as u64
+            || !new_expected_usd.is_finite()
+            || new_expected_usd < 0.0
+        {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
         let conn = self.conn.lock().unwrap();
-        Ok(conn.execute("UPDATE trades SET payment_id = ?2, fee_status = 'pending',
-             status = 'awaiting_result' WHERE id = ?1 AND payment_id IS NULL AND status = 'sending'",
-            params![trade_db_id, payment_id])? == 1)
+        conn.execute(
+            "INSERT INTO trades (
+                channel_id, trade_id, request_hash, request_payload, proposal_hash,
+                proposal_payload, action, amount_usd, amount_btc, btc_price, fee_usd,
+                fee_msat, fee_status, new_expected_usd, new_backing_sats, status,
+                base_sync_version, execution_started
+             ) VALUES (?1, ?2, ?3, ?4, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                       'unpaid', ?11, ?12, 'proposing', ?13, 0)",
+            params![
+                channel_id,
+                trade_id,
+                proposal_hash,
+                proposal_payload,
+                action,
+                amount_usd,
+                amount_btc,
+                btc_price,
+                fee_usd,
+                fee_msat as i64,
+                new_expected_usd,
+                new_backing_sats as i64,
+                base_sync_version as i64,
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn attach_trade_proposal_payment_id(
+        &self,
+        trade_db_id: i64,
+        proposal_payment_id: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(proposal_payment_id) {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET proposal_payment_id = ?2, status = 'awaiting_confirmation'
+             WHERE id = ?1 AND proposal_payment_id IS NULL AND status = 'proposing'",
+            params![trade_db_id, proposal_payment_id],
+        )? == 1)
+    }
+
+    pub fn wallet_trade_by_proposal(
+        &self,
+        trade_id: &str,
+        proposal_payment_id: &str,
+        proposal_hash: &str,
+    ) -> SqliteResult<Option<WalletTradeConfirmation>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, channel_id, trade_id, proposal_payment_id, proposal_hash,
+                    proposal_payload, confirmation_id, confirmation_payload, confirmation_expires_at,
+                    base_sync_version, fee_msat, new_expected_usd, btc_price,
+                    new_backing_sats, action, status, amount_usd, amount_btc, fee_usd
+             FROM trades WHERE trade_id = ?1 AND proposal_payment_id = ?2
+               AND proposal_hash = ?3 LIMIT 1",
+            params![trade_id, proposal_payment_id, proposal_hash],
+            |row| {
+                Ok(WalletTradeConfirmation {
+                    id: row.get(0)?,
+                    channel_id: row.get(1)?,
+                    trade_id: row.get(2)?,
+                    proposal_payment_id: row.get(3)?,
+                    proposal_hash: row.get(4)?,
+                    proposal_payload: row.get(5)?,
+                    confirmation_id: row.get(6)?,
+                    confirmation_payload: row.get(7)?,
+                    confirmation_expires_at: row.get(8)?,
+                    base_sync_version: row.get::<_, i64>(9)?.max(0) as u64,
+                    fee_msat: row.get::<_, i64>(10)?.max(0) as u64,
+                    new_expected_usd: row.get(11)?,
+                    btc_price: row.get(12)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(13)?.map(|v| v.max(0) as u64),
+                    action: row.get(14)?,
+                    status: row.get(15)?,
+                    amount_usd: row.get(16)?,
+                    amount_btc: row.get(17)?,
+                    fee_usd: row.get(18)?,
+                })
+            },
+        )
+        .optional()
+    }
+
+    pub fn latest_wallet_trade_review(&self) -> SqliteResult<Option<WalletTradeConfirmation>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, channel_id, trade_id, proposal_payment_id, proposal_hash,
+                    proposal_payload, confirmation_id, confirmation_payload, confirmation_expires_at,
+                    base_sync_version, fee_msat, new_expected_usd, btc_price,
+                    new_backing_sats, action, status, amount_usd, amount_btc, fee_usd
+             FROM trades WHERE execution_started = 0
+               AND status IN ('proposing', 'awaiting_confirmation', 'confirmed')
+               AND proposal_payment_id IS NOT NULL
+             ORDER BY id DESC LIMIT 1",
+            [],
+            |row| {
+                Ok(WalletTradeConfirmation {
+                    id: row.get(0)?,
+                    channel_id: row.get(1)?,
+                    trade_id: row.get(2)?,
+                    proposal_payment_id: row.get(3)?,
+                    proposal_hash: row.get(4)?,
+                    proposal_payload: row.get(5)?,
+                    confirmation_id: row.get(6)?,
+                    confirmation_payload: row.get(7)?,
+                    confirmation_expires_at: row.get(8)?,
+                    base_sync_version: row.get::<_, i64>(9)?.max(0) as u64,
+                    fee_msat: row.get::<_, i64>(10)?.max(0) as u64,
+                    new_expected_usd: row.get(11)?,
+                    btc_price: row.get(12)?,
+                    new_backing_sats: row.get::<_, Option<i64>>(13)?.map(|v| v.max(0) as u64),
+                    action: row.get(14)?,
+                    status: row.get(15)?,
+                    amount_usd: row.get(16)?,
+                    amount_btc: row.get(17)?,
+                    fee_usd: row.get(18)?,
+                })
+            },
+        )
+        .optional()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_trade_confirmation(
+        &self,
+        trade_db_id: i64,
+        confirmation_id: &str,
+        confirmation_payload: &str,
+        expires_at: i64,
+        quote_price: f64,
+        fee_msat: u64,
+        fee_usd: f64,
+        backing_sats: u64,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_confirmation_id(confirmation_id)
+            || expires_at <= 0
+            || !quote_price.is_finite()
+            || quote_price <= 0.0
+            || fee_msat == 0
+            || fee_msat > i64::MAX as u64
+            || backing_sats > i64::MAX as u64
+        {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET confirmation_id = ?2, confirmation_payload = ?3,
+                    confirmation_expires_at = ?4, btc_price = ?5, fee_msat = ?6,
+                    fee_usd = ?7, new_backing_sats = ?8, status = 'confirmed'
+             WHERE id = ?1 AND status IN ('proposing', 'awaiting_confirmation', 'confirmed')
+               AND execution_started = 0",
+            params![
+                trade_db_id,
+                confirmation_id,
+                confirmation_payload,
+                expires_at,
+                quote_price,
+                fee_msat as i64,
+                fee_usd,
+                backing_sats as i64
+            ],
+        )? == 1)
+    }
+
+    pub fn prepare_trade_execution(
+        &self,
+        trade_db_id: i64,
+        payment_id: &str,
+        execution_hash: &str,
+        execution_payload: &str,
+        expires_at: i64,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(payment_id)
+            || !crate::trade::is_request_hash(execution_hash)
+            || crate::trade::request_hash(execution_payload.as_bytes()) != execution_hash
+        {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET request_hash = ?2, request_payload = ?3,
+                    payment_id = ?4, fee_status = 'pending', status = 'execution_sending',
+                    execution_started = 1, expires_at = ?5
+             WHERE id = ?1 AND status = 'confirmed' AND execution_started = 0",
+            params![
+                trade_db_id,
+                execution_hash,
+                execution_payload,
+                payment_id,
+                expires_at
+            ],
+        )? == 1)
+    }
+
+    pub fn mark_trade_proposal_send_failed(&self, trade_db_id: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET status = 'proposal_failed', failure_code = 'payment_failed',
+                    resolved_at = strftime('%s', 'now')
+             WHERE id = ?1 AND status = 'proposing' AND execution_started = 0",
+            params![trade_db_id],
+        )? == 1)
+    }
+
+    pub fn cancel_trade_proposal(&self, trade_db_id: i64) -> SqliteResult<bool> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET status = 'cancelled', failure_code = 'client_cancelled',
+                    resolved_at = strftime('%s', 'now')
+             WHERE id = ?1 AND execution_started = 0
+               AND status IN ('proposing', 'awaiting_confirmation', 'confirmed')",
+            params![trade_db_id],
+        )? == 1)
+    }
+
+    pub fn attach_trade_cancellation_payment(
+        &self,
+        trade_db_id: i64,
+        payment_id: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(payment_id) {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET cancellation_payment_id = ?2 WHERE id = ?1
+             AND cancellation_payment_id IS NULL",
+            params![trade_db_id, payment_id],
+        )? == 1)
+    }
+
+    pub fn attach_trade_payment_id(
+        &self,
+        trade_db_id: i64,
+        payment_id: &str,
+    ) -> SqliteResult<bool> {
+        if !crate::trade::is_payment_id(payment_id) {
+            return Ok(false);
+        }
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "UPDATE trades SET payment_id = ?2, fee_status = 'pending',
+             status = 'awaiting_result' WHERE id = ?1
+             AND (payment_id IS NULL OR payment_id = ?2)
+             AND status IN ('sending', 'execution_sending')",
+            params![trade_db_id, payment_id],
+        )? == 1)
     }
 
     pub fn mark_trade_send_failed(&self, trade_db_id: i64) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
-        Ok(conn.execute("UPDATE trades SET status = 'payment_failed', fee_status = 'failed',
+        Ok(conn.execute(
+            "UPDATE trades SET status = 'payment_failed', fee_status = 'failed',
              failure_code = 'payment_failed', resolved_at = strftime('%s', 'now')
-             WHERE id = ?1 AND status = 'sending'", params![trade_db_id])? == 1)
+             WHERE id = ?1 AND status IN ('sending', 'execution_sending')",
+            params![trade_db_id],
+        )? == 1)
     }
 
     pub fn mark_trade_fee_paid(&self, payment_id: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
-        Ok(conn.execute("UPDATE trades SET fee_status = 'paid' WHERE payment_id = ?1
-             AND status IN ('sending', 'awaiting_result', 'outcome_unknown')", params![payment_id])? == 1)
+        Ok(conn.execute(
+            "UPDATE trades SET fee_status = 'paid' WHERE payment_id = ?1
+             AND status IN ('sending', 'awaiting_result', 'outcome_unknown')",
+            params![payment_id],
+        )? == 1)
     }
 
     /// Look up a still-pending trade by its payment_id, for restart recovery. Only returns rows
@@ -1703,68 +2698,137 @@ impl Database {
         .optional()
     }
 
-    pub fn get_trade_by_correlation(&self, trade_id: &str, trade_payment_id: &str,
-        request_hash: &str) -> SqliteResult<Option<PendingTradeRow>> {
-        if !crate::trade::is_trade_id(trade_id) || !crate::trade::is_payment_id(trade_payment_id)
-            || !crate::trade::is_request_hash(request_hash) { return Ok(None); }
+    pub fn get_trade_by_correlation(
+        &self,
+        trade_id: &str,
+        trade_payment_id: &str,
+        request_hash: &str,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
+        if !crate::trade::is_trade_id(trade_id)
+            || !crate::trade::is_payment_id(trade_payment_id)
+            || !crate::trade::is_request_hash(request_hash)
+        {
+            return Ok(None);
+        }
         let conn = self.conn.lock().unwrap();
-        conn.query_row("SELECT id, channel_id, trade_id, payment_id, request_hash, fee_msat,
+        conn.query_row(
+            "SELECT id, channel_id, trade_id, payment_id, request_hash, fee_msat,
              new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
-             WHERE trade_id = ?1 AND request_hash = ?2 AND (payment_id IS NULL OR payment_id = ?3)
-             LIMIT 1", params![trade_id, request_hash, trade_payment_id], pending_trade_from_row).optional()
+             WHERE trade_id = ?1
+               AND (request_hash = ?2 OR proposal_hash = ?2)
+               AND (payment_id = ?3 OR proposal_payment_id = ?3 OR cancellation_payment_id = ?3
+                    OR (payment_id IS NULL AND execution_started = 1 AND request_hash = ?2))
+             LIMIT 1",
+            params![trade_id, request_hash, trade_payment_id],
+            pending_trade_from_row,
+        )
+        .optional()
     }
 
-    pub fn mark_trade_rejected(&self, trade_db_id: i64, trade_payment_id: &str,
-        reason_code: &str, decided_at: i64) -> SqliteResult<bool> {
+    pub fn mark_trade_rejected(
+        &self,
+        trade_db_id: i64,
+        trade_payment_id: &str,
+        reason_code: &str,
+        decided_at: i64,
+    ) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
-        Ok(conn.execute("UPDATE trades SET status = 'rejected', fee_status = 'paid',
-             failure_code = ?3, payment_id = COALESCE(payment_id, ?2), resolved_at = ?4
-             WHERE id = ?1 AND status IN ('sending', 'awaiting_result', 'outcome_unknown')
-             AND (payment_id IS NULL OR payment_id = ?2)",
-            params![trade_db_id, trade_payment_id, reason_code, decided_at])? == 1)
+        Ok(conn.execute(
+            "UPDATE trades SET
+             status = CASE WHEN ?3 = 'client_cancelled' THEN 'cancelled'
+                           WHEN execution_started = 0 THEN 'proposal_rejected'
+                           ELSE 'rejected' END,
+             fee_status = CASE WHEN execution_started = 0 THEN fee_status ELSE 'paid' END,
+             payment_id = CASE WHEN execution_started = 1 THEN COALESCE(payment_id, ?2)
+                               ELSE payment_id END,
+             failure_code = ?3, resolved_at = ?4
+             WHERE id = ?1 AND status IN ('proposing', 'awaiting_confirmation', 'confirmed',
+                                           'execution_sending', 'sending', 'awaiting_result',
+                                           'outcome_unknown')
+             AND (payment_id = ?2 OR proposal_payment_id = ?2
+                  OR (payment_id IS NULL AND execution_started = 1))",
+            params![trade_db_id, trade_payment_id, reason_code, decided_at],
+        )? == 1)
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn apply_correlated_trade_acceptance(&self, user_channel_id: &str, sync_version: u64,
-        expected_usd: f64, backing_sats: u64, native_sats: u64, trade_db_id: i64,
-        trade_payment_id: &str) -> SqliteResult<CorrelatedTradeAcceptance> {
-        let none = CorrelatedTradeAcceptance { trade_resolved: false, allocation_applied: false };
-        if sync_version == 0 || sync_version > i64::MAX as u64 || !expected_usd.is_finite()
-            || expected_usd < 0.0 || backing_sats > i64::MAX as u64
-            || native_sats > i64::MAX as u64 { return Ok(none); }
+    pub fn apply_correlated_trade_acceptance(
+        &self,
+        user_channel_id: &str,
+        sync_version: u64,
+        expected_usd: f64,
+        backing_sats: u64,
+        native_sats: u64,
+        trade_db_id: i64,
+        trade_payment_id: &str,
+    ) -> SqliteResult<CorrelatedTradeAcceptance> {
+        let none = CorrelatedTradeAcceptance {
+            trade_resolved: false,
+            allocation_applied: false,
+        };
+        if sync_version == 0
+            || sync_version > i64::MAX as u64
+            || !expected_usd.is_finite()
+            || expected_usd < 0.0
+            || backing_sats > i64::MAX as u64
+            || native_sats > i64::MAX as u64
+        {
+            return Ok(none);
+        }
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        let trade: Option<(f64, Option<String>, String, Option<String>)> = tx.query_row(
-            "SELECT new_expected_usd, payment_id, status, trade_id FROM trades WHERE id = ?1",
-            params![trade_db_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-        ).optional()?;
+        let trade: Option<(f64, Option<String>, String, Option<String>)> = tx
+            .query_row(
+                "SELECT new_expected_usd, payment_id, status, trade_id FROM trades WHERE id = ?1",
+                params![trade_db_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
         let Some((requested_usd, stored_payment_id, status, correlated_trade_id)) = trade else {
             tx.commit()?;
             return Ok(none);
         };
         if !crate::trade::target_matches(requested_usd, expected_usd)
-            || stored_payment_id.as_deref().is_some_and(|stored| stored != trade_payment_id) {
-            tx.commit()?; return Ok(none);
+            || stored_payment_id
+                .as_deref()
+                .is_some_and(|stored| stored != trade_payment_id)
+        {
+            tx.commit()?;
+            return Ok(none);
         }
-        let unresolved = matches!(status.as_str(), "sending" | "awaiting_result" | "outcome_unknown");
-        let (current_version, before_expected, before_backing, before_native):
-            (i64, f64, i64, i64) = tx.query_row(
-                "SELECT sync_version, expected_usd, stable_sats, native_sats FROM channels
+        let unresolved = matches!(
+            status.as_str(),
+            "sending" | "execution_sending" | "awaiting_result" | "outcome_unknown"
+        );
+        let (current_version, before_expected, before_backing, before_native): (
+            i64,
+            f64,
+            i64,
+            i64,
+        ) = tx.query_row(
+            "SELECT sync_version, expected_usd, stable_sats, native_sats FROM channels
                  WHERE user_channel_id = ?1",
-                params![user_channel_id],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-            )?;
-        let allocation_applied = unresolved && current_version < sync_version as i64 && tx.execute(
-            "UPDATE channels SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
+            params![user_channel_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        let allocation_applied = unresolved
+            && current_version < sync_version as i64
+            && tx.execute(
+                "UPDATE channels SET expected_usd = ?1, stable_sats = ?2, native_sats = ?3,
              sync_version = ?4, updated_at = strftime('%s', 'now')
              WHERE user_channel_id = ?5 AND sync_version < ?4",
-            params![expected_usd, backing_sats as i64, native_sats as i64,
-                sync_version as i64, user_channel_id])? == 1;
+                params![
+                    expected_usd,
+                    backing_sats as i64,
+                    native_sats as i64,
+                    sync_version as i64,
+                    user_channel_id
+                ],
+            )? == 1;
         let trade_resolved = unresolved && tx.execute(
             "UPDATE trades SET status = 'accepted', fee_status = 'paid',
              payment_id = COALESCE(payment_id, ?2), resolved_at = strftime('%s', 'now')
-             WHERE id = ?1 AND status IN ('sending', 'awaiting_result', 'outcome_unknown')",
+             WHERE id = ?1 AND status IN ('sending', 'execution_sending', 'awaiting_result', 'outcome_unknown')",
             params![trade_db_id, trade_payment_id])? == 1;
         let ledger_mirror = if allocation_applied {
             let draft = LedgerEventDraft {
@@ -1782,9 +2846,8 @@ impl Database {
                     expected_usd: Some(before_expected),
                     backing_sats: u64::try_from(before_backing).ok(),
                     native_sats: u64::try_from(before_native).ok(),
-                    live_receiver_sats: u64::try_from(
-                        before_backing.saturating_add(before_native),
-                    ).ok(),
+                    live_receiver_sats: u64::try_from(before_backing.saturating_add(before_native))
+                        .ok(),
                     ..Default::default()
                 }),
                 after: Some(AccountingSnapshot {
@@ -1817,18 +2880,34 @@ impl Database {
                 crate::audit::mirror_committed_ledger_event(&draft, outcome.event_id);
             }
         }
-        Ok(CorrelatedTradeAcceptance { trade_resolved, allocation_applied })
+        Ok(CorrelatedTradeAcceptance {
+            trade_resolved,
+            allocation_applied,
+        })
     }
 
-    pub fn mark_trade_payment_failed(&self, payment_id: &str) -> SqliteResult<Option<PendingTradeRow>> {
+    pub fn mark_trade_payment_failed(
+        &self,
+        payment_id: &str,
+    ) -> SqliteResult<Option<PendingTradeRow>> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        let trade = tx.query_row("SELECT id, channel_id, trade_id, payment_id, request_hash,
+        let trade = tx
+            .query_row(
+                "SELECT id, channel_id, trade_id, payment_id, request_hash,
              fee_msat, new_expected_usd, btc_price, new_backing_sats, action, status FROM trades
-             WHERE payment_id = ?1 AND status IN ('pending', 'sending', 'awaiting_result', 'outcome_unknown')
-             ORDER BY id DESC LIMIT 1", params![payment_id], pending_trade_from_row).optional()?;
+             WHERE (payment_id = ?1 OR proposal_payment_id = ?1)
+               AND status IN ('pending', 'proposing', 'awaiting_confirmation', 'confirmed',
+                              'execution_sending', 'sending', 'awaiting_result', 'outcome_unknown')
+             ORDER BY id DESC LIMIT 1",
+                params![payment_id],
+                pending_trade_from_row,
+            )
+            .optional()?;
         if let Some(trade) = trade.as_ref() {
-            tx.execute("UPDATE trades SET status = 'payment_failed', fee_status = 'failed',
+            tx.execute("UPDATE trades SET
+                 status = CASE WHEN execution_started = 0 THEN 'proposal_failed' ELSE 'payment_failed' END,
+                 fee_status = CASE WHEN execution_started = 0 THEN fee_status ELSE 'failed' END,
                  failure_code = 'payment_failed', resolved_at = strftime('%s', 'now') WHERE id = ?1",
                 params![trade.id])?;
         }
@@ -1838,16 +2917,37 @@ impl Database {
 
     pub fn mark_unresolved_trades_unknown(&self, now: i64) -> SqliteResult<usize> {
         let conn = self.conn.lock().unwrap();
-        conn.execute("UPDATE trades SET status = 'outcome_unknown'
+        let abandoned_proposals = conn.execute(
+            "UPDATE trades SET status = 'proposal_failed', failure_code = 'restart_during_send',
+                    resolved_at = ?1
+             WHERE status = 'proposing' AND proposal_payment_id IS NULL",
+            params![now],
+        )?;
+        let uncertain = conn.execute(
+            "UPDATE trades SET status = 'outcome_unknown'
+             WHERE status = 'execution_sending'",
+            [],
+        )?;
+        let expired = conn.execute(
+            "UPDATE trades SET status = 'outcome_unknown'
              WHERE status IN ('sending', 'awaiting_result') AND expires_at IS NOT NULL
-             AND expires_at <= ?1", params![now])
+             AND expires_at <= ?1",
+            params![now],
+        )?;
+        Ok(abandoned_proposals
+            .saturating_add(uncertain)
+            .saturating_add(expired))
     }
 
     pub fn has_unresolved_trade_for_channel(&self, channel_id: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
-        conn.query_row("SELECT EXISTS(SELECT 1 FROM trades WHERE channel_id = ?1
-             AND status IN ('sending', 'awaiting_result', 'outcome_unknown'))",
-            params![channel_id], |row| row.get(0))
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM trades WHERE channel_id = ?1
+             AND status IN ('proposing', 'awaiting_confirmation', 'confirmed',
+                            'execution_sending', 'sending', 'awaiting_result', 'outcome_unknown'))",
+            params![channel_id],
+            |row| row.get(0),
+        )
     }
 
     /// Whether this payment id belongs to any trade, including one already completed by an
@@ -1856,7 +2956,9 @@ impl Database {
     pub fn is_trade_payment(&self, payment_id: &str) -> SqliteResult<bool> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM trades WHERE payment_id = ?1)",
+            "SELECT EXISTS(SELECT 1 FROM trades
+             WHERE payment_id = ?1 OR proposal_payment_id = ?1
+                OR cancellation_payment_id = ?1)",
             params![payment_id],
             |row| row.get(0),
         )
@@ -1879,6 +2981,7 @@ impl Database {
             "SELECT id, channel_id, action, amount_usd, amount_btc, btc_price, fee_usd,
                     payment_id, status, created_at, failure_code
              FROM trades
+             WHERE execution_started = 1 OR trade_id IS NULL
              ORDER BY id DESC
              LIMIT ?1",
         )?;
@@ -2377,7 +3480,14 @@ impl Database {
                                      note = ?4, user_channel_id = ?5, native_sats = ?6,
                                      closed_at = NULL, updated_at = strftime('%s', 'now')
                  WHERE user_channel_id = ?5",
-                params![channel_id, expected_usd, after, note, user_channel_id, native],
+                params![
+                    channel_id,
+                    expected_usd,
+                    after,
+                    note,
+                    user_channel_id,
+                    native
+                ],
             )?;
             if updated == 0 {
                 conn.execute(
@@ -2388,7 +3498,14 @@ impl Database {
                         user_channel_id = ?2, expected_usd = ?3, stable_sats = ?4,
                         native_sats = ?5, note = ?6, closed_at = NULL,
                         updated_at = strftime('%s', 'now')",
-                    params![channel_id, user_channel_id, expected_usd, after, native, note],
+                    params![
+                        channel_id,
+                        user_channel_id,
+                        expected_usd,
+                        after,
+                        native,
+                        note
+                    ],
                 )?;
             }
 
@@ -2602,8 +3719,15 @@ impl Database {
     ) -> SqliteResult<bool> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        let payment: Option<(i64, Option<String>, i64, Option<f64>, Option<f64>, Option<String>)> =
-            tx.query_row(
+        let payment: Option<(
+            i64,
+            Option<String>,
+            i64,
+            Option<f64>,
+            Option<f64>,
+            Option<String>,
+        )> = tx
+            .query_row(
                 "SELECT id, user_channel_id, amount_msat, amount_usd, btc_price, counterparty
                  FROM payments
                  WHERE payment_id = ?1 AND payment_type = 'stability'
@@ -2622,8 +3746,14 @@ impl Database {
                 },
             )
             .optional()?;
-        let Some((payment_db_id, user_channel_id, amount_msat, amount_usd, btc_price, counterparty)) =
-            payment
+        let Some((
+            payment_db_id,
+            user_channel_id,
+            amount_msat,
+            amount_usd,
+            btc_price,
+            counterparty,
+        )) = payment
         else {
             tx.commit()?;
             return Ok(false);
@@ -2651,8 +3781,9 @@ impl Database {
             None => None,
         };
         let amount_msat = u64::try_from(amount_msat).ok();
-        let after = channel.as_ref().map(|(_, expected_usd, backing, native)| {
-            AccountingSnapshot {
+        let after = channel
+            .as_ref()
+            .map(|(_, expected_usd, backing, native)| AccountingSnapshot {
                 expected_usd: Some(*expected_usd),
                 backing_sats: u64::try_from(*backing).ok(),
                 native_sats: u64::try_from(*native).ok(),
@@ -2662,8 +3793,7 @@ impl Database {
                 amount_usd,
                 fee_msat: fee_paid_msat,
                 ..Default::default()
-            }
-        });
+            });
         let mut refs = vec![
             LedgerRef::new("payment_id", payment_id),
             LedgerRef::new("payment_hash", payment_hash),
@@ -2787,11 +3917,7 @@ impl Database {
             "completed",
             Some(user_channel_id),
             None,
-            Some((
-                backing_sats_before,
-                backing_sats_after,
-                native_sats_after,
-            )),
+            Some((backing_sats_before, backing_sats_after, native_sats_after)),
             Some(settlement_id),
         )
     }
@@ -2974,16 +4100,17 @@ impl Database {
                 }
             }
             let after_backing = new_backing.and_then(|value| u64::try_from(value).ok());
-            let before_snapshot = channel_before.map(|(expected, backing, native)| AccountingSnapshot {
-                expected_usd: Some(expected),
-                backing_sats: u64::try_from(backing).ok(),
-                native_sats: u64::try_from(native).ok(),
-                live_receiver_sats: u64::try_from(backing.saturating_add(native)).ok(),
-                btc_price,
-                amount_msat: Some(amount_msat),
-                amount_usd,
-                ..Default::default()
-            });
+            let before_snapshot =
+                channel_before.map(|(expected, backing, native)| AccountingSnapshot {
+                    expected_usd: Some(expected),
+                    backing_sats: u64::try_from(backing).ok(),
+                    native_sats: u64::try_from(native).ok(),
+                    live_receiver_sats: u64::try_from(backing.saturating_add(native)).ok(),
+                    btc_price,
+                    amount_msat: Some(amount_msat),
+                    amount_usd,
+                    ..Default::default()
+                });
             let after_snapshot = before_snapshot.as_ref().map(|before| AccountingSnapshot {
                 expected_usd: before.expected_usd,
                 backing_sats: after_backing.or(before.backing_sats),
@@ -3017,7 +4144,12 @@ impl Database {
             }
             let draft = LedgerEventDraft {
                 event_type: event_type.to_owned(),
-                category: if payment_type == "stability" { "stability" } else { "payment" }.to_owned(),
+                category: if payment_type == "stability" {
+                    "stability"
+                } else {
+                    "payment"
+                }
+                .to_owned(),
                 severity: "info".to_owned(),
                 status: status.to_owned(),
                 source: "ldk_event".to_owned(),
@@ -3025,7 +4157,9 @@ impl Database {
                 occurred_at_ms: Utc::now().timestamp_millis(),
                 dedup_key: Some(format!(
                     "ldk-event:payment-recorded:{}:{status}",
-                    payment_id.map(str::to_owned).unwrap_or_else(|| format!("row-{payment_row_id}"))
+                    payment_id
+                        .map(str::to_owned)
+                        .unwrap_or_else(|| format!("row-{payment_row_id}"))
                 )),
                 before: before_snapshot,
                 after: after_snapshot,
@@ -3579,9 +4713,7 @@ impl Database {
             .optional()?;
         created_at
             .map(|value| {
-                u64::try_from(value).map_err(|_| {
-                    rusqlite::Error::IntegralValueOutOfRange(0, value)
-                })
+                u64::try_from(value).map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, value))
             })
             .transpose()
     }
@@ -3602,9 +4734,8 @@ impl Database {
         let settlements = statement
             .query_map(params![limit], |row| {
                 let amount_msat: i64 = row.get(2)?;
-                let amount_msat = u64::try_from(amount_msat).map_err(|_| {
-                    rusqlite::Error::IntegralValueOutOfRange(2, amount_msat)
-                })?;
+                let amount_msat = u64::try_from(amount_msat)
+                    .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(2, amount_msat))?;
                 Ok(PendingInboundStabilitySettlement {
                     settlement_id: row.get(0)?,
                     payment_id: row.get(1)?,
@@ -3723,7 +4854,9 @@ impl Database {
                     expected_usd: Some(expected_usd),
                     backing_sats: Some(backing_sats_before),
                     native_sats: Some(native_sats_before),
-                    live_receiver_sats: Some(backing_sats_before.saturating_add(native_sats_before)),
+                    live_receiver_sats: Some(
+                        backing_sats_before.saturating_add(native_sats_before),
+                    ),
                     amount_msat: Some(amount_msat),
                     ..Default::default()
                 });
@@ -3829,8 +4962,9 @@ impl Database {
                 .optional()?,
             None => None,
         };
-        let after = channel.as_ref().map(|(_, expected_usd, backing, native)| {
-            AccountingSnapshot {
+        let after = channel
+            .as_ref()
+            .map(|(_, expected_usd, backing, native)| AccountingSnapshot {
                 expected_usd: Some(*expected_usd),
                 backing_sats: u64::try_from(*backing).ok(),
                 native_sats: u64::try_from(*native).ok(),
@@ -3838,8 +4972,7 @@ impl Database {
                 amount_msat,
                 fee_msat: fee_paid_msat,
                 ..Default::default()
-            }
-        });
+            });
         let mut refs = vec![LedgerRef::new("payment_id", payment_id)];
         if let Some(user_channel_id) = user_channel_id.as_deref() {
             refs.push(LedgerRef::new("user_channel_id", user_channel_id));
@@ -3865,7 +4998,10 @@ impl Database {
             source: "lsp".to_owned(),
             completeness: LedgerCompleteness::Observed,
             occurred_at_ms: Utc::now().timestamp_millis(),
-            dedup_key: Some(format!("lsp:{}:{payment_id}", event_type.to_ascii_lowercase())),
+            dedup_key: Some(format!(
+                "lsp:{}:{payment_id}",
+                event_type.to_ascii_lowercase()
+            )),
             before: None,
             after,
             detail: serde_json::json!({
@@ -3918,7 +5054,16 @@ impl Database {
                 },
             )
             .optional()?;
-        let Some((Some(user_channel_id), Some(before), Some(after), Some(native_before), Some(expected_usd), last_before, outcome)) = row else {
+        let Some((
+            Some(user_channel_id),
+            Some(before),
+            Some(after),
+            Some(native_before),
+            Some(expected_usd),
+            last_before,
+            outcome,
+        )) = row
+        else {
             return Ok(None);
         };
         if outcome != "pending"
@@ -4071,9 +5216,8 @@ impl Database {
     /// Return the stored `user_channel_id` for a payment_id, or None if absent/NULL/not found.
     pub fn get_settlement_channel(&self, payment_id: &str) -> SqliteResult<Option<String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT user_channel_id FROM settlement_payments WHERE payment_id = ?1",
-        )?;
+        let mut stmt =
+            conn.prepare("SELECT user_channel_id FROM settlement_payments WHERE payment_id = ?1")?;
         let mut rows = stmt.query(params![payment_id])?;
         if let Some(row) = rows.next()? {
             Ok(row.get::<_, Option<String>>(0)?)
@@ -4179,6 +5323,306 @@ mod tests {
     use super::*;
 
     #[test]
+    fn swept_reservation_accepts_an_execution_that_settled_before_expiry() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "11".repeat(32);
+        let trade_id = "22".repeat(32);
+        let proposal_payment_id = "33".repeat(32);
+        let proposal_hash = "44".repeat(32);
+        let confirmation_id = "55".repeat(32);
+        let execution_payment_id = "66".repeat(32);
+        let execution_hash = "77".repeat(32);
+        db.save_channel(&channel_id, "7", 10.0, 10_000, 5_000, None)
+            .unwrap();
+
+        assert!(db
+            .reserve_trade_proposal(
+                &proposal_payment_id,
+                &trade_id,
+                &proposal_hash,
+                &channel_id,
+                "7",
+                "70",
+                "counterparty",
+                &confirmation_id,
+                12.0,
+                12_000,
+                2_000,
+                100_000.0,
+                1_000,
+                0,
+                100,
+                160,
+                None,
+                "signed-confirmation",
+            )
+            .unwrap());
+        assert_eq!(
+            db.active_trade_reservation(&channel_id, 120).unwrap(),
+            Some(trade_id.clone())
+        );
+
+        // Native-only incoming capacity is compatible and is added to the reserved allocation.
+        db.save_channel(&channel_id, "7", 10.0, 10_000, 5_500, None)
+            .unwrap();
+        assert_eq!(db.expire_trade_reservations(160).unwrap(), 1);
+        assert_eq!(
+            db.trade_reservation_by_trade_id(&trade_id)
+                .unwrap()
+                .unwrap()
+                .outcome,
+            "expired"
+        );
+        assert!(db
+            .execute_trade_reservation(
+                &trade_id,
+                &confirmation_id,
+                &execution_payment_id,
+                &execution_hash,
+                159,
+                170,
+                "signed-sync",
+            )
+            .unwrap());
+        let channel = db.load_channel("7").unwrap().unwrap();
+        assert_eq!(channel.expected_usd, 12.0);
+        assert_eq!(channel.backing_sats, 12_000);
+        assert_eq!(channel.native_sats, 2_500);
+        assert!(!db
+            .execute_trade_reservation(
+                &trade_id,
+                &confirmation_id,
+                &execution_payment_id,
+                &execution_hash,
+                159,
+                171,
+                "signed-sync",
+            )
+            .unwrap());
+    }
+
+    #[test]
+    fn execution_sync_recovers_when_payment_id_was_not_attached() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "12".repeat(32);
+        let trade_id = "23".repeat(32);
+        let proposal_payment_id = "34".repeat(32);
+        let execution_payment_id = "45".repeat(32);
+        let proposal_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "propose",
+            "trade_id": trade_id,
+            "ts": 100,
+        })
+        .to_string();
+        let proposal_hash = crate::trade::request_hash(proposal_payload.as_bytes());
+        db.save_channel(&channel_id, "wallet-channel", 10.0, 10_000, 5_000, None)
+            .unwrap();
+        let row_id = db
+            .record_trade_proposal(
+                &channel_id,
+                &trade_id,
+                &proposal_hash,
+                &proposal_payload,
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.1,
+                100_000,
+                20.0,
+                20_000,
+                0,
+            )
+            .unwrap();
+        assert!(db
+            .attach_trade_proposal_payment_id(row_id, &proposal_payment_id)
+            .unwrap());
+        assert!(db
+            .store_trade_confirmation(
+                row_id,
+                &"56".repeat(32),
+                "signed-confirmation",
+                160,
+                100_000.0,
+                100_000,
+                0.1,
+                20_000,
+            )
+            .unwrap());
+        let execution_payload = "exact signed execution payload";
+        let execution_hash = crate::trade::request_hash(execution_payload.as_bytes());
+        let prepared_payment_id = "57".repeat(32);
+        assert!(db
+            .prepare_trade_execution(
+                row_id,
+                &prepared_payment_id,
+                &execution_hash,
+                execution_payload,
+                1_000,
+            )
+            .unwrap());
+        assert!(db.is_trade_payment(&prepared_payment_id).unwrap());
+
+        // Simulate a row created by the previous implementation, where the keysend succeeded
+        // before its returned payment id could be attached.
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE trades SET payment_id = NULL WHERE id = ?1",
+                params![row_id],
+            )
+            .unwrap();
+
+        let correlated = db
+            .get_trade_by_correlation(&trade_id, &execution_payment_id, &execution_hash)
+            .unwrap()
+            .unwrap();
+        assert_eq!(correlated.id, row_id);
+        assert_eq!(correlated.payment_id, None);
+
+        let result = db
+            .apply_correlated_trade_acceptance(
+                "wallet-channel",
+                1,
+                20.0,
+                20_000,
+                5_000,
+                row_id,
+                &execution_payment_id,
+            )
+            .unwrap();
+        assert!(result.trade_resolved);
+        assert!(result.allocation_applied);
+        assert_eq!(
+            db.get_trade_by_correlation(&trade_id, &execution_payment_id, &execution_hash)
+                .unwrap()
+                .unwrap()
+                .payment_id
+                .as_deref(),
+            Some(execution_payment_id.as_str())
+        );
+    }
+
+    #[test]
+    fn cancelling_a_proposal_releases_the_wallet_channel_guard() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "67".repeat(32);
+        let trade_id = "78".repeat(32);
+        let proposal_payment_id = "89".repeat(32);
+        let proposal_payload = serde_json::json!({
+            "type": "TRADE_V1",
+            "phase": "propose",
+            "trade_id": trade_id,
+            "ts": 100,
+        })
+        .to_string();
+        let proposal_hash = crate::trade::request_hash(proposal_payload.as_bytes());
+        let row_id = db
+            .record_trade_proposal(
+                &channel_id,
+                &trade_id,
+                &proposal_hash,
+                &proposal_payload,
+                "sell",
+                10.0,
+                0.0001,
+                100_000.0,
+                0.1,
+                100_000,
+                20.0,
+                20_000,
+                0,
+            )
+            .unwrap();
+        assert!(db
+            .attach_trade_proposal_payment_id(row_id, &proposal_payment_id)
+            .unwrap());
+        assert!(db.has_unresolved_trade_for_channel(&channel_id).unwrap());
+
+        assert!(db.cancel_trade_proposal(row_id).unwrap());
+        assert!(!db.has_unresolved_trade_for_channel(&channel_id).unwrap());
+    }
+
+    #[test]
+    fn reservation_replacement_is_atomic_and_spends_block_execution() {
+        let db = Database::open_in_memory().unwrap();
+        let channel_id = "81".repeat(32);
+        db.save_channel(&channel_id, "9", 20.0, 20_000, 10_000, None)
+            .unwrap();
+        let reserve = |db: &Database,
+                       trade_byte: &str,
+                       payment_byte: &str,
+                       hash_byte: &str,
+                       confirmation_byte: &str,
+                       replaces: Option<&str>| {
+            db.reserve_trade_proposal(
+                &payment_byte.repeat(32),
+                &trade_byte.repeat(32),
+                &hash_byte.repeat(32),
+                &channel_id,
+                "9",
+                "90",
+                "counterparty",
+                &confirmation_byte.repeat(32),
+                25.0,
+                25_000,
+                4_000,
+                100_000.0,
+                1_000,
+                0,
+                100,
+                160,
+                replaces,
+                "signed-confirmation",
+            )
+            .unwrap()
+        };
+        let old_trade_id = "82".repeat(32);
+        assert!(reserve(&db, "82", "83", "84", "85", None));
+        assert!(reserve(&db, "86", "87", "88", "89", Some(&old_trade_id)));
+        assert_eq!(
+            db.trade_reservation_by_trade_id(&old_trade_id)
+                .unwrap()
+                .unwrap()
+                .outcome,
+            "cancelled"
+        );
+        let new_trade_id = "86".repeat(32);
+        assert_eq!(
+            db.active_trade_reservation(&channel_id, 120).unwrap(),
+            Some(new_trade_id.clone())
+        );
+
+        // An unavoidable outgoing mutation makes the base snapshot incompatible.
+        db.save_channel(&channel_id, "9", 20.0, 20_000, 9_000, None)
+            .unwrap();
+        assert!(!db
+            .execute_trade_reservation(
+                &new_trade_id,
+                &"89".repeat(32),
+                &"90".repeat(32),
+                &"91".repeat(32),
+                150,
+                151,
+                "signed-sync",
+            )
+            .unwrap());
+        let channel = db.load_channel("9").unwrap().unwrap();
+        assert_eq!(
+            (
+                channel.expected_usd,
+                channel.backing_sats,
+                channel.native_sats
+            ),
+            (20.0, 20_000, 9_000)
+        );
+        assert_eq!(db.expire_trade_reservations(161).unwrap(), 1);
+        assert_eq!(db.active_trade_reservation(&channel_id, 161).unwrap(), None);
+    }
+
+    #[test]
     fn inbound_stability_registration_detects_replays_and_conflicts() {
         let db = Database::open_in_memory().unwrap();
         let settlement_id = "11".repeat(32);
@@ -4208,9 +5652,7 @@ mod tests {
             InboundStabilityRegistration::Pending
         );
         assert_eq!(
-            db.pending_inbound_stability_settlements(10)
-                .unwrap()
-                .len(),
+            db.pending_inbound_stability_settlements(10).unwrap().len(),
             1
         );
         assert!(db
@@ -4343,10 +5785,7 @@ mod tests {
             )
             .unwrap();
         assert!(!replay.is_new);
-        assert_eq!(
-            db.load_channel("42").unwrap().unwrap().backing_sats,
-            9_091
-        );
+        assert_eq!(db.load_channel("42").unwrap().unwrap().backing_sats, 9_091);
     }
 
     #[test]
@@ -4374,8 +5813,12 @@ mod tests {
     fn test_settlement_channel_round_trip() {
         let db = Database::open_in_memory().unwrap();
         // with-channel variant stores and retrieves user_channel_id
-        db.record_settlement_with_channel("pmt1", "stability", "12345").unwrap();
-        assert_eq!(db.get_settlement_channel("pmt1").unwrap(), Some("12345".to_string()));
+        db.record_settlement_with_channel("pmt1", "stability", "12345")
+            .unwrap();
+        assert_eq!(
+            db.get_settlement_channel("pmt1").unwrap(),
+            Some("12345".to_string())
+        );
         // absent key returns None
         assert_eq!(db.get_settlement_channel("absent").unwrap(), None);
         // plain record_settlement leaves user_channel_id as NULL (returns None)
@@ -4390,8 +5833,18 @@ mod tests {
             .unwrap();
         assert!(db
             .record_stability_settlement_with_rollback(
-                "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 17,
-                12_500_000, "lsp_to_user", "counterparty", None,
+                "payment",
+                "user-channel",
+                "channel",
+                50_000,
+                62_500,
+                50_000,
+                50.0,
+                17,
+                12_500_000,
+                "lsp_to_user",
+                "counterparty",
+                None,
             )
             .unwrap());
         db.save_channel("channel", "user-channel", 50.0, 62_500, 50_000, None)
@@ -4420,8 +5873,18 @@ mod tests {
         db.save_channel("channel", "user-channel", 50.0, 50_000, 50_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
-            12_500_000, "lsp_to_user", "counterparty", None,
+            "payment",
+            "user-channel",
+            "channel",
+            50_000,
+            62_500,
+            50_000,
+            50.0,
+            0,
+            12_500_000,
+            "lsp_to_user",
+            "counterparty",
+            None,
         )
         .unwrap();
         db.save_channel("channel", "user-channel", 55.0, 70_000, 30_000, None)
@@ -4443,17 +5906,22 @@ mod tests {
         db.save_channel("channel", "user-channel", 50.0, 62_500, 50_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "user-channel", "channel", 50_000, 62_500, 50_000, 50.0, 0,
-            12_500_000, "lsp_to_user", "counterparty", None,
+            "payment",
+            "user-channel",
+            "channel",
+            50_000,
+            62_500,
+            50_000,
+            50.0,
+            0,
+            12_500_000,
+            "lsp_to_user",
+            "counterparty",
+            None,
         )
         .unwrap();
         assert!(db
-            .mark_settlement_succeeded(
-                "payment",
-                Some(12_500_000),
-                Some(1_000),
-                Some("outbound"),
-            )
+            .mark_settlement_succeeded("payment", Some(12_500_000), Some(1_000), Some("outbound"),)
             .unwrap());
         assert!(db
             .rollback_failed_stability_settlement("payment")
@@ -4566,9 +6034,7 @@ mod tests {
                 None,
             )
             .is_err());
-        assert!(!db
-            .is_splice_stable_reconciled("rollback-txid")
-            .unwrap());
+        assert!(!db.is_splice_stable_reconciled("rollback-txid").unwrap());
     }
 
     #[test]
@@ -4690,7 +6156,8 @@ mod tests {
              );
              CREATE INDEX idx_trade_decisions_response_due
                 ON trade_decisions(response_status, next_response_attempt_at);",
-        ).unwrap();
+        )
+        .unwrap();
         conn.execute(
             "INSERT INTO trade_decisions (
                 inbound_payment_id, trade_id, channel_id, user_channel_id, counterparty,
@@ -4700,22 +6167,28 @@ mod tests {
              ) VALUES (?1, ?2, ?3, 'user-channel', 'counterparty', 'accepted', 20.0,
                 20000, 7, 'old-signed-sync', 1, ?4, 'succeeded', 1, 101, 100, 102)",
             params![payment_id, trade_id, "33".repeat(32), "44".repeat(32)],
-        ).unwrap();
+        )
+        .unwrap();
         drop(conn);
 
         let db = Database::open(directory.path()).unwrap();
-        assert_eq!(db.trade_decision_by_payment(&payment_id).unwrap(), Some(TradeDecisionIdentity {
-            inbound_payment_id: payment_id.clone(),
-            trade_id: trade_id.clone(),
-            request_hash: payment_id.clone(),
-        }));
+        assert_eq!(
+            db.trade_decision_by_payment(&payment_id).unwrap(),
+            Some(TradeDecisionIdentity {
+                inbound_payment_id: payment_id.clone(),
+                trade_id: trade_id.clone(),
+                request_hash: payment_id.clone(),
+            })
+        );
         let conn = db.conn.lock().unwrap();
-        let (status, delivered_at): (String, Option<i64>) = conn.query_row(
-            "SELECT response_status, delivered_at FROM trade_decisions
+        let (status, delivered_at): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT response_status, delivered_at FROM trade_decisions
              WHERE inbound_payment_id = ?1",
-            params![payment_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        ).unwrap();
+                params![payment_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
         assert_eq!(status, "delivered");
         assert_eq!(delivered_at, Some(102));
         let columns = trade_decision_columns(&conn).unwrap();
@@ -4724,11 +6197,19 @@ mod tests {
         assert!(!columns.contains("response_amount_msat"));
         drop(conn);
 
-        assert!(db.persist_trade_rejection(
-            &"55".repeat(32), &"66".repeat(32), &"77".repeat(32), &"88".repeat(32),
-            "user-channel", "counterparty", "internal_failure", 200,
-            "new-signed-rejection",
-        ).unwrap());
+        assert!(db
+            .persist_trade_rejection(
+                &"55".repeat(32),
+                &"66".repeat(32),
+                &"77".repeat(32),
+                &"88".repeat(32),
+                "user-channel",
+                "counterparty",
+                "internal_failure",
+                200,
+                "new-signed-rejection",
+            )
+            .unwrap());
         drop(db);
 
         let reopened = Database::open(directory.path()).unwrap();
@@ -4847,11 +6328,15 @@ mod tests {
         let due = db.due_trade_responses(100, 10).unwrap();
         assert_eq!(due.len(), 1);
         assert_eq!(due[0].attempts, 0);
-        assert!(db.reserve_trade_response_attempt(&payment_id, 0, 100).unwrap());
+        assert!(db
+            .reserve_trade_response_attempt(&payment_id, 0, 100)
+            .unwrap());
         assert!(db.due_trade_responses(104, 10).unwrap().is_empty());
         assert_eq!(db.due_trade_responses(105, 10).unwrap()[0].attempts, 1);
 
-        assert!(db.reserve_trade_response_attempt(&payment_id, 1, 105).unwrap());
+        assert!(db
+            .reserve_trade_response_attempt(&payment_id, 1, 105)
+            .unwrap());
         let response_payment_id = "99".repeat(32);
         assert!(db
             .mark_trade_response_in_flight(&payment_id, &response_payment_id)
@@ -4866,7 +6351,9 @@ mod tests {
         assert!(db.due_trade_responses(114, 10).unwrap().is_empty());
         assert_eq!(db.due_trade_responses(115, 10).unwrap().len(), 1);
 
-        assert!(db.reserve_trade_response_attempt(&payment_id, 2, 115).unwrap());
+        assert!(db
+            .reserve_trade_response_attempt(&payment_id, 2, 115)
+            .unwrap());
         assert!(db
             .mark_trade_response_in_flight(&payment_id, &response_payment_id)
             .unwrap());
@@ -4960,18 +6447,32 @@ mod tests {
         let payment_id = "c1".repeat(32);
         let request_hash = crate::trade::request_hash(b"exact signed payload");
         let row_id = prepare_correlated_trade(
-            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+            &db,
+            &channel_id,
+            "user-channel-1",
+            &trade_id,
+            &payment_id,
+            &request_hash,
         );
 
         let result = db
             .apply_correlated_trade_acceptance(
-                "user-channel-1", 1, 20.0, 20_000, 5_000, row_id, &payment_id,
+                "user-channel-1",
+                1,
+                20.0,
+                20_000,
+                5_000,
+                row_id,
+                &payment_id,
             )
             .unwrap();
-        assert_eq!(result, CorrelatedTradeAcceptance {
-            trade_resolved: true,
-            allocation_applied: true,
-        });
+        assert_eq!(
+            result,
+            CorrelatedTradeAcceptance {
+                trade_resolved: true,
+                allocation_applied: true,
+            }
+        );
         let events = db
             .list_ledger_events(&LedgerQuery {
                 identifier: Some("user-channel-1".to_owned()),
@@ -4998,18 +6499,33 @@ mod tests {
         let payment_id = "c2".repeat(32);
         let request_hash = crate::trade::request_hash(b"exact signed payload");
         let row_id = prepare_correlated_trade(
-            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+            &db,
+            &channel_id,
+            "user-channel-1",
+            &trade_id,
+            &payment_id,
+            &request_hash,
         );
-        db.conn.lock().unwrap().execute_batch(
-            "CREATE TRIGGER inject_correlated_sync_ledger_failure
+        db.conn
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER inject_correlated_sync_ledger_failure
              BEFORE INSERT ON ledger_events
              WHEN NEW.event_type = 'SYNC_V1_APPLIED'
              BEGIN SELECT RAISE(ABORT, 'injected ledger failure'); END;",
-        ).unwrap();
+            )
+            .unwrap();
 
         assert!(db
             .apply_correlated_trade_acceptance(
-                "user-channel-1", 1, 20.0, 20_000, 5_000, row_id, &payment_id,
+                "user-channel-1",
+                1,
+                20.0,
+                20_000,
+                5_000,
+                row_id,
+                &payment_id,
             )
             .is_err());
         let channel = db.load_channel("user-channel-1").unwrap().unwrap();
@@ -5033,7 +6549,12 @@ mod tests {
         let payment_id = "cc".repeat(32);
         let request_hash = crate::trade::request_hash(b"exact signed payload");
         let row_id = prepare_correlated_trade(
-            &db, &channel_id, "user-channel-1", &trade_id, &payment_id, &request_hash,
+            &db,
+            &channel_id,
+            "user-channel-1",
+            &trade_id,
+            &payment_id,
+            &request_hash,
         );
         assert!(db
             .apply_sync_if_newer("user-channel-1", 2, 30.0, 30_000, 7_000)
@@ -5094,12 +6615,7 @@ mod tests {
             .unwrap();
         assert!(db.attach_trade_payment_id(row_id, &payment_id).unwrap());
         assert!(db
-            .mark_trade_rejected(
-                row_id,
-                &payment_id,
-                "insufficient_capacity",
-                100,
-            )
+            .mark_trade_rejected(row_id, &payment_id, "insufficient_capacity", 100,)
             .unwrap());
         let result = db
             .apply_correlated_trade_acceptance(
@@ -5770,20 +7286,35 @@ mod tests {
     fn user_channel_id_by_channel_id_roundtrips() {
         let db = Database::open_in_memory().unwrap();
         db.save_channel("chan_x", "42", 0.0, 0, 0, None).unwrap();
-        assert_eq!(db.get_user_channel_id_by_channel_id("chan_x").unwrap(), Some("42".to_string()));
         assert_eq!(
-            db.get_active_user_channel_id_by_channel_id("chan_x").unwrap(),
+            db.get_user_channel_id_by_channel_id("chan_x").unwrap(),
             Some("42".to_string())
         );
-        assert_eq!(db.get_user_channel_id_by_channel_id("missing").unwrap(), None);
-        assert_eq!(db.get_active_user_channel_id_by_channel_id("missing").unwrap(), None);
+        assert_eq!(
+            db.get_active_user_channel_id_by_channel_id("chan_x")
+                .unwrap(),
+            Some("42".to_string())
+        );
+        assert_eq!(
+            db.get_user_channel_id_by_channel_id("missing").unwrap(),
+            None
+        );
+        assert_eq!(
+            db.get_active_user_channel_id_by_channel_id("missing")
+                .unwrap(),
+            None
+        );
 
         db.mark_channel_closed("42").unwrap();
         assert_eq!(
             db.get_user_channel_id_by_channel_id("chan_x").unwrap(),
             Some("42".to_string())
         );
-        assert_eq!(db.get_active_user_channel_id_by_channel_id("chan_x").unwrap(), None);
+        assert_eq!(
+            db.get_active_user_channel_id_by_channel_id("chan_x")
+                .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -5824,7 +7355,10 @@ mod tests {
             .collect::<SqliteResult<Vec<_>>>()
             .unwrap()
             .join(" ");
-        assert!(plan.contains("idx_ledger_refs_exact"), "query plan was {plan}");
+        assert!(
+            plan.contains("idx_ledger_refs_exact"),
+            "query plan was {plan}"
+        );
     }
 
     #[test]
@@ -5863,14 +7397,20 @@ mod tests {
                     ..Default::default()
                 })
                 .unwrap();
-            assert_eq!(page.events.len(), 1, "missing backfilled ref for {identifier}");
+            assert_eq!(
+                page.events.len(),
+                1,
+                "missing backfilled ref for {identifier}"
+            );
         }
         drop(reopened);
 
         let reopened_again = Database::open(dir.path()).unwrap();
         let conn = reopened_again.conn.lock().unwrap();
         let ref_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM ledger_event_refs", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM ledger_event_refs", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(ref_count, 3);
         let metadata_count: i64 = conn
@@ -5897,7 +7437,9 @@ mod tests {
                 "txid": "funding-tx"
             }),
         );
-        first.refs.push(LedgerRef::new("channel_id", "physical-new"));
+        first
+            .refs
+            .push(LedgerRef::new("channel_id", "physical-new"));
         let one = db.append_ledger_event(&first).unwrap();
         let replay = db.append_ledger_event(&first).unwrap();
         assert!(one.inserted);
@@ -5945,7 +7487,10 @@ mod tests {
         assert_eq!(filtered.events[0].id, one.event_id);
 
         let newest = db
-            .list_ledger_events(&LedgerQuery { limit: 3, ..Default::default() })
+            .list_ledger_events(&LedgerQuery {
+                limit: 3,
+                ..Default::default()
+            })
             .unwrap();
         assert_eq!(newest.events.len(), 3);
         assert!(newest.events.windows(2).all(|pair| pair[0].id < pair[1].id));
@@ -5973,7 +7518,10 @@ mod tests {
         }
 
         let newest = db
-            .list_ledger_events(&LedgerQuery { limit: 2, ..Default::default() })
+            .list_ledger_events(&LedgerQuery {
+                limit: 2,
+                ..Default::default()
+            })
             .unwrap();
         assert_eq!(
             newest
@@ -6147,16 +7695,21 @@ mod tests {
             })
             .unwrap();
         assert_eq!(page.events.len(), 2);
-        assert!(page.events.iter().all(|event| event.completeness == LedgerCompleteness::Legacy));
-        assert_eq!(db
-            .list_ledger_events(&LedgerQuery {
+        assert!(page
+            .events
+            .iter()
+            .all(|event| event.completeness == LedgerCompleteness::Legacy));
+        assert_eq!(
+            db.list_ledger_events(&LedgerQuery {
                 identifier: Some("42".to_owned()),
                 limit: 10,
                 ..Default::default()
             })
             .unwrap()
             .events
-            .len(), 1);
+            .len(),
+            1
+        );
     }
 
     #[test]
@@ -6192,12 +7745,25 @@ mod tests {
 
         assert!(db
             .record_pending_stability_payment(
-                "payment", 1_000_000, Some(1.0), 100_000.0, "counterparty", "physical",
-                "stable", 10.0, 10_000, 9_000, 5_000, None,
+                "payment",
+                1_000_000,
+                Some(1.0),
+                100_000.0,
+                "counterparty",
+                "physical",
+                "stable",
+                10.0,
+                10_000,
+                9_000,
+                5_000,
+                None,
             )
             .is_err());
         assert!(!db.payment_exists("payment").unwrap());
-        assert_eq!(db.load_channel("stable").unwrap().unwrap().backing_sats, 10_000);
+        assert_eq!(
+            db.load_channel("stable").unwrap().unwrap().backing_sats,
+            10_000
+        );
     }
 
     #[test]
@@ -6206,8 +7772,18 @@ mod tests {
         db.save_channel("physical", "stable", 10.0, 10_000, 5_000, None)
             .unwrap();
         db.record_stability_settlement_with_rollback(
-            "payment", "stable", "physical", 10_000, 9_000, 5_000, 10.0, 0,
-            1_000_000, "lsp_to_user", "counterparty", None,
+            "payment",
+            "stable",
+            "physical",
+            10_000,
+            9_000,
+            5_000,
+            10.0,
+            0,
+            1_000_000,
+            "lsp_to_user",
+            "counterparty",
+            None,
         )
         .unwrap();
         {
@@ -6221,12 +7797,20 @@ mod tests {
         }
 
         assert!(db.rollback_failed_stability_settlement("payment").is_err());
-        assert_eq!(db.load_channel("stable").unwrap().unwrap().backing_sats, 9_000);
-        let outcome: String = db.conn.lock().unwrap().query_row(
-            "SELECT outcome FROM settlement_payments WHERE payment_id = 'payment'",
-            [],
-            |row| row.get(0),
-        ).unwrap();
+        assert_eq!(
+            db.load_channel("stable").unwrap().unwrap().backing_sats,
+            9_000
+        );
+        let outcome: String = db
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT outcome FROM settlement_payments WHERE payment_id = 'payment'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert_eq!(outcome, "pending");
     }
 
@@ -6498,8 +8082,8 @@ mod tests {
         assert!(db
             .apply_sync_if_newer("stable", 1, 12.0, 12_000, 3_000)
             .unwrap());
-        assert!(db
-            .record_payment_and_maybe_update_backing(
+        assert!(
+            db.record_payment_and_maybe_update_backing(
                 Some("stability-payment"),
                 "stability",
                 "received",
@@ -6511,7 +8095,8 @@ mod tests {
                 Some(1_000),
             )
             .unwrap()
-            .is_new);
+            .is_new
+        );
         assert!(db
             .persist_outgoing_reconciliation(
                 "outgoing-payment",
@@ -6564,9 +8149,18 @@ mod tests {
             "PAYMENT_OUTGOING_RECONCILED",
             "SPLICE_RECONCILED",
         ] {
-            let event = events.iter().find(|event| event.event_type == event_type).unwrap();
-            assert!(event.refs.iter().any(|reference| reference.role == "user_channel_id"));
-            for snapshot in [event.before.as_ref().unwrap(), event.after.as_ref().unwrap()] {
+            let event = events
+                .iter()
+                .find(|event| event.event_type == event_type)
+                .unwrap();
+            assert!(event
+                .refs
+                .iter()
+                .any(|reference| reference.role == "user_channel_id"));
+            for snapshot in [
+                event.before.as_ref().unwrap(),
+                event.after.as_ref().unwrap(),
+            ] {
                 assert_eq!(
                     snapshot.backing_sats.unwrap() + snapshot.native_sats.unwrap(),
                     snapshot.live_receiver_sats.unwrap(),

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -423,6 +423,15 @@ pub fn trade_backing_after_delta(
     }
     let current_target_sats = current_target_sats_f.floor() as u64;
     let new_target_sats = new_target_sats_f.floor() as u64;
+
+    // A signed target within one cent of the post-fee receiver's USD value is a full peg. Compare
+    // the USD values directly: flooring the target to whole sats first can turn a sub-cent gap
+    // into a one-cent sat residue and leave native BTC behind. Absorb peer-local backing drift at
+    // this boundary; the strict capacity check above still rejects targets above the receiver.
+    if receiver_usd - new_expected_usd < 0.01 {
+        return Some(receiver_sats);
+    }
+
     let mut backing_sats = if new_expected_usd >= current_expected_usd {
         current_backing_sats.checked_add(new_target_sats.checked_sub(current_target_sats)?)?
     } else {
@@ -1662,6 +1671,29 @@ mod tests {
         assert_eq!(sc.backing_sats, 57_444);
         assert_eq!(sc.native_sats, 0);
         assert_eq!(sc.native_channel_btc.sats, 0);
+    }
+
+    #[test]
+    fn full_peg_absorbs_existing_peer_drift_at_post_fee_capacity() {
+        let backing = trade_backing_after_delta(68_418, 55_278, 34.8404, 43.1366, 63_052.275);
+
+        assert_eq!(backing, Some(68_418));
+    }
+
+    #[test]
+    fn full_peg_uses_signed_usd_headroom_before_sat_flooring() {
+        // Production-shaped boundary: the signed target is less than one cent below capacity,
+        // but flooring it to 67_042 sats would leave 16 sats worth slightly more than one cent.
+        let backing = trade_backing_after_delta(67_058, 0, 0.0, 42.2532, 63_024.15);
+
+        assert_eq!(backing, Some(67_058));
+    }
+
+    #[test]
+    fn full_peg_does_not_absorb_an_actionable_cent() {
+        let backing = trade_backing_after_delta(100_000, 0, 0.0, 99.99, 100_000.0);
+
+        assert_eq!(backing, Some(99_990));
     }
 
     #[test]

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -17,6 +17,12 @@ pub enum TradeRejectionReason {
     SettlementRequired,
     UnsafeAllocation,
     InternalFailure,
+    ChannelBusy,
+    StaleState,
+    InvalidConfirmation,
+    ConfirmationExpired,
+    ReservationInvalidated,
+    ClientCancelled,
 }
 
 impl TradeRejectionReason {
@@ -30,6 +36,12 @@ impl TradeRejectionReason {
         Self::SettlementRequired,
         Self::UnsafeAllocation,
         Self::InternalFailure,
+        Self::ChannelBusy,
+        Self::StaleState,
+        Self::InvalidConfirmation,
+        Self::ConfirmationExpired,
+        Self::ReservationInvalidated,
+        Self::ClientCancelled,
     ];
 
     pub const fn as_str(self) -> &'static str {
@@ -43,6 +55,12 @@ impl TradeRejectionReason {
             Self::SettlementRequired => "settlement_required",
             Self::UnsafeAllocation => "unsafe_allocation",
             Self::InternalFailure => "internal_failure",
+            Self::ChannelBusy => "channel_busy",
+            Self::StaleState => "stale_state",
+            Self::InvalidConfirmation => "invalid_confirmation",
+            Self::ConfirmationExpired => "confirmation_expired",
+            Self::ReservationInvalidated => "reservation_invalidated",
+            Self::ClientCancelled => "client_cancelled",
         }
     }
 
@@ -73,8 +91,38 @@ impl TradeRejectionReason {
                 "This trade cannot preserve the current channel allocation safely."
             }
             Self::InternalFailure => "The provider could not process the trade. Try again later.",
+            Self::ChannelBusy => "Another order is already being reviewed for this channel.",
+            Self::StaleState => {
+                "The channel changed while the order was prepared. Refresh and retry."
+            }
+            Self::InvalidConfirmation => "The order confirmation was invalid. Refresh and retry.",
+            Self::ConfirmationExpired => "The order confirmation expired. Refresh the quote.",
+            Self::ReservationInvalidated => {
+                "The channel changed after confirmation. Refresh and retry."
+            }
+            Self::ClientCancelled => "The order was cancelled.",
         }
     }
+}
+
+/// Signed LSP reservation. The wallet verifies every field before enabling the fee payment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfirmTradeV1 {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub channel_id: String,
+    pub user_channel_id: String,
+    pub trade_id: String,
+    pub proposal_payment_id: String,
+    pub proposal_hash: String,
+    pub confirmation_id: String,
+    pub expected_usd: f64,
+    pub quote_price: f64,
+    pub fee_msat: u64,
+    pub base_sync_version: u64,
+    pub confirmed_at: u64,
+    pub expires_at: u64,
 }
 
 /// Signed LSP rejection carried inside the existing stable-channel TLV.
@@ -111,8 +159,54 @@ pub fn is_request_hash(value: &str) -> bool {
     is_canonical_32_byte_hex(value)
 }
 
+pub fn is_confirmation_id(value: &str) -> bool {
+    is_canonical_32_byte_hex(value)
+}
+
+impl ConfirmTradeV1 {
+    pub fn has_valid_shape(&self) -> bool {
+        self.kind == crate::constants::CONFIRM_TRADE_MESSAGE_TYPE
+            && is_channel_id(&self.channel_id)
+            && is_user_channel_id(&self.user_channel_id)
+            && is_trade_id(&self.trade_id)
+            && is_payment_id(&self.proposal_payment_id)
+            && is_request_hash(&self.proposal_hash)
+            && is_confirmation_id(&self.confirmation_id)
+            && self.expected_usd.is_finite()
+            && self.expected_usd >= 0.0
+            && self.quote_price.is_finite()
+            && self.quote_price > 0.0
+            && self.fee_msat > 0
+            && self.base_sync_version < i64::MAX as u64
+            && self.confirmed_at <= self.expires_at
+            && self.expires_at.saturating_sub(self.confirmed_at)
+                == crate::constants::TRADE_CONFIRMATION_TTL_SECS
+    }
+
+    /// Convert the LSP's absolute expiry into a conservative wallet-local deadline.
+    ///
+    /// A future-dated LSP clock makes `expires_at` look farther away to the wallet. The signed
+    /// proposal timestamp is on the wallet's clock, so cap the usable deadline at one confirmation
+    /// TTL after that timestamp. For an aligned or slow LSP clock, the signed expiry remains the
+    /// tighter bound.
+    pub fn wallet_deadline(&self, proposal_timestamp: u64) -> Option<u64> {
+        self.has_valid_shape().then(|| {
+            self.expires_at.min(
+                proposal_timestamp.saturating_add(crate::constants::TRADE_CONFIRMATION_TTL_SECS),
+            )
+        })
+    }
+}
+
 pub fn is_channel_id(value: &str) -> bool {
     is_canonical_32_byte_hex(value)
+}
+
+/// Upgraded desktop messages carry the wallet's LDK-local identifier as canonical decimal u128.
+pub fn is_user_channel_id(value: &str) -> bool {
+    value
+        .parse::<u128>()
+        .is_ok_and(|parsed| parsed.to_string() == value)
 }
 
 /// Hash the exact signed TRADE_V1 payload bytes, without parsing or reserialization.
@@ -137,8 +231,13 @@ mod tests {
         assert!(is_trade_id(&valid));
         assert!(is_payment_id(&valid));
         assert!(is_request_hash(&valid));
+        assert!(is_confirmation_id(&valid));
         assert!(!is_trade_id(&valid.to_ascii_uppercase()));
         assert!(!is_trade_id("abcd"));
+        assert!(is_user_channel_id("0"));
+        assert!(is_user_channel_id(&u128::MAX.to_string()));
+        assert!(!is_user_channel_id("01"));
+        assert!(!is_user_channel_id("not-decimal"));
     }
 
     #[test]
@@ -173,5 +272,57 @@ mod tests {
         assert!(target_matches(10.0, 10.0));
         assert!(!target_matches(10.0, 9.99));
         assert!(!target_matches(f64::NAN, 10.0));
+    }
+
+    #[test]
+    fn confirmation_shape_is_strict_and_time_bounded() {
+        let id = "11".repeat(32);
+        let confirmation = ConfirmTradeV1 {
+            kind: crate::constants::CONFIRM_TRADE_MESSAGE_TYPE.to_owned(),
+            channel_id: "22".repeat(32),
+            user_channel_id: "7".to_owned(),
+            trade_id: id.clone(),
+            proposal_payment_id: "33".repeat(32),
+            proposal_hash: "44".repeat(32),
+            confirmation_id: id,
+            expected_usd: 25.0,
+            quote_price: 100_000.0,
+            fee_msat: 2_000,
+            base_sync_version: 4,
+            confirmed_at: 100,
+            expires_at: 160,
+        };
+        assert!(confirmation.has_valid_shape());
+        let mut bad = confirmation.clone();
+        bad.expires_at += 1;
+        assert!(!bad.has_valid_shape());
+        let mut value = serde_json::to_value(confirmation).unwrap();
+        value["unexpected"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<ConfirmTradeV1>(value).is_err());
+    }
+
+    #[test]
+    fn confirmation_wallet_deadline_caps_future_lsp_clock() {
+        let mut confirmation = ConfirmTradeV1 {
+            kind: crate::constants::CONFIRM_TRADE_MESSAGE_TYPE.to_string(),
+            channel_id: "11".repeat(32),
+            user_channel_id: "42".to_string(),
+            trade_id: "22".repeat(32),
+            proposal_payment_id: "33".repeat(32),
+            proposal_hash: "44".repeat(32),
+            confirmation_id: "55".repeat(32),
+            expected_usd: 10.0,
+            quote_price: 100_000.0,
+            fee_msat: 1_000,
+            base_sync_version: 0,
+            confirmed_at: 160,
+            expires_at: 220,
+        };
+
+        assert_eq!(confirmation.wallet_deadline(100), Some(160));
+
+        confirmation.confirmed_at = 40;
+        confirmation.expires_at = 100;
+        assert_eq!(confirmation.wallet_deadline(100), Some(100));
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -10,6 +10,7 @@ use chrono::{TimeZone, Utc};
 use egui::{Color32, CursorIcon, OpenUrl, RichText, Sense, TextureOptions};
 use image::{GrayImage, Luma};
 use ldk_node::lightning::ln::channelmanager::PaymentId;
+use ldk_node::lightning_types::payment::{PaymentHash, PaymentPreimage};
 use ldk_node::payment::{PaymentDirection, PaymentKind};
 use qrcode::QrCode;
 use serde_json::json;
@@ -107,7 +108,7 @@ pub enum TransferTab {
     Receive,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TradeAction {
     BuyBtc,
     SellBtc,
@@ -157,6 +158,20 @@ pub struct PendingTrade {
     pub btc_sats: u64,
     pub net_amount_usd: f64,
     pub is_full_peg: bool,
+    protocol: Option<PendingTradeProtocol>,
+}
+
+#[derive(Clone, Debug)]
+struct PendingTradeProtocol {
+    trade_db_id: i64,
+    trade_id: String,
+    proposal_payment_id: String,
+    proposal_hash: String,
+    base_sync_version: u64,
+    expected_usd: f64,
+    backing_sats: u64,
+    confirmation: Option<stable_channels::trade::ConfirmTradeV1>,
+    confirmation_deadline: Option<u64>,
 }
 
 /// Trade payment that's been sent but not yet confirmed by LDK.
@@ -822,10 +837,68 @@ impl UserApp {
 
         // Load persisted channel settings from database
         app.load_channel_settings();
+        app.restore_trade_review();
 
         // Background thread is started via start_background_if_needed() in the update loop
 
         Ok(app)
+    }
+
+    fn restore_trade_review(&mut self) {
+        let Ok(Some(row)) = self.db.latest_wallet_trade_review() else {
+            return;
+        };
+        let confirmation = row
+            .confirmation_payload
+            .as_deref()
+            .and_then(parse_trade_confirmation);
+        let confirmation_deadline = confirmation.as_ref().and_then(|confirmation| {
+            row.proposal_payload
+                .as_deref()
+                .and_then(trade_proposal_timestamp)
+                .and_then(|timestamp| confirmation.wallet_deadline(timestamp))
+        });
+        if row.status == "confirmed" && (confirmation.is_none() || confirmation_deadline.is_none())
+        {
+            return;
+        }
+        let action = if row.action == "buy" {
+            TradeAction::BuyBtc
+        } else if row.action == "sell" {
+            TradeAction::SellBtc
+        } else {
+            return;
+        };
+        let net_amount_usd = (row.amount_usd - row.fee_usd).max(0.0);
+        let btc_sats = (row.amount_btc * SATS_IN_BTC as f64).floor() as u64;
+        self.pending_trade = Some(PendingTrade {
+            action,
+            amount_usd: row.amount_usd,
+            btc_price: row.btc_price,
+            fee_usd: row.fee_usd,
+            btc_amount: row.amount_btc,
+            btc_sats,
+            net_amount_usd,
+            is_full_peg: false,
+            protocol: Some(PendingTradeProtocol {
+                trade_db_id: row.id,
+                trade_id: row.trade_id,
+                proposal_payment_id: row.proposal_payment_id,
+                proposal_hash: row.proposal_hash,
+                base_sync_version: row.base_sync_version,
+                expected_usd: row.new_expected_usd,
+                backing_sats: row.new_backing_sats.unwrap_or(0),
+                confirmation,
+                confirmation_deadline,
+            }),
+        });
+        self.show_confirm_trade = true;
+        if action == TradeAction::BuyBtc {
+            self.show_buy_modal = true;
+        } else {
+            self.show_sell_modal = true;
+        }
+        self.status_message = "Restored an order awaiting confirmation.".to_string();
     }
 
     fn start_background_if_needed(&mut self) {
@@ -892,9 +965,9 @@ impl UserApp {
                                 }
                             }
 
-                            if let Some(payment_info) = stable_channels::stable::check_stability(
-                                &node_arc, &mut sc, price,
-                            ) {
+                            if let Some(payment_info) =
+                                stable_channels::stable::check_stability(&node_arc, &mut sc, price)
+                            {
                                 // Record sent stability payment as pending (confirmed on PaymentSuccessful)
                                 let amount_usd =
                                     (payment_info.amount_msat as f64 / 1000.0 / 100_000_000.0)
@@ -1942,6 +2015,427 @@ impl UserApp {
     /// Send a trade message to the LSP with the new stabilized USD amount.
     /// The fee is sent as the keysend payment amount.
     /// Returns the PaymentId and wallet-derived backing allocation so the caller can track it.
+    fn send_trade_proposal(
+        &mut self,
+        trade: &PendingTrade,
+        replaces: Option<&PendingTradeProtocol>,
+    ) -> Option<PendingTradeProtocol> {
+        let fee_sats = if trade.btc_price > 0.0 && trade.fee_usd > 0.0 {
+            (trade.fee_usd / trade.btc_price * SATS_IN_BTC as f64) as u64
+        } else {
+            0
+        };
+        let fee_msat = fee_sats.saturating_mul(1000).max(1);
+        let (channel_id, user_channel_id, counterparty, old_expected_usd, backing_sats) = {
+            let mut sc = self.stable_channel.lock().unwrap();
+            let (updated, _) = stable::update_balances(&self.node, &mut sc);
+            if !updated {
+                self.trade_error = "The live channel balance is unavailable.".to_string();
+                return None;
+            }
+            let new_expected_usd = match trade.action {
+                TradeAction::BuyBtc => (sc.expected_usd.0 - trade.amount_usd).max(0.0),
+                TradeAction::SellBtc => sc.expected_usd.0 + trade.net_amount_usd,
+            };
+            let new_expected_usd = if new_expected_usd < 0.01 {
+                0.0
+            } else {
+                stable::normalize_trade_expected_usd(new_expected_usd)
+            };
+            let (_, backing_sats) = match local_trade_backing_sats(
+                sc.stable_receiver_btc.sats,
+                fee_sats,
+                sc.backing_sats,
+                sc.expected_usd.0,
+                new_expected_usd,
+                trade.btc_price,
+            ) {
+                Ok(allocation) => allocation,
+                Err(reason) => {
+                    self.trade_error = match reason {
+                        LocalTradeAllocationError::SettlementRequired => {
+                            "Settle the current stability adjustment, then retry this trade."
+                        }
+                        LocalTradeAllocationError::FeeExceedsBalance => {
+                            "The trade fee exceeds the live channel balance."
+                        }
+                        LocalTradeAllocationError::TargetExceedsCapacity => {
+                            "The trade target exceeds the wallet's local channel capacity."
+                        }
+                        LocalTradeAllocationError::InvalidValues => {
+                            "A trusted local price is required before trading."
+                        }
+                        LocalTradeAllocationError::LiveBalanceUnavailable => {
+                            "The live channel balance is unavailable."
+                        }
+                        LocalTradeAllocationError::UnsafeAllocation => {
+                            "This trade cannot preserve the current allocation safely."
+                        }
+                    }
+                    .to_string();
+                    return None;
+                }
+            };
+            (
+                sc.channel_id.to_string(),
+                format!("{}", sc.user_channel_id),
+                sc.counterparty,
+                sc.expected_usd.0,
+                (new_expected_usd, backing_sats),
+            )
+        };
+        let (new_expected_usd, backing_sats) = backing_sats;
+        if replaces.is_none()
+            && self
+                .db
+                .has_unresolved_trade_for_channel(&channel_id)
+                .unwrap_or(true)
+        {
+            self.trade_error =
+                "A previous trade on this channel is still awaiting its result.".to_string();
+            return None;
+        }
+        let base_sync_version = match self.db.get_sync_version(&user_channel_id) {
+            Ok(Some(version)) => version,
+            _ => {
+                self.trade_error =
+                    "The channel state is unavailable. Refresh and retry.".to_string();
+                return None;
+            }
+        };
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let trade_id = hex::encode(rand::random::<[u8; 32]>());
+        let mut payload = json!({
+            "type": TRADE_MESSAGE_TYPE,
+            "phase": "propose",
+            "channel_id": channel_id,
+            "user_channel_id": user_channel_id,
+            "trade_id": trade_id,
+            "expected_usd": new_expected_usd,
+            "quote_price": trade.btc_price,
+            "base_sync_version": base_sync_version,
+            "ts": ts,
+        });
+        if let Some(previous) = replaces {
+            payload["replaces_trade_id"] = json!(previous.trade_id);
+        }
+        let payload_str = payload.to_string();
+        let proposal_hash = stable_channels::trade::request_hash(payload_str.as_bytes());
+        let signature = self.node.sign_message(payload_str.as_bytes());
+        let envelope = json!({ "payload": payload_str, "signature": signature }).to_string();
+        let action = match trade.action {
+            TradeAction::BuyBtc => "buy",
+            TradeAction::SellBtc => "sell",
+        };
+        let trade_db_id = match self.db.record_trade_proposal(
+            &channel_id,
+            &trade_id,
+            &proposal_hash,
+            &payload_str,
+            action,
+            trade.amount_usd,
+            trade.btc_amount,
+            trade.btc_price,
+            trade.fee_usd,
+            fee_msat,
+            new_expected_usd,
+            backing_sats,
+            base_sync_version,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                self.trade_error = "The order proposal could not be saved.".to_string();
+                audit_event(
+                    "TRADE_PROPOSAL_PERSIST_FAILED",
+                    json!({ "error": error.to_string() }),
+                );
+                return None;
+            }
+        };
+        let custom_tlv = ldk_node::CustomTlvRecord {
+            type_num: STABLE_CHANNEL_TLV_TYPE,
+            value: envelope.into_bytes(),
+        };
+        match self.node.spontaneous_payment().send_with_custom_tlvs(
+            1,
+            counterparty,
+            None,
+            vec![custom_tlv],
+        ) {
+            Ok(payment_id) => {
+                let proposal_payment_id = format!("{payment_id}");
+                if !self
+                    .db
+                    .attach_trade_proposal_payment_id(trade_db_id, &proposal_payment_id)
+                    .unwrap_or(false)
+                {
+                    self.trade_error = "The proposal payment could not be recorded.".to_string();
+                    return None;
+                }
+                if let Some(previous) = replaces {
+                    let _ = self.db.cancel_trade_proposal(previous.trade_db_id);
+                }
+                self.status_message = "Waiting for a signed order confirmation…".to_string();
+                audit_event(
+                    "TRADE_PROPOSAL_SENT",
+                    json!({
+                        "trade_id": trade_id,
+                        "proposal_payment_id": proposal_payment_id,
+                        "proposal_hash": proposal_hash,
+                        "base_sync_version": base_sync_version,
+                        "old_expected_usd": old_expected_usd,
+                        "new_expected_usd": new_expected_usd,
+                    }),
+                );
+                Some(PendingTradeProtocol {
+                    trade_db_id,
+                    trade_id,
+                    proposal_payment_id,
+                    proposal_hash,
+                    base_sync_version,
+                    expected_usd: new_expected_usd,
+                    backing_sats,
+                    confirmation: None,
+                    confirmation_deadline: None,
+                })
+            }
+            Err(error) => {
+                let _ = self.db.mark_trade_proposal_send_failed(trade_db_id);
+                self.trade_error = format!("Failed to send order proposal: {error}");
+                None
+            }
+        }
+    }
+
+    fn execute_confirmed_trade(&mut self) -> bool {
+        let Some((protocol, action)) = self.pending_trade.as_ref().and_then(|trade| {
+            trade
+                .protocol
+                .clone()
+                .map(|protocol| (protocol, trade.action))
+        }) else {
+            self.trade_error = "No confirmed order is available.".to_string();
+            return false;
+        };
+        let Some(confirmation) = protocol.confirmation.clone() else {
+            self.trade_error = "Waiting for the provider's signed confirmation.".to_string();
+            return false;
+        };
+        let Some(confirmation_deadline) = protocol.confirmation_deadline else {
+            self.trade_error = "The signed confirmation has no safe local deadline.".to_string();
+            return false;
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if !confirmation.has_valid_shape()
+            || confirmation.trade_id != protocol.trade_id
+            || confirmation.proposal_payment_id != protocol.proposal_payment_id
+            || confirmation.proposal_hash != protocol.proposal_hash
+            || confirmation.base_sync_version != protocol.base_sync_version
+            || !stable_channels::trade::target_matches(
+                confirmation.expected_usd,
+                protocol.expected_usd,
+            )
+            || confirmation_deadline.saturating_sub(now) < TRADE_CONFIRMATION_SEND_MARGIN_SECS
+        {
+            self.trade_error = "Quote expired. Refresh to continue.".to_string();
+            return false;
+        }
+        let payload = json!({
+            "type": TRADE_MESSAGE_TYPE,
+            "phase": "execute",
+            "channel_id": confirmation.channel_id,
+            "user_channel_id": confirmation.user_channel_id,
+            "trade_id": confirmation.trade_id,
+            "proposal_payment_id": confirmation.proposal_payment_id,
+            "proposal_hash": confirmation.proposal_hash,
+            "confirmation_id": confirmation.confirmation_id,
+            "expected_usd": confirmation.expected_usd,
+            "quote_price": confirmation.quote_price,
+            "fee_msat": confirmation.fee_msat,
+            "ts": now,
+        });
+        let payload_str = payload.to_string();
+        let execution_hash = stable_channels::trade::request_hash(payload_str.as_bytes());
+        let payment_preimage = PaymentPreimage(rand::random::<[u8; 32]>());
+        let payment_id = PaymentId(PaymentHash::from(payment_preimage).0);
+        let payment_id_str = format!("{payment_id}");
+        let result_expires_at = now
+            .saturating_add(TRADE_RESULT_TIMEOUT_SECS)
+            .min(i64::MAX as u64) as i64;
+        if !self
+            .db
+            .prepare_trade_execution(
+                protocol.trade_db_id,
+                &payment_id_str,
+                &execution_hash,
+                &payload_str,
+                result_expires_at,
+            )
+            .unwrap_or(false)
+        {
+            self.trade_error =
+                "The fee was not sent because execution could not be saved.".to_string();
+            return false;
+        }
+        let signature = self.node.sign_message(payload_str.as_bytes());
+        let envelope = json!({ "payload": payload_str, "signature": signature }).to_string();
+        let counterparty = self.stable_channel.lock().unwrap().counterparty;
+        let custom_tlv = ldk_node::CustomTlvRecord {
+            type_num: STABLE_CHANNEL_TLV_TYPE,
+            value: envelope.into_bytes(),
+        };
+        match self
+            .node
+            .spontaneous_payment()
+            .send_with_preimage_and_custom_tlvs(
+                confirmation.fee_msat,
+                counterparty,
+                vec![custom_tlv],
+                payment_preimage,
+                None,
+            ) {
+            Ok(sent_payment_id) => {
+                let sent_payment_id_str = format!("{sent_payment_id}");
+                match self
+                    .db
+                    .attach_trade_payment_id(protocol.trade_db_id, &sent_payment_id_str)
+                {
+                    Ok(true) => {}
+                    Ok(false) => audit_event(
+                        "TRADE_EXECUTION_PAYMENT_ID_NOT_ATTACHED",
+                        json!({
+                            "trade_id": &protocol.trade_id,
+                            "trade_payment_id": &sent_payment_id_str,
+                        }),
+                    ),
+                    Err(error) => audit_event(
+                        "DB_WRITE_FAILED",
+                        json!({
+                            "op": "attach_trade_payment_id",
+                            "trade_id": &protocol.trade_id,
+                            "trade_payment_id": &sent_payment_id_str,
+                            "error": error.to_string(),
+                        }),
+                    ),
+                }
+                self.pending_trade_payments.insert(
+                    sent_payment_id,
+                    PendingTradePayment {
+                        new_expected_usd: confirmation.expected_usd,
+                        backing_sats: Some(protocol.backing_sats),
+                        trade_db_id: protocol.trade_db_id,
+                        action: match action {
+                            TradeAction::BuyBtc => "buy",
+                            TradeAction::SellBtc => "sell",
+                        }
+                        .to_string(),
+                    },
+                );
+                self.status_message = "Order fee sent; awaiting authoritative result.".to_string();
+                true
+            }
+            Err(error) => {
+                let _ = self.db.mark_trade_send_failed(protocol.trade_db_id);
+                self.trade_error = format!("Failed to send order fee: {error}");
+                false
+            }
+        }
+    }
+
+    fn cancel_pending_trade(&mut self) {
+        let pending = self.pending_trade.as_ref().and_then(|trade| {
+            trade
+                .protocol
+                .clone()
+                .map(|protocol| (protocol, trade.btc_price))
+        });
+        let Some((protocol, fallback_quote)) = pending else {
+            return;
+        };
+        let _ = self.db.cancel_trade_proposal(protocol.trade_db_id);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let mut payload = json!({
+            "type": TRADE_MESSAGE_TYPE,
+            "phase": "cancel",
+            "channel_id": self.stable_channel.lock().unwrap().channel_id.to_string(),
+            "user_channel_id": format!("{}", self.stable_channel.lock().unwrap().user_channel_id),
+            "trade_id": protocol.trade_id,
+            "proposal_payment_id": protocol.proposal_payment_id,
+            "proposal_hash": protocol.proposal_hash,
+            "expected_usd": protocol.expected_usd,
+            "quote_price": fallback_quote,
+            "ts": now,
+        });
+        if let Some(confirmation) = protocol.confirmation.as_ref() {
+            payload["confirmation_id"] = json!(confirmation.confirmation_id);
+            payload["fee_msat"] = json!(confirmation.fee_msat);
+        }
+        let payload_str = payload.to_string();
+        let signature = self.node.sign_message(payload_str.as_bytes());
+        let envelope = json!({ "payload": payload_str, "signature": signature }).to_string();
+        let counterparty = self.stable_channel.lock().unwrap().counterparty;
+        if let Ok(payment_id) = self.node.spontaneous_payment().send_with_custom_tlvs(
+            1,
+            counterparty,
+            None,
+            vec![ldk_node::CustomTlvRecord {
+                type_num: STABLE_CHANNEL_TLV_TYPE,
+                value: envelope.into_bytes(),
+            }],
+        ) {
+            let _ = self
+                .db
+                .attach_trade_cancellation_payment(protocol.trade_db_id, &format!("{payment_id}"));
+        }
+    }
+
+    fn refresh_pending_trade(&mut self) {
+        let Some(mut refreshed) = self.pending_trade.clone() else {
+            return;
+        };
+        let Some(previous) = refreshed.protocol.clone() else {
+            return;
+        };
+        let quote = get_cached_price_no_fetch();
+        if !quote.is_finite() || quote <= 0.0 {
+            self.trade_error = "A fresh quote is unavailable.".to_string();
+            return;
+        }
+        refreshed.btc_price = quote;
+        refreshed.fee_usd = Self::stable_trade_fee(refreshed.amount_usd);
+        refreshed.net_amount_usd = refreshed.amount_usd - refreshed.fee_usd;
+        if refreshed.action == TradeAction::BuyBtc {
+            refreshed.btc_amount = refreshed.net_amount_usd / quote;
+            refreshed.btc_sats = (refreshed.btc_amount * SATS_IN_BTC as f64).floor() as u64;
+        }
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let replace = previous.confirmation.is_some()
+            && previous
+                .confirmation_deadline
+                .is_some_and(|deadline| deadline > now);
+        if !replace {
+            let _ = self.db.cancel_trade_proposal(previous.trade_db_id);
+        }
+        if let Some(protocol) = self.send_trade_proposal(&refreshed, replace.then_some(&previous)) {
+            refreshed.protocol = Some(protocol);
+            self.pending_trade = Some(refreshed);
+            self.trade_error.clear();
+        }
+    }
+
+    #[allow(dead_code)]
     fn send_trade(
         &mut self,
         new_expected_usd: f64,
@@ -2431,20 +2925,20 @@ impl UserApp {
                 sc.stable_receiver_btc.sats.saturating_sub(backing_after),
             )
         };
-        let amount_usd = (price > 0.0)
-            .then(|| amount_sats as f64 / SATS_IN_BTC as f64 * price);
+        let amount_usd = (price > 0.0).then(|| amount_sats as f64 / SATS_IN_BTC as f64 * price);
         let persist = |backing_sats_before, backing_sats_after, native_sats_after| {
-            self.db.record_signed_stability_payment_and_update_allocation(
-                payment_hash,
-                &payload.settlement_id,
-                amount_msat,
-                amount_usd,
-                (price > 0.0).then_some(price),
-                &user_channel_id,
-                backing_sats_before,
-                backing_sats_after,
-                native_sats_after,
-            )
+            self.db
+                .record_signed_stability_payment_and_update_allocation(
+                    payment_hash,
+                    &payload.settlement_id,
+                    amount_msat,
+                    amount_usd,
+                    (price > 0.0).then_some(price),
+                    &user_channel_id,
+                    backing_sats_before,
+                    backing_sats_after,
+                    native_sats_after,
+                )
         };
         let mut reloaded_expected_usd = None;
         let persisted = match persist(backing_before, backing_after, native_after) {
@@ -2469,15 +2963,13 @@ impl UserApp {
                         return SignedStabilityHandling::Retry;
                     }
                 };
-                let Some(reloaded_backing_after) =
-                    stable::backing_after_lsp_to_user_stability(
-                        durable.backing_sats,
-                        durable.expected_usd,
-                        price,
-                        amount_sats,
-                        live_receiver_sats,
-                    )
-                else {
+                let Some(reloaded_backing_after) = stable::backing_after_lsp_to_user_stability(
+                    durable.backing_sats,
+                    durable.expected_usd,
+                    price,
+                    amount_sats,
+                    live_receiver_sats,
+                ) else {
                     *ack = false;
                     audit_event(
                         "STABILITY_PAYMENT_ALLOCATION_RETRY_DEFERRED",
@@ -2580,8 +3072,8 @@ impl UserApp {
             return;
         }
         let price = self.stable_channel.lock().unwrap().latest_price;
-        let amount_usd = (price > 0.0)
-            .then(|| amount_msat as f64 / 1000.0 / SATS_IN_BTC as f64 * price);
+        let amount_usd =
+            (price > 0.0).then(|| amount_msat as f64 / 1000.0 / SATS_IN_BTC as f64 * price);
         match self.db.record_payment_and_maybe_update_backing(
             Some(payment_hash),
             "lightning",
@@ -2879,8 +3371,7 @@ impl UserApp {
                     return;
                 }
 
-                let pending =
-                    payment_id.and_then(|pid| self.pending_payments.get(&pid).cloned());
+                let pending = payment_id.and_then(|pid| self.pending_payments.get(&pid).cloned());
                 let payment_sent_message = pending
                     .as_ref()
                     .map(|p| {
@@ -2908,10 +3399,8 @@ impl UserApp {
                         let before_reconcile = sc.clone();
                         let old_expected_usd = sc.expected_usd.0;
                         let usd_deducted = stable::reconcile_outgoing(&mut sc, price);
-                        sc.native_sats = sc
-                            .stable_receiver_btc
-                            .sats
-                            .saturating_sub(sc.backing_sats);
+                        sc.native_sats =
+                            sc.stable_receiver_btc.sats.saturating_sub(sc.backing_sats);
                         stable::recompute_native(&mut sc);
 
                         let result = self.db.persist_outgoing_reconciliation(
@@ -2927,12 +3416,9 @@ impl UserApp {
                             Some(price),
                         );
                         match result {
-                            Ok(true) => Ok((
-                                true,
-                                usd_deducted,
-                                old_expected_usd,
-                                sc.expected_usd.0,
-                            )),
+                            Ok(true) => {
+                                Ok((true, usd_deducted, old_expected_usd, sc.expected_usd.0))
+                            }
                             Ok(false) => {
                                 *sc = before_reconcile;
                                 Ok((false, None, old_expected_usd, old_expected_usd))
@@ -2999,7 +3485,7 @@ impl UserApp {
                             if let Some(pid) = payment_id {
                                 self.pending_payments.remove(&pid);
                             }
-                        },
+                        }
                         Err(error) => {
                             *ack = false;
                             audit_event(
@@ -3013,7 +3499,7 @@ impl UserApp {
                             self.status_message =
                                 "Stability payment settled but could not be saved; retrying"
                                     .to_string();
-                        },
+                        }
                     }
                 }
 
@@ -3251,10 +3737,7 @@ impl UserApp {
                     // Splice rows were already completed above (exact txid match,
                     // or the legacy latest-row fallback). Everything else with a
                     // known funding txid is a regular channel open.
-                    if !completed_splice
-                        && splice_direction.is_none()
-                        && txid_str != "unknown"
-                    {
+                    if !completed_splice && splice_direction.is_none() && txid_str != "unknown" {
                         let _ = self
                             .db
                             .update_payment_confirmations(&txid_str, 1, "completed");
@@ -3369,6 +3852,7 @@ impl UserApp {
                                 let kind = payload.get("type").and_then(|value| value.as_str());
                                 if kind != Some(SYNC_MESSAGE_TYPE)
                                     && kind != Some(TRADE_REJECTED_MESSAGE_TYPE)
+                                    && kind != Some(CONFIRM_TRADE_MESSAGE_TYPE)
                                 {
                                     continue;
                                 }
@@ -3386,6 +3870,212 @@ impl UserApp {
                                     continue;
                                 }
 
+                                if kind == Some(CONFIRM_TRADE_MESSAGE_TYPE) {
+                                    let Some(confirmation) = parse_trade_confirmation(payload_str)
+                                    else {
+                                        audit_event(
+                                            "CONFIRM_TRADE_V1_PAYLOAD_INVALID",
+                                            json!({ "payment_hash": &payment_hash_str }),
+                                        );
+                                        break 'sync true;
+                                    };
+                                    let now = SystemTime::now()
+                                        .duration_since(UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    let wallet_channel_id =
+                                        self.stable_channel.lock().unwrap().channel_id.to_string();
+                                    if amount_msat != 1
+                                        || confirmation.channel_id != wallet_channel_id
+                                        || confirmation.expires_at <= now
+                                        || confirmation.confirmed_at
+                                            > now.saturating_add(STABILITY_PAYMENT_CLOCK_SKEW_SECS)
+                                    {
+                                        audit_event(
+                                            "CONFIRM_TRADE_V1_CONTEXT_INVALID",
+                                            json!({ "payment_hash": &payment_hash_str }),
+                                        );
+                                        break 'sync true;
+                                    }
+                                    let trade = match self.db.wallet_trade_by_proposal(
+                                        &confirmation.trade_id,
+                                        &confirmation.proposal_payment_id,
+                                        &confirmation.proposal_hash,
+                                    ) {
+                                        Ok(Some(trade))
+                                            if matches!(
+                                                trade.status.as_str(),
+                                                "proposing" | "awaiting_confirmation" | "confirmed"
+                                            ) =>
+                                        {
+                                            trade
+                                        }
+                                        Ok(_) => {
+                                            audit_event(
+                                                "CONFIRM_TRADE_V1_UNMATCHED",
+                                                json!({ "payment_hash": &payment_hash_str }),
+                                            );
+                                            break 'sync true;
+                                        }
+                                        Err(error) => {
+                                            audit_event(
+                                                "DB_READ_FAILED",
+                                                json!({ "op": "wallet_trade_by_proposal", "error": error.to_string() }),
+                                            );
+                                            ack = false;
+                                            break 'sync true;
+                                        }
+                                    };
+                                    let Some(confirmation_deadline) = trade
+                                        .proposal_payload
+                                        .as_deref()
+                                        .and_then(trade_proposal_timestamp)
+                                        .and_then(|timestamp| {
+                                            confirmation.wallet_deadline(timestamp)
+                                        })
+                                    else {
+                                        audit_event(
+                                            "CONFIRM_TRADE_V1_PROPOSAL_TIMESTAMP_INVALID",
+                                            json!({ "trade_id": confirmation.trade_id }),
+                                        );
+                                        break 'sync true;
+                                    };
+                                    if confirmation_deadline <= now {
+                                        audit_event(
+                                            "CONFIRM_TRADE_V1_CONTEXT_INVALID",
+                                            json!({
+                                                "trade_id": confirmation.trade_id,
+                                                "reason": "wallet_deadline_expired",
+                                            }),
+                                        );
+                                        break 'sync true;
+                                    }
+                                    let quote_deviation = ((confirmation.quote_price
+                                        - trade.btc_price)
+                                        / trade.btc_price
+                                        * 100.0)
+                                        .abs();
+                                    let (backing_sats, fee_usd) = {
+                                        let mut sc = self.stable_channel.lock().unwrap();
+                                        let wallet_user_channel_id =
+                                            format!("{}", sc.user_channel_id);
+                                        let current_version = self
+                                            .db
+                                            .get_sync_version(&wallet_user_channel_id)
+                                            .ok()
+                                            .flatten();
+                                        let expected_fee = expected_trade_fee_msat_wallet(
+                                            sc.expected_usd.0,
+                                            confirmation.expected_usd,
+                                            confirmation.quote_price,
+                                        );
+                                        if trade.channel_id != confirmation.channel_id
+                                            || trade.base_sync_version
+                                                != confirmation.base_sync_version
+                                            || confirmation.user_channel_id
+                                                != wallet_user_channel_id
+                                            || current_version
+                                                != Some(confirmation.base_sync_version)
+                                            || !stable_channels::trade::target_matches(
+                                                trade.new_expected_usd,
+                                                confirmation.expected_usd,
+                                            )
+                                            || expected_fee != Some(confirmation.fee_msat)
+                                            || !quote_deviation.is_finite()
+                                            || quote_deviation > MAX_TRADE_QUOTE_DEVIATION_PERCENT
+                                        {
+                                            audit_event(
+                                                "CONFIRM_TRADE_V1_FIELDS_INVALID",
+                                                json!({ "trade_id": confirmation.trade_id }),
+                                            );
+                                            break 'sync true;
+                                        }
+                                        let (updated, _) =
+                                            stable::update_balances(&self.node, &mut sc);
+                                        if !updated {
+                                            ack = false;
+                                            break 'sync true;
+                                        }
+                                        let fee_sats = confirmation.fee_msat / 1000;
+                                        let Ok((_, backing_sats)) = local_trade_backing_sats(
+                                            sc.stable_receiver_btc.sats,
+                                            fee_sats,
+                                            sc.backing_sats,
+                                            sc.expected_usd.0,
+                                            confirmation.expected_usd,
+                                            confirmation.quote_price,
+                                        ) else {
+                                            audit_event(
+                                                "CONFIRM_TRADE_V1_LOCAL_ALLOCATION_INVALID",
+                                                json!({ "trade_id": confirmation.trade_id }),
+                                            );
+                                            break 'sync true;
+                                        };
+                                        let fee_usd = fee_sats as f64 / SATS_IN_BTC as f64
+                                            * confirmation.quote_price;
+                                        (backing_sats, fee_usd)
+                                    };
+                                    match self.db.store_trade_confirmation(
+                                        trade.id,
+                                        &confirmation.confirmation_id,
+                                        payload_str,
+                                        confirmation_deadline.min(i64::MAX as u64) as i64,
+                                        confirmation.quote_price,
+                                        confirmation.fee_msat,
+                                        fee_usd,
+                                        backing_sats,
+                                    ) {
+                                        Ok(true) => {
+                                            if let Some(pending) = self.pending_trade.as_mut() {
+                                                if let Some(protocol) = pending.protocol.as_mut() {
+                                                    if protocol.trade_id == confirmation.trade_id {
+                                                        protocol.backing_sats = backing_sats;
+                                                        protocol.confirmation =
+                                                            Some(confirmation.clone());
+                                                        protocol.confirmation_deadline =
+                                                            Some(confirmation_deadline);
+                                                        pending.btc_price =
+                                                            confirmation.quote_price;
+                                                        pending.fee_usd = fee_usd;
+                                                        pending.net_amount_usd =
+                                                            (pending.amount_usd - fee_usd).max(0.0);
+                                                        if pending.action == TradeAction::BuyBtc {
+                                                            pending.btc_amount = pending
+                                                                .net_amount_usd
+                                                                / confirmation.quote_price;
+                                                            pending.btc_sats = (pending.btc_amount
+                                                                * SATS_IN_BTC as f64)
+                                                                .floor()
+                                                                as u64;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            self.status_message =
+                                                "Order confirmed. Review and send the fee."
+                                                    .to_string();
+                                            audit_event(
+                                                "TRADE_CONFIRMATION_ACCEPTED",
+                                                json!({
+                                                    "trade_id": confirmation.trade_id,
+                                                    "confirmation_id": confirmation.confirmation_id,
+                                                    "expires_at": confirmation.expires_at,
+                                                    "wallet_deadline": confirmation_deadline,
+                                                }),
+                                            );
+                                        }
+                                        Ok(false) => {}
+                                        Err(error) => {
+                                            ack = false;
+                                            audit_event(
+                                                "DB_WRITE_FAILED",
+                                                json!({ "op": "store_trade_confirmation", "error": error.to_string() }),
+                                            );
+                                        }
+                                    }
+                                    break 'sync true;
+                                }
+
                                 if kind == Some(TRADE_REJECTED_MESSAGE_TYPE) {
                                     let Some(rejection) = parse_trade_rejection(payload_str) else {
                                         audit_event(
@@ -3396,8 +4086,7 @@ impl UserApp {
                                     };
                                     let wallet_channel_id =
                                         self.stable_channel.lock().unwrap().channel_id.to_string();
-                                    if amount_msat != 1
-                                        || rejection.channel_id != wallet_channel_id
+                                    if amount_msat != 1 || rejection.channel_id != wallet_channel_id
                                     {
                                         audit_event(
                                             "TRADE_REJECTED_V1_CONTEXT_INVALID",
@@ -3410,7 +4099,11 @@ impl UserApp {
                                         &rejection.trade_payment_id,
                                         &rejection.request_hash,
                                     ) {
-                                        Ok(Some(trade)) if trade.channel_id == rejection.channel_id => trade,
+                                        Ok(Some(trade))
+                                            if trade.channel_id == rejection.channel_id =>
+                                        {
+                                            trade
+                                        }
                                         Ok(_) => {
                                             audit_event(
                                                 "TRADE_REJECTED_V1_UNMATCHED",
@@ -3437,9 +4130,26 @@ impl UserApp {
                                             self.pending_trade_payments.retain(|_, pending| {
                                                 pending.trade_db_id != trade.id
                                             });
-                                            self.status_message =
+                                            let rejection_message =
                                                 rejection.reason_code.user_message().to_string();
-                                            self.show_toast("Trade rejected", "X");
+                                            self.status_message = rejection_message.clone();
+                                            if self
+                                                .pending_trade
+                                                .as_ref()
+                                                .and_then(|pending| pending.protocol.as_ref())
+                                                .is_some_and(|protocol| {
+                                                    protocol.trade_db_id == trade.id
+                                                })
+                                            {
+                                                self.trade_error = rejection_message;
+                                            }
+                                            if rejection.reason_code
+                                                == stable_channels::trade::TradeRejectionReason::ClientCancelled
+                                            {
+                                                self.show_toast("Order cancelled", "✓");
+                                            } else {
+                                                self.show_toast("Trade rejected", "X");
+                                            }
                                             audit_event(
                                                 "TRADE_REJECTED_BY_LSP",
                                                 json!({
@@ -3500,16 +4210,16 @@ impl UserApp {
                                 }
 
                                 let pending_trade = match correlation {
-                                    Some((trade_id, payment_id, request_hash)) => self
-                                        .db
-                                        .get_trade_by_correlation(
+                                    Some((trade_id, payment_id, request_hash)) => {
+                                        self.db.get_trade_by_correlation(
                                             trade_id,
                                             payment_id,
                                             request_hash,
-                                        ),
-                                    None => self
-                                        .db
-                                        .get_pending_trade_by_expected_usd(sync.expected_usd),
+                                        )
+                                    }
+                                    None => {
+                                        self.db.get_pending_trade_by_expected_usd(sync.expected_usd)
+                                    }
                                 };
                                 let pending_trade = match pending_trade {
                                     Ok(trade) => trade,
@@ -3594,7 +4304,9 @@ impl UserApp {
                                             native_sats,
                                             pending_trade.as_ref().map(|trade| trade.id),
                                         )
-                                        .map(|applied| (applied, applied && pending_trade.is_some()))
+                                        .map(|applied| {
+                                            (applied, applied && pending_trade.is_some())
+                                        })
                                 };
                                 match persistence {
                                     Ok((allocation_applied, trade_resolved)) => {
@@ -3662,8 +4374,7 @@ impl UserApp {
                             tlv.type_num == STABLE_CHANNEL_TLV_TYPE && tlv.value.as_slice() != [1u8]
                         });
                         let has_legacy_stability_marker = custom_records.iter().any(|tlv| {
-                            tlv.type_num == STABLE_CHANNEL_TLV_TYPE
-                                && tlv.value.as_slice() == [1u8]
+                            tlv.type_num == STABLE_CHANNEL_TLV_TYPE && tlv.value.as_slice() == [1u8]
                         });
                         if has_legacy_stability_marker {
                             audit_event(
@@ -3797,8 +4508,8 @@ impl UserApp {
 
                     // Payment success proves that the fee reached the LSP, not that it accepted the
                     // trade. Keep it pending until the LSP's signed SYNC_V1 arrives.
-                    let mut pending_trade = payment_id
-                        .and_then(|pid| self.pending_trade_payments.get(&pid).cloned());
+                    let mut pending_trade =
+                        payment_id.and_then(|pid| self.pending_trade_payments.get(&pid).cloned());
                     if pending_trade.is_none() {
                         if let Some(pid) = payment_id {
                             if let Some(row) = self
@@ -3883,10 +4594,7 @@ impl UserApp {
                 } => {
                     let mut handled_stability_failure = false;
                     if let Some(pid) = payment_id {
-                        match self
-                            .db
-                            .fail_pending_stability_payment(&format!("{pid}"))
-                        {
+                        match self.db.fail_pending_stability_payment(&format!("{pid}")) {
                             Ok(Some(rollback)) => {
                                 handled_stability_failure = true;
                                 if rollback.restored {
@@ -3900,10 +4608,8 @@ impl UserApp {
                                             && sc.backing_sats == after
                                         {
                                             sc.backing_sats = before;
-                                            sc.native_sats = sc
-                                                .stable_receiver_btc
-                                                .sats
-                                                .saturating_sub(before);
+                                            sc.native_sats =
+                                                sc.stable_receiver_btc.sats.saturating_sub(before);
                                             stable::recompute_native(&mut sc);
                                             sc.last_stability_payment = 0;
                                             sc.payment_made = false;
@@ -3940,12 +4646,31 @@ impl UserApp {
                             match self.db.mark_trade_payment_failed(&format!("{pid}")) {
                                 Ok(Some(row)) => {
                                     is_trade_payment = true;
-                                    Some(PendingTradePayment {
-                                        new_expected_usd: row.new_expected_usd,
-                                        backing_sats: row.new_backing_sats,
-                                        trade_db_id: row.id,
-                                        action: row.action,
-                                    })
+                                    if matches!(
+                                        row.status.as_str(),
+                                        "proposing" | "awaiting_confirmation" | "confirmed"
+                                    ) {
+                                        if self
+                                            .pending_trade
+                                            .as_ref()
+                                            .and_then(|trade| trade.protocol.as_ref())
+                                            .is_some_and(|protocol| protocol.trade_db_id == row.id)
+                                        {
+                                            self.pending_trade = None;
+                                            self.show_confirm_trade = false;
+                                            self.trade_error =
+                                                "The order proposal payment failed. Retry."
+                                                    .to_string();
+                                        }
+                                        None
+                                    } else {
+                                        Some(PendingTradePayment {
+                                            new_expected_usd: row.new_expected_usd,
+                                            backing_sats: row.new_backing_sats,
+                                            trade_db_id: row.id,
+                                            action: row.action,
+                                        })
+                                    }
                                 }
                                 Ok(None) => match self.db.is_trade_payment(&format!("{pid}")) {
                                     Ok(found) => {
@@ -3997,9 +4722,9 @@ impl UserApp {
                             let pending =
                                 payment_id.and_then(|pid| self.pending_payments.remove(&pid));
                             if let Some(p) = pending {
-                                let _ = self
-                                    .db
-                                    .update_payment_status(p.payment_db_id, "failed", None);
+                                let _ =
+                                    self.db
+                                        .update_payment_status(p.payment_db_id, "failed", None);
                             }
 
                             audit_event(
@@ -4299,9 +5024,8 @@ impl UserApp {
         let price = sc.latest_price;
         if !price.is_finite() || price <= 0.0 {
             drop(sc);
-            pending.retry_after = Some(
-                std::time::Instant::now() + Duration::from_secs(BALANCE_UPDATE_INTERVAL_SECS),
-            );
+            pending.retry_after =
+                Some(std::time::Instant::now() + Duration::from_secs(BALANCE_UPDATE_INTERVAL_SECS));
             self.pending_splice_deduction = Some(pending);
             audit_event(
                 "SPLICE_OUT_RECONCILE_DEFERRED_NO_PRICE",
@@ -4382,7 +5106,10 @@ impl UserApp {
     fn lookup_funding_output_sats_esplora(txid: &str, vout: u32) -> Option<u64> {
         let url = format!("{}/tx/{}", DEFAULT_CHAIN_URL, txid);
 
-        let response = stable_channels::price_feeds::bounded_agent().get(&url).call().ok()?;
+        let response = stable_channels::price_feeds::bounded_agent()
+            .get(&url)
+            .call()
+            .ok()?;
 
         let json: serde_json::Value = response.into_json().ok()?;
         let vouts = json["vout"].as_array()?;
@@ -4606,10 +5333,7 @@ impl UserApp {
         if fee_sats == 0 {
             "Expected fee: none".to_string()
         } else {
-            format!(
-                "Expected fee: ~{}",
-                Self::format_sats_as_btc(fee_sats)
-            )
+            format!("Expected fee: ~{}", Self::format_sats_as_btc(fee_sats))
         }
     }
 
@@ -4739,8 +5463,15 @@ impl UserApp {
                 match stable_channels::price_feeds::fetch_kraken_ohlc(&agent, None) {
                     Ok(prices) => {
                         for (date, open, high, low, close, volume) in prices {
-                            let _ = db
-                                .record_daily_price(&date, open, high, low, close, volume, Some("kraken"));
+                            let _ = db.record_daily_price(
+                                &date,
+                                open,
+                                high,
+                                low,
+                                close,
+                                volume,
+                                Some("kraken"),
+                            );
                         }
                     }
                     Err(e) => eprintln!("[Chart] Failed to fetch Kraken OHLC data: {}", e),
@@ -5063,22 +5794,21 @@ impl UserApp {
                         });
 
                         cols[1].vertical_centered(|ui| {
-                            let onchain_btn = egui::Button::new(
-                                egui::RichText::new("Onchain").size(14.0).color(
+                            let onchain_btn =
+                                egui::Button::new(egui::RichText::new("Onchain").size(14.0).color(
                                     if onchain_selected {
                                         Color32::WHITE
                                     } else {
                                         Color32::BLACK
                                     },
-                                ),
-                            )
-                            .fill(if onchain_selected {
-                                theme::PRIMARY
-                            } else {
-                                theme::SELECTED_BG
-                            })
-                            .corner_radius(theme::RADIUS_SM)
-                            .min_size(egui::vec2(130.0, 34.0));
+                                ))
+                                .fill(if onchain_selected {
+                                    theme::PRIMARY
+                                } else {
+                                    theme::SELECTED_BG
+                                })
+                                .corner_radius(theme::RADIUS_SM)
+                                .min_size(egui::vec2(130.0, 34.0));
 
                             if ui.add(onchain_btn).clicked() {
                                 self.fund_tab = FundTab::Onchain;
@@ -7305,6 +8035,7 @@ impl UserApp {
                     .add(make_action_btn("USD → BTC", theme::IOS_ORANGE))
                     .clicked()
                 {
+                    self.cancel_pending_trade();
                     self.trade_amount_input.clear();
                     self.trade_error.clear();
                     self.pending_trade = None;
@@ -7318,6 +8049,7 @@ impl UserApp {
                     .add(make_action_btn("BTC → USD", theme::IOS_RED))
                     .clicked()
                 {
+                    self.cancel_pending_trade();
                     self.trade_amount_input.clear();
                     self.trade_error.clear();
                     self.pending_trade = None;
@@ -9538,7 +10270,7 @@ impl UserApp {
                     let btc_amount = net_amount / btc_price;
                     let btc_sats = (btc_amount * SATS_IN_BTC as f64).floor() as u64;
 
-                    self.pending_trade = Some(PendingTrade {
+                    let mut pending = PendingTrade {
                         action: TradeAction::BuyBtc,
                         amount_usd: amount,
                         btc_price,
@@ -9547,9 +10279,14 @@ impl UserApp {
                         btc_sats,
                         net_amount_usd: net_amount,
                         is_full_peg: false,
-                    });
-                    self.show_confirm_trade = true;
-                    self.trade_error.clear();
+                        protocol: None,
+                    };
+                    if let Some(protocol) = self.send_trade_proposal(&pending, None) {
+                        pending.protocol = Some(protocol);
+                        self.pending_trade = Some(pending);
+                        self.show_confirm_trade = true;
+                        self.trade_error.clear();
+                    }
                 }
             } else {
                 self.trade_error = "Invalid amount".to_string();
@@ -9694,14 +10431,38 @@ impl UserApp {
                 });
             });
 
-        let confirmation_blocked = !self.trade_error.is_empty();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let protocol = self
+            .pending_trade
+            .as_ref()
+            .and_then(|trade| trade.protocol.as_ref());
+        let confirmation = protocol.and_then(|protocol| protocol.confirmation.as_ref());
+        let needs_refresh = confirmation.is_some()
+            && protocol
+                .and_then(|protocol| protocol.confirmation_deadline)
+                .map_or(true, |deadline| {
+                    deadline.saturating_sub(now) < TRADE_CONFIRMATION_SEND_MARGIN_SECS
+                });
+        let confirmation_blocked =
+            !self.trade_error.is_empty() || confirmation.is_none() || needs_refresh;
         if confirmation_blocked {
             ui.add_space(12.0);
-            ui.label(
-                RichText::new(&self.trade_error)
-                    .color(theme::DANGER_HOVER)
-                    .size(12.0),
-            );
+            let message = if !self.trade_error.is_empty() {
+                self.trade_error.clone()
+            } else if confirmation.is_none() {
+                "Waiting for the provider's signed confirmation…".to_string()
+            } else {
+                "Quote expired. Refresh to continue.".to_string()
+            };
+            ui.label(RichText::new(message).color(theme::DANGER_HOVER).size(12.0));
+            if (needs_refresh || !self.trade_error.is_empty())
+                && ui.button("Refresh quote").clicked()
+            {
+                self.refresh_pending_trade();
+            }
             ui.add_space(8.0);
         } else {
             ui.add_space(20.0);
@@ -9719,16 +10480,12 @@ impl UserApp {
             .fill(theme::IOS_BLUE)
             .corner_radius(theme::RADIUS_PILL)
             .min_size(egui::vec2(280.0, 50.0));
-            if ui
-                .add_enabled(!confirmation_blocked, confirm_btn)
-                .clicked()
-            {
+            if ui.add_enabled(!confirmation_blocked, confirm_btn).clicked() {
                 should_confirm = true;
             }
         });
         if should_confirm {
-            self.execute_buy(amount_usd, btc_price);
-            if self.trade_error.is_empty() {
+            if self.execute_confirmed_trade() {
                 self.trade_success = Some(TradeAction::BuyBtc);
                 self.pending_trade = None;
                 self.show_confirm_trade = false;
@@ -9744,7 +10501,9 @@ impl UserApp {
                 .add(egui::Button::new(RichText::new("Back").color(Color32::GRAY)).frame(false))
                 .clicked()
             {
+                self.cancel_pending_trade();
                 self.show_confirm_trade = false;
+                self.pending_trade = None;
             }
         });
     }
@@ -9922,7 +10681,7 @@ impl UserApp {
                     }
                     let btc_amount = btc_sats as f64 / SATS_IN_BTC as f64;
 
-                    self.pending_trade = Some(PendingTrade {
+                    let mut pending = PendingTrade {
                         action: TradeAction::SellBtc,
                         amount_usd: amount,
                         btc_price,
@@ -9931,9 +10690,14 @@ impl UserApp {
                         btc_sats,
                         net_amount_usd: net_amount,
                         is_full_peg: amount_cents == available_btc_usd_cents,
-                    });
-                    self.show_confirm_trade = true;
-                    self.trade_error.clear();
+                        protocol: None,
+                    };
+                    if let Some(protocol) = self.send_trade_proposal(&pending, None) {
+                        pending.protocol = Some(protocol);
+                        self.pending_trade = Some(pending);
+                        self.show_confirm_trade = true;
+                        self.trade_error.clear();
+                    }
                 }
             } else {
                 self.trade_error = "Invalid amount".to_string();
@@ -9982,7 +10746,6 @@ impl UserApp {
         let btc_price = trade.btc_price;
         let fee_usd = trade.fee_usd;
         let btc_amount = trade.btc_amount;
-        let btc_sats = trade.btc_sats;
         let net_amount = trade.net_amount_usd;
         let is_full_peg = trade.is_full_peg;
 
@@ -10085,7 +10848,7 @@ impl UserApp {
             ui.add(
                 egui::Label::new(
                     RichText::new(
-                        "This trade may be rejected by the LSP if the price changes, and the trade fee will not be refunded.",
+                        "Full conversion must fit the provider's confirmed channel capacity. No trade fee is sent unless you confirm an accepted quote.",
                     )
                     .size(12.0)
                     .color(theme::WARNING),
@@ -10094,14 +10857,38 @@ impl UserApp {
             );
         }
 
-        let confirmation_blocked = !self.trade_error.is_empty();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let protocol = self
+            .pending_trade
+            .as_ref()
+            .and_then(|trade| trade.protocol.as_ref());
+        let confirmation = protocol.and_then(|protocol| protocol.confirmation.as_ref());
+        let needs_refresh = confirmation.is_some()
+            && protocol
+                .and_then(|protocol| protocol.confirmation_deadline)
+                .map_or(true, |deadline| {
+                    deadline.saturating_sub(now) < TRADE_CONFIRMATION_SEND_MARGIN_SECS
+                });
+        let confirmation_blocked =
+            !self.trade_error.is_empty() || confirmation.is_none() || needs_refresh;
         if confirmation_blocked {
             ui.add_space(12.0);
-            ui.label(
-                RichText::new(&self.trade_error)
-                    .color(theme::DANGER_HOVER)
-                    .size(12.0),
-            );
+            let message = if !self.trade_error.is_empty() {
+                self.trade_error.clone()
+            } else if confirmation.is_none() {
+                "Waiting for the provider's signed confirmation…".to_string()
+            } else {
+                "Quote expired. Refresh to continue.".to_string()
+            };
+            ui.label(RichText::new(message).color(theme::DANGER_HOVER).size(12.0));
+            if (needs_refresh || !self.trade_error.is_empty())
+                && ui.button("Refresh quote").clicked()
+            {
+                self.refresh_pending_trade();
+            }
             ui.add_space(8.0);
         } else {
             ui.add_space(20.0);
@@ -10119,16 +10906,12 @@ impl UserApp {
             .fill(theme::IOS_BLUE)
             .corner_radius(theme::RADIUS_PILL)
             .min_size(egui::vec2(280.0, 50.0));
-            if ui
-                .add_enabled(!confirmation_blocked, confirm_btn)
-                .clicked()
-            {
+            if ui.add_enabled(!confirmation_blocked, confirm_btn).clicked() {
                 should_confirm = true;
             }
         });
         if should_confirm {
-            self.execute_sell(amount_usd, btc_price, btc_sats);
-            if self.trade_error.is_empty() {
+            if self.execute_confirmed_trade() {
                 self.trade_success = Some(TradeAction::SellBtc);
                 self.pending_trade = None;
                 self.show_confirm_trade = false;
@@ -10144,7 +10927,9 @@ impl UserApp {
                 .add(egui::Button::new(RichText::new("Back").color(Color32::GRAY)).frame(false))
                 .clicked()
             {
+                self.cancel_pending_trade();
                 self.show_confirm_trade = false;
+                self.pending_trade = None;
             }
         });
     }
@@ -10389,6 +11174,7 @@ impl UserApp {
         });
     }
 
+    #[allow(dead_code)]
     fn execute_buy(&mut self, amount_usd: f64, btc_price: f64) {
         self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
@@ -10430,8 +11216,7 @@ impl UserApp {
             btc_price,
             amount_usd,
             btc_amount,
-        )
-        {
+        ) {
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
@@ -10448,6 +11233,7 @@ impl UserApp {
         }
     }
 
+    #[allow(dead_code)]
     fn execute_sell(&mut self, amount_usd: f64, btc_price: f64, btc_sats: u64) {
         self.trade_error.clear();
         let fee_usd = Self::stable_trade_fee(amount_usd);
@@ -10488,8 +11274,7 @@ impl UserApp {
             btc_price,
             amount_usd,
             btc_amount,
-        )
-        {
+        ) {
             self.pending_trade_payments.insert(
                 payment_id,
                 PendingTradePayment {
@@ -10510,46 +11295,59 @@ impl UserApp {
         if !self.show_diagnostics_window {
             return;
         }
-        
+
         let mut is_open = self.show_diagnostics_window;
         let mut do_export = false;
-        
+
         egui::Window::new("Logs & Diagnostics")
             .resizable(false)
             .collapsible(false)
             .open(&mut is_open)
             .show(ctx, |ui| {
                 let icon_badge = |ui: &mut egui::Ui, symbol: &str, color: Color32| {
-                    let (rect, _) = ui.allocate_exact_size(egui::vec2(28.0, 28.0), egui::Sense::hover());
-                    ui.painter().rect_filled(rect, 4.0, color.gamma_multiply(0.12));
+                    let (rect, _) =
+                        ui.allocate_exact_size(egui::vec2(28.0, 28.0), egui::Sense::hover());
+                    ui.painter()
+                        .rect_filled(rect, 4.0, color.gamma_multiply(0.12));
                     ui.painter().text(
                         rect.center(),
                         egui::Align2::CENTER_CENTER,
                         symbol,
                         egui::FontId::proportional(14.0),
-                        color
+                        color,
                     );
                 };
                 ui.vertical(|ui| {
-                    ui.label(RichText::new(
-                        "Save app logs to a file for debugging and support."
-                    ).size(12.0).color(Color32::DARK_GRAY));
-                    
+                    ui.label(
+                        RichText::new("Save app logs to a file for debugging and support.")
+                            .size(12.0)
+                            .color(Color32::DARK_GRAY),
+                    );
+
                     ui.add_space(12.0);
                     let support_color = Color32::from_rgb(76, 175, 80);
 
                     ui.horizontal(|ui| {
                         icon_badge(ui, "📤", support_color);
                         ui.add_space(8.0);
-                        if ui.add(egui::Button::new(
-                            RichText::new("Download logs").size(14.0).color(support_color),
-                        ).fill(Color32::TRANSPARENT).frame(false)).clicked() {
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    RichText::new("Download logs")
+                                        .size(14.0)
+                                        .color(support_color),
+                                )
+                                .fill(Color32::TRANSPARENT)
+                                .frame(false),
+                            )
+                            .clicked()
+                        {
                             do_export = true;
                         }
                     });
                 });
             });
-            
+
         self.show_diagnostics_window = is_open;
         if do_export {
             if export_logs_to_zip() {
@@ -10877,6 +11675,7 @@ impl App for UserApp {
         if self.show_buy_modal {
             self.show_buy_modal_ui(ctx);
             if self.check_click_outside_modal(ctx) {
+                self.cancel_pending_trade();
                 self.show_buy_modal = false;
                 self.show_confirm_trade = false;
                 self.pending_trade = None;
@@ -10887,6 +11686,7 @@ impl App for UserApp {
         if self.show_sell_modal {
             self.show_sell_modal_ui(ctx);
             if self.check_click_outside_modal(ctx) {
+                self.cancel_pending_trade();
                 self.show_sell_modal = false;
                 self.show_confirm_trade = false;
                 self.pending_trade = None;
@@ -11291,8 +12091,7 @@ fn parse_incoming_sync(payload: &serde_json::Value) -> Option<IncomingSync> {
         return None;
     }
     let channel_id = channel_id.to_string();
-    let expected_usd =
-        stable::normalize_trade_expected_usd(payload.get("expected_usd")?.as_f64()?);
+    let expected_usd = stable::normalize_trade_expected_usd(payload.get("expected_usd")?.as_f64()?);
     let backing_sats = payload.get("backing_sats")?.as_u64()?;
     let sync_version = payload.get("sync_version")?.as_u64()?;
     if !expected_usd.is_finite()
@@ -11357,6 +12156,48 @@ fn parse_trade_rejection(payload: &str) -> Option<stable_channels::trade::TradeR
     Some(rejection)
 }
 
+fn parse_trade_confirmation(payload: &str) -> Option<stable_channels::trade::ConfirmTradeV1> {
+    let confirmation: stable_channels::trade::ConfirmTradeV1 =
+        serde_json::from_str(payload).ok()?;
+    confirmation.has_valid_shape().then_some(confirmation)
+}
+
+fn trade_proposal_timestamp(payload: &str) -> Option<u64> {
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    (value.get("type")?.as_str()? == TRADE_MESSAGE_TYPE
+        && value.get("phase")?.as_str()? == "propose")
+        .then(|| value.get("ts")?.as_u64())?
+}
+
+fn expected_trade_fee_msat_wallet(
+    old_expected_usd: f64,
+    new_expected_usd: f64,
+    quote_price: f64,
+) -> Option<u64> {
+    let fee_rate = STABLE_CHANNEL_TRADE_FEE_RATE;
+    if !old_expected_usd.is_finite()
+        || old_expected_usd < 0.0
+        || !new_expected_usd.is_finite()
+        || new_expected_usd < 0.0
+        || !quote_price.is_finite()
+        || quote_price <= 0.0
+        || !(0.0..1.0).contains(&fee_rate)
+    {
+        return None;
+    }
+    let target_delta = (new_expected_usd - old_expected_usd).abs();
+    let gross_usd = if new_expected_usd > old_expected_usd {
+        target_delta / (1.0 - fee_rate)
+    } else {
+        target_delta
+    };
+    let fee_sats = gross_usd * fee_rate / quote_price * SATS_IN_BTC as f64;
+    if !fee_sats.is_finite() || fee_sats < 0.0 || fee_sats > (u64::MAX / 1000) as f64 {
+        return None;
+    }
+    Some((fee_sats as u64).saturating_mul(1000).max(1))
+}
+
 fn trade_reduction_exhausts_backing(
     current_backing_sats: u64,
     current_expected_usd: f64,
@@ -11401,8 +12242,7 @@ fn local_trade_backing_sats(
     let post_fee_receiver_sats = live_receiver_sats
         .checked_sub(fee_sats)
         .ok_or(LocalTradeAllocationError::FeeExceedsBalance)?;
-    let receiver_usd =
-        post_fee_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
+    let receiver_usd = post_fee_receiver_sats as f64 / SATS_IN_BTC as f64 * current_price;
     if new_expected_usd > receiver_usd {
         return Err(LocalTradeAllocationError::TargetExceedsCapacity);
     }
@@ -11413,18 +12253,20 @@ fn local_trade_backing_sats(
         new_expected_usd,
         current_price,
     )
-    .ok_or(if new_expected_usd == 0.0
-        || trade_reduction_exhausts_backing(
-            current_backing_sats,
-            current_expected_usd,
-            new_expected_usd,
-            current_price,
-        )
-    {
-        LocalTradeAllocationError::SettlementRequired
-    } else {
-        LocalTradeAllocationError::UnsafeAllocation
-    })?;
+    .ok_or(
+        if new_expected_usd == 0.0
+            || trade_reduction_exhausts_backing(
+                current_backing_sats,
+                current_expected_usd,
+                new_expected_usd,
+                current_price,
+            )
+        {
+            LocalTradeAllocationError::SettlementRequired
+        } else {
+            LocalTradeAllocationError::UnsafeAllocation
+        },
+    )?;
     Ok((post_fee_receiver_sats, backing_sats))
 }
 
@@ -11589,12 +12431,13 @@ fn btc_amount_to_msat(input: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
-        local_sync_backing_sats, local_trade_backing_sats, max_sell_trade_usd_cents,
-        parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
-        restrict_secret_file_permissions, sats_for_usd_cents,
-        splice_in_overlap_sats, splice_reconcile_action, write_secret_file, IncomingSync,
-        LocalTradeAllocationError, PendingSplice, SpliceReconcileAction, UserApp,
+        btc_amount_to_msat, channel_balance_split, collapse_double_paste,
+        expected_trade_fee_msat_wallet, floor_usd_cents, local_sync_backing_sats,
+        local_trade_backing_sats, max_sell_trade_usd_cents, parse_incoming_sync,
+        parse_trade_confirmation, parse_trade_rejection, parse_trade_usd_cents,
+        restrict_secret_file_permissions, sats_for_usd_cents, splice_in_overlap_sats,
+        splice_reconcile_action, write_secret_file, IncomingSync, LocalTradeAllocationError,
+        PendingSplice, SpliceReconcileAction, UserApp,
     };
     use stable_channels::db::PendingTradeRow;
 
@@ -11653,6 +12496,30 @@ mod tests {
         assert_eq!(
             max_sell_trade_usd_cents(150_000, 50_000, 100_000, 100.0, f64::NAN),
             0,
+        );
+    }
+
+    #[test]
+    fn production_full_peg_uses_the_complete_post_fee_balance() {
+        assert_eq!(
+            max_sell_trade_usd_cents(68_550, 13_403, 55_147, 34.8404, 63_052.275),
+            838,
+        );
+        assert_eq!(
+            local_trade_backing_sats(68_550, 132, 55_147, 34.8404, 43.1366, 63_052.275,),
+            Ok((68_418, 68_418)),
+        );
+    }
+
+    #[test]
+    fn production_full_peg_does_not_leave_a_one_cent_sat_rounding_residue() {
+        assert_eq!(
+            max_sell_trade_usd_cents(67_735, 67_735, 0, 0.0, 63_024.5675),
+            4_268,
+        );
+        assert_eq!(
+            local_trade_backing_sats(67_735, 677, 0, 0.0, 42.2532, 63_024.15),
+            Ok((67_058, 67_058)),
         );
     }
 
@@ -11864,14 +12731,7 @@ mod tests {
             "an authenticated full-exit sync needs no local price",
         );
         assert_eq!(
-            local_sync_backing_sats(
-                &closed,
-                100_000,
-                100_001.0,
-                60.0,
-                59_999,
-                None,
-            ),
+            local_sync_backing_sats(&closed, 100_000, 100_001.0, 60.0, 59_999, None,),
             Ok(0),
             "a full exit with insignificant drift is safe",
         );
@@ -12081,6 +12941,34 @@ mod tests {
         assert_eq!(parse_trade_rejection(&extra.to_string()), None);
     }
 
+    #[test]
+    fn confirmation_parser_and_fee_are_exact() {
+        let id = "ab".repeat(32);
+        let payload = serde_json::json!({
+            "type": "CONFIRM_TRADE_V1",
+            "channel_id": "cd".repeat(32),
+            "user_channel_id": "7",
+            "trade_id": id,
+            "proposal_payment_id": "ef".repeat(32),
+            "proposal_hash": "12".repeat(32),
+            "confirmation_id": "34".repeat(32),
+            "expected_usd": 50.0,
+            "quote_price": 100000.0,
+            "fee_msat": 500000,
+            "base_sync_version": 3,
+            "confirmed_at": 100,
+            "expires_at": 160,
+        });
+        assert!(parse_trade_confirmation(&payload.to_string()).is_some());
+        assert_eq!(
+            expected_trade_fee_msat_wallet(100.0, 50.0, 100_000.0),
+            Some(500_000)
+        );
+        let mut malformed = payload;
+        malformed["expires_at"] = serde_json::json!(161);
+        assert!(parse_trade_confirmation(&malformed.to_string()).is_none());
+    }
+
     #[cfg(unix)]
     #[test]
     fn seed_file_is_written_and_repaired_as_owner_only() {
@@ -12194,7 +13082,9 @@ mod tests {
     fn closure_reason_structured_variants_and_unknown() {
         use ldk_node::lightning::events::ClosureReason;
 
-        let pe = Some(ClosureReason::ProcessingError { err: "bad htlc".to_string() });
+        let pe = Some(ClosureReason::ProcessingError {
+            err: "bad htlc".to_string(),
+        });
         let v = super::closure_reason_to_json(&pe);
         assert_eq!(v["kind"], "PROCESSING_ERROR");
         assert_eq!(v["err"], "bad htlc");
@@ -12234,7 +13124,10 @@ fn closure_reason_to_json(
         CR::CounterpartyForceClosed { peer_msg } => {
             json!({ "kind": "COUNTERPARTY_FORCE_CLOSED", "peer_msg": peer_msg.to_string() })
         }
-        CR::HolderForceClosed { broadcasted_latest_txn, message } => json!({
+        CR::HolderForceClosed {
+            broadcasted_latest_txn,
+            message,
+        } => json!({
             "kind": "HOLDER_FORCE_CLOSED",
             "broadcasted_latest_txn": broadcasted_latest_txn,
             "message": message,
@@ -12279,8 +13172,8 @@ fn export_logs_to_zip() -> bool {
     let zip_path = out_dir.join("stable_channels_logs.zip");
     if let Ok(file) = std::fs::File::create(&zip_path) {
         let mut zip = zip::ZipWriter::new(file);
-        let options = zip::write::FileOptions::default()
-            .compression_method(zip::CompressionMethod::Deflated);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         // ldk-node's default filesystem logger writes to `ldk_node.log`; keep the hyphenated
         // name as a fallback in case a custom logger path is configured.
         for filename in &["audit_log.txt", "ldk_node.log", "ldk-node.log"] {


### PR DESCRIPTION
This PR prevents users from paying a trade fee before knowing whether the LSP will accept the trade.

  Desktop trades now use a two-step flow. The wallet first sends a 1-msat proposal, and the LSP validates the quote, channel capacity and post-fee allocation before reserving the trade for 60 seconds. The wallet enables confirmation only after verifying the LSP’s signed response. Once confirmed, it sends the exact fee and the LSP atomically applies the reserved allocation.

  The reservation locks the approved price, fee and allocation, so later market movement cannot invalidate it. Refreshing creates a new quote at the current price, while cancelling releases the reservation. Expired confirmations cannot be executed, but payments that settled before expiry remain valid even if processed later.

  The flow is persisted across restarts, prevents duplicate execution, and keeps the final signed `SYNC_V1` authoritative. Full-peg trades use post-fee channel capacity without exceeding the available sats.

  Android, iOS and older wallets remain unchanged: trades without a `phase` continue through the existing fee-first flow.