### PR TITLE
build(android): sync version to 0.9.6 (vc8) past Play-consumed codes; document target-API trap

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,9 +17,15 @@ android {
     defaultConfig {
         applicationId = "com.stablechannels.app"
         minSdk = 26
+        // Google Play requires target API 36+ from 2026-08-31 (evaluated across ALL
+        // active tracks, not just production — a stale testing-track bundle targeting
+        // 35 trips the requirement for the whole app).
         targetSdk = 36
-        versionCode = 5
-        versionName = "0.9.4"
+        // Play has already consumed versionCodes 6 and 7 (0.9.5, released 2026-08-06
+        // from the sheet-to-edge-fix branch); those bumps never landed on main, so
+        // main's next uploadable build starts at 8.
+        versionCode = 8
+        versionName = "0.9.6"
     }
 
     // Play upload signing. Reads STABLECHANNELS_UPLOAD_* Gradle properties


### PR DESCRIPTION
## Summary
Play Console flags the app for the **target API 36 (by 2026-08-31)** requirement even though the Aug 6 production release (0.9.5, vc7) already targets 36 — verified from the uploaded bundle's manifest. The requirement is evaluated across **all active tracks**: Closed testing Alpha (v0.9.2, vc3) and Internal testing (v0.9, vc2) still carry pre-July-25 bundles targeting API 35.

Main also lagged the store: the 0.9.5 bumps (vc6, vc7) lived on `sheet-to-edge-fix` and never merged back, so main claimed versionCode 5 / 0.9.4 while Play had consumed 7.

## Changes
- `versionCode` 5 → **8**, `versionName` 0.9.4 → **0.9.6** (next uploadable build from main).
- Comments on `targetSdk`/`versionCode` documenting both traps (all-tracks evaluation; consumed versionCodes on side branches).

## Console follow-up (not in this PR)
The compliance warning clears by superseding the stale testing-track releases — either promote the existing vc7 library bundle to both tracks (no build needed), or roll this 0.9.6 build to them once merged. Debug build verified (`assembleDebug` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Lyu5AQVGpQN4RAhnv47S