### PR TITLE
Prevent wallet payments before initial chain sync

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1617,6 +1617,18 @@ class AppState(private val context: Context) : ViewModel() {
             val amountMsat = USD(abs(result.dollarsFromPar)).toMsats(price)
             if (amountMsat == 0L) return
 
+            // Chain-freshness gate (see #243): never pay on a stale chain tip, and check
+            // BEFORE claiming so a deferral leaves no claimed-but-unsent marker. The next
+            // stability tick retries once LDK's background sync catches up.
+            val syncAge = nodeService.lightningSyncAgeSecs()
+            if (syncAge == null || syncAge > Constants.STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS) {
+                AuditService.log(
+                    "STABILITY_SKIP",
+                    mapOf("reason" to "stale_lightning_sync", "sync_age_secs" to syncAge)
+                )
+                return
+            }
+
             // Atomically claim the send. A denied claim means another sender (e.g. the
             // background push service) already owns an in-flight send — skip this tick.
             val claimed = try {
@@ -1634,11 +1646,20 @@ class AppState(private val context: Context) : ViewModel() {
                 // Tag with the STABLE_CHANNEL_TLV [0x01] marker so the LSP classifies
                 // this as a settlement (operator GUI) and runs reconcile_incoming_stability
                 // immediately, matching every other sender. See issue #161.
-                nodeService.sendKeysendWithTLV(
+                nodeService.sendStabilityPayment(
                     amountMsat,
                     sc.counterparty,
                     listOf(CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), byteArrayOf(1)))
                 )
+            } catch (e: NodeService.StaleLightningSyncException) {
+                // The wrapper's send-boundary gate fired (sync went stale after the precheck
+                // above). Send never happened — release the claim and retry next tick.
+                try { databaseService?.clearPendingSend() } catch (_: Exception) {}
+                AuditService.log(
+                    "STABILITY_SKIP",
+                    mapOf("reason" to "stale_lightning_sync", "sync_age_secs" to e.syncAgeSecs)
+                )
+                return
             } catch (e: Exception) {
                 // Send never happened — release the claim.
                 try { databaseService?.clearPendingSend() } catch (_: Exception) {}

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -603,9 +603,9 @@ class StabilityProcessingService : Service() {
                 FCMService.flagPendingPayment(this)
                 return
             }
-            logStabilityGateEvent("stability_background_sent_after_sync", initialSyncAge, waitedMs)
+            logStabilityGateEvent("stability_background_fresh_after_wait", initialSyncAge, waitedMs)
         } else {
-            logStabilityGateEvent("stability_background_sent_fresh", initialSyncAge, waitedMs)
+            logStabilityGateEvent("stability_background_fresh_ready", initialSyncAge, waitedMs)
         }
 
         // Atomically claim the send before starting it. If another process (foreground timer)
@@ -613,6 +613,17 @@ class StabilityProcessingService : Service() {
         // check-and-set that prevents a double send.
         if (!claimPendingSendInDB(dbPath, amountMsat, price)) {
             Log.d(TAG, "Pending send already claimed by another sender — skipping this tick")
+            return
+        }
+
+        // Re-check after the claim: the SQLite claim can take up to ~2s under cross-process
+        // contention and could carry the timestamp past the 120s boundary. No send happened,
+        // so clear the claim rather than blocking the foreground retry.
+        if (!lightningSyncIsFresh(node)) {
+            try { clearPendingSendInDB(dbPath) } catch (_: Exception) {}
+            logStabilityGateEvent("stability_background_deferred_stale_sync", initialSyncAge, waitedMs)
+            Log.w(TAG, "Lightning sync went stale during claim — deferring to foreground")
+            FCMService.flagPendingPayment(this)
             return
         }
 
@@ -632,6 +643,13 @@ class StabilityProcessingService : Service() {
             Log.e(TAG, "Stability keysend failed", e)
             throw e
         }
+        // Only an accepted send counts as sent_* — denied-claim and send-failure runs must
+        // not inflate the pilot's send numbers.
+        logStabilityGateEvent(
+            if (waitedMs > 0) "stability_background_sent_after_sync" else "stability_background_sent_fresh",
+            initialSyncAge,
+            waitedMs
+        )
         Log.d(TAG, "Stability keysend sent successfully")
 
         try {

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -17,6 +17,7 @@ import com.stablechannels.app.util.PriceFeedConfig
 import com.stablechannels.app.util.PriceOracle
 import com.stablechannels.app.util.PriceOracleAnchorStore
 import com.stablechannels.app.util.PriceOracleException
+import com.stablechannels.app.util.StabilityFreshness
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
@@ -44,11 +45,16 @@ class StabilityProcessingService : Service() {
         private const val TAG = "StabilityBgService"
         private const val POLL_TIMEOUT_SECS = 25
         private const val DB_RETRY_BACKOFF_MS = 500L
+        private const val SYNC_FRESHNESS_POLL_MS = 500L
 
         @Volatile
         var isRunning = false
             private set
     }
+
+    /** Whether this run's gossip strip deleted node_metrics — resetting LDK's persisted
+     *  Lightning-sync timestamp, so the freshness gate can't inherit the app's last sync. */
+    private var nodeMetricsReset = false
 
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(Constants.PRICE_FETCH_TIMEOUT_SECS, TimeUnit.SECONDS)
@@ -182,7 +188,7 @@ class StabilityProcessingService : Service() {
         try {
             // Strip gossip from SQLite to avoid OOM in the foreground service.
             // The service doesn't need gossip (it only routes to the LSP, a direct peer).
-            stripGossipFromDB(dataDir)
+            nodeMetricsReset = stripGossipFromDB(dataDir)
 
             val lspPubkey = LspPreferencesManager.getLspPubkey(this)
             val lspAddress = LspPreferencesManager.getLspAddress(this)
@@ -574,6 +580,34 @@ class StabilityProcessingService : Service() {
 
         Log.d(TAG, "Sending stability payment: $amountMsat msat ($$dollarsFromPar)")
 
+        // Chain-freshness gate (see #243): never keysend on a stale chain tip — an outbound
+        // HTLC built on an old best block understates its expiry, and LDK later force-closes
+        // on it. If stale, wait for LDK's background sync within this service's existing
+        // work budget. Checked BEFORE the claim so a deferral never leaves a
+        // claimed-but-unsent marker that would block the foreground retry.
+        val initialSyncAge = lightningSyncAgeSecs(node)
+        logStabilityGateEvent("stability_background_attempted", initialSyncAge, waitedMs = 0)
+        var waitedMs = 0L
+        if (!lightningSyncIsFresh(node)) {
+            val waitStart = System.currentTimeMillis()
+            val waitDeadline = waitStart + POLL_TIMEOUT_SECS * 1000L
+            while (System.currentTimeMillis() < waitDeadline && !lightningSyncIsFresh(node)) {
+                Thread.sleep(SYNC_FRESHNESS_POLL_MS)
+            }
+            waitedMs = System.currentTimeMillis() - waitStart
+            if (!lightningSyncIsFresh(node)) {
+                logStabilityGateEvent(
+                    "stability_background_deferred_stale_sync", initialSyncAge, waitedMs
+                )
+                Log.w(TAG, "Lightning sync still stale after ${waitedMs}ms — deferring to foreground")
+                FCMService.flagPendingPayment(this)
+                return
+            }
+            logStabilityGateEvent("stability_background_sent_after_sync", initialSyncAge, waitedMs)
+        } else {
+            logStabilityGateEvent("stability_background_sent_fresh", initialSyncAge, waitedMs)
+        }
+
         // Atomically claim the send before starting it. If another process (foreground timer)
         // already holds the marker, the claim is denied and we skip this tick — this is the
         // check-and-set that prevents a double send.
@@ -623,6 +657,30 @@ class StabilityProcessingService : Service() {
         }
         clearPendingSendInDB(dbPath)
         Log.d(TAG, "Recorded outgoing payment and updated backingSats -= $amountSats atomically")
+    }
+
+    private fun lightningSyncAgeSecs(node: Node): Long? =
+        StabilityFreshness.syncAgeSecs(
+            node.status().latestLightningWalletSyncTimestamp?.toLong(),
+            System.currentTimeMillis() / 1000
+        )
+
+    private fun lightningSyncIsFresh(node: Node): Boolean =
+        StabilityFreshness.isFresh(
+            node.status().latestLightningWalletSyncTimestamp?.toLong(),
+            System.currentTimeMillis() / 1000
+        )
+
+    /** Structured pilot metric for the background user_to_lsp freshness gate. No wallet
+     *  secrets or payment identifiers — platform, sync age, wait time, and strip state only. */
+    private fun logStabilityGateEvent(event: String, prevSyncAgeSecs: Long?, waitedMs: Long) {
+        val json = JSONObject()
+            .put("event", event)
+            .put("platform", "android")
+            .put("prev_sync_age_secs", prevSyncAgeSecs ?: JSONObject.NULL)
+            .put("waited_ms", waitedMs)
+            .put("node_metrics_reset", nodeMetricsReset)
+        Log.i(TAG, "STABILITY_GATE $json")
     }
 
     /** Resolve any leftover pending-send marker. Returns true when no unresolved marker
@@ -935,10 +993,14 @@ class StabilityProcessingService : Service() {
      * Delete network_graph, scorer, and node_metrics from the LDK SQLite DB.
      * The background service doesn't need gossip (it only routes to the LSP, a direct peer).
      * This reduces the DB from ~10MB to ~30KB, preventing OOM on low-memory devices.
+     *
+     * Returns true when node_metrics was deleted: that resets LDK's persisted
+     * latest_lightning_wallet_sync_timestamp, so the freshness gate must wait for a new
+     * sync on this run instead of inheriting the foreground app's recent one.
      */
-    private fun stripGossipFromDB(dataDir: File) {
+    private fun stripGossipFromDB(dataDir: File): Boolean {
         val ldkDbPath = File(dataDir, "ldk_node_data.sqlite")
-        if (!ldkDbPath.exists()) return
+        if (!ldkDbPath.exists()) return false
 
         try {
             val db = SQLiteDatabase.openDatabase(ldkDbPath.absolutePath, null, SQLiteDatabase.OPEN_READWRITE)
@@ -947,7 +1009,8 @@ class StabilityProcessingService : Service() {
             val cursor = db.rawQuery("SELECT LENGTH(value) FROM ldk_node_data WHERE key = 'network_graph'", null)
             val graphSize = cursor.use { if (it.moveToFirst()) it.getInt(0) else 0 }
 
-            if (graphSize > 100_000) {
+            val stripped = graphSize > 100_000
+            if (stripped) {
                 db.execSQL("DELETE FROM ldk_node_data WHERE key = 'network_graph'")
                 db.execSQL("DELETE FROM ldk_node_data WHERE key = 'scorer'")
                 db.execSQL("DELETE FROM ldk_node_data WHERE key = 'node_metrics'")
@@ -956,8 +1019,10 @@ class StabilityProcessingService : Service() {
                 Log.d(TAG, "Gossip data small ($graphSize bytes), skipping strip")
             }
             db.close()
+            return stripped
         } catch (e: Exception) {
             Log.w(TAG, "Failed to strip gossip from LDK DB: ${e.message}")
+            return false
         }
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import com.stablechannels.app.util.LspPreferencesManager
+import com.stablechannels.app.util.StabilityFreshness
 import org.lightningdevkit.ldknode.*
 import java.io.File
 
@@ -255,6 +256,28 @@ class NodeService(private val context: Context) {
         return n.spontaneousPayment().sendWithCustomTlvs(amountMsat.toULong(), toNodeId, null, tlvs)
     }
 
+    /** Age in seconds of LDK's last successful Lightning-wallet chain sync, or null when the
+     *  node isn't running, the wallet has never synced, or the timestamp is in the future. */
+    fun lightningSyncAgeSecs(): Long? {
+        val n = node ?: return null
+        val ts = n.status().latestLightningWalletSyncTimestamp?.toLong()
+        return StabilityFreshness.syncAgeSecs(ts, System.currentTimeMillis() / 1000)
+    }
+
+    /** Send-boundary gate for stability payments (see #243): all foreground stability sends
+     *  must go through this wrapper, which refuses to pay on a stale chain tip. Throws
+     *  [StaleLightningSyncException] so the caller can release its send claim and retry on
+     *  the next stability tick once LDK's background sync catches up. */
+    fun sendStabilityPayment(amountMsat: Long, toNodeId: String, tlvs: List<CustomTlvRecord>): String {
+        val n = node ?: throw NodeServiceError()
+        val ts = n.status().latestLightningWalletSyncTimestamp?.toLong()
+        val now = System.currentTimeMillis() / 1000
+        if (!StabilityFreshness.isFresh(ts, now)) {
+            throw StaleLightningSyncException(StabilityFreshness.syncAgeSecs(ts, now))
+        }
+        return n.spontaneousPayment().sendWithCustomTlvs(amountMsat.toULong(), toNodeId, null, tlvs)
+    }
+
     fun receivePayment(amountMsat: Long, description: String): Bolt11Invoice {
         val n = node ?: throw NodeServiceError()
         return n.bolt11Payment().receive(
@@ -378,4 +401,9 @@ class NodeService(private val context: Context) {
     }
 
     class NodeServiceError : Exception("Node not running")
+
+    /** Thrown by [sendStabilityPayment] when the Lightning wallet's chain sync is too old
+     *  to safely pay. [syncAgeSecs] is null when the wallet has never synced. */
+    class StaleLightningSyncException(val syncAgeSecs: Long?) :
+        Exception("Lightning wallet sync is stale (age=${syncAgeSecs ?: "never"}s)")
 }

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -41,6 +41,11 @@ object Constants {
     const val STABILITY_THRESHOLD_PERCENT: Double = 0.1
     const val STABILITY_THRESHOLD_USD: Double = 0.25
     const val STABILITY_PAYMENT_COOLDOWN_SECS: Long = 120
+
+    // A stability payment may only be sent when the Lightning wallet synced to chain within
+    // this window (two 60s background sync intervals, so one missed tick is tolerated).
+    // Keep in sync with STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS in src/constants.rs.
+    const val STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS: Long = 120
     const val MIN_DISPLAY_USD: Double = 2.0
     const val MAX_CHANNEL_USD: Double = 100.0
     /** Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount. */

--- a/android/app/src/main/java/com/stablechannels/app/util/StabilityFreshness.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/StabilityFreshness.kt
@@ -1,0 +1,35 @@
+package com.stablechannels.app.util
+
+/**
+ * Chain-freshness rule for stability payments (see #243).
+ *
+ * A stability payment may only be sent when LDK completed a Lightning-wallet chain sync
+ * within [Constants.STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS]. Paying on a stale chain tip
+ * understates outbound HTLC expiry, which LDK later force-closes on.
+ *
+ * Keep in sync with `lightning_sync_is_fresh` in `src/stable.rs` and `StabilityFreshness`
+ * in the iOS app.
+ */
+object StabilityFreshness {
+
+    /**
+     * True when [latestSyncTimestampSecs] exists, is not in the future, and is at most
+     * [maxAgeSecs] old (exactly [maxAgeSecs] old is accepted). A missing timestamp means
+     * the wallet has never synced; a future one means clock skew — both block the send.
+     */
+    fun isFresh(
+        latestSyncTimestampSecs: Long?,
+        nowSecs: Long,
+        maxAgeSecs: Long = Constants.STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS
+    ): Boolean {
+        if (latestSyncTimestampSecs == null) return false
+        if (latestSyncTimestampSecs > nowSecs) return false
+        return nowSecs - latestSyncTimestampSecs <= maxAgeSecs
+    }
+
+    /** Age of the last sync in seconds, or null when missing or in the future. */
+    fun syncAgeSecs(latestSyncTimestampSecs: Long?, nowSecs: Long): Long? {
+        if (latestSyncTimestampSecs == null || latestSyncTimestampSecs > nowSecs) return null
+        return nowSecs - latestSyncTimestampSecs
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/StabilityFreshnessTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/StabilityFreshnessTest.kt
@@ -1,0 +1,57 @@
+package com.stablechannels.app
+
+import com.stablechannels.app.util.Constants
+import com.stablechannels.app.util.StabilityFreshness
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Chain-freshness rule for stability payments (see #243): a stability payment may only be
+ * sent when LDK completed a Lightning-wallet sync within the last 120 seconds.
+ */
+class StabilityFreshnessTest {
+
+    private val now = 1_000_000L
+    private val maxAge = Constants.STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS
+
+    @Test
+    fun `missing timestamp blocks the send`() {
+        assertFalse(StabilityFreshness.isFresh(null, now))
+    }
+
+    @Test
+    fun `future timestamp blocks the send`() {
+        assertFalse(StabilityFreshness.isFresh(now + 1, now))
+    }
+
+    @Test
+    fun `timestamp older than the window blocks the send`() {
+        assertFalse(StabilityFreshness.isFresh(now - maxAge - 1, now))
+    }
+
+    @Test
+    fun `timestamp exactly at the window boundary is accepted`() {
+        assertTrue(StabilityFreshness.isFresh(now - maxAge, now))
+    }
+
+    @Test
+    fun `fresh timestamp is accepted`() {
+        assertTrue(StabilityFreshness.isFresh(now, now))
+        assertTrue(StabilityFreshness.isFresh(now - 1, now))
+    }
+
+    @Test
+    fun `sync age is null for missing or future timestamps`() {
+        assertNull(StabilityFreshness.syncAgeSecs(null, now))
+        assertNull(StabilityFreshness.syncAgeSecs(now + 1, now))
+    }
+
+    @Test
+    fun `sync age reports seconds since the last sync`() {
+        assertEquals(0L, StabilityFreshness.syncAgeSecs(now, now))
+        assertEquals(90L, StabilityFreshness.syncAgeSecs(now - 90, now))
+    }
+}

--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -80,12 +80,13 @@ enum StabilityFreshness {
 class NotificationService: UNNotificationServiceExtension {
     // MARK: - Constants
 
-    /// user_to_lsp only: how long after `extensionStart` the freshness wait may run. iOS
-    /// grants the extension ~30s total; stopping the wait at +20s reserves ~10s for the
-    /// send, persistence, notification mutation, and cleanup. This is an outer limit, not a
-    /// promise — node build, LSP connect, and price work all consume part of it.
+    /// user_to_lsp only: how long after `extensionStart` the handler's chain-freshness wait
+    /// may run (see StabilitySyncGate). iOS grants the extension ~30s total; the +20s
+    /// deadline reserves ~10s for the send, persistence, notification mutation, and
+    /// cleanup. This is an outer limit, not a promise — node build, LSP connect, and price
+    /// work all consume part of it, and the deadline is authoritative even over a sync that
+    /// becomes fresh late.
     private static let userToLspFreshnessDeadlineSecs: TimeInterval = 20
-    private static let freshnessPollIntervalSecs: TimeInterval = 0.5
 
     // MARK: - Dependencies (injected for testability)
 
@@ -297,34 +298,6 @@ class NotificationService: UNNotificationServiceExtension {
             Thread.sleep(forTimeInterval: 3)
 
             startHeartbeat()
-
-            // Chain-freshness gate (see #243) — user_to_lsp only: never keysend on a stale
-            // chain tip. An outbound HTLC built on an old best block understates its expiry,
-            // and LDK later force-closes on it. Waits here on the background processing
-            // queue (never the main thread), before any send claim is taken.
-            if direction == .userToLsp {
-                switch waitForFreshLightningSync(node: node) {
-                case .fresh:
-                    break
-                case .deadlineReached:
-                    stopHeartbeat()
-                    UserDefaults(suiteName: Constants.appGroup)?.set(true, forKey: "pending_push_payment")
-                    cleanup()
-                    finish(contentMutator.buildPending(
-                        base: content,
-                        title: "Payment Pending",
-                        body: "Open app to process stability payment"
-                    ))
-                    return
-                case .cancelled:
-                    // Expiry got there first: the expire handler already set the pending
-                    // flag and delivered the notification. Just hand back the wallet dir.
-                    stopHeartbeat()
-                    cleanup()
-                    return
-                }
-            }
-
             processPayment(
                 node: node,
                 content: content,
@@ -354,7 +327,24 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
 
-        let handler = PaymentHandlerFactory.handler(for: direction)
+        // The user_to_lsp handler waits for a fresh Lightning-wallet sync at its send
+        // boundary (see #243); this gate lets that wait observe the extension lifecycle
+        // (checked under the lock each iteration) and the extension-wide deadline.
+        let syncGate: StabilitySyncGate? = direction == .userToLsp
+            ? StabilitySyncGate(
+                deadline: extensionStart.addingTimeInterval(Self.userToLspFreshnessDeadlineSecs),
+                isCancelled: { [weak self] in
+                    guard let self else { return true }
+                    self.lifecycleLock.lock()
+                    let cancelled = self.timeExpired || self.didFinish
+                    self.lifecycleLock.unlock()
+                    return cancelled
+                },
+                log: { [logger] message in logger.log(message) }
+            )
+            : nil
+
+        let handler = PaymentHandlerFactory.handler(for: direction, syncGate: syncGate)
         handler
             .handle(node: node, db: db, priceFetcher: priceFetcher, baseContent: content,
                     mutator: contentMutator) { [weak self] resultContent, newPendingState in
@@ -371,68 +361,6 @@ class NotificationService: UNNotificationServiceExtension {
                 self.cleanup()
                 self.finish(resultContent)
             }
-    }
-
-    private enum FreshnessWaitOutcome {
-        case fresh
-        case deadlineReached
-        case cancelled
-    }
-
-    /// Poll `node.status()` every 500ms until the Lightning-wallet sync timestamp is fresh,
-    /// the extension-wide deadline (`extensionStart` + 20s) passes, or the run is cancelled
-    /// by expiry. The timestamp is persisted by LDK, so a run that kept node_metrics can be
-    /// fresh immediately off the main app's last sync; otherwise this rides the initial
-    /// background sync ldk-node kicks off at start(). Each iteration re-checks lifecycle
-    /// state under the lock so expiry cancels the wait promptly.
-    private func waitForFreshLightningSync(node: Node) -> FreshnessWaitOutcome {
-        let deadline = extensionStart.addingTimeInterval(Self.userToLspFreshnessDeadlineSecs)
-        let initialAge = StabilityFreshness.syncAgeSecs(
-            node.status().latestLightningWalletSyncTimestamp,
-            now: UInt64(Date().timeIntervalSince1970)
-        )
-        let waitStart = Date()
-        logGateEvent("stability_background_attempted", initialAge: initialAge, waitStart: waitStart)
-
-        var waited = false
-        while true {
-            lifecycleLock.lock()
-            let aborted = timeExpired || didFinish
-            lifecycleLock.unlock()
-            if aborted {
-                logGateEvent("stability_background_deferred_stale_sync",
-                             initialAge: initialAge, waitStart: waitStart, outcome: "cancelled")
-                return .cancelled
-            }
-            let now = UInt64(Date().timeIntervalSince1970)
-            if StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: now) {
-                logGateEvent(waited ? "stability_background_sent_after_sync" : "stability_background_sent_fresh",
-                             initialAge: initialAge, waitStart: waitStart, outcome: "fresh")
-                return .fresh
-            }
-            if Date() >= deadline {
-                logGateEvent("stability_background_deferred_stale_sync",
-                             initialAge: initialAge, waitStart: waitStart, outcome: "deadline_reached")
-                return .deadlineReached
-            }
-            waited = true
-            Thread.sleep(forTimeInterval: Self.freshnessPollIntervalSecs)
-        }
-    }
-
-    /// Structured pilot metric for the background user_to_lsp freshness gate. No wallet
-    /// secrets or payment identifiers — platform, sync age, wait time, and outcome only.
-    private func logGateEvent(
-        _ event: String, initialAge: UInt64?, waitStart: Date, outcome: String? = nil
-    ) {
-        let waitedMs = Int(Date().timeIntervalSince(waitStart) * 1000)
-        let age = initialAge.map { "\($0)" } ?? "null"
-        let outcomeJson = outcome.map { "\"\($0)\"" } ?? "null"
-        logger.log(
-            "stability_gate {\"event\":\"\(event)\",\"platform\":\"ios\"," +
-                "\"prev_sync_age_secs\":\(age),\"waited_ms\":\(waitedMs)," +
-                "\"deadline_outcome\":\(outcomeJson)}"
-        )
     }
 
     private func finishWithError(

--- a/ios/StableChannels/NotificationService/NotificationService.swift
+++ b/ios/StableChannels/NotificationService/NotificationService.swift
@@ -49,10 +49,43 @@ final class NodeDirLock: @unchecked Sendable {
     }
 }
 
+/// Chain-freshness rule for stability payments (see #243): a user_to_lsp stability payment
+/// may only be sent when LDK completed a Lightning-wallet chain sync within
+/// `maxAgeSecs`. Paying on a stale chain tip understates outbound HTLC expiry, which LDK
+/// later force-closes on. The timestamp is persisted by LDK (node_metrics), so a run whose
+/// gossip strip kept node_metrics can inherit the main app's recent sync and send at once.
+///
+/// Keep in sync with `lightning_sync_is_fresh` in `src/stable.rs` and the copy in
+/// StableChannels/Services/NodeService.swift.
+enum StabilityFreshness {
+    /// Keep in sync with STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS in src/constants.rs.
+    static let maxAgeSecs: UInt64 = 120
+
+    /// True when the timestamp exists, is not in the future, and is at most `maxAgeSecs`
+    /// old (exactly `maxAgeSecs` old is accepted).
+    static func isFresh(_ latestSyncTimestampSecs: UInt64?, now nowSecs: UInt64) -> Bool {
+        guard let ts = latestSyncTimestampSecs, ts <= nowSecs else { return false }
+        return nowSecs - ts <= maxAgeSecs
+    }
+
+    /// Age of the last sync in seconds, or nil when missing or in the future.
+    static func syncAgeSecs(_ latestSyncTimestampSecs: UInt64?, now nowSecs: UInt64) -> UInt64? {
+        guard let ts = latestSyncTimestampSecs, ts <= nowSecs else { return nil }
+        return nowSecs - ts
+    }
+}
+
 /// Notification Service Extension — handles stability payments while main app is killed.
 /// Uses dependency injection for testability and SOLID compliance.
 class NotificationService: UNNotificationServiceExtension {
     // MARK: - Constants
+
+    /// user_to_lsp only: how long after `extensionStart` the freshness wait may run. iOS
+    /// grants the extension ~30s total; stopping the wait at +20s reserves ~10s for the
+    /// send, persistence, notification mutation, and cleanup. This is an outer limit, not a
+    /// promise — node build, LSP connect, and price work all consume part of it.
+    private static let userToLspFreshnessDeadlineSecs: TimeInterval = 20
+    private static let freshnessPollIntervalSecs: TimeInterval = 0.5
 
     // MARK: - Dependencies (injected for testability)
 
@@ -67,6 +100,11 @@ class NotificationService: UNNotificationServiceExtension {
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var bestAttemptContent: UNMutableNotificationContent?
     private var node: Node?
+
+    /// When this run's notification arrived — anchor for the user_to_lsp freshness
+    /// deadline. Recorded before node build or price work so those costs count against
+    /// the wait budget, not on top of it.
+    private var extensionStart = Date()
 
     /// Coordinates serviceExtensionTimeWillExpire with an in-flight node
     /// build: while `buildInFlight`, the expire handler must NOT release the
@@ -97,6 +135,7 @@ class NotificationService: UNNotificationServiceExtension {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
+        extensionStart = Date()
         self.contentHandler = contentHandler
         self.bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
@@ -258,6 +297,34 @@ class NotificationService: UNNotificationServiceExtension {
             Thread.sleep(forTimeInterval: 3)
 
             startHeartbeat()
+
+            // Chain-freshness gate (see #243) — user_to_lsp only: never keysend on a stale
+            // chain tip. An outbound HTLC built on an old best block understates its expiry,
+            // and LDK later force-closes on it. Waits here on the background processing
+            // queue (never the main thread), before any send claim is taken.
+            if direction == .userToLsp {
+                switch waitForFreshLightningSync(node: node) {
+                case .fresh:
+                    break
+                case .deadlineReached:
+                    stopHeartbeat()
+                    UserDefaults(suiteName: Constants.appGroup)?.set(true, forKey: "pending_push_payment")
+                    cleanup()
+                    finish(contentMutator.buildPending(
+                        base: content,
+                        title: "Payment Pending",
+                        body: "Open app to process stability payment"
+                    ))
+                    return
+                case .cancelled:
+                    // Expiry got there first: the expire handler already set the pending
+                    // flag and delivered the notification. Just hand back the wallet dir.
+                    stopHeartbeat()
+                    cleanup()
+                    return
+                }
+            }
+
             processPayment(
                 node: node,
                 content: content,
@@ -304,6 +371,68 @@ class NotificationService: UNNotificationServiceExtension {
                 self.cleanup()
                 self.finish(resultContent)
             }
+    }
+
+    private enum FreshnessWaitOutcome {
+        case fresh
+        case deadlineReached
+        case cancelled
+    }
+
+    /// Poll `node.status()` every 500ms until the Lightning-wallet sync timestamp is fresh,
+    /// the extension-wide deadline (`extensionStart` + 20s) passes, or the run is cancelled
+    /// by expiry. The timestamp is persisted by LDK, so a run that kept node_metrics can be
+    /// fresh immediately off the main app's last sync; otherwise this rides the initial
+    /// background sync ldk-node kicks off at start(). Each iteration re-checks lifecycle
+    /// state under the lock so expiry cancels the wait promptly.
+    private func waitForFreshLightningSync(node: Node) -> FreshnessWaitOutcome {
+        let deadline = extensionStart.addingTimeInterval(Self.userToLspFreshnessDeadlineSecs)
+        let initialAge = StabilityFreshness.syncAgeSecs(
+            node.status().latestLightningWalletSyncTimestamp,
+            now: UInt64(Date().timeIntervalSince1970)
+        )
+        let waitStart = Date()
+        logGateEvent("stability_background_attempted", initialAge: initialAge, waitStart: waitStart)
+
+        var waited = false
+        while true {
+            lifecycleLock.lock()
+            let aborted = timeExpired || didFinish
+            lifecycleLock.unlock()
+            if aborted {
+                logGateEvent("stability_background_deferred_stale_sync",
+                             initialAge: initialAge, waitStart: waitStart, outcome: "cancelled")
+                return .cancelled
+            }
+            let now = UInt64(Date().timeIntervalSince1970)
+            if StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: now) {
+                logGateEvent(waited ? "stability_background_sent_after_sync" : "stability_background_sent_fresh",
+                             initialAge: initialAge, waitStart: waitStart, outcome: "fresh")
+                return .fresh
+            }
+            if Date() >= deadline {
+                logGateEvent("stability_background_deferred_stale_sync",
+                             initialAge: initialAge, waitStart: waitStart, outcome: "deadline_reached")
+                return .deadlineReached
+            }
+            waited = true
+            Thread.sleep(forTimeInterval: Self.freshnessPollIntervalSecs)
+        }
+    }
+
+    /// Structured pilot metric for the background user_to_lsp freshness gate. No wallet
+    /// secrets or payment identifiers — platform, sync age, wait time, and outcome only.
+    private func logGateEvent(
+        _ event: String, initialAge: UInt64?, waitStart: Date, outcome: String? = nil
+    ) {
+        let waitedMs = Int(Date().timeIntervalSince(waitStart) * 1000)
+        let age = initialAge.map { "\($0)" } ?? "null"
+        let outcomeJson = outcome.map { "\"\($0)\"" } ?? "null"
+        logger.log(
+            "stability_gate {\"event\":\"\(event)\",\"platform\":\"ios\"," +
+                "\"prev_sync_age_secs\":\(age),\"waited_ms\":\(waitedMs)," +
+                "\"deadline_outcome\":\(outcomeJson)}"
+        )
     }
 
     private func finishWithError(

--- a/ios/StableChannels/NotificationService/Services/NodeStarter.swift
+++ b/ios/StableChannels/NotificationService/Services/NodeStarter.swift
@@ -24,7 +24,13 @@ final class DefaultNodeStarter: NodeStarter {
         let dbSize = (attrs?[.size] as? UInt64) ?? 0
         logger.log("ldk_node_data size: \(dbSize / 1024 / 1024) MB")
 
-        Self.stripGossipFromDB(path: ldkDbPath.path)
+        // A strip deletes node_metrics along with the graph, resetting LDK's persisted
+        // latest_lightning_wallet_sync_timestamp — so on strip runs the freshness gate must
+        // wait for a new sync instead of inheriting the main app's recent one. Logged so the
+        // pilot metrics can split immediate-send runs from forced-resync runs.
+        let nodeMetricsReset = Self.stripGossipFromDB(path: ldkDbPath.path)
+        logger
+            .log("stability_gate {\"event\":\"node_metrics_reset\",\"platform\":\"ios\",\"reset\":\(nodeMetricsReset)}")
 
         // Node config
         var config = LDKNode.defaultConfig()
@@ -92,14 +98,16 @@ final class DefaultNodeStarter: NodeStarter {
         )
     }
 
-    private static func stripGossipFromDB(path: String) {
+    /// Returns true when the strip ran and deleted node_metrics (resetting LDK's persisted
+    /// Lightning-sync timestamp along with the graph and scorer).
+    private static func stripGossipFromDB(path: String) -> Bool {
         var db: OpaquePointer?
-        guard sqlite3_open(path, &db) == SQLITE_OK else { return }
+        guard sqlite3_open(path, &db) == SQLITE_OK else { return false }
         defer { sqlite3_close(db) }
 
         var stmt: OpaquePointer?
         let sql = "SELECT LENGTH(value) FROM ldk_node_data WHERE key = 'network_graph'"
-        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
         let hasGraph: Bool
         if sqlite3_step(stmt) == SQLITE_ROW {
             let size = sqlite3_column_int64(stmt, 0)
@@ -115,5 +123,6 @@ final class DefaultNodeStarter: NodeStarter {
             sqlite3_exec(db, "DELETE FROM ldk_node_data WHERE key = 'node_metrics'", nil, nil, nil)
             sqlite3_exec(db, "VACUUM", nil, nil, nil)
         }
+        return hasGraph
     }
 }

--- a/ios/StableChannels/NotificationService/Services/Protocols/PaymentHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/Protocols/PaymentHandler.swift
@@ -17,11 +17,13 @@ protocol PaymentHandler {
 
 /// Factory to create the appropriate handler for a direction
 enum PaymentHandlerFactory {
-    static func handler(for direction: PaymentDirection) -> PaymentHandler {
+    /// `syncGate` carries the user_to_lsp chain-freshness wait context (see #243);
+    /// the other directions ignore it.
+    static func handler(for direction: PaymentDirection, syncGate: StabilitySyncGate? = nil) -> PaymentHandler {
         switch direction {
         case .lspToUser: return LSPToUserHandler()
         case .incomingPayment: return IncomingPaymentHandler()
-        case .userToLsp: return UserToLSPHandler()
+        case .userToLsp: return UserToLSPHandler(syncGate: syncGate)
         }
     }
 }

--- a/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
@@ -93,6 +93,23 @@ final class UserToLSPHandler: PaymentHandler {
         let amountMsat = UInt64(btcAmount * Constants.satsInBTC * 1000)
         let amountSats = amountMsat / 1000
 
+        // Final chain-freshness gate at the send boundary (see #243). NotificationService
+        // already waited for a fresh sync before dispatching here; this backstop catches the
+        // sync going stale in between. Checked BEFORE the claim so a deferral never leaves a
+        // claimed-but-unsent marker that would block the foreground retry.
+        let nowSecs = UInt64(Date().timeIntervalSince1970)
+        guard StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: nowSecs) else {
+            completion(
+                mutator.buildPending(
+                    base: baseContent,
+                    title: "Payment Pending",
+                    body: "Open app to process stability payment"
+                ),
+                true
+            )
+            return
+        }
+
         // Claim slot
         guard db.claimPendingSend(amountMsat: amountMsat, price: price) else {
             completion(

--- a/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
@@ -2,9 +2,31 @@ import Foundation
 import UserNotifications
 import LDKNode
 
+/// Deadline- and cancellation-aware context for the user_to_lsp chain-freshness wait,
+/// built by NotificationService so the handler's wait observes the extension lifecycle.
+struct StabilitySyncGate {
+    /// Absolute wall-clock limit for the wait (extensionStart + 20s). The deadline is
+    /// authoritative: once passed, the run defers even if a sync just became fresh, so the
+    /// reserved tail of the execution window is never consumed by payment work started late.
+    let deadline: Date
+    /// True once the run expired or already finished; polled between wait iterations
+    /// (reads the extension's lifecycle state under its lock).
+    let isCancelled: () -> Bool
+    /// Structured pilot-metric sink (the extension's file logger).
+    let log: (String) -> Void
+}
+
 /// Handler for "user_to_lsp" direction - calculate and send payment to LSP
 final class UserToLSPHandler: PaymentHandler {
     var direction: PaymentDirection { .userToLsp }
+
+    private static let syncPollIntervalSecs: TimeInterval = 0.5
+
+    private let syncGate: StabilitySyncGate?
+
+    init(syncGate: StabilitySyncGate? = nil) {
+        self.syncGate = syncGate
+    }
 
     func handle(
         node: LDKNode.Node,
@@ -93,21 +115,54 @@ final class UserToLSPHandler: PaymentHandler {
         let amountMsat = UInt64(btcAmount * Constants.satsInBTC * 1000)
         let amountSats = amountMsat / 1000
 
-        // Final chain-freshness gate at the send boundary (see #243). NotificationService
-        // already waited for a fresh sync before dispatching here; this backstop catches the
-        // sync going stale in between. Checked BEFORE the claim so a deferral never leaves a
-        // claimed-but-unsent marker that would block the foreground retry.
-        let nowSecs = UInt64(Date().timeIntervalSince1970)
-        guard StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: nowSecs) else {
-            completion(
-                mutator.buildPending(
-                    base: baseContent,
-                    title: "Payment Pending",
-                    body: "Open app to process stability payment"
-                ),
-                true
-            )
-            return
+        // Chain-freshness gate at the send boundary (see #243): never keysend on a stale
+        // chain tip — an outbound HTLC built on an old best block understates its expiry,
+        // and LDK later force-closes on it. The gate sits here, after the cooldown/threshold
+        // checks and the price fetch, so stable positions never wait or defer, and LDK's
+        // background sync runs concurrently with the price work above. Checked BEFORE the
+        // claim so a deferral never leaves a claimed-but-unsent marker.
+        let gateStart = Date()
+        let initialSyncAge = StabilityFreshness.syncAgeSecs(
+            node.status().latestLightningWalletSyncTimestamp,
+            now: UInt64(gateStart.timeIntervalSince1970)
+        )
+        logGateEvent("stability_background_attempted", initialAge: initialSyncAge, gateStart: gateStart)
+        var waitedForSync = false
+        while true {
+            // Order matters: cancellation, then deadline, then freshness — a fresh sync
+            // observed after the deadline still defers, keeping the reserved execution
+            // budget intact for runs that started slow.
+            if let gate = syncGate, gate.isCancelled() {
+                logGateEvent("stability_background_deferred_stale_sync",
+                             initialAge: initialSyncAge, gateStart: gateStart, outcome: "cancelled")
+                deferToForeground(baseContent: baseContent, mutator: mutator, completion: completion)
+                return
+            }
+            if let gate = syncGate, Date() >= gate.deadline {
+                logGateEvent("stability_background_deferred_stale_sync",
+                             initialAge: initialSyncAge, gateStart: gateStart, outcome: "deadline_reached")
+                deferToForeground(baseContent: baseContent, mutator: mutator, completion: completion)
+                return
+            }
+            let now = UInt64(Date().timeIntervalSince1970)
+            if StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: now) {
+                logGateEvent(
+                    waitedForSync ? "stability_background_fresh_after_wait" : "stability_background_fresh_ready",
+                    initialAge: initialSyncAge,
+                    gateStart: gateStart,
+                    outcome: "fresh"
+                )
+                break
+            }
+            guard syncGate != nil else {
+                // No wait context (direct construction) — single check, fail safe.
+                logGateEvent("stability_background_deferred_stale_sync",
+                             initialAge: initialSyncAge, gateStart: gateStart, outcome: "no_wait_context")
+                deferToForeground(baseContent: baseContent, mutator: mutator, completion: completion)
+                return
+            }
+            waitedForSync = true
+            Thread.sleep(forTimeInterval: Self.syncPollIntervalSecs)
         }
 
         // Claim slot
@@ -123,6 +178,18 @@ final class UserToLSPHandler: PaymentHandler {
             return
         }
 
+        // Re-check after the claim: the SQLite claim can take up to ~2s under cross-process
+        // contention and could carry the timestamp past the 120s boundary. No send happened,
+        // so clear the claim rather than blocking the foreground retry.
+        let nowAfterClaim = UInt64(Date().timeIntervalSince1970)
+        guard StabilityFreshness.isFresh(node.status().latestLightningWalletSyncTimestamp, now: nowAfterClaim) else {
+            db.clearPendingSend()
+            logGateEvent("stability_background_deferred_stale_sync",
+                         initialAge: initialSyncAge, gateStart: gateStart, outcome: "stale_after_claim")
+            deferToForeground(baseContent: baseContent, mutator: mutator, completion: completion)
+            return
+        }
+
         // Send keysend
         do {
             let tlvRecord = CustomTlvRecord(typeNum: Constants.stableChannelTLVType, value: Data([1]))
@@ -132,6 +199,11 @@ final class UserToLSPHandler: PaymentHandler {
                 routeParameters: nil,
                 customTlvs: [tlvRecord]
             )
+
+            // Only an accepted send counts as sent_* — cooldown, no-action, denied-claim,
+            // and send-failure runs must not inflate the pilot's send numbers.
+            logGateEvent(waitedForSync ? "stability_background_sent_after_sync" : "stability_background_sent_fresh",
+                         initialAge: initialSyncAge, gateStart: gateStart, outcome: "sent")
 
             // Payment ID Guard
             let guardSaved = db.setPendingSendPaymentId(paymentId: "\(paymentId)")
@@ -190,5 +262,39 @@ final class UserToLSPHandler: PaymentHandler {
                 true
             )
         }
+    }
+
+    /// Freshness-gate deferral: hand the payment to the foreground via the existing
+    /// pending-notification path. If the run was cancelled by expiry, the completion is
+    /// harmless — the extension's exactly-once finish already delivered the notification.
+    private func deferToForeground(
+        baseContent: UNMutableNotificationContent,
+        mutator: NotificationContentMutator,
+        completion: @escaping (UNMutableNotificationContent, Bool?) -> Void
+    ) {
+        completion(
+            mutator.buildPending(
+                base: baseContent,
+                title: "Payment Pending",
+                body: "Open app to process stability payment"
+            ),
+            true
+        )
+    }
+
+    /// Structured pilot metric for the user_to_lsp freshness gate. No wallet secrets or
+    /// payment identifiers — platform, sync age, wait time, and outcome only.
+    private func logGateEvent(
+        _ event: String, initialAge: UInt64?, gateStart: Date, outcome: String? = nil
+    ) {
+        guard let log = syncGate?.log else { return }
+        let waitedMs = Int(Date().timeIntervalSince(gateStart) * 1000)
+        let age = initialAge.map { "\($0)" } ?? "null"
+        let outcomeJson = outcome.map { "\"\($0)\"" } ?? "null"
+        log(
+            "stability_gate {\"event\":\"\(event)\",\"platform\":\"ios\"," +
+                "\"prev_sync_age_secs\":\(age),\"waited_ms\":\(waitedMs)," +
+                "\"deadline_outcome\":\(outcomeJson)}"
+        )
     }
 }

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -2163,6 +2163,18 @@ class AppState {
 
         guard let databaseService else { return }
 
+        // Chain-freshness gate (see #243): never pay on a stale chain tip, and check BEFORE
+        // claiming so a deferral leaves no claimed-but-unsent marker. The next stability
+        // tick retries once LDK's background sync catches up.
+        let syncAge = nodeService.lightningSyncAgeSecs()
+        guard let syncAge, syncAge <= Constants.stabilityMaxLightningSyncAgeSecs else {
+            AuditService.log("STABILITY_PAYMENT_SKIPPED", data: [
+                "reason": "stale_lightning_sync",
+                "sync_age_secs": syncAge.map { "\($0)" } ?? "never"
+            ])
+            return
+        }
+
         // Claim the durable send slot (cross-process atomic via BEGIN IMMEDIATE).
         // If the NSE — or a previous run — already holds it, abort this run.
         guard databaseService.stabilityRepo.claimPendingSend(amountMsat: amountMsat, price: price) else {
@@ -2178,11 +2190,19 @@ class AppState {
             // Tag with the STABLE_CHANNEL_TLV [0x01] marker so the LSP classifies
             // this as a settlement (operator GUI) and runs reconcile_incoming_stability
             // immediately, matching every other sender. See issue #161.
-            paymentId = try nodeService.sendKeysendWithTLV(
+            paymentId = try nodeService.sendStabilityPayment(
                 amountMsat: amountMsat,
                 to: stableChannel.counterparty,
                 tlvs: [CustomTlvRecord(typeNum: Constants.stableChannelTLVType, value: Data([1]))]
             )
+        } catch NodeServiceError.staleLightningSync {
+            // The wrapper's send-boundary gate fired (sync went stale after the precheck
+            // above). Send never happened — release the claim and retry next tick.
+            databaseService.stabilityRepo.clearPendingSend()
+            AuditService.log("STABILITY_PAYMENT_SKIPPED", data: [
+                "reason": "stale_lightning_sync"
+            ])
+            return
         } catch {
             databaseService.stabilityRepo.clearPendingSend()
             AuditService.log("STABILITY_PAYMENT_FAILED", data: [

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -470,6 +470,40 @@ class NodeService: NodeServiceProtocol {
         )
     }
 
+    /// Age in seconds of LDK's last successful Lightning-wallet chain sync, or nil when the
+    /// node isn't running, the wallet has never synced, or the timestamp is in the future.
+    func lightningSyncAgeSecs() -> UInt64? {
+        guard let node else { return nil }
+        return StabilityFreshness.syncAgeSecs(
+            node.status().latestLightningWalletSyncTimestamp,
+            now: UInt64(Date().timeIntervalSince1970)
+        )
+    }
+
+    /// Send-boundary gate for stability payments (see #243): all foreground stability sends
+    /// must go through this wrapper, which refuses to pay on a stale chain tip. Throws
+    /// `NodeServiceError.staleLightningSync` so the caller can release its send claim and
+    /// retry on the next stability tick once LDK's background sync catches up.
+    func sendStabilityPayment(
+        amountMsat: UInt64,
+        to nodeId: PublicKey,
+        tlvs: [CustomTlvRecord]
+    ) throws -> PaymentId {
+        guard let node else { throw NodeServiceError.notRunning }
+        let now = UInt64(Date().timeIntervalSince1970)
+        guard StabilityFreshness.isFresh(
+            node.status().latestLightningWalletSyncTimestamp, now: now
+        ) else {
+            throw NodeServiceError.staleLightningSync
+        }
+        return try node.spontaneousPayment().sendWithCustomTlvs(
+            amountMsat: amountMsat,
+            nodeId: nodeId,
+            routeParameters: nil,
+            customTlvs: tlvs
+        )
+    }
+
     func receivePayment(amountMsat: UInt64, description: String) throws -> Bolt11Invoice {
         guard let node else { throw NodeServiceError.notRunning }
         return try node.bolt11Payment().receive(
@@ -557,13 +591,41 @@ enum NodeServiceError: LocalizedError {
     case notRunning
     case alreadyRunning
     case dataDirLocked
+    case staleLightningSync
 
     var errorDescription: String? {
         switch self {
         case .notRunning: return "Node is not running"
         case .alreadyRunning: return "Node is already running"
         case .dataDirLocked: return "Wallet is busy in another process. Please try again."
+        case .staleLightningSync: return "Lightning wallet chain sync is too old to safely pay"
         }
+    }
+}
+
+/// Chain-freshness rule for stability payments (see #243): a stability payment may only be
+/// sent when LDK completed a Lightning-wallet chain sync within
+/// `Constants.stabilityMaxLightningSyncAgeSecs`. Paying on a stale chain tip understates
+/// outbound HTLC expiry, which LDK later force-closes on.
+///
+/// Keep in sync with `lightning_sync_is_fresh` in `src/stable.rs` and the NSE copy in
+/// NotificationService/NotificationService.swift.
+enum StabilityFreshness {
+    /// True when the timestamp exists, is not in the future, and is at most `maxAgeSecs`
+    /// old (exactly `maxAgeSecs` old is accepted).
+    static func isFresh(
+        _ latestSyncTimestampSecs: UInt64?,
+        now nowSecs: UInt64,
+        maxAgeSecs: UInt64 = Constants.stabilityMaxLightningSyncAgeSecs
+    ) -> Bool {
+        guard let ts = latestSyncTimestampSecs, ts <= nowSecs else { return false }
+        return nowSecs - ts <= maxAgeSecs
+    }
+
+    /// Age of the last sync in seconds, or nil when missing or in the future.
+    static func syncAgeSecs(_ latestSyncTimestampSecs: UInt64?, now nowSecs: UInt64) -> UInt64? {
+        guard let ts = latestSyncTimestampSecs, ts <= nowSecs else { return nil }
+        return nowSecs - ts
     }
 }
 

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -59,6 +59,11 @@ enum Constants {
     static let stabilityThresholdPercent: Double = 0.1
     static let stabilityThresholdUSD: Double = 0.25
     static let stabilityPaymentCooldownSecs: UInt64 = 120
+    /// A stability payment may only be sent when the Lightning wallet synced to chain within
+    /// this window (two 60s background sync intervals, so one missed tick is tolerated).
+    /// Keep in sync with STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS in src/constants.rs and the
+    /// NSE's copy in NotificationService.swift.
+    static let stabilityMaxLightningSyncAgeSecs: UInt64 = 120
     static let minDisplayUSD: Double = 2.0
     static let maxChannelUSD: Double = 100.0
     /// Stable-channel trade fee paid to the LSP as the TRADE_V1 keysend amount.

--- a/ios/StableChannels/StableChannelsTests/StabilityServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/StabilityServiceTests.swift
@@ -306,4 +306,34 @@ final class StabilityServiceTests: XCTestCase {
         let result = StabilityService.checkStabilityAction(sc, price: 200_000.0)
         XCTAssertEqual(result.action, .pay)
     }
+
+    // MARK: - StabilityFreshness (chain-freshness gate for stability sends, see #243)
+
+    private let freshnessNow: UInt64 = 1_000_000
+
+    func testMissingSyncTimestampBlocksSend() {
+        XCTAssertFalse(StabilityFreshness.isFresh(nil, now: freshnessNow))
+        XCTAssertNil(StabilityFreshness.syncAgeSecs(nil, now: freshnessNow))
+    }
+
+    func testFutureSyncTimestampBlocksSend() {
+        XCTAssertFalse(StabilityFreshness.isFresh(freshnessNow + 1, now: freshnessNow))
+        XCTAssertNil(StabilityFreshness.syncAgeSecs(freshnessNow + 1, now: freshnessNow))
+    }
+
+    func testSyncTimestampOlderThanWindowBlocksSend() {
+        let maxAge = Constants.stabilityMaxLightningSyncAgeSecs
+        XCTAssertFalse(StabilityFreshness.isFresh(freshnessNow - maxAge - 1, now: freshnessNow))
+    }
+
+    func testSyncTimestampExactlyAtWindowBoundaryIsAccepted() {
+        let maxAge = Constants.stabilityMaxLightningSyncAgeSecs
+        XCTAssertTrue(StabilityFreshness.isFresh(freshnessNow - maxAge, now: freshnessNow))
+    }
+
+    func testFreshSyncTimestampIsAccepted() {
+        XCTAssertTrue(StabilityFreshness.isFresh(freshnessNow, now: freshnessNow))
+        XCTAssertTrue(StabilityFreshness.isFresh(freshnessNow - 1, now: freshnessNow))
+        XCTAssertEqual(StabilityFreshness.syncAgeSecs(freshnessNow - 90, now: freshnessNow), 90)
+    }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -77,6 +77,11 @@ pub const ONCHAIN_WALLET_SYNC_INTERVAL_SECS: u64 = 120;
 pub const LIGHTNING_WALLET_SYNC_INTERVAL_SECS: u64 = 60;
 pub const FEE_RATE_CACHE_UPDATE_INTERVAL_SECS: u64 = 1200;
 
+/// A stability payment may only be sent when the Lightning wallet completed a chain sync
+/// within this window. Paying on a stale chain tip understates outbound HTLC expiry, which
+/// LDK later force-closes on. Two background sync intervals, so one missed tick is tolerated.
+pub const STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS: u64 = 120;
+
 /// Invoice expiration time (in seconds)
 pub const INVOICE_EXPIRY_SECS: u32 = 3600;
 

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -1,8 +1,9 @@
 use crate::audit::audit_event;
 use crate::constants::{
-    MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_PAYMENT_AUTH_TTL_SECS,
-    STABILITY_PAYMENT_CLOCK_SKEW_SECS, STABILITY_PAYMENT_COOLDOWN_SECS,
-    STABILITY_PAYMENT_MESSAGE_TYPE, STABILITY_THRESHOLD_PERCENT, STABILITY_THRESHOLD_USD,
+    MAX_RISK_LEVEL, SATS_IN_BTC, STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS,
+    STABILITY_PAYMENT_AUTH_TTL_SECS, STABILITY_PAYMENT_CLOCK_SKEW_SECS,
+    STABILITY_PAYMENT_COOLDOWN_SECS, STABILITY_PAYMENT_MESSAGE_TYPE,
+    STABILITY_THRESHOLD_PERCENT, STABILITY_THRESHOLD_USD,
 };
 use crate::price_feeds::get_fresh_cached_price_no_fetch;
 use crate::types::{Bitcoin, StableChannel, USD};
@@ -785,6 +786,22 @@ pub fn backing_after_lsp_to_user_stability(
         .map(|backing| backing.min(equilibrium))
 }
 
+/// Whether the Lightning wallet's last successful chain sync is recent enough to send a
+/// stability payment. A missing timestamp (never synced), a timestamp in the future (clock
+/// skew), or one older than `max_age_secs` all block the send: paying on a stale chain tip
+/// understates outbound HTLC expiry, which LDK later force-closes on. Exactly `max_age_secs`
+/// old is accepted.
+pub fn lightning_sync_is_fresh(
+    latest_sync_timestamp: Option<u64>,
+    now_secs: u64,
+    max_age_secs: u64,
+) -> bool {
+    match latest_sync_timestamp {
+        Some(ts) => ts <= now_secs && now_secs - ts <= max_age_secs,
+        None => false,
+    }
+}
+
 /// Check and enforce stability for a channel.
 ///
 /// The stability logic keeps the user's expected_usd amount stable:
@@ -982,6 +999,26 @@ pub fn check_stability(
     if amt == 0 {
         return None;
     }
+
+    // Send-boundary chain-freshness gate (see #243): never pay on a stale chain tip.
+    // Skipping here leaves no durable state — the cooldown is only set after a real send —
+    // so the next stability tick retries once LDK's background sync catches up.
+    let latest_sync = node.status().latest_lightning_wallet_sync_timestamp;
+    if !lightning_sync_is_fresh(latest_sync, now.max(0) as u64, STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS)
+    {
+        audit_event(
+            "STABILITY_SKIP",
+            json!({
+                "user_channel_id": format!("{}", sc.user_channel_id),
+                "reason": "stale_lightning_sync",
+                "latest_lightning_wallet_sync_timestamp": latest_sync,
+                "sync_age_secs": latest_sync.map(|ts| (now.max(0) as u64).saturating_sub(ts)),
+                "max_age_secs": STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS,
+            }),
+        );
+        return None;
+    }
+
     let settlement_id = new_stability_settlement_id();
     let created_at = now.max(0) as u64;
     let expires_at = created_at.saturating_add(STABILITY_PAYMENT_AUTH_TTL_SECS);
@@ -1080,6 +1117,34 @@ pub fn check_stability(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_future_or_old_lightning_sync_blocks_stability_send() {
+        let max_age = STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS;
+        // Never synced.
+        assert!(!lightning_sync_is_fresh(None, 1_000_000, max_age));
+        // Timestamp in the future (clock skew).
+        assert!(!lightning_sync_is_fresh(Some(1_000_001), 1_000_000, max_age));
+        // One second past the freshness window.
+        assert!(!lightning_sync_is_fresh(
+            Some(1_000_000 - max_age - 1),
+            1_000_000,
+            max_age
+        ));
+    }
+
+    #[test]
+    fn fresh_lightning_sync_allows_stability_send() {
+        let max_age = STABILITY_MAX_LIGHTNING_SYNC_AGE_SECS;
+        // Exactly max_age old is accepted.
+        assert!(lightning_sync_is_fresh(
+            Some(1_000_000 - max_age),
+            1_000_000,
+            max_age
+        ));
+        // Just synced.
+        assert!(lightning_sync_is_fresh(Some(1_000_000), 1_000_000, max_age));
+    }
 
     #[test]
     fn signed_stability_payload_round_trips_and_enforces_expiry() {

--- a/src/user.rs
+++ b/src/user.rs
@@ -475,21 +475,6 @@ pub struct UserApp {
     trade_success: Option<TradeAction>,
 }
 
-fn require_initial_wallet_sync(
-    sync_wallets: impl FnOnce() -> Result<(), String>,
-    stop_node: impl FnOnce(),
-) -> Result<(), String> {
-    match sync_wallets() {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            stop_node();
-            Err(format!(
-                "Initial wallet synchronization failed; payments remain disabled: {error}"
-            ))
-        }
-    }
-}
-
 /// Renders a single-line amount text field with iOS-style rounded, light-gray styling.
 /// Returns the inner `Response` so callers can check `has_focus()` etc.
 fn amount_field(ui: &mut egui::Ui, text: &mut String, hint: &str, width: f32) -> egui::Response {
@@ -644,17 +629,7 @@ impl UserApp {
         let node = Arc::new(builder.build(entropy).expect("Failed to build node"));
         node.start().expect("Failed to start node");
 
-        println!("Synchronizing wallet with the chain before enabling payments...");
-        require_initial_wallet_sync(
-            || node.sync_wallets().map_err(|e| e.to_string()),
-            || {
-                if let Err(e) = node.stop() {
-                    eprintln!("Failed to stop node after wallet synchronization error: {e}");
-                }
-            },
-        )?;
-
-        println!("User node started and synchronized: {}", node.node_id());
+        println!("User node started: {}", node.node_id());
 
         // And the LSP
         if let Ok(socket_addr) = SocketAddress::from_str(DEFAULT_LSP_ADDRESS) {
@@ -11657,38 +11632,11 @@ mod tests {
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
         local_sync_backing_sats, local_trade_backing_sats, max_sell_trade_usd_cents,
         parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
-        require_initial_wallet_sync, restrict_secret_file_permissions, sats_for_usd_cents,
+        restrict_secret_file_permissions, sats_for_usd_cents,
         splice_in_overlap_sats, splice_reconcile_action, write_secret_file, IncomingSync,
         LocalTradeAllocationError, PendingSplice, SpliceReconcileAction, UserApp,
     };
     use stable_channels::db::PendingTradeRow;
-
-    #[test]
-    fn initial_wallet_sync_success_allows_startup() {
-        let stop_called = std::cell::Cell::new(false);
-
-        let result = require_initial_wallet_sync(|| Ok(()), || stop_called.set(true));
-
-        assert_eq!(result, Ok(()));
-        assert!(!stop_called.get());
-    }
-
-    #[test]
-    fn initial_wallet_sync_failure_stops_node_and_blocks_startup() {
-        let stop_called = std::cell::Cell::new(false);
-
-        let result = require_initial_wallet_sync(
-            || Err("chain source unavailable".to_string()),
-            || stop_called.set(true),
-        );
-
-        assert_eq!(
-            result,
-            Err("Initial wallet synchronization failed; payments remain disabled: chain source unavailable"
-                .to_string())
-        );
-        assert!(stop_called.get());
-    }
 
     #[test]
     fn trade_usd_input_is_exactly_cent_denominated() {

--- a/src/user.rs
+++ b/src/user.rs
@@ -475,6 +475,21 @@ pub struct UserApp {
     trade_success: Option<TradeAction>,
 }
 
+fn require_initial_wallet_sync(
+    sync_wallets: impl FnOnce() -> Result<(), String>,
+    stop_node: impl FnOnce(),
+) -> Result<(), String> {
+    match sync_wallets() {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            stop_node();
+            Err(format!(
+                "Initial wallet synchronization failed; payments remain disabled: {error}"
+            ))
+        }
+    }
+}
+
 /// Renders a single-line amount text field with iOS-style rounded, light-gray styling.
 /// Returns the inner `Response` so callers can check `has_focus()` etc.
 fn amount_field(ui: &mut egui::Ui, text: &mut String, hint: &str, width: f32) -> egui::Response {
@@ -629,7 +644,17 @@ impl UserApp {
         let node = Arc::new(builder.build(entropy).expect("Failed to build node"));
         node.start().expect("Failed to start node");
 
-        println!("User node started: {}", node.node_id());
+        println!("Synchronizing wallet with the chain before enabling payments...");
+        require_initial_wallet_sync(
+            || node.sync_wallets().map_err(|e| e.to_string()),
+            || {
+                if let Err(e) = node.stop() {
+                    eprintln!("Failed to stop node after wallet synchronization error: {e}");
+                }
+            },
+        )?;
+
+        println!("User node started and synchronized: {}", node.node_id());
 
         // And the LSP
         if let Ok(socket_addr) = SocketAddress::from_str(DEFAULT_LSP_ADDRESS) {
@@ -11632,11 +11657,38 @@ mod tests {
         btc_amount_to_msat, channel_balance_split, collapse_double_paste, floor_usd_cents,
         local_sync_backing_sats, local_trade_backing_sats, max_sell_trade_usd_cents,
         parse_incoming_sync, parse_trade_rejection, parse_trade_usd_cents,
-        restrict_secret_file_permissions, sats_for_usd_cents,
+        require_initial_wallet_sync, restrict_secret_file_permissions, sats_for_usd_cents,
         splice_in_overlap_sats, splice_reconcile_action, write_secret_file, IncomingSync,
         LocalTradeAllocationError, PendingSplice, SpliceReconcileAction, UserApp,
     };
     use stable_channels::db::PendingTradeRow;
+
+    #[test]
+    fn initial_wallet_sync_success_allows_startup() {
+        let stop_called = std::cell::Cell::new(false);
+
+        let result = require_initial_wallet_sync(|| Ok(()), || stop_called.set(true));
+
+        assert_eq!(result, Ok(()));
+        assert!(!stop_called.get());
+    }
+
+    #[test]
+    fn initial_wallet_sync_failure_stops_node_and_blocks_startup() {
+        let stop_called = std::cell::Cell::new(false);
+
+        let result = require_initial_wallet_sync(
+            || Err("chain source unavailable".to_string()),
+            || stop_called.set(true),
+        );
+
+        assert_eq!(
+            result,
+            Err("Initial wallet synchronization failed; payments remain disabled: chain source unavailable"
+                .to_string())
+        );
+        assert!(stop_called.get());
+    }
 
     #[test]
     fn trade_usd_input_is_exactly_cent_denominated() {


### PR DESCRIPTION
Bug: After being offline, the wallet could reconnect and send a stability payment using its stale block height. Once chain synchronization completed, the HTLC appeared already expired, causing the wallet to force-close the channel.

Fix: The wallet must now finish its initial Lightning and on-chain synchronization before connecting to the LSP or enabling payments. If synchronization fails, startup stops safely with payments disabled.