### PR TITLE
Harden Android and iOS trade-result accounting

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -32,8 +32,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run Rust tests
-        run: cargo test --workspace --locked
+      - name: Run affected Rust tests
+        run: cargo test -p stable-channels -p stable-channels-lsp --locked
 
-      - name: Build Rust workspace
-        run: cargo build --workspace --locked
+      - name: Build affected Rust packages
+        run: cargo build -p stable-channels -p stable-channels-lsp --locked

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,39 @@
+name: Rust Tests
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "server/**"
+      - ".github/workflows/rust-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "server/**"
+      - ".github/workflows/rust-tests.yml"
+
+concurrency:
+  group: rust-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run Rust tests
+        run: cargo test --workspace --locked
+
+      - name: Build Rust workspace
+        run: cargo build --workspace --locked

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -66,6 +66,10 @@ android {
         compose = true
         buildConfig = true
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -138,4 +142,5 @@ dependencies {
     // Unit tests
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("org.robolectric:robolectric:4.16.1")
 }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -20,6 +20,7 @@ import com.stablechannels.app.util.usdFormatted
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 import okhttp3.Request
@@ -228,6 +229,34 @@ class AppState(private val context: Context) : ViewModel() {
     data class TradeOutcome(val accepted: Boolean, val message: String)
     private val _tradeOutcomes = MutableStateFlow<Map<String, TradeOutcome>>(emptyMap())
     val tradeOutcomes: StateFlow<Map<String, TradeOutcome>> = _tradeOutcomes
+
+    /** Rehydrate a trade's terminal outcome from SQLite. Background services commit
+     *  accepted/rejected results directly to the database without touching the in-memory
+     *  map, so the sheets poll this while pending and it runs for every known payment id
+     *  on startup/foreground. */
+    fun refreshTradeOutcome(paymentId: String) {
+        if (_tradeOutcomes.value.containsKey(paymentId)) return
+        viewModelScope.launch(Dispatchers.IO) {
+            val terminal = try {
+                databaseService?.terminalTradeOutcome(paymentId)
+            } catch (_: Exception) { null } ?: return@launch
+            val (accepted, reason) = terminal
+            // update {} — this runs on an IO thread while the handler path writes from
+            // the event loop, and a read-modify-write on .value could drop an entry.
+            _tradeOutcomes.update { outcomes ->
+                outcomes + (paymentId to if (accepted) {
+                    TradeOutcome(true, "")
+                } else {
+                    TradeOutcome(false, TradeProtocol.rejectionMessage(reason ?: "internal_failure"))
+                })
+            }
+            _pendingTradePayments.update { it - paymentId }
+        }
+    }
+
+    private fun refreshAllTradeOutcomes(paymentIds: Collection<String>) {
+        paymentIds.forEach { refreshTradeOutcome(it) }
+    }
     var pendingSplice: PendingSplice? = null
     private val _isChannelClosing = MutableStateFlow(false)
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
@@ -312,6 +341,7 @@ class AppState(private val context: Context) : ViewModel() {
                 tradeService = TradeService(nodeService, db)
                 db.markExpiredTradesUncertain()
                 _pendingTradePayments.value = db.unresolvedTradePayments()
+                refreshAllTradeOutcomes(_tradeOutcomes.value.keys + _pendingTradePayments.value.keys)
 
                 val auditPath = File(Constants.userDataDir(context), "audit_log.txt").absolutePath
                 AuditService.setLogPath(auditPath)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -221,6 +221,13 @@ class AppState(private val context: Context) : ViewModel() {
 
     private val _pendingTradePayments = MutableStateFlow<Map<String, PendingTradePayment>>(emptyMap())
     val pendingTradePayments: StateFlow<Map<String, PendingTradePayment>> = _pendingTradePayments
+
+    /** Terminal result of a correlated trade, keyed by its fee payment id. Only a signed
+     *  acceptance or rejection lands here — the trade sheets read this instead of inferring
+     *  success from absence in the pending map (a rejection also clears pending). */
+    data class TradeOutcome(val accepted: Boolean, val message: String)
+    private val _tradeOutcomes = MutableStateFlow<Map<String, TradeOutcome>>(emptyMap())
+    val tradeOutcomes: StateFlow<Map<String, TradeOutcome>> = _tradeOutcomes
     var pendingSplice: PendingSplice? = null
     private val _isChannelClosing = MutableStateFlow(false)
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
@@ -1064,6 +1071,13 @@ class AppState(private val context: Context) : ViewModel() {
             TradeControlApplyStatus.DUPLICATE -> {
                 result.paymentId?.let { paymentId ->
                     _pendingTradePayments.value = _pendingTradePayments.value - paymentId
+                    _tradeOutcomes.value = _tradeOutcomes.value + (
+                        paymentId to if (message is TradeControlMessage.Rejected) {
+                            TradeOutcome(false, TradeProtocol.rejectionMessage(message.reasonCode))
+                        } else {
+                            TradeOutcome(true, "")
+                        }
+                    )
                 }
                 val channel = db.loadChannel(_stableChannel.value.userChannelId)
                     ?: throw RetryableSyncException("Duplicate result channel could not be reloaded")
@@ -1080,6 +1094,13 @@ class AppState(private val context: Context) : ViewModel() {
             TradeControlApplyStatus.APPLIED -> {
                 result.paymentId?.let { paymentId ->
                     _pendingTradePayments.value = _pendingTradePayments.value - paymentId
+                    _tradeOutcomes.value = _tradeOutcomes.value + (
+                        paymentId to if (message is TradeControlMessage.Rejected) {
+                            TradeOutcome(false, TradeProtocol.rejectionMessage(message.reasonCode))
+                        } else {
+                            TradeOutcome(true, "")
+                        }
+                    )
                 }
                 val channel = db.loadChannel(_stableChannel.value.userChannelId)
                     ?: throw RetryableSyncException("Applied result channel could not be reloaded")

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -298,10 +298,13 @@ class AppState(private val context: Context) : ViewModel() {
     fun start() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                databaseService = DatabaseService(context)
+                val db = DatabaseService(context)
+                databaseService = db
                 launch { databaseService?.seedHistoricalPrices() }
                 launch { backfillHourlyPrices() }
-                tradeService = TradeService(nodeService)
+                tradeService = TradeService(nodeService, db)
+                db.markExpiredTradesUncertain()
+                _pendingTradePayments.value = db.unresolvedTradePayments()
 
                 val auditPath = File(Constants.userDataDir(context), "audit_log.txt").absolutePath
                 AuditService.setLogPath(auditPath)
@@ -863,10 +866,25 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                 }
                 val curPending = _pendingTradePayments.value
-                if (pid != null && curPending.containsKey(pid)) {
-                    val ptp = curPending[pid]!!
+                var failedTrade = pid?.let(curPending::get)
+                if (pid != null && failedTrade == null) {
+                    val amountMsat = try {
+                        nodeService.node?.payment(pid)?.amountMsat?.toLong()
+                    } catch (_: Exception) {
+                        null
+                    }
+                    if (amountMsat != null) {
+                        failedTrade = try {
+                            databaseService?.failUnattachedPreparedTrade(pid, amountMsat)
+                        } catch (_: Exception) {
+                            null
+                        }
+                    }
+                }
+                if (pid != null && failedTrade != null) {
+                    val ptp = failedTrade
                     _pendingTradePayments.value = curPending - pid
-                    databaseService?.updateTradeStatus(ptp.tradeDbId, "failed")
+                    databaseService?.markTradeSendFailed(ptp.tradeDbId)
                     val verb = if (ptp.action == "buy") "Buy" else "Sell"
                     _statusMessage.value = "$verb trade failed"
                     AuditService.log("TRADE_PAYMENT_FAILED", mapOf("payment_id" to pid))
@@ -907,7 +925,7 @@ class AppState(private val context: Context) : ViewModel() {
     private fun handlePaymentReceived(paymentId: String?, amountMsat: Long, paymentHash: String, customRecords: List<CustomTlvRecord>) {
         isWaitingForPayment = false
         // Check for sync message
-        if (handleSyncMessage(customRecords, paymentHash)) {
+        if (handleSyncMessage(customRecords, paymentHash, amountMsat)) {
             refreshBalances()
             updateStableBalances()
             return
@@ -993,36 +1011,123 @@ class AppState(private val context: Context) : ViewModel() {
         }
     }
 
-    private fun handleSyncMessage(customRecords: List<CustomTlvRecord>, paymentHash: String): Boolean {
+    private fun handleSyncMessage(
+        customRecords: List<CustomTlvRecord>,
+        paymentHash: String,
+        amountMsat: Long
+    ): Boolean {
         val tlv = customRecords.find { it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() } ?: return false
         val data = tlv.value.map { it.toByte() }.toByteArray()
-        val parsed = TradeService.parseIncomingTLV(data, _stableChannel.value.counterparty) { msg, sig, pk ->
+        if (data.contentEquals(byteArrayOf(1))) return false
+        val message = TradeProtocol.parseSignedControl(data, _stableChannel.value.counterparty) { msg, sig, pk ->
             nodeService.verifySignature(msg, sig, pk)
-        } ?: return false
-
-        val (type, expectedUsd, _) = parsed
-        if (type != Constants.SYNC_MESSAGE_TYPE) return false
-
-        val price = priceService.currentAccountingPrice()
-        if (price <= 0.0) {
-            AuditService.log("SYNC_V1_DEFERRED", mapOf("reason" to "untrusted_price"))
-            // Propagate to the event collector so it completes the ack with false and LDK
-            // re-delivers this authenticated sync after the price oracle recovers.
-            throw RetryableSyncException("Cannot apply SYNC_V1 without a trusted BTC price")
+        } ?: run {
+            AuditService.log("TRADE_RESULT_INVALID", mapOf("payment_hash" to paymentHash))
+            return true
         }
-        val sc = StabilityService.applyTrade(_stableChannel.value, expectedUsd, price)
-        _stableChannel.value = sc
-        saveChannelToDB()
-        AuditService.log("SYNC_V1_APPLIED", mapOf("expected_usd" to expectedUsd))
-        return true
+        val db = databaseService ?: throw RetryableSyncException("Trade database unavailable")
+        val result = when (message) {
+            is TradeControlMessage.Rejected -> {
+                if (amountMsat != TradeProtocol.RESULT_CONTROL_AMOUNT_MSAT) {
+                    AuditService.log("TRADE_REJECTED_V1_CONTEXT_INVALID", mapOf("amount_msat" to amountMsat))
+                    return true
+                }
+                db.applyTradeRejection(message)
+            }
+            is TradeControlMessage.Sync -> {
+                if (amountMsat != TradeProtocol.RESULT_CONTROL_AMOUNT_MSAT) {
+                    AuditService.log("SYNC_V1_CONTROL_AMOUNT_INVALID", mapOf("amount_msat" to amountMsat))
+                    return true
+                }
+                if (message.correlation != null) {
+                    db.applyCorrelatedTradeAcceptance(message)
+                } else {
+                    val price = priceService.currentAccountingPrice()
+                    if (price <= 0.0) {
+                        AuditService.log("SYNC_V1_DEFERRED", mapOf("reason" to "untrusted_price"))
+                        throw RetryableSyncException("Cannot apply SYNC_V1 without a trusted BTC price")
+                    }
+                    db.applyUncorrelatedSyncIfNewer(message, price)
+                }
+            }
+        }
+        when (result.status) {
+            TradeControlApplyStatus.RETRY -> {
+                try { db.markTradeResponseNotCommittable(message) } catch (_: Exception) {}
+                AuditService.log("TRADE_RESULT_DEFERRED", mapOf("payment_hash" to paymentHash))
+                throw RetryableSyncException("Signed trade result could not be committed")
+            }
+            TradeControlApplyStatus.INVALID -> {
+                AuditService.log("TRADE_RESULT_INVALID", mapOf("payment_hash" to paymentHash))
+                return true
+            }
+            TradeControlApplyStatus.DUPLICATE -> {
+                result.paymentId?.let { paymentId ->
+                    _pendingTradePayments.value = _pendingTradePayments.value - paymentId
+                }
+                val channel = db.loadChannel(_stableChannel.value.userChannelId)
+                    ?: throw RetryableSyncException("Duplicate result channel could not be reloaded")
+                val updated = _stableChannel.value.copy(
+                    channelId = channel.channelId,
+                    expectedUSD = USD(channel.expectedUSD),
+                    backingSats = channel.backingSats,
+                    latestPrice = channel.latestPrice
+                )
+                StabilityService.recomputeNative(updated)
+                _stableChannel.value = updated
+                return true
+            }
+            TradeControlApplyStatus.APPLIED -> {
+                result.paymentId?.let { paymentId ->
+                    _pendingTradePayments.value = _pendingTradePayments.value - paymentId
+                }
+                val channel = db.loadChannel(_stableChannel.value.userChannelId)
+                    ?: throw RetryableSyncException("Applied result channel could not be reloaded")
+                val updated = _stableChannel.value.copy(
+                    channelId = channel.channelId,
+                    expectedUSD = USD(channel.expectedUSD),
+                    backingSats = channel.backingSats,
+                    latestPrice = channel.latestPrice
+                )
+                StabilityService.recomputeNative(updated)
+                _stableChannel.value = updated
+                val divergence = result.localBackingSats != null &&
+                    result.peerBackingSats != null &&
+                    result.localBackingSats != result.peerBackingSats
+                AuditService.log("TRADE_RESULT_APPLIED", mapOf(
+                    "payment_hash" to paymentHash,
+                    "local_backing_sats" to (result.localBackingSats ?: -1L),
+                    "peer_backing_sats" to (result.peerBackingSats ?: -1L),
+                    "allocation_diverged" to divergence,
+                    "allocation_applied" to result.allocationApplied
+                ))
+                if (message is TradeControlMessage.Rejected) {
+                    _statusMessage.value = TradeProtocol.rejectionMessage(message.reasonCode)
+                } else if (result.paymentId != null) {
+                    val verb = if (result.action == "buy") "Buy" else "Sell"
+                    _statusMessage.value = "$verb confirmed"
+                    triggerPaymentFlash()
+                }
+                return true
+            }
+        }
     }
 
     fun setStatus(message: String) {
         _statusMessage.value = message
     }
 
-    fun addPendingTradePayment(paymentId: String, payment: PendingTradePayment) {
+    fun addPendingTradePayment(paymentId: String, payment: PendingTradePayment): Boolean {
         _pendingTradePayments.value = _pendingTradePayments.value + (paymentId to payment)
+        val unresolved = try {
+            databaseService?.tradeIsUnresolved(payment.tradeDbId) == true
+        } catch (_: Exception) {
+            true
+        }
+        if (!unresolved) {
+            _pendingTradePayments.value = _pendingTradePayments.value - paymentId
+        }
+        return unresolved
     }
 
     fun triggerPaymentFlash() {
@@ -1035,55 +1140,99 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun handlePaymentSuccessful(paymentId: String?, paymentHash: String, feePaidMsat: Long?) {
         val currentPending = _pendingTradePayments.value
-        if (paymentId != null && currentPending.containsKey(paymentId)) {
-            val ptp = currentPending[paymentId]!!
-            _pendingTradePayments.value = currentPending - paymentId
-            val sc = StabilityService.applyTrade(_stableChannel.value, ptp.newExpectedUSD, ptp.price)
-            _stableChannel.value = sc
-            saveChannelToDB()
-            databaseService?.updateTradeStatus(ptp.tradeDbId, "completed")
-            refreshBalances()
-            updateStableBalances()
-            val verb = if (ptp.action == "buy") "Buy" else "Sell"
-            _statusMessage.value = "$verb confirmed"
-            triggerPaymentFlash()
-            AuditService.log("TRADE_COMPLETED", mapOf("payment_id" to paymentId, "action" to ptp.action))
-        } else {
-            if (handleStabilityPaymentSuccessful(paymentId, feePaidMsat)) return
-
-            refreshBalances()
-            updateStableBalances()
-            val price = priceService.currentPrice.value
-            val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
-            val reconciled = result.first
-            if (result.second != null) {
-                reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
-            }
-            _stableChannel.value = reconciled
-            var displayVal: String? = null
-            if (paymentId != null) {
-                databaseService?.updatePaymentStatus(paymentId, "completed", feePaidMsat ?: 0)
-                try {
-                    val db = databaseService?.readableDatabase
-                    val cursor = db?.rawQuery("SELECT amount_msat, amount_usd FROM payments WHERE payment_id = ?", arrayOf(paymentId))
-                    cursor?.use {
-                        if (it.moveToFirst()) {
-                            val amountMsat = it.getLong(0)
-                            val amountUsd = if (!it.isNull(1)) it.getDouble(1) else 0.0
-                            val usdVal = if (amountUsd > 0.0) amountUsd else ((amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price)
-                            displayVal = usdVal.usdFormatted()
-                        }
+        if (paymentId != null) {
+            val db = databaseService
+            var pending = currentPending[paymentId]
+            var recognizedTrade = pending != null
+            if (db != null) {
+                val marked = try {
+                    if (pending != null) {
+                        db.markKnownTradeFeePaid(pending.tradeDbId, paymentId)
+                    } else {
+                        db.markTradeFeePaid(paymentId)
                     }
-                } catch (e: Exception) {
-                    Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
+                } catch (_: Exception) {
+                    false
+                }
+                recognizedTrade = recognizedTrade || marked
+
+                var eventAmountMsat: Long? = null
+                if (!recognizedTrade) {
+                    eventAmountMsat = try {
+                        nodeService.node?.payment(paymentId)?.amountMsat?.toLong()
+                    } catch (_: Exception) {
+                        null
+                    }
+                    if (eventAmountMsat != null) {
+                        pending = try {
+                            db.adoptUnattachedPreparedTrade(paymentId, eventAmountMsat)
+                        } catch (_: Exception) {
+                            null
+                        }
+                        recognizedTrade = pending != null
+                    }
+                }
+                if (!recognizedTrade) {
+                    recognizedTrade = try { db.tradePaymentExists(paymentId) } catch (_: Exception) { false }
+                }
+                if (!recognizedTrade && eventAmountMsat == null &&
+                    try { db.hasUnattachedPreparedTrade() } catch (_: Exception) { false }
+                ) {
+                    _statusMessage.value = "Payment confirmed; awaiting signed trade result"
+                    AuditService.log("TRADE_FEE_ID_UNRESOLVED", mapOf("payment_id" to paymentId))
+                    return
                 }
             }
-            saveChannelToDB(preserveBacking = true)
-            val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""
-            val successMsg = if (displayVal != null) "Payment sent: $displayVal$feeSuffix" else "Payment sent$feeSuffix"
-            _statusMessage.value = successMsg
-            _lastPaymentResult.value = successMsg
+            if (recognizedTrade) {
+                if (pending != null) {
+                    _pendingTradePayments.value = currentPending +
+                        (paymentId to pending.copy(status = "fee_paid"))
+                }
+                val verb = if (pending?.action == "buy") "Buy" else "Sell"
+                _statusMessage.value = "$verb fee paid; awaiting signed result"
+                AuditService.log("TRADE_FEE_PAID", mapOf(
+                    "payment_id" to paymentId,
+                    "action" to (pending?.action ?: "unknown"),
+                    "fee_paid_msat" to (feePaidMsat ?: 0L)
+                ))
+                return
+            }
         }
+
+        if (handleStabilityPaymentSuccessful(paymentId, feePaidMsat)) return
+
+        refreshBalances()
+        updateStableBalances()
+        val price = priceService.currentPrice.value
+        val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
+        val reconciled = result.first
+        if (result.second != null) {
+            reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
+        }
+        _stableChannel.value = reconciled
+        var displayVal: String? = null
+        if (paymentId != null) {
+            databaseService?.updatePaymentStatus(paymentId, "completed", feePaidMsat ?: 0)
+            try {
+                val db = databaseService?.readableDatabase
+                val cursor = db?.rawQuery("SELECT amount_msat, amount_usd FROM payments WHERE payment_id = ?", arrayOf(paymentId))
+                cursor?.use {
+                    if (it.moveToFirst()) {
+                        val amountMsat = it.getLong(0)
+                        val amountUsd = if (!it.isNull(1)) it.getDouble(1) else 0.0
+                        val usdVal = if (amountUsd > 0.0) amountUsd else ((amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price)
+                        displayVal = usdVal.usdFormatted()
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
+            }
+        }
+        saveChannelToDB(preserveBacking = true)
+        val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""
+        val successMsg = if (displayVal != null) "Payment sent: $displayVal$feeSuffix" else "Payment sent$feeSuffix"
+        _statusMessage.value = successMsg
+        _lastPaymentResult.value = successMsg
     }
 
     private fun handleStabilityPaymentSuccessful(paymentId: String?, feePaidMsat: Long?): Boolean {
@@ -1415,10 +1564,28 @@ class AppState(private val context: Context) : ViewModel() {
                 delay(Constants.STABILITY_CHECK_INTERVAL_SECS * 1000)
                 ensureLSPConnected()
                 recordCurrentPrice()
+                refreshTradeUncertainty()
                 runStabilityCheck()
                 detectOnchainDeposit()
                 pollPaymentConfirmations()
             }
+        }
+    }
+
+    private fun refreshTradeUncertainty() {
+        val db = databaseService ?: return
+        val changed = try { db.markExpiredTradesUncertain() } catch (_: Exception) { 0 }
+        if (changed > 0) {
+            _pendingTradePayments.value = try {
+                db.unresolvedTradePayments()
+            } catch (_: Exception) {
+                _pendingTradePayments.value
+            }
+            _statusMessage.value = "Trade result delayed; it will still be accepted when received"
+            AuditService.log("TRADE_RESULT_UNCERTAIN", mapOf(
+                "reason" to "no_response",
+                "count" to changed
+            ))
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/models/Trade.kt
+++ b/android/app/src/main/java/com/stablechannels/app/models/Trade.kt
@@ -30,7 +30,8 @@ data class PendingTradePayment(
     val newExpectedUSD: Double,
     val price: Double,
     val tradeDbId: Long,
-    val action: String
+    val action: String,
+    val status: String = "sent"
 )
 
 data class PendingSplice(
@@ -46,7 +47,8 @@ data class ChannelRecord(
     val note: String?,
     val backingSats: Long,
     val receiverSats: Long = 0,
-    val latestPrice: Double = 0.0
+    val latestPrice: Double = 0.0,
+    val syncVersion: Long = 0
 )
 
 data class TradeRecord(

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -9,7 +9,10 @@ import androidx.core.app.NotificationCompat
 import com.stablechannels.app.R
 import com.stablechannels.app.StableChannelsApp
 import com.stablechannels.app.services.LdkNodeOwner
-import com.stablechannels.app.services.TradeService
+import com.stablechannels.app.services.DatabaseService
+import com.stablechannels.app.services.TradeControlApplyStatus
+import com.stablechannels.app.services.TradeControlMessage
+import com.stablechannels.app.services.TradeProtocol
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.LspPreferencesManager
 import com.stablechannels.app.util.NamedPrice
@@ -27,7 +30,6 @@ import org.lightningdevkit.ldknode.*
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
-import kotlin.math.roundToLong
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.TimeoutCancellationException
@@ -74,51 +76,45 @@ class StabilityProcessingService : Service() {
                 !it.value.contentEquals(byteArrayOf(1))
         }
 
-    private fun handleStableControlMessage(node: Node, dbPath: String, records: List<CustomTlvRecord>): Boolean {
+    private fun handleStableControlMessage(
+        node: Node,
+        records: List<CustomTlvRecord>,
+        amountMsat: Long
+    ): Boolean {
         val tlv = records.firstOrNull {
             it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() &&
                 !it.value.contentEquals(byteArrayOf(1))
         } ?: return false
 
-        val parsed = TradeService.parseIncomingTLV(tlv.value, LspPreferencesManager.getLspPubkey(this)) { msg, sig, pk ->
+        val message = TradeProtocol.parseSignedControl(
+            tlv.value,
+            LspPreferencesManager.getLspPubkey(this)
+        ) { msg, sig, pk ->
             node.verifySignature(msg.map { it.toUByte() }, sig, pk)
-        } ?: return false
-
-        val (type, expectedUsd, parsedUserChannelId) = parsed
-        if (type != Constants.SYNC_MESSAGE_TYPE) return false
-
-        val price = fetchMedianPrice()
-        if (price <= 0.0) throw BackingUpdateFailed("Cannot apply SYNC_V1 without a BTC price")
-
-        val userChannelId = parsedUserChannelId.takeIf { it.isNotEmpty() }
-            ?: activeUserChannelId()
-            ?: throw BackingUpdateFailed("Cannot apply SYNC_V1 without a channel row")
-
-        applySyncMessageInDB(dbPath, userChannelId, expectedUsd, price)
-        Log.d(TAG, "Applied background SYNC_V1 expected_usd=$expectedUsd")
-        return true
-    }
-
-    private fun applySyncMessageInDB(dbPath: String, userChannelId: String, expectedUsd: Double, price: Double) {
-        val db = SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READWRITE)
-        db.execSQL("BEGIN IMMEDIATE")
-        try {
-            val backingSats = ((expectedUsd / price) * Constants.SATS_IN_BTC).roundToLong().coerceAtLeast(0L)
-            val stmt = db.compileStatement(
-                "UPDATE channels SET expected_usd = ?, stable_sats = ?, latest_price = ?, updated_at = strftime('%s','now') WHERE user_channel_id = ?"
-            )
-            stmt.bindDouble(1, expectedUsd)
-            stmt.bindLong(2, backingSats)
-            stmt.bindDouble(3, price)
-            stmt.bindString(4, userChannelId)
-            val rowsAffected = stmt.executeUpdateDelete()
-            if (rowsAffected != 1) {
-                throw BackingUpdateFailed("SYNC_V1 UPDATE affected $rowsAffected rows, expected 1")
+        } ?: return true
+        if (amountMsat != TradeProtocol.RESULT_CONTROL_AMOUNT_MSAT) return true
+        val db = DatabaseService(this)
+        return try {
+            val result = when (message) {
+                is TradeControlMessage.Rejected -> db.applyTradeRejection(message)
+                is TradeControlMessage.Sync -> if (message.correlation != null) {
+                    db.applyCorrelatedTradeAcceptance(message)
+                } else {
+                    val price = fetchMedianPrice()
+                    if (price <= 0.0) {
+                        throw BackingUpdateFailed("Cannot apply SYNC_V1 without a BTC price")
+                    }
+                    db.applyUncorrelatedSyncIfNewer(message, price)
+                }
             }
-            db.execSQL("COMMIT")
-        } catch (e: Exception) {
-            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
-            throw e
+            when (result.status) {
+                TradeControlApplyStatus.APPLIED, TradeControlApplyStatus.DUPLICATE,
+                TradeControlApplyStatus.INVALID -> true
+                TradeControlApplyStatus.RETRY -> {
+                    try { db.markTradeResponseNotCommittable(message) } catch (_: Exception) {}
+                    throw BackingUpdateFailed("Signed trade result could not be committed")
+                }
+            }
         } finally {
             db.close()
         }
@@ -279,7 +275,9 @@ class StabilityProcessingService : Service() {
                     is Event.PaymentReceived -> {
                         Log.d(TAG, "Payment received: ${event.amountMsat} msat")
                         if (hasStableControlMessage(event.customRecords)) {
-                            if (handleStableControlMessage(node, dbPath, event.customRecords)) {
+                            if (handleStableControlMessage(
+                                    node, event.customRecords, event.amountMsat.toLong()
+                                )) {
                                 node.eventHandled()
                                 hasUnpersistedEvent = false
                                 continue
@@ -448,7 +446,9 @@ class StabilityProcessingService : Service() {
                     is Event.PaymentReceived -> {
                         Log.d(TAG, "Payment received: ${event.amountMsat} msat")
                         if (hasStableControlMessage(event.customRecords)) {
-                            if (handleStableControlMessage(node, dbPath, event.customRecords)) {
+                            if (handleStableControlMessage(
+                                    node, event.customRecords, event.amountMsat.toLong()
+                                )) {
                                 node.eventHandled()
                                 received = true
                                 hasUnpersistedEvent = false

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -15,6 +15,17 @@ data class PaymentPersistenceResult(
     val backingSats: Long?
 )
 
+enum class TradeControlApplyStatus { APPLIED, DUPLICATE, INVALID, RETRY }
+
+data class TradeControlApplyResult(
+    val status: TradeControlApplyStatus,
+    val localBackingSats: Long? = null,
+    val peerBackingSats: Long? = null,
+    val paymentId: String? = null,
+    val action: String? = null,
+    val allocationApplied: Boolean? = null
+)
+
 /** A backing update targeted a user_channel_id with no channels row. Callers can recreate the
  *  row from in-memory state and retry, unlike generic persistence failures. */
 class MissingChannelRowException(userChannelId: String) :
@@ -37,7 +48,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
 ) {
     companion object {
         private const val DB_FILENAME = "stablechannels.db"
-        private const val DB_VERSION = 2
+        internal const val DB_VERSION = 3
     }
 
     override fun onCreate(db: SQLiteDatabase) {
@@ -50,6 +61,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 note TEXT,
                 receiver_sats INTEGER NOT NULL DEFAULT 0,
                 latest_price REAL NOT NULL DEFAULT 0.0,
+                sync_version INTEGER NOT NULL DEFAULT 0,
                 created_at INTEGER DEFAULT (strftime('%s','now')),
                 updated_at INTEGER DEFAULT (strftime('%s','now'))
             )
@@ -66,6 +78,21 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 fee_usd REAL DEFAULT 0,
                 payment_id TEXT,
                 status TEXT DEFAULT 'pending',
+                user_channel_id TEXT,
+                trade_id TEXT,
+                request_hash TEXT,
+                request_payload TEXT,
+                trade_payment_id TEXT,
+                old_expected_usd REAL,
+                new_expected_usd REAL,
+                new_backing_sats INTEGER,
+                quote_price REAL,
+                fee_msat INTEGER NOT NULL DEFAULT 0,
+                expires_at INTEGER,
+                outcome TEXT,
+                reason_code TEXT,
+                uncertainty_reason TEXT,
+                resolved_at INTEGER,
                 created_at INTEGER DEFAULT (strftime('%s','now'))
             )
         """)
@@ -123,6 +150,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_price_history_ts ON price_history(timestamp)")
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_payments_created ON payments(created_at)")
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_trades_created ON trades(created_at)")
+        createTradeIndexes(db)
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_onchain_txs_created ON onchain_txs(created_at)")
     }
 
@@ -131,6 +159,27 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             db.execSQL("ALTER TABLE channels ADD COLUMN receiver_sats INTEGER NOT NULL DEFAULT 0")
             db.execSQL("ALTER TABLE channels ADD COLUMN latest_price REAL NOT NULL DEFAULT 0.0")
         }
+        if (oldVersion < 3) {
+            db.execSQL("ALTER TABLE channels ADD COLUMN sync_version INTEGER NOT NULL DEFAULT 0")
+            listOf(
+                "user_channel_id TEXT",
+                "trade_id TEXT",
+                "request_hash TEXT",
+                "request_payload TEXT",
+                "trade_payment_id TEXT",
+                "old_expected_usd REAL",
+                "new_expected_usd REAL",
+                "new_backing_sats INTEGER",
+                "quote_price REAL",
+                "fee_msat INTEGER NOT NULL DEFAULT 0",
+                "expires_at INTEGER",
+                "outcome TEXT",
+                "reason_code TEXT",
+                "uncertainty_reason TEXT",
+                "resolved_at INTEGER"
+            ).forEach { column -> db.execSQL("ALTER TABLE trades ADD COLUMN $column") }
+            createTradeIndexes(db)
+        }
     }
 
     override fun onOpen(db: SQLiteDatabase) {
@@ -138,6 +187,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         // IF NOT EXISTS so either process (main app or background service) can create it,
         // including on databases created before this table existed.
         createPendingStabilitySendTable(db)
+        createTradeIndexes(db)
     }
 
     private fun createPendingStabilitySendTable(db: SQLiteDatabase) {
@@ -150,6 +200,13 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 created_at INTEGER NOT NULL
             )
         """)
+    }
+
+    private fun createTradeIndexes(db: SQLiteDatabase) {
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_trade_id_unique ON trades(trade_id) WHERE trade_id IS NOT NULL")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_request_hash_unique ON trades(request_hash) WHERE request_hash IS NOT NULL")
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_payment_id_unique ON trades(trade_payment_id) WHERE trade_payment_id IS NOT NULL")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_trades_unresolved_channel ON trades(channel_id, status)")
     }
 
     // --- Channels ---
@@ -212,7 +269,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     fun loadChannel(userChannelId: String): ChannelRecord? {
         val db = readableDatabase
         val cursor = db.rawQuery(
-            "SELECT channel_id, user_channel_id, expected_usd, note, stable_sats, receiver_sats, latest_price FROM channels WHERE user_channel_id = ?",
+            "SELECT channel_id, user_channel_id, expected_usd, note, stable_sats, receiver_sats, latest_price, sync_version FROM channels WHERE user_channel_id = ?",
             arrayOf(userChannelId)
         )
         return cursor.use {
@@ -224,7 +281,8 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                     note = it.getStringOrNull(3),
                     backingSats = it.getLong(4),
                     receiverSats = it.getLong(5),
-                    latestPrice = it.getDouble(6)
+                    latestPrice = it.getDouble(6),
+                    syncVersion = it.getLong(7)
                 )
             } else null
         }
@@ -281,6 +339,523 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     fun updateTradeStatus(tradeId: Long, status: String) {
         val cv = ContentValues().apply { put("status", status) }
         writableDatabase.update("trades", cv, "id = ?", arrayOf(tradeId.toString()))
+    }
+
+    fun recordPreparedTrade(trade: PreparedTrade): Long {
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val unresolved = db.rawQuery(
+                "SELECT 1 FROM trades WHERE channel_id = ? AND status IN ('prepared','sent','fee_paid','uncertain') LIMIT 1",
+                arrayOf(trade.channelId)
+            ).use { it.moveToFirst() }
+            if (unresolved) throw IllegalStateException("A previous trade is still awaiting its signed result")
+            val cv = ContentValues().apply {
+                put("channel_id", trade.channelId)
+                put("user_channel_id", trade.userChannelId)
+                put("action", trade.action)
+                put("amount_usd", trade.amountUsd)
+                put("amount_btc", trade.amountBtc)
+                put("btc_price", trade.quotePrice)
+                put("fee_usd", trade.feeUsd)
+                put("status", "prepared")
+                put("trade_id", trade.tradeId)
+                put("request_hash", trade.requestHash)
+                put("request_payload", trade.requestPayload)
+                put("old_expected_usd", trade.oldExpectedUsd)
+                put("new_expected_usd", trade.newExpectedUsd)
+                put("new_backing_sats", trade.newBackingSats)
+                put("quote_price", trade.quotePrice)
+                put("fee_msat", trade.feeMsat)
+                put("expires_at", trade.expiresAt)
+                put("created_at", trade.createdAt)
+            }
+            val id = db.insertOrThrow("trades", null, cv)
+            db.execSQL("COMMIT")
+            return id
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
+    fun attachTradePaymentId(tradeDbId: Long, paymentId: String): Boolean {
+        if (!TradeProtocol.isCanonicalIdentifier(paymentId)) return false
+        val cv = ContentValues().apply {
+            put("payment_id", paymentId)
+            put("trade_payment_id", paymentId)
+            put("status", "sent")
+        }
+        return writableDatabase.update(
+            "trades", cv, "id = ? AND status = 'prepared'", arrayOf(tradeDbId.toString())
+        ) == 1
+    }
+
+    fun markTradeFeePaid(paymentId: String): Boolean {
+        val cv = ContentValues().apply { put("status", "fee_paid") }
+        return writableDatabase.update(
+            "trades", cv,
+            "trade_payment_id = ? AND status IN ('prepared','sent','uncertain')",
+            arrayOf(paymentId)
+        ) == 1
+    }
+
+    fun markKnownTradeFeePaid(tradeDbId: Long, paymentId: String): Boolean {
+        if (!TradeProtocol.isCanonicalIdentifier(paymentId)) return false
+        val cv = ContentValues().apply {
+            put("payment_id", paymentId)
+            put("trade_payment_id", paymentId)
+            put("status", "fee_paid")
+        }
+        return writableDatabase.update(
+            "trades", cv,
+            "id = ? AND status IN ('prepared','sent','uncertain') AND (trade_payment_id IS NULL OR trade_payment_id = ?)",
+            arrayOf(tradeDbId.toString(), paymentId)
+        ) == 1
+    }
+
+    fun tradePaymentExists(paymentId: String): Boolean = readableDatabase.rawQuery(
+        "SELECT 1 FROM trades WHERE trade_payment_id = ? LIMIT 1",
+        arrayOf(paymentId)
+    ).use { it.moveToFirst() }
+
+    fun tradeIsUnresolved(tradeDbId: Long): Boolean = readableDatabase.rawQuery(
+        "SELECT 1 FROM trades WHERE id = ? AND status IN ('prepared','sent','fee_paid','uncertain') LIMIT 1",
+        arrayOf(tradeDbId.toString())
+    ).use { it.moveToFirst() }
+
+    fun hasUnattachedPreparedTrade(): Boolean = readableDatabase.rawQuery(
+        "SELECT 1 FROM trades WHERE trade_payment_id IS NULL AND status = 'prepared' LIMIT 1",
+        null
+    ).use { it.moveToFirst() }
+
+    fun adoptUnattachedPreparedTrade(paymentId: String, amountMsat: Long): PendingTradePayment? {
+        if (!TradeProtocol.isCanonicalIdentifier(paymentId) || amountMsat < 0L) return null
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val cutoff = System.currentTimeMillis() / 1000L - TradeProtocol.RESPONSE_RETRY_WINDOW_SECS
+            val rows = mutableListOf<Array<Any>>()
+            db.rawQuery(
+                """
+                SELECT id, new_expected_usd, quote_price, action
+                FROM trades
+                WHERE trade_payment_id IS NULL AND status = 'prepared'
+                  AND fee_msat = ? AND created_at >= ?
+                ORDER BY id DESC LIMIT 2
+                """.trimIndent(),
+                arrayOf(amountMsat.toString(), cutoff.toString())
+            ).use { cursor ->
+                while (cursor.moveToNext()) {
+                    rows.add(arrayOf(
+                        cursor.getLong(0), cursor.getDouble(1),
+                        cursor.getDouble(2), cursor.getString(3)
+                    ))
+                }
+            }
+            if (rows.size != 1) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            val row = rows.single()
+            val tradeDbId = row[0] as Long
+            val cv = ContentValues().apply {
+                put("payment_id", paymentId)
+                put("trade_payment_id", paymentId)
+                put("status", "fee_paid")
+            }
+            if (db.update(
+                    "trades", cv,
+                    "id = ? AND trade_payment_id IS NULL AND status = 'prepared'",
+                    arrayOf(tradeDbId.toString())
+                ) != 1
+            ) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            db.execSQL("COMMIT")
+            return PendingTradePayment(
+                newExpectedUSD = row[1] as Double,
+                price = row[2] as Double,
+                tradeDbId = tradeDbId,
+                action = row[3] as String,
+                status = "fee_paid"
+            )
+        } catch (error: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw error
+        }
+    }
+
+    fun failUnattachedPreparedTrade(paymentId: String, amountMsat: Long): PendingTradePayment? {
+        if (!TradeProtocol.isCanonicalIdentifier(paymentId) || amountMsat < 0L) return null
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val cutoff = System.currentTimeMillis() / 1000L - TradeProtocol.RESPONSE_RETRY_WINDOW_SECS
+            val rows = mutableListOf<Array<Any>>()
+            db.rawQuery(
+                """
+                SELECT id, new_expected_usd, quote_price, action
+                FROM trades
+                WHERE trade_payment_id IS NULL AND status = 'prepared'
+                  AND fee_msat = ? AND created_at >= ?
+                ORDER BY id DESC LIMIT 2
+                """.trimIndent(),
+                arrayOf(amountMsat.toString(), cutoff.toString())
+            ).use { cursor ->
+                while (cursor.moveToNext()) {
+                    rows.add(arrayOf(
+                        cursor.getLong(0), cursor.getDouble(1),
+                        cursor.getDouble(2), cursor.getString(3)
+                    ))
+                }
+            }
+            if (rows.size != 1) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            val row = rows.single()
+            val tradeDbId = row[0] as Long
+            val cv = ContentValues().apply {
+                put("payment_id", paymentId)
+                put("trade_payment_id", paymentId)
+                put("status", "send_failed")
+                put("outcome", "send_failed")
+                put("resolved_at", System.currentTimeMillis() / 1000L)
+            }
+            if (db.update(
+                    "trades", cv,
+                    "id = ? AND trade_payment_id IS NULL AND status = 'prepared'",
+                    arrayOf(tradeDbId.toString())
+                ) != 1
+            ) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            db.execSQL("COMMIT")
+            return PendingTradePayment(
+                newExpectedUSD = row[1] as Double,
+                price = row[2] as Double,
+                tradeDbId = tradeDbId,
+                action = row[3] as String,
+                status = "send_failed"
+            )
+        } catch (error: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw error
+        }
+    }
+
+    fun markTradeSendFailed(tradeDbId: Long): Boolean {
+        val cv = ContentValues().apply {
+            put("status", "send_failed")
+            put("outcome", "send_failed")
+            put("resolved_at", System.currentTimeMillis() / 1000L)
+        }
+        return writableDatabase.update(
+            "trades", cv, "id = ? AND status IN ('prepared','sent','uncertain')",
+            arrayOf(tradeDbId.toString())
+        ) == 1
+    }
+
+    fun unresolvedTradePayments(): Map<String, PendingTradePayment> {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT trade_payment_id, new_expected_usd, quote_price, id, action, status
+            FROM trades
+            WHERE trade_payment_id IS NOT NULL
+              AND status IN ('sent','fee_paid','uncertain')
+            ORDER BY id
+            """.trimIndent(), null
+        )
+        return cursor.use { c ->
+            buildMap {
+                while (c.moveToNext()) {
+                    put(c.getString(0), PendingTradePayment(
+                        newExpectedUSD = c.getDouble(1),
+                        price = c.getDouble(2),
+                        tradeDbId = c.getLong(3),
+                        action = c.getString(4),
+                        status = c.getString(5)
+                    ))
+                }
+            }
+        }
+    }
+
+    fun markExpiredTradesUncertain(now: Long = System.currentTimeMillis() / 1000L): Int {
+        val cv = ContentValues().apply {
+            put("status", "uncertain")
+            put("uncertainty_reason", "no_response")
+        }
+        return writableDatabase.update(
+            "trades", cv,
+            "expires_at IS NOT NULL AND expires_at <= ? AND status IN ('prepared','sent','fee_paid')",
+            arrayOf(now.toString())
+        )
+    }
+
+    fun markTradeResponseNotCommittable(message: TradeControlMessage): Boolean {
+        val channelId: String
+        val correlation: TradeCorrelation
+        when (message) {
+            is TradeControlMessage.Sync -> {
+                channelId = message.channelId
+                correlation = message.correlation ?: return false
+            }
+            is TradeControlMessage.Rejected -> {
+                channelId = message.channelId
+                correlation = message.correlation
+            }
+        }
+        val cv = ContentValues().apply {
+            put("status", "uncertain")
+            put("uncertainty_reason", "response_not_committable")
+        }
+        return writableDatabase.update(
+            "trades", cv,
+            """
+            channel_id = ? AND trade_id = ? AND request_hash = ?
+              AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+              AND status IN ('prepared','sent','fee_paid','uncertain')
+            """.trimIndent(),
+            arrayOf(
+                channelId, correlation.tradeId, correlation.requestHash,
+                correlation.tradePaymentId
+            )
+        ) == 1
+    }
+
+    fun applyCorrelatedTradeAcceptance(sync: TradeControlMessage.Sync): TradeControlApplyResult {
+        val correlation = sync.correlation ?: return TradeControlApplyResult(TradeControlApplyStatus.INVALID)
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val trade = db.rawQuery(
+                """
+                SELECT id, channel_id, user_channel_id, trade_payment_id, new_expected_usd,
+                       new_backing_sats, status, action
+                FROM trades
+                WHERE trade_id = ? AND request_hash = ?
+                  AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+                LIMIT 1
+                """.trimIndent(),
+                arrayOf(correlation.tradeId, correlation.requestHash, correlation.tradePaymentId)
+            ).use { c ->
+                if (!c.moveToFirst()) null else arrayOf<Any?>(
+                    c.getLong(0), c.getString(1), c.getString(2), c.getStringOrNull(3),
+                    c.getDouble(4), c.getLong(5), c.getString(6), c.getString(7)
+                )
+            } ?: return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            val tradeId = trade[0] as Long
+            val tradeChannelId = trade[1] as String
+            val tradeUserChannelId = trade[2] as String
+            val storedPaymentId = trade[3] as String?
+            val storedExpected = trade[4] as Double
+            val storedBacking = trade[5] as Long
+            val status = trade[6] as String
+            val action = trade[7] as String
+            if (tradeChannelId != sync.channelId || tradeUserChannelId != sync.userChannelId ||
+                storedPaymentId != null && storedPaymentId != correlation.tradePaymentId ||
+                kotlin.math.abs(storedExpected - sync.expectedUsd) > 0.000000001
+            ) return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            if (status == "accepted") {
+                db.execSQL("ROLLBACK")
+                return TradeControlApplyResult(
+                    TradeControlApplyStatus.DUPLICATE, storedBacking, sync.backingSats,
+                    correlation.tradePaymentId, action
+                )
+            }
+            if (status == "rejected" || status == "send_failed") {
+                return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            }
+            val channel = db.rawQuery(
+                "SELECT channel_id, receiver_sats, sync_version, stable_sats FROM channels WHERE user_channel_id = ?",
+                arrayOf(sync.userChannelId)
+            ).use { c ->
+                if (!c.moveToFirst()) null else arrayOf<Any>(
+                    c.getString(0), c.getLong(1), c.getLong(2), c.getLong(3)
+                )
+            } ?: return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            if (channel[0] as String != sync.channelId) {
+                return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            }
+            val receiverSats = channel[1] as Long
+            val currentVersion = channel[2] as Long
+            val currentBacking = channel[3] as Long
+            val allocationApplied = sync.syncVersion > currentVersion
+            if (allocationApplied) {
+                if (storedBacking < 0L || storedBacking > receiverSats) {
+                    return rollbackResult(db, TradeControlApplyStatus.RETRY)
+                }
+                val channelValues = ContentValues().apply {
+                    put("expected_usd", sync.expectedUsd)
+                    put("stable_sats", storedBacking)
+                    put("sync_version", sync.syncVersion)
+                    put("updated_at", System.currentTimeMillis() / 1000L)
+                }
+                if (db.update(
+                        "channels", channelValues,
+                        "user_channel_id = ? AND channel_id = ? AND sync_version < ?",
+                        arrayOf(sync.userChannelId, sync.channelId, sync.syncVersion.toString())
+                    ) != 1
+                ) return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            }
+            val tradeValues = ContentValues().apply {
+                put("payment_id", correlation.tradePaymentId)
+                put("trade_payment_id", correlation.tradePaymentId)
+                put("status", "accepted")
+                put("outcome", "accepted")
+                put("resolved_at", System.currentTimeMillis() / 1000L)
+                putNull("uncertainty_reason")
+            }
+            if (db.update("trades", tradeValues, "id = ?", arrayOf(tradeId.toString())) != 1) {
+                return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            }
+            db.execSQL("COMMIT")
+            return TradeControlApplyResult(
+                TradeControlApplyStatus.APPLIED,
+                if (allocationApplied) storedBacking else currentBacking,
+                sync.backingSats,
+                correlation.tradePaymentId, action, allocationApplied
+            )
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
+    fun applyTradeRejection(rejection: TradeControlMessage.Rejected): TradeControlApplyResult {
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val row = db.rawQuery(
+                """
+                SELECT id, channel_id, trade_payment_id, status, action
+                FROM trades WHERE trade_id = ? AND request_hash = ?
+                  AND (trade_payment_id = ? OR trade_payment_id IS NULL) LIMIT 1
+                """.trimIndent(),
+                arrayOf(
+                    rejection.correlation.tradeId,
+                    rejection.correlation.requestHash,
+                    rejection.correlation.tradePaymentId
+                )
+            ).use { c ->
+                if (!c.moveToFirst()) null else arrayOf<Any?>(
+                    c.getLong(0), c.getString(1), c.getStringOrNull(2), c.getString(3), c.getString(4)
+                )
+            } ?: return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            val id = row[0] as Long
+            val channelId = row[1] as String
+            val storedPayment = row[2] as String?
+            val status = row[3] as String
+            val action = row[4] as String
+            if (channelId != rejection.channelId ||
+                storedPayment != null && storedPayment != rejection.correlation.tradePaymentId
+            ) return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            if (status == "rejected") {
+                db.execSQL("ROLLBACK")
+                return TradeControlApplyResult(
+                    TradeControlApplyStatus.DUPLICATE,
+                    paymentId = rejection.correlation.tradePaymentId,
+                    action = action
+                )
+            }
+            if (status == "accepted" || status == "send_failed") {
+                return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            }
+            val cv = ContentValues().apply {
+                put("payment_id", rejection.correlation.tradePaymentId)
+                put("trade_payment_id", rejection.correlation.tradePaymentId)
+                put("status", "rejected")
+                put("outcome", "rejected")
+                put("reason_code", rejection.reasonCode)
+                put("resolved_at", rejection.decidedAt)
+                putNull("uncertainty_reason")
+            }
+            if (db.update("trades", cv, "id = ?", arrayOf(id.toString())) != 1) {
+                return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            }
+            db.execSQL("COMMIT")
+            return TradeControlApplyResult(
+                TradeControlApplyStatus.APPLIED,
+                paymentId = rejection.correlation.tradePaymentId,
+                action = action
+            )
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
+    fun applyUncorrelatedSyncIfNewer(
+        sync: TradeControlMessage.Sync,
+        trustedPrice: Double
+    ): TradeControlApplyResult {
+        if (sync.correlation != null || !trustedPrice.isFinite() || trustedPrice <= 0.0) {
+            return TradeControlApplyResult(TradeControlApplyStatus.INVALID)
+        }
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val row = db.rawQuery(
+                """
+                SELECT channel_id, expected_usd, stable_sats, receiver_sats, sync_version
+                FROM channels WHERE user_channel_id = ?
+                """.trimIndent(), arrayOf(sync.userChannelId)
+            ).use { c ->
+                if (!c.moveToFirst()) null else arrayOf<Any>(
+                    c.getString(0), c.getDouble(1), c.getLong(2), c.getLong(3), c.getLong(4)
+                )
+            } ?: return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            if (row[0] as String != sync.channelId) return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            val currentVersion = row[4] as Long
+            if (sync.syncVersion <= currentVersion) {
+                db.execSQL("ROLLBACK")
+                return TradeControlApplyResult(TradeControlApplyStatus.DUPLICATE)
+            }
+            val currentExpected = row[1] as Double
+            val currentBacking = row[2] as Long
+            val receiverSats = row[3] as Long
+            val localBacking = if (sync.expectedUsd == 0.0) 0L else if (
+                currentBacking > 0L && sync.expectedUsd == currentExpected
+            ) {
+                currentBacking.coerceAtMost(receiverSats)
+            } else {
+                TradeProtocol.tradeBackingAfterDelta(
+                    receiverSats, currentBacking, currentExpected, sync.expectedUsd, trustedPrice
+                ) ?: return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            }
+            val cv = ContentValues().apply {
+                put("expected_usd", sync.expectedUsd)
+                put("stable_sats", localBacking)
+                put("sync_version", sync.syncVersion)
+                put("latest_price", trustedPrice)
+                put("updated_at", System.currentTimeMillis() / 1000L)
+            }
+            if (db.update(
+                    "channels", cv,
+                    "user_channel_id = ? AND channel_id = ? AND sync_version < ?",
+                    arrayOf(sync.userChannelId, sync.channelId, sync.syncVersion.toString())
+                ) != 1
+            ) return rollbackResult(db, TradeControlApplyStatus.RETRY)
+            db.execSQL("COMMIT")
+            return TradeControlApplyResult(
+                TradeControlApplyStatus.APPLIED, localBacking, sync.backingSats
+            )
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
+    private fun rollbackResult(
+        db: SQLiteDatabase,
+        status: TradeControlApplyStatus
+    ): TradeControlApplyResult {
+        try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+        return TradeControlApplyResult(status)
     }
 
     // --- Payments ---

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -559,6 +559,20 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         ) == 1
     }
 
+    /** Terminal outcome for a trade's fee payment id, straight from SQLite — the source
+     *  of truth that BOTH the foreground handler and the background service write. The
+     *  in-memory outcome map alone misses results committed while the app was backgrounded
+     *  or before a restart. Returns (accepted, reason_code) or null while unresolved. */
+    fun terminalTradeOutcome(paymentId: String): Pair<Boolean, String?>? {
+        val cursor = readableDatabase.rawQuery(
+            "SELECT status, reason_code FROM trades WHERE trade_payment_id = ? AND status IN ('accepted','rejected') ORDER BY id DESC LIMIT 1",
+            arrayOf(paymentId)
+        )
+        return cursor.use { c ->
+            if (c.moveToFirst()) Pair(c.getString(0) == "accepted", c.getString(1)) else null
+        }
+    }
+
     fun unresolvedTradePayments(): Map<String, PendingTradePayment> {
         val cursor = readableDatabase.rawQuery(
             """

--- a/android/app/src/main/java/com/stablechannels/app/services/TradeProtocol.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/TradeProtocol.kt
@@ -1,0 +1,319 @@
+package com.stablechannels.app.services
+
+import com.stablechannels.app.models.StableChannel
+import com.stablechannels.app.util.Constants
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.security.SecureRandom
+import kotlin.math.abs
+import kotlin.math.floor
+
+data class TradeCorrelation(
+    val tradeId: String,
+    val tradePaymentId: String,
+    val requestHash: String
+)
+
+sealed interface TradeControlMessage {
+    data class Sync(
+        val channelId: String,
+        val userChannelId: String,
+        val expectedUsd: Double,
+        val backingSats: Long,
+        val syncVersion: Long,
+        val correlation: TradeCorrelation?
+    ) : TradeControlMessage
+
+    data class Rejected(
+        val channelId: String,
+        val correlation: TradeCorrelation,
+        val reasonCode: String,
+        val decidedAt: Long
+    ) : TradeControlMessage
+}
+
+data class PreparedTrade(
+    val channelId: String,
+    val userChannelId: String,
+    val tradeId: String,
+    val requestHash: String,
+    val requestPayload: String,
+    val action: String,
+    val amountUsd: Double,
+    val amountBtc: Double,
+    val feeUsd: Double,
+    val feeMsat: Long,
+    val oldExpectedUsd: Double,
+    val newExpectedUsd: Double,
+    val newBackingSats: Long,
+    val quotePrice: Double,
+    val createdAt: Long,
+    val expiresAt: Long
+)
+
+object TradeProtocol {
+    const val RESULT_CONTROL_AMOUNT_MSAT = 1L
+    const val RESULT_TIMEOUT_SECS = 15L * 60L
+    const val RESPONSE_RETRY_WINDOW_SECS = 14L * 24L * 60L * 60L
+    private val rejectionReasons = setOf(
+        "invalid_amount",
+        "stale_request",
+        "invalid_fee",
+        "invalid_quote",
+        "quote_deviation",
+        "insufficient_capacity",
+        "settlement_required",
+        "unsafe_allocation",
+        "internal_failure"
+    )
+
+    fun normalizeExpectedUsd(value: Double): Double =
+        if (value.isFinite() && value >= 0.0 && value < 0.01) 0.0 else value
+
+    fun requestHash(payload: ByteArray): String = MessageDigest
+        .getInstance("SHA-256")
+        .digest(payload)
+        .joinToString("") { "%02x".format(it) }
+
+    fun expectedTradeFeeMsat(
+        oldExpectedUsd: Double,
+        newExpectedUsd: Double,
+        quotePrice: Double
+    ): Long? {
+        val feeRate = Constants.STABLE_CHANNEL_TRADE_FEE_RATE
+        if (!oldExpectedUsd.isFinite() || oldExpectedUsd < 0.0 ||
+            !newExpectedUsd.isFinite() || newExpectedUsd < 0.0 ||
+            !quotePrice.isFinite() || quotePrice <= 0.0 ||
+            !feeRate.isFinite() || feeRate < 0.0 || feeRate >= 1.0
+        ) return null
+
+        val targetDelta = abs(newExpectedUsd - oldExpectedUsd)
+        val grossUsd = if (newExpectedUsd > oldExpectedUsd) {
+            targetDelta / (1.0 - feeRate)
+        } else {
+            targetDelta
+        }
+        val feeSats = grossUsd * feeRate / quotePrice * Constants.SATS_IN_BTC.toDouble()
+        if (!feeSats.isFinite() || feeSats < 0.0 || feeSats > Long.MAX_VALUE / 1000.0) {
+            return null
+        }
+        return (feeSats.toLong() * 1000L).coerceAtLeast(1L)
+    }
+
+    fun prepare(
+        sc: StableChannel,
+        action: String,
+        amountUsd: Double,
+        amountBtc: Double,
+        feeUsd: Double,
+        newExpectedUsd: Double,
+        quotePrice: Double,
+        now: Long = System.currentTimeMillis() / 1000L,
+        tradeId: String = randomIdentifier()
+    ): PreparedTrade? {
+        val normalizedExpected = normalizeExpectedUsd(newExpectedUsd)
+        if (!isCanonicalIdentifier(sc.channelId) || sc.userChannelId.isBlank() ||
+            !isCanonicalIdentifier(tradeId) || !amountUsd.isFinite() || amountUsd <= 0.0 ||
+            !amountBtc.isFinite() || amountBtc < 0.0 || !feeUsd.isFinite() || feeUsd < 0.0
+        ) return null
+        val feeMsat = expectedTradeFeeMsat(sc.expectedUSD.amount, normalizedExpected, quotePrice)
+            ?: return null
+        val feeSats = feeMsat / 1000L
+        val postFeeReceiver = sc.stableReceiverBTC.sats - feeSats
+        if (postFeeReceiver < 0L) return null
+        val backing = tradeBackingAfterDelta(
+            receiverSats = postFeeReceiver,
+            currentBackingSats = sc.backingSats,
+            currentExpectedUsd = sc.expectedUSD.amount,
+            newExpectedUsd = normalizedExpected,
+            price = quotePrice
+        ) ?: return null
+
+        val payload = JSONObject().apply {
+            put("type", Constants.TRADE_MESSAGE_TYPE)
+            put("channel_id", sc.channelId)
+            put("user_channel_id", sc.userChannelId)
+            put("trade_id", tradeId)
+            put("expected_usd", normalizedExpected)
+            put("quote_price", quotePrice)
+            put("ts", now)
+        }.toString()
+        return PreparedTrade(
+            channelId = sc.channelId,
+            userChannelId = sc.userChannelId,
+            tradeId = tradeId,
+            requestHash = requestHash(payload.toByteArray(Charsets.UTF_8)),
+            requestPayload = payload,
+            action = action,
+            amountUsd = amountUsd,
+            amountBtc = amountBtc,
+            feeUsd = feeUsd,
+            feeMsat = feeMsat,
+            oldExpectedUsd = sc.expectedUSD.amount,
+            newExpectedUsd = normalizedExpected,
+            newBackingSats = backing,
+            quotePrice = quotePrice,
+            createdAt = now,
+            expiresAt = now + RESULT_TIMEOUT_SECS
+        )
+    }
+
+    fun tradeBackingAfterDelta(
+        receiverSats: Long,
+        currentBackingSats: Long,
+        currentExpectedUsd: Double,
+        newExpectedUsd: Double,
+        price: Double
+    ): Long? {
+        val normalizedExpected = normalizeExpectedUsd(newExpectedUsd)
+        if (receiverSats < 0L || currentBackingSats < 0L ||
+            !currentExpectedUsd.isFinite() || currentExpectedUsd < 0.0 ||
+            !normalizedExpected.isFinite() || normalizedExpected < 0.0 ||
+            !price.isFinite() || price <= 0.0
+        ) return null
+        val receiverUsd = receiverSats.toDouble() / Constants.SATS_IN_BTC.toDouble() * price
+        if (normalizedExpected > receiverUsd) return null
+        if (normalizedExpected == 0.0) {
+            return if (!allocationDriftIsActionable(currentBackingSats, currentExpectedUsd, price)) 0L else null
+        }
+
+        val currentTarget = currentExpectedUsd / price * Constants.SATS_IN_BTC.toDouble()
+        val newTarget = normalizedExpected / price * Constants.SATS_IN_BTC.toDouble()
+        if (!currentTarget.isFinite() || !newTarget.isFinite() ||
+            currentTarget < 0.0 || newTarget < 0.0 ||
+            currentTarget >= Long.MAX_VALUE.toDouble() || newTarget >= Long.MAX_VALUE.toDouble()
+        ) return null
+        val currentTargetSats = floor(currentTarget).toLong()
+        val newTargetSats = floor(newTarget).toLong()
+        var backing = try {
+            if (normalizedExpected >= currentExpectedUsd) {
+                Math.addExact(currentBackingSats, Math.subtractExact(newTargetSats, currentTargetSats))
+            } else {
+                Math.subtractExact(currentBackingSats, Math.subtractExact(currentTargetSats, newTargetSats))
+            }
+        } catch (_: ArithmeticException) {
+            return null
+        }
+        if (backing < 0L) return null
+        if (currentExpectedUsd < 0.01 && currentBackingSats == 0L && backing <= receiverSats) {
+            val nativeUsd = (receiverSats - backing).toDouble() / Constants.SATS_IN_BTC.toDouble() * price
+            if (nativeUsd < 0.01) backing = receiverSats
+        }
+        return backing.takeIf { it > 0L && it <= receiverSats }
+    }
+
+    fun parseSignedControl(
+        data: ByteArray,
+        expectedCounterparty: String,
+        verifySignature: (ByteArray, String, String) -> Boolean
+    ): TradeControlMessage? {
+        return try {
+            val envelope = JSONObject(String(data, Charsets.UTF_8))
+            val payloadStr = envelope.getString("payload")
+            val signature = envelope.getString("signature")
+            val payloadBytes = payloadStr.toByteArray(Charsets.UTF_8)
+            if (!verifySignature(payloadBytes, signature, expectedCounterparty)) return null
+            val payload = JSONObject(payloadStr)
+            when (payload.optString("type")) {
+                Constants.SYNC_MESSAGE_TYPE -> parseSync(payload)
+                Constants.TRADE_REJECTED_MESSAGE_TYPE -> parseRejection(payload)
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun parseSync(payload: JSONObject): TradeControlMessage.Sync? {
+        val channelId = payload.optString("channel_id")
+        val userChannelId = payload.optString("user_channel_id")
+        val expectedUsd = jsonDouble(payload, "expected_usd")?.let(::normalizeExpectedUsd)
+            ?: return null
+        val backingSats = jsonInteger(payload, "backing_sats") ?: return null
+        val syncVersion = jsonInteger(payload, "sync_version") ?: return null
+        if (!isCanonicalIdentifier(channelId) || userChannelId.isBlank() ||
+            !expectedUsd.isFinite() || expectedUsd < 0.0 || backingSats < 0L || syncVersion <= 0L
+        ) return null
+
+        val correlationKeys = listOf("trade_id", "trade_payment_id", "request_hash")
+        val present = correlationKeys.count { payload.has(it) && !payload.isNull(it) }
+        val correlation = when (present) {
+            0 -> null
+            3 -> TradeCorrelation(
+                payload.getString("trade_id"),
+                payload.getString("trade_payment_id"),
+                payload.getString("request_hash")
+            ).takeIf {
+                isCanonicalIdentifier(it.tradeId) && isCanonicalIdentifier(it.tradePaymentId) &&
+                    isCanonicalIdentifier(it.requestHash)
+            } ?: return null
+            else -> return null
+        }
+        return TradeControlMessage.Sync(
+            channelId, userChannelId, expectedUsd, backingSats, syncVersion, correlation
+        )
+    }
+
+    private fun parseRejection(payload: JSONObject): TradeControlMessage.Rejected? {
+        val allowed = setOf(
+            "type", "channel_id", "trade_id", "trade_payment_id", "request_hash",
+            "reason_code", "decided_at"
+        )
+        if (payload.keys().asSequence().any { it !in allowed }) return null
+        val channelId = payload.getString("channel_id")
+        val correlation = TradeCorrelation(
+            payload.getString("trade_id"),
+            payload.getString("trade_payment_id"),
+            payload.getString("request_hash")
+        )
+        val reason = payload.getString("reason_code")
+        val decidedAt = jsonInteger(payload, "decided_at") ?: return null
+        if (!isCanonicalIdentifier(channelId) || !isCanonicalIdentifier(correlation.tradeId) ||
+            !isCanonicalIdentifier(correlation.tradePaymentId) ||
+            !isCanonicalIdentifier(correlation.requestHash) || reason !in rejectionReasons || decidedAt < 0L
+        ) return null
+        return TradeControlMessage.Rejected(channelId, correlation, reason, decidedAt)
+    }
+
+    fun rejectionMessage(reason: String): String = when (reason) {
+        "invalid_amount" -> "The trade amount is invalid. Review the amount and retry."
+        "stale_request" -> "The quote expired before it could be accepted. Refresh and retry."
+        "invalid_fee" -> "The trade fee was invalid. Refresh the quote before retrying."
+        "invalid_quote" -> "A valid market quote is required. Refresh and retry."
+        "quote_deviation" -> "The market moved outside the quote range. Refresh and retry."
+        "insufficient_capacity" -> "The channel does not have enough capacity for this trade. Reduce the amount."
+        "settlement_required" -> "Settle the current stability adjustment before retrying this trade."
+        "unsafe_allocation" -> "This trade cannot preserve the current channel allocation safely."
+        else -> "The provider could not process the trade. Try again later."
+    }
+
+    fun isCanonicalIdentifier(value: String): Boolean =
+        value.length == 64 && value.all { it in '0'..'9' || it in 'a'..'f' }
+
+    private fun jsonDouble(payload: JSONObject, key: String): Double? =
+        (payload.opt(key) as? Number)?.toDouble()?.takeIf { it.isFinite() }
+
+    private fun jsonInteger(payload: JSONObject, key: String): Long? {
+        val value = payload.opt(key)
+        return when (value) {
+            is Byte -> value.toLong()
+            is Short -> value.toLong()
+            is Int -> value.toLong()
+            is Long -> value
+            else -> null
+        }
+    }
+
+    private fun allocationDriftIsActionable(backingSats: Long, expectedUsd: Double, price: Double): Boolean {
+        val currentValue = backingSats.toDouble() / Constants.SATS_IN_BTC.toDouble() * price
+        val driftUsd = abs(currentValue - expectedUsd)
+        if (expectedUsd < 0.01) return driftUsd >= Constants.STABILITY_THRESHOLD_USD
+        val driftPercent = driftUsd / expectedUsd * 100.0
+        return driftUsd >= Constants.STABILITY_THRESHOLD_USD &&
+            driftPercent >= Constants.STABILITY_THRESHOLD_PERCENT
+    }
+
+    private fun randomIdentifier(): String = ByteArray(32)
+        .also { SecureRandom().nextBytes(it) }
+        .joinToString("") { "%02x".format(it) }
+}

--- a/android/app/src/main/java/com/stablechannels/app/services/TradeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/TradeService.kt
@@ -10,11 +10,14 @@ import kotlin.math.min
 data class TradeResult(
     val paymentId: String,
     val newExpectedUSD: Double,
-    val btcAmount: Double
+    val btcAmount: Double,
+    val tradeDbId: Long
 )
 
-class TradeService(private val nodeService: NodeService) {
-
+class TradeService(
+    private val nodeService: NodeService,
+    private val databaseService: DatabaseService
+) {
     fun executeBuy(
         sc: StableChannel,
         amountUSD: Double,
@@ -25,8 +28,9 @@ class TradeService(private val nodeService: NodeService) {
         val netAmount = amountUSD - feeUSD
         val newExpectedUSD = max(sc.expectedUSD.amount - amountUSD, 0.0)
         val btcAmount = netAmount / price
-        val paymentId = sendTradeMessage(newExpectedUSD, sc.userChannelId, sc.channelId, sc.counterparty, feeUSD, price)
-        return TradeResult(paymentId, newExpectedUSD, btcAmount)
+        return preparePersistAndSend(
+            sc, "buy", amountUSD, btcAmount, feeUSD, newExpectedUSD, price
+        )
     }
 
     fun executeSell(
@@ -40,56 +44,72 @@ class TradeService(private val nodeService: NodeService) {
         val netAmount = amountUSD - feeUSD
         val newExpectedUSD = min(sc.expectedUSD.amount + netAmount, maxUSD)
         val btcAmount = netAmount / price
-        val paymentId = sendTradeMessage(newExpectedUSD, sc.userChannelId, sc.channelId, sc.counterparty, feeUSD, price)
-        return TradeResult(paymentId, newExpectedUSD, btcAmount)
+        return preparePersistAndSend(
+            sc, "sell", amountUSD, btcAmount, feeUSD, newExpectedUSD, price
+        )
     }
 
-    fun sendTradeMessage(expectedUSD: Double, userChannelId: String, channelId: String, counterparty: String, feeUSD: Double, price: Double): String {
-        val payload = JSONObject().apply {
-            put("type", Constants.TRADE_MESSAGE_TYPE)
-            put("user_channel_id", userChannelId)
-            put("channel_id", channelId)
-            put("expected_usd", expectedUSD)
+    private fun preparePersistAndSend(
+        sc: StableChannel,
+        action: String,
+        amountUsd: Double,
+        amountBtc: Double,
+        feeUsd: Double,
+        newExpectedUsd: Double,
+        price: Double
+    ): TradeResult? {
+        val prepared = TradeProtocol.prepare(
+            sc = sc,
+            action = action,
+            amountUsd = amountUsd,
+            amountBtc = amountBtc,
+            feeUsd = feeUsd,
+            newExpectedUsd = newExpectedUsd,
+            quotePrice = price
+        ) ?: return null
+
+        // This row is the recovery authority. It must exist before the non-refundable fee send.
+        val tradeDbId = databaseService.recordPreparedTrade(prepared)
+        val paymentId = try {
+            val signature = nodeService.signMessage(
+                prepared.requestPayload.toByteArray(Charsets.UTF_8)
+            )
+            val envelope = JSONObject().apply {
+                put("payload", prepared.requestPayload)
+                put("signature", signature)
+            }.toString().toByteArray(Charsets.UTF_8)
+            nodeService.sendKeysendWithTLV(
+                prepared.feeMsat,
+                sc.counterparty,
+                listOf(CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), envelope))
+            )
+        } catch (error: Exception) {
+            databaseService.markTradeSendFailed(tradeDbId)
+            throw error
         }
-        val payloadStr = payload.toString()
-        val signature = nodeService.signMessage(payloadStr.toByteArray(Charsets.UTF_8))
 
-        val envelope = JSONObject().apply {
-            put("payload", payloadStr)
-            put("signature", signature)
+        // The payment has left the node at this point. A local bookkeeping failure must not
+        // report a send failure (or invite the user to pay the non-refundable fee twice).
+        val attached = try {
+            databaseService.attachTradePaymentId(tradeDbId, paymentId)
+        } catch (error: Exception) {
+            false
         }
-        val envelopeBytes = envelope.toString().toByteArray(Charsets.UTF_8)
-
-        val feeMsat = max((feeUSD / price * Constants.SATS_IN_BTC).toLong() * 1000, 1)
-        val tlv = CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), envelopeBytes)
-        return nodeService.sendKeysendWithTLV(feeMsat, counterparty, listOf(tlv))
-    }
-
-    companion object {
-        fun parseIncomingTLV(
-            data: ByteArray,
-            expectedCounterparty: String,
-            verifySignature: (ByteArray, String, String) -> Boolean
-        ): Triple<String, Double, String>? {
-            return try {
-                val envelopeStr = String(data, Charsets.UTF_8)
-                val envelope = JSONObject(envelopeStr)
-                val payloadStr = envelope.getString("payload")
-                val signature = envelope.getString("signature")
-
-                if (!verifySignature(payloadStr.toByteArray(Charsets.UTF_8), signature, expectedCounterparty)) {
-                    return null
-                }
-
-                val payload = JSONObject(payloadStr)
-                val type = payload.getString("type")
-                val expectedUsd = payload.getDouble("expected_usd")
-                val userChannelId = payload.getString("user_channel_id")
-
-                Triple(type, expectedUsd, userChannelId)
-            } catch (_: Exception) {
-                null
-            }
+        if (!attached) {
+            AuditService.log("TRADE_PAYMENT_ID_PERSIST_FAILED", mapOf(
+                "trade_db_id" to tradeDbId,
+                "trade_id" to prepared.tradeId,
+                "payment_id" to paymentId
+            ))
         }
+        AuditService.log("TRADE_MESSAGE_SENT", mapOf(
+            "trade_id" to prepared.tradeId,
+            "request_hash" to prepared.requestHash,
+            "payment_id" to paymentId,
+            "fee_msat" to prepared.feeMsat,
+            "new_expected_usd" to prepared.newExpectedUsd,
+            "new_backing_sats" to prepared.newBackingSats
+        ))
+        return TradeResult(paymentId, prepared.newExpectedUsd, amountBtc, tradeDbId)
     }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -264,6 +264,16 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                 // "Order Confirmed" for rejected trades (caught by e2e flow 13).
                 val tradeOutcomes by appState.tradeOutcomes.collectAsState()
                 val outcome = pendingPaymentId?.let { tradeOutcomes[it] }
+                // Background services commit results straight to SQLite without touching
+                // the in-memory outcome map, so poll the database while the result is
+                // unknown — otherwise a trade resolved while backgrounded stays "Pending".
+                LaunchedEffect(pendingPaymentId) {
+                    val pid = pendingPaymentId ?: return@LaunchedEffect
+                    while (!appState.tradeOutcomes.value.containsKey(pid)) {
+                        appState.refreshTradeOutcome(pid)
+                        kotlinx.coroutines.delay(2_000)
+                    }
+                }
                 val isConfirmed = outcome?.accepted == true
                 val isRejected = outcome?.accepted == false
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -229,20 +229,16 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                                 }
                                 val result = appState.tradeService?.executeBuy(sc, amountUSD, feeUSD, tradePrice)
                                     ?: throw Exception("Trade service unavailable")
-                                val tradeDbId = appState.databaseService?.recordTrade(
-                                    channelId = sc.channelId, action = "buy",
-                                    amountUSD = amountUSD, amountBTC = result.btcAmount,
-                                    btcPrice = tradePrice, feeUSD = feeUSD,
-                                    paymentId = result.paymentId, status = "pending"
-                                ) ?: 0
-                                appState.addPendingTradePayment(result.paymentId, PendingTradePayment(
+                                val awaitingResult = appState.addPendingTradePayment(result.paymentId, PendingTradePayment(
                                     newExpectedUSD = result.newExpectedUSD,
                                     price = tradePrice,
-                                    tradeDbId = tradeDbId,
+                                    tradeDbId = result.tradeDbId,
                                     action = "buy"
                                 ))
                                 pendingPaymentId = result.paymentId
-                                appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
+                                if (awaitingResult) {
+                                    appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
+                                }
                                 step = TradeStep.DONE
                             } catch (e: Exception) {
                                 error = e.message ?: "Trade failed"

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/BuyScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -257,10 +258,30 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
             }
 
             TradeStep.DONE -> {
-                val pendingPayments by appState.pendingTradePayments.collectAsState()
-                val isConfirmed = pendingPaymentId != null && !pendingPayments.containsKey(pendingPaymentId)
+                // Only a signed, correlated acceptance confirms the order and only a signed
+                // rejection fails it. Absence from the pending map proves nothing — a
+                // rejection also clears it, and the old absence heuristic showed
+                // "Order Confirmed" for rejected trades (caught by e2e flow 13).
+                val tradeOutcomes by appState.tradeOutcomes.collectAsState()
+                val outcome = pendingPaymentId?.let { tradeOutcomes[it] }
+                val isConfirmed = outcome?.accepted == true
+                val isRejected = outcome?.accepted == false
 
-                if (isConfirmed) {
+                if (isRejected) {
+                    Icon(
+                        Icons.Filled.Cancel,
+                        contentDescription = "Rejected",
+                        tint = Color(0xFFEF4444),
+                        modifier = Modifier.size(48.dp)
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text("Order Rejected", style = MaterialTheme.typography.headlineMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        outcome?.message ?: "The provider could not process the trade.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                } else if (isConfirmed) {
                     Icon(
                         Icons.Filled.CheckCircle,
                         contentDescription = "Confirmed",
@@ -285,7 +306,7 @@ fun BuyScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: () 
                     )
                 }
                 Spacer(Modifier.height(16.dp))
-                if (isConfirmed) {
+                if (isConfirmed || isRejected) {
                     Button(onClick = onDismiss) { Text("Done") }
                 }
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -231,20 +231,16 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                                 val totalUSD = USD.fromBitcoin(sc.stableReceiverBTC, tradePrice).amount
                                 val result = appState.tradeService?.executeSell(sc, amountUSD, feeUSD, tradePrice, totalUSD)
                                     ?: throw Exception("Trade service unavailable")
-                                val tradeDbId = appState.databaseService?.recordTrade(
-                                    channelId = sc.channelId, action = "sell",
-                                    amountUSD = amountUSD, amountBTC = result.btcAmount,
-                                    btcPrice = tradePrice, feeUSD = feeUSD,
-                                    paymentId = result.paymentId, status = "pending"
-                                ) ?: 0
-                                appState.addPendingTradePayment(result.paymentId, PendingTradePayment(
+                                val awaitingResult = appState.addPendingTradePayment(result.paymentId, PendingTradePayment(
                                     newExpectedUSD = result.newExpectedUSD,
                                     price = tradePrice,
-                                    tradeDbId = tradeDbId,
+                                    tradeDbId = result.tradeDbId,
                                     action = "sell"
                                 ))
                                 pendingPaymentId = result.paymentId
-                                appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
+                                if (awaitingResult) {
+                                    appState.setStatus(String.format(Locale.US, "Order pending (fee: $%.2f)", feeUSD))
+                                }
                                 step = TradeStep.DONE
                             } catch (e: Exception) {
                                 error = e.message ?: "Trade failed"

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -259,10 +260,30 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
             }
 
             TradeStep.DONE -> {
-                val pendingPayments by appState.pendingTradePayments.collectAsState()
-                val isConfirmed = pendingPaymentId != null && !pendingPayments.containsKey(pendingPaymentId)
+                // Only a signed, correlated acceptance confirms the order and only a signed
+                // rejection fails it. Absence from the pending map proves nothing — a
+                // rejection also clears it, and the old absence heuristic showed
+                // "Order Confirmed" for rejected trades (caught by e2e flow 13).
+                val tradeOutcomes by appState.tradeOutcomes.collectAsState()
+                val outcome = pendingPaymentId?.let { tradeOutcomes[it] }
+                val isConfirmed = outcome?.accepted == true
+                val isRejected = outcome?.accepted == false
 
-                if (isConfirmed) {
+                if (isRejected) {
+                    Icon(
+                        Icons.Filled.Cancel,
+                        contentDescription = "Rejected",
+                        tint = Color(0xFFEF4444),
+                        modifier = Modifier.size(48.dp)
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text("Order Rejected", style = MaterialTheme.typography.headlineMedium)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        outcome?.message ?: "The provider could not process the trade.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                } else if (isConfirmed) {
                     Icon(
                         Icons.Filled.CheckCircle,
                         contentDescription = "Confirmed",
@@ -287,7 +308,7 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                     )
                 }
                 Spacer(Modifier.height(16.dp))
-                if (isConfirmed) {
+                if (isConfirmed || isRejected) {
                     Button(onClick = onDismiss) { Text("Done") }
                 }
             }

--- a/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/trade/SellScreen.kt
@@ -266,6 +266,16 @@ fun SellScreen(appState: AppState, prefillAmountUSD: Double = 0.0, onDismiss: ()
                 // "Order Confirmed" for rejected trades (caught by e2e flow 13).
                 val tradeOutcomes by appState.tradeOutcomes.collectAsState()
                 val outcome = pendingPaymentId?.let { tradeOutcomes[it] }
+                // Background services commit results straight to SQLite without touching
+                // the in-memory outcome map, so poll the database while the result is
+                // unknown — otherwise a trade resolved while backgrounded stays "Pending".
+                LaunchedEffect(pendingPaymentId) {
+                    val pid = pendingPaymentId ?: return@LaunchedEffect
+                    while (!appState.tradeOutcomes.value.containsKey(pid)) {
+                        appState.refreshTradeOutcome(pid)
+                        kotlinx.coroutines.delay(2_000)
+                    }
+                }
                 val isConfirmed = outcome?.accepted == true
                 val isRejected = outcome?.accepted == false
 

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
     const val STABLE_CHANNEL_TLV_TYPE: Long = 13_377_331L
     const val TRADE_MESSAGE_TYPE = "TRADE_V1"
     const val SYNC_MESSAGE_TYPE = "SYNC_V1"
+    const val TRADE_REJECTED_MESSAGE_TYPE = "TRADE_REJECTED_V1"
 
     const val DEFAULT_NETWORK = "bitcoin"
     const val DEFAULT_USER_ALIAS = "user"

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -233,6 +233,96 @@ class TradeDatabaseServiceTest {
     }
 
     @Test
+    fun terminalTradeOutcomeReflectsResultsCommittedOutsideTheHandler() {
+        val identifier = "ab".repeat(32)
+        val now = System.currentTimeMillis() / 1000L
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUSD = 50.0,
+            backingSats = 55_000,
+            note = null,
+            receiverSats = 100_000,
+            latestPrice = 100_000.0
+        )
+
+        // Rejected trade: outcome must surface with the persisted reason code.
+        val rejectedTrade = TradeProtocol.prepare(
+            sc = StableChannel(
+                channelId = identifier,
+                userChannelId = "7",
+                expectedUSD = USD(50.0),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = 55_000
+            ),
+            action = "sell",
+            amountUsd = 10.0,
+            amountBtc = 0.000099,
+            feeUsd = 0.1,
+            newExpectedUsd = 59.9,
+            quotePrice = 100_000.0,
+            now = now,
+            tradeId = "ef".repeat(32)
+        )!!
+        val rejectedDbId = service.recordPreparedTrade(rejectedTrade)
+        val rejectedPaymentId = "cd".repeat(32)
+        assertTrue(service.attachTradePaymentId(rejectedDbId, rejectedPaymentId))
+        assertNull(service.terminalTradeOutcome(rejectedPaymentId))
+
+        val rejection = TradeControlMessage.Rejected(
+            channelId = identifier,
+            correlation = TradeCorrelation(
+                rejectedTrade.tradeId, rejectedPaymentId, rejectedTrade.requestHash
+            ),
+            reasonCode = "quote_deviation",
+            decidedAt = now
+        )
+        assertEquals(TradeControlApplyStatus.APPLIED, service.applyTradeRejection(rejection).status)
+        assertEquals(Pair(false, "quote_deviation"), service.terminalTradeOutcome(rejectedPaymentId))
+
+        // Accepted trade: outcome must flip to accepted with no reason code.
+        val acceptedTrade = TradeProtocol.prepare(
+            sc = StableChannel(
+                channelId = identifier,
+                userChannelId = "7",
+                expectedUSD = USD(50.0),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = 55_000
+            ),
+            action = "sell",
+            amountUsd = 10.0,
+            amountBtc = 0.000099,
+            feeUsd = 0.1,
+            newExpectedUsd = 59.9,
+            quotePrice = 100_000.0,
+            now = now + 1,
+            tradeId = "aa".repeat(32)
+        )!!
+        val acceptedDbId = service.recordPreparedTrade(acceptedTrade)
+        val acceptedPaymentId = "bb".repeat(32)
+        assertTrue(service.attachTradePaymentId(acceptedDbId, acceptedPaymentId))
+        assertNull(service.terminalTradeOutcome(acceptedPaymentId))
+
+        val sync = TradeControlMessage.Sync(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUsd = acceptedTrade.newExpectedUsd,
+            backingSats = acceptedTrade.newBackingSats,
+            syncVersion = 1,
+            correlation = TradeCorrelation(
+                acceptedTrade.tradeId, acceptedPaymentId, acceptedTrade.requestHash
+            )
+        )
+        assertEquals(
+            TradeControlApplyStatus.APPLIED,
+            service.applyCorrelatedTradeAcceptance(sync).status
+        )
+        assertEquals(Pair(true, null as String?), service.terminalTradeOutcome(acceptedPaymentId))
+        service.close()
+    }
+
+    @Test
     fun failedPaymentRecoversPreparedTradeWhenPaymentIdAttachmentWasLost() {
         val channelId = "12".repeat(32)
         val paymentId = "34".repeat(32)

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -1,0 +1,275 @@
+package com.stablechannels.app
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import com.stablechannels.app.models.Bitcoin
+import com.stablechannels.app.models.StableChannel
+import com.stablechannels.app.models.USD
+import com.stablechannels.app.services.DatabaseService
+import com.stablechannels.app.services.TradeControlApplyStatus
+import com.stablechannels.app.services.TradeControlMessage
+import com.stablechannels.app.services.TradeCorrelation
+import com.stablechannels.app.services.TradeProtocol
+import com.stablechannels.app.util.Constants
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class TradeDatabaseServiceTest {
+    private lateinit var context: Context
+    private lateinit var dbFile: File
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        dbFile = File(Constants.userDataDir(context), "stablechannels.db")
+        deleteDatabaseFiles()
+    }
+
+    @After
+    fun tearDown() {
+        deleteDatabaseFiles()
+    }
+
+    @Test
+    fun versionTwoSchemaMigratesWithoutLosingRows() {
+        val legacy = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        legacy.execSQL(
+            """
+            CREATE TABLE channels (
+                channel_id TEXT PRIMARY KEY,
+                user_channel_id TEXT UNIQUE,
+                expected_usd REAL DEFAULT 0,
+                stable_sats INTEGER DEFAULT 0,
+                note TEXT,
+                receiver_sats INTEGER NOT NULL DEFAULT 0,
+                latest_price REAL NOT NULL DEFAULT 0.0,
+                created_at INTEGER DEFAULT (strftime('%s','now')),
+                updated_at INTEGER DEFAULT (strftime('%s','now'))
+            )
+            """.trimIndent()
+        )
+        legacy.execSQL(
+            """
+            CREATE TABLE trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_id TEXT,
+                action TEXT NOT NULL,
+                amount_usd REAL NOT NULL,
+                amount_btc REAL NOT NULL,
+                btc_price REAL NOT NULL,
+                fee_usd REAL DEFAULT 0,
+                payment_id TEXT,
+                status TEXT DEFAULT 'pending',
+                created_at INTEGER DEFAULT (strftime('%s','now'))
+            )
+            """.trimIndent()
+        )
+        legacy.execSQL(
+            "INSERT INTO channels (channel_id, user_channel_id, expected_usd, stable_sats) VALUES (?, ?, ?, ?)",
+            arrayOf<Any>("legacy-channel", "legacy-user-channel", 25.0, 25_000)
+        )
+        legacy.execSQL(
+            "INSERT INTO trades (channel_id, action, amount_usd, amount_btc, btc_price) VALUES (?, ?, ?, ?, ?)",
+            arrayOf<Any>("legacy-channel", "buy", 5.0, 0.00005, 100_000.0)
+        )
+        legacy.version = 2
+        legacy.close()
+
+        val upgraded = DatabaseService(context)
+        val channelColumns = upgraded.readableDatabase.rawQuery(
+            "PRAGMA table_info(channels)", null
+        ).use { cursor ->
+            buildSet { while (cursor.moveToNext()) add(cursor.getString(1)) }
+        }
+        val tradeColumns = upgraded.readableDatabase.rawQuery(
+            "PRAGMA table_info(trades)", null
+        ).use { cursor ->
+            buildSet { while (cursor.moveToNext()) add(cursor.getString(1)) }
+        }
+        assertTrue(channelColumns.contains("sync_version"))
+        assertTrue(tradeColumns.contains("trade_id"))
+        assertTrue(tradeColumns.contains("uncertainty_reason"))
+        val channel = upgraded.loadChannel("legacy-user-channel")
+        assertNotNull(channel)
+        channel!!
+        assertEquals(25.0, channel.expectedUSD, 0.0)
+        assertEquals(25_000L, channel.backingSats)
+        val tradeCount = upgraded.readableDatabase.rawQuery(
+            "SELECT COUNT(*) FROM trades", null
+        ).use { cursor -> cursor.moveToFirst(); cursor.getLong(0) }
+        assertEquals(1L, tradeCount)
+        upgraded.close()
+    }
+
+    @Test
+    fun feePaymentDoesNotApplyAllocationBeforeCorrelatedAcceptance() {
+        val identifier = "ab".repeat(32)
+        val paymentId = "cd".repeat(32)
+        val tradeId = "ef".repeat(32)
+        val now = System.currentTimeMillis() / 1000L
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUSD = 50.0,
+            backingSats = 55_000,
+            note = null,
+            receiverSats = 100_000,
+            latestPrice = 100_000.0
+        )
+        val prepared = TradeProtocol.prepare(
+            sc = StableChannel(
+                channelId = identifier,
+                userChannelId = "7",
+                expectedUSD = USD(50.0),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = 55_000
+            ),
+            action = "sell",
+            amountUsd = 10.0,
+            amountBtc = 0.000099,
+            feeUsd = 0.1,
+            newExpectedUsd = 59.9,
+            quotePrice = 100_000.0,
+            now = now,
+            tradeId = tradeId
+        )
+        assertNotNull(prepared)
+        prepared!!
+        val tradeDbId = service.recordPreparedTrade(prepared)
+        val adopted = service.adoptUnattachedPreparedTrade(paymentId, prepared.feeMsat)
+        assertNotNull(adopted)
+        assertEquals(tradeDbId, adopted?.tradeDbId)
+        assertTrue(service.tradePaymentExists(paymentId))
+        assertTrue(service.tradeIsUnresolved(tradeDbId))
+
+        val before = service.loadChannel("7")
+        assertNotNull(before)
+        before!!
+        assertEquals(50.0, before.expectedUSD, 0.0)
+        assertEquals(55_000L, before.backingSats)
+        assertEquals("fee_paid", service.unresolvedTradePayments()[paymentId]?.status)
+
+        val sync = TradeControlMessage.Sync(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUsd = prepared.newExpectedUsd,
+            backingSats = prepared.newBackingSats + 1,
+            syncVersion = 1,
+            correlation = TradeCorrelation(tradeId, paymentId, prepared.requestHash)
+        )
+        assertTrue(service.markTradeResponseNotCommittable(sync))
+        assertEquals("uncertain", service.unresolvedTradePayments()[paymentId]?.status)
+        val accepted = service.applyCorrelatedTradeAcceptance(sync)
+        assertEquals(TradeControlApplyStatus.APPLIED, accepted.status)
+        assertEquals(prepared.newBackingSats, accepted.localBackingSats)
+        assertEquals(prepared.newBackingSats + 1, accepted.peerBackingSats)
+
+        val after = service.loadChannel("7")
+        assertNotNull(after)
+        after!!
+        assertEquals(prepared.newExpectedUsd, after.expectedUSD, 0.000000001)
+        assertEquals(prepared.newBackingSats, after.backingSats)
+        assertEquals(1L, after.syncVersion)
+        assertNull(service.unresolvedTradePayments()[paymentId])
+        assertFalse(service.tradeIsUnresolved(tradeDbId))
+        assertEquals(
+            TradeControlApplyStatus.DUPLICATE,
+            service.applyCorrelatedTradeAcceptance(sync).status
+        )
+
+        val superseded = TradeProtocol.prepare(
+            sc = StableChannel(
+                channelId = identifier,
+                userChannelId = "7",
+                expectedUSD = USD(prepared.newExpectedUsd),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = prepared.newBackingSats
+            ),
+            action = "buy",
+            amountUsd = 1.0,
+            amountBtc = 0.0000099,
+            feeUsd = 0.01,
+            newExpectedUsd = prepared.newExpectedUsd - 1.0,
+            quotePrice = 100_000.0,
+            now = now + 1,
+            tradeId = "aa".repeat(32)
+        )!!
+        val supersededDbId = service.recordPreparedTrade(superseded)
+        val supersededPaymentId = "bb".repeat(32)
+        assertTrue(service.attachTradePaymentId(supersededDbId, supersededPaymentId))
+        val staleAcceptance = TradeControlMessage.Sync(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUsd = superseded.newExpectedUsd,
+            backingSats = superseded.newBackingSats,
+            syncVersion = 1,
+            correlation = TradeCorrelation(
+                superseded.tradeId, supersededPaymentId, superseded.requestHash
+            )
+        )
+        val staleResult = service.applyCorrelatedTradeAcceptance(staleAcceptance)
+        assertEquals(TradeControlApplyStatus.APPLIED, staleResult.status)
+        assertFalse(staleResult.allocationApplied!!)
+        val afterSupersededAcceptance = service.loadChannel("7")!!
+        assertEquals(prepared.newExpectedUsd, afterSupersededAcceptance.expectedUSD, 0.000000001)
+        assertEquals(prepared.newBackingSats, afterSupersededAcceptance.backingSats)
+        assertEquals(1L, afterSupersededAcceptance.syncVersion)
+        assertFalse(service.tradeIsUnresolved(supersededDbId))
+        service.close()
+    }
+
+    @Test
+    fun failedPaymentRecoversPreparedTradeWhenPaymentIdAttachmentWasLost() {
+        val channelId = "12".repeat(32)
+        val paymentId = "34".repeat(32)
+        val service = DatabaseService(context)
+        val prepared = TradeProtocol.prepare(
+            sc = StableChannel(
+                channelId = channelId,
+                userChannelId = "9",
+                expectedUSD = USD(25.0),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = 25_000
+            ),
+            action = "buy",
+            amountUsd = 5.0,
+            amountBtc = 0.0000495,
+            feeUsd = 0.05,
+            newExpectedUsd = 20.0,
+            quotePrice = 100_000.0,
+            tradeId = "56".repeat(32)
+        )
+        assertNotNull(prepared)
+        val tradeDbId = service.recordPreparedTrade(prepared!!)
+
+        val failed = service.failUnattachedPreparedTrade(paymentId, prepared.feeMsat)
+
+        assertNotNull(failed)
+        assertEquals(tradeDbId, failed?.tradeDbId)
+        assertEquals("send_failed", failed?.status)
+        assertTrue(service.tradePaymentExists(paymentId))
+        assertNull(service.unresolvedTradePayments()[paymentId])
+        assertFalse(service.tradeIsUnresolved(tradeDbId))
+        service.close()
+    }
+
+    private fun deleteDatabaseFiles() {
+        listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
+            .forEach { file -> if (file.exists()) assertTrue(file.delete()) }
+        assertFalse(dbFile.exists())
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/TradeProtocolTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeProtocolTest.kt
@@ -1,0 +1,121 @@
+package com.stablechannels.app
+
+import com.stablechannels.app.models.Bitcoin
+import com.stablechannels.app.models.StableChannel
+import com.stablechannels.app.models.USD
+import com.stablechannels.app.services.TradeControlMessage
+import com.stablechannels.app.services.TradeProtocol
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class TradeProtocolTest {
+    private val identifier = "ab".repeat(32)
+
+    @Test
+    fun requestHashUsesForwardLowercaseSha256OfExactBytes() {
+        val payload = "{\"type\":\"TRADE_V1\",\"user_channel_id\":\"7\",\"expected_usd\":25.0}"
+        assertEquals(
+            "c07dcdff3aae2fc7ebd4fb19a7f1cd60b8e61c94a89acd35c5c600935d671602",
+            TradeProtocol.requestHash(payload.toByteArray())
+        )
+    }
+
+    @Test
+    fun feeVectorsMatchRustWholeSatTruncation() {
+        assertEquals(500_000L, TradeProtocol.expectedTradeFeeMsat(50.0, 99.5, 100_000.0))
+        assertEquals(500_000L, TradeProtocol.expectedTradeFeeMsat(100.0, 50.0, 100_000.0))
+        assertEquals(1_000L, TradeProtocol.expectedTradeFeeMsat(1.0, 0.0, 1_000_000.0))
+        assertEquals(1L, TradeProtocol.expectedTradeFeeMsat(1.0, 0.1, 1_000_000.0))
+        assertEquals(0.0, TradeProtocol.normalizeExpectedUsd(0.009), 0.0)
+        assertEquals(1L, TradeProtocol.expectedTradeFeeMsat(0.0, 0.0, 100_000.0))
+    }
+
+    @Test
+    fun preparedTradeContainsCorrelationQuoteTimestampAndStoredAllocation() {
+        val sc = StableChannel(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUSD = USD(50.0),
+            stableReceiverBTC = Bitcoin(100_000),
+            backingSats = 55_000
+        )
+        val prepared = TradeProtocol.prepare(
+            sc = sc,
+            action = "sell",
+            amountUsd = 10.0,
+            amountBtc = 0.000099,
+            feeUsd = 0.1,
+            newExpectedUsd = 59.9,
+            quotePrice = 100_000.0,
+            now = 1_786_310_000L,
+            tradeId = identifier
+        )
+        assertNotNull(prepared)
+        prepared!!
+        val payload = JSONObject(prepared.requestPayload)
+        assertEquals("TRADE_V1", payload.getString("type"))
+        assertEquals(identifier, payload.getString("channel_id"))
+        assertEquals("7", payload.getString("user_channel_id"))
+        assertEquals(identifier, payload.getString("trade_id"))
+        assertEquals(100_000.0, payload.getDouble("quote_price"), 0.0)
+        assertEquals(1_786_310_000L, payload.getLong("ts"))
+        assertEquals(99_000L, prepared.feeMsat)
+        assertEquals(64, prepared.requestHash.length)
+        assertTrue(prepared.newBackingSats <= 100_000L - prepared.feeMsat / 1000L)
+    }
+
+    @Test
+    fun signedControlRequiresCompleteCanonicalCorrelation() {
+        val payload = JSONObject().apply {
+            put("type", "SYNC_V1")
+            put("channel_id", identifier)
+            put("user_channel_id", "7")
+            put("expected_usd", 25.0)
+            put("backing_sats", 31_250)
+            put("sync_version", 4)
+            put("trade_id", identifier)
+            put("trade_payment_id", identifier)
+            put("request_hash", identifier)
+        }.toString()
+        val envelope = JSONObject().apply {
+            put("payload", payload)
+            put("signature", "valid")
+        }.toString().toByteArray()
+        val parsed = TradeProtocol.parseSignedControl(envelope, "peer") { bytes, signature, peer ->
+            bytes.contentEquals(payload.toByteArray()) && signature == "valid" && peer == "peer"
+        }
+        assertTrue(parsed is TradeControlMessage.Sync)
+        assertNotNull((parsed as TradeControlMessage.Sync).correlation)
+
+        val partial = JSONObject(payload).apply { remove("request_hash") }.toString()
+        val partialEnvelope = JSONObject().apply {
+            put("payload", partial)
+            put("signature", "valid")
+        }.toString().toByteArray()
+        assertNull(TradeProtocol.parseSignedControl(partialEnvelope, "peer") { _, _, _ -> true })
+        assertNull(TradeProtocol.parseSignedControl(envelope, "peer") { _, _, _ -> false })
+
+        val fractionalVersion = JSONObject(payload).apply { put("sync_version", 1.5) }.toString()
+        val fractionalEnvelope = JSONObject().apply {
+            put("payload", fractionalVersion)
+            put("signature", "valid")
+        }.toString().toByteArray()
+        assertNull(TradeProtocol.parseSignedControl(fractionalEnvelope, "peer") { _, _, _ -> true })
+
+        val booleanExpected = JSONObject(payload).apply { put("expected_usd", true) }.toString()
+        val booleanEnvelope = JSONObject().apply {
+            put("payload", booleanExpected)
+            put("signature", "valid")
+        }.toString().toByteArray()
+        assertNull(TradeProtocol.parseSignedControl(booleanEnvelope, "peer") { _, _, _ -> true })
+    }
+}

--- a/ios/StableChannels/NotificationService/Services/IncomingPaymentHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/IncomingPaymentHandler.swift
@@ -39,7 +39,8 @@ final class IncomingPaymentHandler: PaymentHandler {
                     node: node,
                     db: db,
                     priceFetcher: priceFetcher,
-                    customRecords: customRecords
+                    customRecords: customRecords,
+                    amountMsat: amountMsat
                 )
                 switch stableControl {
                 case .handled:

--- a/ios/StableChannels/NotificationService/Services/LSPToUserHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/LSPToUserHandler.swift
@@ -38,7 +38,8 @@ final class LSPToUserHandler: PaymentHandler {
                     node: node,
                     db: db,
                     priceFetcher: priceFetcher,
-                    customRecords: customRecords
+                    customRecords: customRecords,
+                    amountMsat: amountMsat
                 )
                 switch stableControl {
                 case .handled:

--- a/ios/StableChannels/NotificationService/Services/Protocols/PaymentDatabase.swift
+++ b/ios/StableChannels/NotificationService/Services/Protocols/PaymentDatabase.swift
@@ -17,12 +17,22 @@ protocol PaymentDatabase {
     func paymentExists(paymentId: String) -> Bool
     func readChannelState() -> ChannelState?
     func activeUserChannelId() -> String?
-    func applySyncMessage(expectedUSD: Double, payloadUserChannelId: String?, priceFetcher: PriceFetcher) -> Bool
+    func applyTradeControl(
+        _ message: TradeControlMessage,
+        trustedPrice: Double?
+    ) -> StableControlDatabaseResult
     func setPendingSendPaymentId(paymentId: String) -> Bool
     func claimPendingSend(amountMsat: UInt64, price: Double) -> Bool
     func loadPendingSend() -> PendingOutgoingStabilityPayment?
     func clearPendingSend()
     func reconcilePendingOutgoingPayment(node: LDKNode.Node) -> Bool
+}
+
+enum StableControlDatabaseResult {
+    case applied
+    case duplicate
+    case invalid
+    case retry
 }
 
 /// Result of recording a payment

--- a/ios/StableChannels/NotificationService/Services/SQLitePaymentDatabase.swift
+++ b/ios/StableChannels/NotificationService/Services/SQLitePaymentDatabase.swift
@@ -222,83 +222,369 @@ final class SQLitePaymentDatabase: PaymentDatabase {
         readChannelState()?.userChannelId
     }
 
-    func applySyncMessage(expectedUSD: Double, payloadUserChannelId: String?, priceFetcher: PriceFetcher) -> Bool {
-        let ucid: String
-        if let payloadUserChannelId, !payloadUserChannelId.isEmpty {
-            ucid = payloadUserChannelId
-        } else if let active = activeUserChannelId() {
-            ucid = active
-        } else {
-            return false
+    func applyTradeControl(
+        _ message: TradeControlMessage,
+        trustedPrice: Double?
+    ) -> StableControlDatabaseResult {
+        let result: StableControlDatabaseResult = switch message {
+        case .rejected(let rejection):
+            applyRejection(rejection)
+        case .sync(let sync):
+            if sync.correlation != nil {
+                applyCorrelatedSync(sync)
+            } else if let price = trustedPrice, PriceOracle.isPlausibleBitcoinPrice(price) {
+                applyUncorrelatedSync(sync, trustedPrice: price)
+            } else {
+                .retry
+            }
         }
+        if case .retry = result { markTradeResponseNotCommittable(message) }
+        return result
+    }
 
-        // SYNC_V1 changes the backing allocation. Never derive that allocation from the
-        // indefinitely cached channel price, and do not hold a SQLite write lock while fetching.
-        let finalPrice = priceFetcher.fetchPrice()
-        guard PriceOracle.isPlausibleBitcoinPrice(finalPrice) else { return false }
-
-        guard let db = openDB() else { return false }
+    private func markTradeResponseNotCommittable(_ message: TradeControlMessage) {
+        let channelId: String
+        let correlation: TradeCorrelation
+        switch message {
+        case .sync(let sync):
+            guard let syncCorrelation = sync.correlation else { return }
+            channelId = sync.channelId
+            correlation = syncCorrelation
+        case .rejected(let rejection):
+            channelId = rejection.channelId
+            correlation = rejection.correlation
+        }
+        guard let db = openDB() else { return }
         defer { sqlite3_close(db) }
-
-        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return false }
-
-        // Read current state
-        var selectStmt: OpaquePointer?
-        let selectSql = "SELECT receiver_sats FROM channels WHERE user_channel_id = ?"
-        guard sqlite3_prepare_v2(db, selectSql, -1, &selectStmt, nil) == SQLITE_OK else {
-            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
-            return false
-        }
-        sqlite3_bind_text(
-            selectStmt,
-            1,
-            (ucid as NSString).utf8String,
-            -1,
-            SQLITE_TRANSIENT
-        )
-        guard sqlite3_step(selectStmt) == SQLITE_ROW else {
-            sqlite3_finalize(selectStmt)
-            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
-            return false
-        }
-        let receiverSats = UInt64(sqlite3_column_int64(selectStmt, 0))
-        sqlite3_finalize(selectStmt)
-
-        let newBacking = UInt64(max(0.0, expectedUSD / finalPrice * Self.satsInBTC))
-        let newNative = receiverSats >= newBacking ? receiverSats - newBacking : 0
-
-        // Update
-        var updateStmt: OpaquePointer?
-        let updateSql = """
-        UPDATE channels
-        SET expected_usd = ?, stable_sats = ?, native_sats = ?, latest_price = ?, updated_at = strftime('%s', 'now')
-        WHERE user_channel_id = ?
+        var update: OpaquePointer?
+        let sql = """
+        UPDATE trades SET status = 'uncertain', uncertainty_reason = 'response_not_committable'
+        WHERE channel_id = ? AND trade_id = ? AND request_hash = ?
+          AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+          AND status IN ('prepared','sent','fee_paid','uncertain')
         """
-        guard sqlite3_prepare_v2(db, updateSql, -1, &updateStmt, nil) == SQLITE_OK else {
-            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
-            return false
-        }
-        defer { sqlite3_finalize(updateStmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &update, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(update) }
+        bindText(update, 1, channelId)
+        bindText(update, 2, correlation.tradeId)
+        bindText(update, 3, correlation.requestHash)
+        bindText(update, 4, correlation.tradePaymentId)
+        sqlite3_step(update)
+    }
 
-        sqlite3_bind_double(updateStmt, 1, expectedUSD)
-        sqlite3_bind_int64(updateStmt, 2, Int64(newBacking))
-        sqlite3_bind_int64(updateStmt, 3, Int64(newNative))
-        sqlite3_bind_double(updateStmt, 4, finalPrice)
-        sqlite3_bind_text(
-            updateStmt,
-            5,
-            (ucid as NSString).utf8String,
+    private func applyCorrelatedSync(
+        _ sync: TradeControlMessage.Sync
+    ) -> StableControlDatabaseResult {
+        guard let correlation = sync.correlation,
+              sync.syncVersion <= UInt64(Int64.max) else { return .invalid }
+        guard let db = openDB() else { return .retry }
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return .retry }
+
+        var tradeStmt: OpaquePointer?
+        let tradeSQL = """
+        SELECT id, channel_id, user_channel_id, trade_payment_id,
+               new_expected_usd, new_backing_sats, status
+        FROM trades
+        WHERE trade_id = ? AND request_hash = ?
+          AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+        LIMIT 1
+        """
+        guard sqlite3_prepare_v2(db, tradeSQL, -1, &tradeStmt, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry // Old schema: foreground app must migrate it first.
+        }
+        bindText(tradeStmt, 1, correlation.tradeId)
+        bindText(tradeStmt, 2, correlation.requestHash)
+        bindText(tradeStmt, 3, correlation.tradePaymentId)
+        guard sqlite3_step(tradeStmt) == SQLITE_ROW else {
+            sqlite3_finalize(tradeStmt)
+            rollback(db)
+            return .invalid
+        }
+        let tradeRowId = sqlite3_column_int64(tradeStmt, 0)
+        let tradeChannel = columnText(tradeStmt, 1)
+        let tradeUserChannel = columnText(tradeStmt, 2)
+        let storedPayment = sqlite3_column_type(tradeStmt, 3) == SQLITE_NULL ? nil : columnText(tradeStmt, 3)
+        let storedExpected = sqlite3_column_double(tradeStmt, 4)
+        let storedBackingSigned = sqlite3_column_int64(tradeStmt, 5)
+        let status = columnText(tradeStmt, 6)
+        sqlite3_finalize(tradeStmt)
+
+        guard tradeChannel == sync.channelId, tradeUserChannel == sync.userChannelId,
+              storedPayment == nil || storedPayment == correlation.tradePaymentId,
+              abs(storedExpected - sync.expectedUSD) <= 0.000000001,
+              storedBackingSigned >= 0 else {
+            rollback(db)
+            return .invalid
+        }
+        if status == "accepted" {
+            rollback(db)
+            return .duplicate
+        }
+        guard status != "rejected", status != "send_failed" else {
+            rollback(db)
+            return .invalid
+        }
+
+        var channelStmt: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db,
+            "SELECT channel_id, receiver_sats, sync_version, stable_sats FROM channels WHERE user_channel_id = ?",
             -1,
-            SQLITE_TRANSIENT
-        )
-
-        guard sqlite3_step(updateStmt) == SQLITE_DONE, sqlite3_changes(db) == 1 else {
-            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
-            return false
+            &channelStmt,
+            nil
+        ) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        bindText(channelStmt, 1, sync.userChannelId)
+        guard sqlite3_step(channelStmt) == SQLITE_ROW else {
+            sqlite3_finalize(channelStmt)
+            rollback(db)
+            return .retry
+        }
+        let channelId = columnText(channelStmt, 0)
+        let receiverSigned = sqlite3_column_int64(channelStmt, 1)
+        let currentVersion = sqlite3_column_int64(channelStmt, 2)
+        let currentBackingSigned = sqlite3_column_int64(channelStmt, 3)
+        sqlite3_finalize(channelStmt)
+        guard channelId == sync.channelId else {
+            rollback(db)
+            return .invalid
+        }
+        guard receiverSigned >= 0, currentBackingSigned >= 0 else {
+            rollback(db)
+            return .retry
+        }
+        if Int64(sync.syncVersion) > currentVersion {
+            guard storedBackingSigned <= receiverSigned else {
+                rollback(db)
+                return .retry
+            }
+            let nativeSigned = receiverSigned - storedBackingSigned
+            var updateChannel: OpaquePointer?
+            let updateChannelSQL = """
+            UPDATE channels
+            SET expected_usd = ?, stable_sats = ?, native_sats = ?, sync_version = ?,
+                updated_at = strftime('%s', 'now')
+            WHERE user_channel_id = ? AND channel_id = ? AND sync_version < ?
+            """
+            guard sqlite3_prepare_v2(db, updateChannelSQL, -1, &updateChannel, nil) == SQLITE_OK else {
+                rollback(db)
+                return .retry
+            }
+            sqlite3_bind_double(updateChannel, 1, sync.expectedUSD)
+            sqlite3_bind_int64(updateChannel, 2, storedBackingSigned)
+            sqlite3_bind_int64(updateChannel, 3, nativeSigned)
+            sqlite3_bind_int64(updateChannel, 4, Int64(sync.syncVersion))
+            bindText(updateChannel, 5, sync.userChannelId)
+            bindText(updateChannel, 6, sync.channelId)
+            sqlite3_bind_int64(updateChannel, 7, Int64(sync.syncVersion))
+            let channelUpdated = sqlite3_step(updateChannel) == SQLITE_DONE && sqlite3_changes(db) == 1
+            sqlite3_finalize(updateChannel)
+            guard channelUpdated else {
+                rollback(db)
+                return .retry
+            }
         }
 
-        guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else { return false }
-        return true
+        var updateTrade: OpaquePointer?
+        let updateTradeSQL = """
+        UPDATE trades
+        SET payment_id = ?, trade_payment_id = ?, status = 'accepted', outcome = 'accepted',
+            resolved_at = strftime('%s', 'now'), uncertainty_reason = NULL
+        WHERE id = ?
+        """
+        guard sqlite3_prepare_v2(db, updateTradeSQL, -1, &updateTrade, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        bindText(updateTrade, 1, correlation.tradePaymentId)
+        bindText(updateTrade, 2, correlation.tradePaymentId)
+        sqlite3_bind_int64(updateTrade, 3, tradeRowId)
+        let tradeUpdated = sqlite3_step(updateTrade) == SQLITE_DONE && sqlite3_changes(db) == 1
+        sqlite3_finalize(updateTrade)
+        guard tradeUpdated, sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        return .applied
+    }
+
+    private func applyRejection(
+        _ rejection: TradeControlMessage.Rejected
+    ) -> StableControlDatabaseResult {
+        guard rejection.decidedAt <= UInt64(Int64.max) else { return .invalid }
+        guard let db = openDB() else { return .retry }
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return .retry }
+
+        var select: OpaquePointer?
+        let sql = """
+        SELECT id, channel_id, trade_payment_id, status
+        FROM trades
+        WHERE trade_id = ? AND request_hash = ?
+          AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+        LIMIT 1
+        """
+        guard sqlite3_prepare_v2(db, sql, -1, &select, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        bindText(select, 1, rejection.correlation.tradeId)
+        bindText(select, 2, rejection.correlation.requestHash)
+        bindText(select, 3, rejection.correlation.tradePaymentId)
+        guard sqlite3_step(select) == SQLITE_ROW else {
+            sqlite3_finalize(select)
+            rollback(db)
+            return .invalid
+        }
+        let rowId = sqlite3_column_int64(select, 0)
+        let channelId = columnText(select, 1)
+        let paymentId = sqlite3_column_type(select, 2) == SQLITE_NULL ? nil : columnText(select, 2)
+        let status = columnText(select, 3)
+        sqlite3_finalize(select)
+        guard channelId == rejection.channelId,
+              paymentId == nil || paymentId == rejection.correlation.tradePaymentId else {
+            rollback(db)
+            return .invalid
+        }
+        if status == "rejected" {
+            rollback(db)
+            return .duplicate
+        }
+        guard status != "accepted", status != "send_failed" else {
+            rollback(db)
+            return .invalid
+        }
+
+        var update: OpaquePointer?
+        let updateSQL = """
+        UPDATE trades
+        SET payment_id = ?, trade_payment_id = ?, status = 'rejected', outcome = 'rejected',
+            reason_code = ?, resolved_at = ?, uncertainty_reason = NULL
+        WHERE id = ?
+        """
+        guard sqlite3_prepare_v2(db, updateSQL, -1, &update, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        bindText(update, 1, rejection.correlation.tradePaymentId)
+        bindText(update, 2, rejection.correlation.tradePaymentId)
+        bindText(update, 3, rejection.reasonCode)
+        sqlite3_bind_int64(update, 4, Int64(rejection.decidedAt))
+        sqlite3_bind_int64(update, 5, rowId)
+        let updated = sqlite3_step(update) == SQLITE_DONE && sqlite3_changes(db) == 1
+        sqlite3_finalize(update)
+        guard updated, sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        return .applied
+    }
+
+    private func applyUncorrelatedSync(
+        _ sync: TradeControlMessage.Sync,
+        trustedPrice: Double
+    ) -> StableControlDatabaseResult {
+        guard sync.correlation == nil, sync.syncVersion <= UInt64(Int64.max) else { return .invalid }
+        guard let db = openDB() else { return .retry }
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return .retry }
+
+        var select: OpaquePointer?
+        let selectSQL = """
+        SELECT channel_id, expected_usd, stable_sats, receiver_sats, sync_version
+        FROM channels WHERE user_channel_id = ?
+        """
+        guard sqlite3_prepare_v2(db, selectSQL, -1, &select, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        bindText(select, 1, sync.userChannelId)
+        guard sqlite3_step(select) == SQLITE_ROW else {
+            sqlite3_finalize(select)
+            rollback(db)
+            return .retry
+        }
+        let channelId = columnText(select, 0)
+        let oldExpected = sqlite3_column_double(select, 1)
+        let oldBackingSigned = sqlite3_column_int64(select, 2)
+        let receiverSigned = sqlite3_column_int64(select, 3)
+        let oldVersion = sqlite3_column_int64(select, 4)
+        sqlite3_finalize(select)
+        guard channelId == sync.channelId else {
+            rollback(db)
+            return .invalid
+        }
+        if Int64(sync.syncVersion) <= oldVersion {
+            rollback(db)
+            return .duplicate
+        }
+        guard oldBackingSigned >= 0, receiverSigned >= 0 else {
+            rollback(db)
+            return .retry
+        }
+        let oldBacking = UInt64(oldBackingSigned)
+        let receiver = UInt64(receiverSigned)
+        let localBacking: UInt64
+        if sync.expectedUSD == 0 {
+            localBacking = 0
+        } else if oldBacking > 0, sync.expectedUSD == oldExpected {
+            localBacking = min(oldBacking, receiver)
+        } else if let calculated = TradeProtocol.tradeBackingAfterDelta(
+            receiverSats: receiver,
+            currentBackingSats: oldBacking,
+            currentExpectedUSD: oldExpected,
+            newExpectedUSD: sync.expectedUSD,
+            price: trustedPrice
+        ) {
+            localBacking = calculated
+        } else {
+            rollback(db)
+            return .retry
+        }
+        let native = receiver - localBacking
+
+        var update: OpaquePointer?
+        let updateSQL = """
+        UPDATE channels
+        SET expected_usd = ?, stable_sats = ?, native_sats = ?, sync_version = ?,
+            latest_price = ?, updated_at = strftime('%s', 'now')
+        WHERE user_channel_id = ? AND channel_id = ? AND sync_version < ?
+        """
+        guard sqlite3_prepare_v2(db, updateSQL, -1, &update, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        sqlite3_bind_double(update, 1, sync.expectedUSD)
+        sqlite3_bind_int64(update, 2, Int64(localBacking))
+        sqlite3_bind_int64(update, 3, Int64(native))
+        sqlite3_bind_int64(update, 4, Int64(sync.syncVersion))
+        sqlite3_bind_double(update, 5, trustedPrice)
+        bindText(update, 6, sync.userChannelId)
+        bindText(update, 7, sync.channelId)
+        sqlite3_bind_int64(update, 8, Int64(sync.syncVersion))
+        let updated = sqlite3_step(update) == SQLITE_DONE && sqlite3_changes(db) == 1
+        sqlite3_finalize(update)
+        guard updated, sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+            rollback(db)
+            return .retry
+        }
+        return .applied
+    }
+
+    private func bindText(_ statement: OpaquePointer?, _ index: Int32, _ value: String) {
+        sqlite3_bind_text(statement, index, (value as NSString).utf8String, -1, SQLITE_TRANSIENT)
+    }
+
+    private func columnText(_ statement: OpaquePointer?, _ index: Int32) -> String {
+        sqlite3_column_text(statement, index).map { String(cString: $0) } ?? ""
+    }
+
+    private func rollback(_ db: OpaquePointer?) {
+        sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
     }
 
     // MARK: - Pending Send Operations

--- a/ios/StableChannels/NotificationService/Services/StableControlParser.swift
+++ b/ios/StableChannels/NotificationService/Services/StableControlParser.swift
@@ -12,33 +12,37 @@ enum StableControlParser {
         node: LDKNode.Node,
         db: PaymentDatabase,
         priceFetcher: PriceFetcher,
-        customRecords: [CustomTlvRecord]
+        customRecords: [CustomTlvRecord],
+        amountMsat: UInt64
     ) -> StableControlResult {
         for record in customRecords where record.typeNum == Constants.stableChannelTLVType {
             if record.value == Data([1]) {
                 continue
             }
-            guard let envelopeStr = String(data: record.value, encoding: .utf8),
-                  let envelopeData = envelopeStr.data(using: .utf8),
-                  let envelope = try? JSONSerialization.jsonObject(with: envelopeData) as? [String: Any],
-                  let payloadStr = envelope["payload"] as? String,
-                  let signature = envelope["signature"] as? String,
-                  node.verifySignature(
-                      msg: Array(payloadStr.utf8),
-                      sig: signature,
-                      pkey: Constants.lspPubkey
-                  ),
-                  let payloadData = payloadStr.data(using: .utf8),
-                  let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
-                  let type = payload["type"] as? String,
-                  type == Constants.syncMessageType,
-                  let expectedUSD = payload["expected_usd"] as? Double else {
-                return .deferToForeground
+            guard let message = TradeProtocol.parseSignedControl(
+                data: record.value,
+                expectedCounterparty: Constants.lspPubkey,
+                verifySignature: { msg, signature, publicKey in
+                    node.verifySignature(msg: msg, sig: signature, pkey: publicKey)
+                }
+            ) else {
+                // Auth failures and malformed control packets are never accounting input and
+                // should not loop forever in the extension.
+                return .handled
             }
-            let ucid = payload["user_channel_id"] as? String
-            return db
-                .applySyncMessage(expectedUSD: expectedUSD, payloadUserChannelId: ucid, priceFetcher: priceFetcher) ?
-                .handled : .deferToForeground
+            guard amountMsat == TradeProtocol.resultControlAmountMsat else { return .handled }
+            let price: Double?
+            if case .sync(let sync) = message, sync.correlation == nil {
+                let fetched = priceFetcher.fetchPrice()
+                price = PriceOracle.isPlausibleBitcoinPrice(fetched) ? fetched : nil
+                if price == nil { return .deferToForeground }
+            } else {
+                price = nil
+            }
+            switch db.applyTradeControl(message, trustedPrice: price) {
+            case .applied, .duplicate, .invalid: return .handled
+            case .retry: return .deferToForeground
+            }
         }
         return .none
     }

--- a/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
+++ b/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
@@ -1,0 +1,347 @@
+import CryptoKit
+import CoreFoundation
+import Foundation
+import Security
+
+struct TradeCorrelation: Equatable {
+    let tradeId: String
+    let tradePaymentId: String
+    let requestHash: String
+}
+
+enum TradeControlMessage: Equatable {
+    struct Sync: Equatable {
+        let channelId: String
+        let userChannelId: String
+        let expectedUSD: Double
+        let backingSats: UInt64
+        let syncVersion: UInt64
+        let correlation: TradeCorrelation?
+    }
+
+    struct Rejected: Equatable {
+        let channelId: String
+        let correlation: TradeCorrelation
+        let reasonCode: String
+        let decidedAt: UInt64
+    }
+
+    case sync(Sync)
+    case rejected(Rejected)
+}
+
+struct PreparedMobileTrade {
+    let channelId: String
+    let userChannelId: String
+    let tradeId: String
+    let requestHash: String
+    let requestPayload: String
+    let action: String
+    let amountUSD: Double
+    let amountBTC: Double
+    let feeUSD: Double
+    let feeMsat: UInt64
+    let oldExpectedUSD: Double
+    let newExpectedUSD: Double
+    let newBackingSats: UInt64
+    let quotePrice: Double
+    let createdAt: UInt64
+    let expiresAt: UInt64
+}
+
+enum TradeProtocol {
+    static let resultControlAmountMsat: UInt64 = 1
+    static let resultTimeoutSecs: UInt64 = 15 * 60
+    static let responseRetryWindowSecs: UInt64 = 14 * 24 * 60 * 60
+    private static let satsInBTC = 100_000_000.0
+    private static let feeRate = 0.01
+    private static let stabilityThresholdUSD = 0.25
+    private static let stabilityThresholdPercent = 0.1
+    private static let rejectionReasons: Set<String> = [
+        "invalid_amount", "stale_request", "invalid_fee", "invalid_quote",
+        "quote_deviation", "insufficient_capacity", "settlement_required",
+        "unsafe_allocation", "internal_failure"
+    ]
+
+    static func normalizeExpectedUSD(_ value: Double) -> Double {
+        value.isFinite && value >= 0 && value < 0.01 ? 0 : value
+    }
+
+    static func requestHash(_ bytes: Data) -> String {
+        SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func expectedTradeFeeMsat(
+        oldExpectedUSD: Double,
+        newExpectedUSD: Double,
+        quotePrice: Double
+    ) -> UInt64? {
+        guard oldExpectedUSD.isFinite, oldExpectedUSD >= 0,
+              newExpectedUSD.isFinite, newExpectedUSD >= 0,
+              quotePrice.isFinite, quotePrice > 0,
+              feeRate.isFinite, feeRate >= 0, feeRate < 1 else { return nil }
+        let targetDelta = abs(newExpectedUSD - oldExpectedUSD)
+        let grossUSD = newExpectedUSD > oldExpectedUSD ? targetDelta / (1 - feeRate) : targetDelta
+        let feeSats = grossUSD * feeRate / quotePrice * satsInBTC
+        // Swift traps on invalid floating-point to UInt64 conversions. Match Rust's valid-input
+        // truncation only after proving the value can be represented and multiplied by 1,000.
+        guard feeSats.isFinite, feeSats >= 0, feeSats <= Double(UInt64.max / 1000) else { return nil }
+        return max(UInt64(feeSats.rounded(.towardZero)) * 1000, 1)
+    }
+
+    static func prepare(
+        channelId: String,
+        userChannelId: String,
+        currentExpectedUSD: Double,
+        currentBackingSats: UInt64,
+        receiverSats: UInt64,
+        action: String,
+        amountUSD: Double,
+        amountBTC: Double,
+        feeUSD: Double,
+        newExpectedUSD: Double,
+        quotePrice: Double,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970),
+        tradeId: String = randomIdentifier()
+    ) -> PreparedMobileTrade? {
+        let normalizedExpected = normalizeExpectedUSD(newExpectedUSD)
+        guard isCanonicalIdentifier(channelId), !userChannelId.isEmpty,
+              isCanonicalIdentifier(tradeId), amountUSD.isFinite, amountUSD > 0,
+              amountBTC.isFinite, amountBTC >= 0, feeUSD.isFinite, feeUSD >= 0,
+              let feeMsat = expectedTradeFeeMsat(
+                  oldExpectedUSD: currentExpectedUSD,
+                  newExpectedUSD: normalizedExpected,
+                  quotePrice: quotePrice
+              ) else { return nil }
+        let feeSats = feeMsat / 1000
+        guard feeSats <= receiverSats else { return nil }
+        let postFeeReceiver = receiverSats - feeSats
+        guard let backing = tradeBackingAfterDelta(
+            receiverSats: postFeeReceiver,
+            currentBackingSats: currentBackingSats,
+            currentExpectedUSD: currentExpectedUSD,
+            newExpectedUSD: normalizedExpected,
+            price: quotePrice
+        ) else { return nil }
+
+        let object: [String: Any] = [
+            "type": "TRADE_V1",
+            "channel_id": channelId,
+            "user_channel_id": userChannelId,
+            "trade_id": tradeId,
+            "expected_usd": normalizedExpected,
+            "quote_price": quotePrice,
+            "ts": now
+        ]
+        guard JSONSerialization.isValidJSONObject(object),
+              let payloadData = try? JSONSerialization.data(
+                  withJSONObject: object,
+                  options: [.sortedKeys, .withoutEscapingSlashes]
+              ),
+              let payload = String(data: payloadData, encoding: .utf8) else { return nil }
+        return PreparedMobileTrade(
+            channelId: channelId,
+            userChannelId: userChannelId,
+            tradeId: tradeId,
+            requestHash: requestHash(payloadData),
+            requestPayload: payload,
+            action: action,
+            amountUSD: amountUSD,
+            amountBTC: amountBTC,
+            feeUSD: feeUSD,
+            feeMsat: feeMsat,
+            oldExpectedUSD: currentExpectedUSD,
+            newExpectedUSD: normalizedExpected,
+            newBackingSats: backing,
+            quotePrice: quotePrice,
+            createdAt: now,
+            expiresAt: now + resultTimeoutSecs
+        )
+    }
+
+    static func tradeBackingAfterDelta(
+        receiverSats: UInt64,
+        currentBackingSats: UInt64,
+        currentExpectedUSD: Double,
+        newExpectedUSD: Double,
+        price: Double
+    ) -> UInt64? {
+        let normalizedExpected = normalizeExpectedUSD(newExpectedUSD)
+        guard currentExpectedUSD.isFinite, currentExpectedUSD >= 0,
+              normalizedExpected.isFinite, normalizedExpected >= 0,
+              price.isFinite, price > 0 else { return nil }
+        let receiverUSD = Double(receiverSats) / satsInBTC * price
+        guard normalizedExpected <= receiverUSD else { return nil }
+        if normalizedExpected == 0 {
+            return allocationDriftIsActionable(
+                backingSats: currentBackingSats,
+                expectedUSD: currentExpectedUSD,
+                price: price
+            ) ? nil : 0
+        }
+
+        let currentTarget = currentExpectedUSD / price * satsInBTC
+        let newTarget = normalizedExpected / price * satsInBTC
+        guard currentTarget.isFinite, newTarget.isFinite,
+              currentTarget >= 0, newTarget >= 0,
+              currentTarget < Double(UInt64.max), newTarget < Double(UInt64.max) else { return nil }
+        let currentTargetSats = UInt64(currentTarget.rounded(.down))
+        let newTargetSats = UInt64(newTarget.rounded(.down))
+        let backing: UInt64
+        if normalizedExpected >= currentExpectedUSD {
+            let delta = newTargetSats - currentTargetSats
+            let (value, overflow) = currentBackingSats.addingReportingOverflow(delta)
+            guard !overflow else { return nil }
+            backing = value
+        } else {
+            let delta = currentTargetSats - newTargetSats
+            guard delta <= currentBackingSats else { return nil }
+            backing = currentBackingSats - delta
+        }
+        var normalizedBacking = backing
+        if currentExpectedUSD < 0.01, currentBackingSats == 0, backing <= receiverSats {
+            let nativeUSD = Double(receiverSats - backing) / satsInBTC * price
+            if nativeUSD < 0.01 { normalizedBacking = receiverSats }
+        }
+        return normalizedBacking > 0 && normalizedBacking <= receiverSats ? normalizedBacking : nil
+    }
+
+    static func parseSignedControl(
+        data: Data,
+        expectedCounterparty: String,
+        verifySignature: ([UInt8], String, String) -> Bool
+    ) -> TradeControlMessage? {
+        guard let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = envelope["payload"] as? String,
+              let signature = envelope["signature"] as? String,
+              verifySignature(Array(payload.utf8), signature, expectedCounterparty),
+              let payloadData = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let type = object["type"] as? String else { return nil }
+        switch type {
+        case "SYNC_V1": return parseSync(object).map(TradeControlMessage.sync)
+        case "TRADE_REJECTED_V1": return parseRejection(object).map(TradeControlMessage.rejected)
+        default: return nil
+        }
+    }
+
+    private static func parseSync(_ object: [String: Any]) -> TradeControlMessage.Sync? {
+        guard let channelId = object["channel_id"] as? String,
+              let userChannelId = object["user_channel_id"] as? String,
+              let expectedValue = jsonDouble(object["expected_usd"]),
+              let backingSigned = jsonInteger(object["backing_sats"]),
+              let versionSigned = jsonInteger(object["sync_version"]) else { return nil }
+        let expected = normalizeExpectedUSD(expectedValue)
+        guard isCanonicalIdentifier(channelId), !userChannelId.isEmpty,
+              expected.isFinite, expected >= 0, backingSigned >= 0, versionSigned > 0 else { return nil }
+        let fields = ["trade_id", "trade_payment_id", "request_hash"]
+        let present = fields.filter { object[$0] != nil }.count
+        let correlation: TradeCorrelation?
+        switch present {
+        case 0: correlation = nil
+        case 3:
+            guard let tradeId = object["trade_id"] as? String,
+                  let paymentId = object["trade_payment_id"] as? String,
+                  let hash = object["request_hash"] as? String,
+                  isCanonicalIdentifier(tradeId), isCanonicalIdentifier(paymentId),
+                  isCanonicalIdentifier(hash) else { return nil }
+            correlation = TradeCorrelation(
+                tradeId: tradeId,
+                tradePaymentId: paymentId,
+                requestHash: hash
+            )
+        default: return nil
+        }
+        return TradeControlMessage.Sync(
+            channelId: channelId,
+            userChannelId: userChannelId,
+            expectedUSD: expected,
+            backingSats: UInt64(backingSigned),
+            syncVersion: UInt64(versionSigned),
+            correlation: correlation
+        )
+    }
+
+    private static func parseRejection(_ object: [String: Any]) -> TradeControlMessage.Rejected? {
+        let allowed: Set = [
+            "type", "channel_id", "trade_id", "trade_payment_id", "request_hash",
+            "reason_code", "decided_at"
+        ]
+        guard Set(object.keys).isSubset(of: allowed),
+              let channelId = object["channel_id"] as? String,
+              let tradeId = object["trade_id"] as? String,
+              let paymentId = object["trade_payment_id"] as? String,
+              let hash = object["request_hash"] as? String,
+              let reason = object["reason_code"] as? String,
+              let decidedAt = jsonInteger(object["decided_at"]),
+              decidedAt >= 0,
+              isCanonicalIdentifier(channelId), isCanonicalIdentifier(tradeId),
+              isCanonicalIdentifier(paymentId), isCanonicalIdentifier(hash),
+              rejectionReasons.contains(reason) else { return nil }
+        return TradeControlMessage.Rejected(
+            channelId: channelId,
+            correlation: TradeCorrelation(
+                tradeId: tradeId,
+                tradePaymentId: paymentId,
+                requestHash: hash
+            ),
+            reasonCode: reason,
+            decidedAt: UInt64(decidedAt)
+        )
+    }
+
+    static func rejectionMessage(_ reason: String) -> String {
+        switch reason {
+        case "invalid_amount": return "The trade amount is invalid. Review the amount and retry."
+        case "stale_request": return "The quote expired before it could be accepted. Refresh and retry."
+        case "invalid_fee": return "The trade fee was invalid. Refresh the quote before retrying."
+        case "invalid_quote": return "A valid market quote is required. Refresh and retry."
+        case "quote_deviation": return "The market moved outside the quote range. Refresh and retry."
+        case "insufficient_capacity": return "The channel does not have enough capacity for this trade. Reduce the amount."
+        case "settlement_required": return "Settle the current stability adjustment before retrying this trade."
+        case "unsafe_allocation": return "This trade cannot preserve the current channel allocation safely."
+        default: return "The provider could not process the trade. Try again later."
+        }
+    }
+
+    static func isCanonicalIdentifier(_ value: String) -> Bool {
+        value.count == 64 && value.utf8.allSatisfy {
+            ($0 >= 48 && $0 <= 57) || ($0 >= 97 && $0 <= 102)
+        }
+    }
+
+    private static func jsonDouble(_ value: Any?) -> Double? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID(),
+              number.doubleValue.isFinite else { return nil }
+        return number.doubleValue
+    }
+
+    private static func jsonInteger(_ value: Any?) -> Int64? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID(),
+              !CFNumberIsFloatType(number) else { return nil }
+        return number.int64Value
+    }
+
+    private static func allocationDriftIsActionable(
+        backingSats: UInt64,
+        expectedUSD: Double,
+        price: Double
+    ) -> Bool {
+        let currentValue = Double(backingSats) / satsInBTC * price
+        let driftUSD = abs(currentValue - expectedUSD)
+        if expectedUSD < 0.01 { return driftUSD >= stabilityThresholdUSD }
+        let driftPercent = driftUSD / expectedUSD * 100
+        return driftUSD >= stabilityThresholdUSD && driftPercent >= stabilityThresholdPercent
+    }
+
+    private static func randomIdentifier() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+                + UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+        }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		4991278C2FFEB51600D9C81F /* PaymentDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499127872FFEB51600D9C81F /* PaymentDatabase.swift */; };
 		4991278F2FFEC05D00D9C81F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4991278D2FFEC05D00D9C81F /* Constants.swift */; };
 		499127902FFEC05D00D9C81F /* StableControlParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4991278E2FFEC05D00D9C81F /* StableControlParser.swift */; };
+		A20400000000000000000002 /* TradeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20400000000000000000001 /* TradeProtocol.swift */; };
+		A20400000000000000000003 /* TradeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20400000000000000000001 /* TradeProtocol.swift */; };
 		499127922FFEC7B700D9C81F /* NotificationContentMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499127912FFEC7B700D9C81F /* NotificationContentMutator.swift */; };
 		49948C312FBB9DF900327290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 49948C302FBB9DF900327290 /* Localizable.xcstrings */; };
 		499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */; };
@@ -228,6 +230,7 @@
 		499127892FFEB51600D9C81F /* PriceFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFetcher.swift; sourceTree = "<group>"; };
 		4991278D2FFEC05D00D9C81F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		4991278E2FFEC05D00D9C81F /* StableControlParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableControlParser.swift; sourceTree = "<group>"; };
+		A20400000000000000000001 /* TradeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeProtocol.swift; sourceTree = "<group>"; };
 		499127912FFEC7B700D9C81F /* NotificationContentMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentMutator.swift; sourceTree = "<group>"; };
 		49948C302FBB9DF900327290 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPushPaymentTests.swift; sourceTree = "<group>"; };
@@ -436,6 +439,7 @@
 				499127912FFEC7B700D9C81F /* NotificationContentMutator.swift */,
 				4991277E2FFEB50B00D9C81F /* SQLitePaymentDatabase.swift */,
 				4991278E2FFEC05D00D9C81F /* StableControlParser.swift */,
+				A20400000000000000000001 /* TradeProtocol.swift */,
 				4991277F2FFEB50B00D9C81F /* UserToLSPHandler.swift */,
 				499127752FFEB4D600D9C81F /* Models */,
 				499127762FFEB4DB00D9C81F /* Protocols */,
@@ -965,6 +969,7 @@
 				55681ED47BE9198B5635346A /* TradeDetailView.swift in Sources */,
 				499F1E573009F03E00936944 /* PaymentProgress.swift in Sources */,
 				6929CC2C37EEDC6219317621 /* TradeService.swift in Sources */,
+				A20400000000000000000002 /* TradeProtocol.swift in Sources */,
 				2C4A664F5F0343319A539889 /* BackupModels.swift in Sources */,
 				A9F8B3821ACA38AD4DF869BD /* CloudBackupService.swift in Sources */,
 				491D2E883008F96B0009FADF /* PaymentDetailCoordinator.swift in Sources */,
@@ -997,6 +1002,7 @@
 				4991278A2FFEB51600D9C81F /* PaymentHandler.swift in Sources */,
 				4991278F2FFEC05D00D9C81F /* Constants.swift in Sources */,
 				499127902FFEC05D00D9C81F /* StableControlParser.swift in Sources */,
+				A20400000000000000000003 /* TradeProtocol.swift in Sources */,
 				4991278B2FFEB51600D9C81F /* PriceFetcher.swift in Sources */,
 				49A0F0033029000000000001 /* PriceOracle.swift in Sources */,
 				4991278C2FFEB51600D9C81F /* PaymentDatabase.swift in Sources */,

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -204,7 +204,8 @@ class AppState {
     }
 
     private func initializeDatabaseServices() throws {
-        databaseService = try DatabaseService(dataDir: Constants.userDataDir)
+        let db = try DatabaseService(dataDir: Constants.userDataDir)
+        databaseService = db
         nodeService.databaseService = databaseService
 
         txidResolutionService.databaseService = databaseService
@@ -220,7 +221,9 @@ class AppState {
             }
         }
 
-        tradeService = TradeService(nodeService: nodeService)
+        tradeService = TradeService(nodeService: nodeService, databaseService: db)
+        _ = try db.channelRepo.markExpiredTradesUncertain()
+        pendingTradePayments = try db.channelRepo.unresolvedTradePayments()
         let pollingService = databaseService.map { db in
             ConfirmationPollingService(
                 databaseService: db,
@@ -1266,8 +1269,19 @@ class AppState {
 
         case .paymentFailed(let paymentId, let paymentHash, let reason):
             // Check if this is a pending trade payment
-            if let pid = paymentId, let trade = pendingTradePayments.removeValue(forKey: "\(pid)") {
-                try? databaseService?.paymentRepo.updateTradeStatus(trade.tradeDbId, status: "failed")
+            var failedTrade = paymentId.flatMap { pendingTradePayments["\($0)"] }
+            if let pid = paymentId, failedTrade == nil,
+               let payment = nodeService.node?.payment(paymentId: pid),
+               payment.direction == .outbound,
+               let amountMsat = payment.amountMsat {
+                failedTrade = try? databaseService?.channelRepo.failUnattachedPreparedTrade(
+                    paymentId: "\(pid)",
+                    amountMsat: amountMsat
+                )
+            }
+            if let pid = paymentId, let trade = failedTrade {
+                pendingTradePayments.removeValue(forKey: "\(pid)")
+                _ = try? databaseService?.channelRepo.markTradeSendFailed(tradeDbId: trade.tradeDbId)
                 statusMessage = "Order failed"
 
                 AuditService.log("TRADE_FAILED", data: [
@@ -1354,7 +1368,11 @@ class AppState {
 
         // Check for SYNC_V1 message from LSP. A valid sync that cannot yet be applied must
         // remain in LDK's event queue; treating it like malformed control traffic loses it.
-        switch handleSyncMessage(customRecords: customRecords, paymentHash: paymentHashStr) {
+        switch handleSyncMessage(
+            customRecords: customRecords,
+            paymentHash: paymentHashStr,
+            amountMsat: amountMsat
+        ) {
         case .applied:
             refreshBalances()
             updateStableBalances()
@@ -1473,40 +1491,108 @@ class AppState {
     /// Parse a SYNC_V1 TLV and distinguish invalid control traffic from retryable processing.
     private func handleSyncMessage(
         customRecords: [CustomTlvRecord],
-        paymentHash: String
+        paymentHash: String,
+        amountMsat: UInt64
     ) -> SyncMessageHandlingResult {
         for tlv in customRecords {
             guard tlv.typeNum == Constants.stableChannelTLVType else { continue }
 
-            guard let parsed = TradeService.parseIncomingTLV(
-                data: [UInt8](tlv.value),
+            guard let message = TradeProtocol.parseSignedControl(
+                data: tlv.value,
                 expectedCounterparty: stableChannel.counterparty,
                 verifySignature: { [weak self] msg, sig, pubkey in
                     self?.nodeService.verifySignature(message: msg, signature: sig, pubkey: pubkey) ?? false
                 }
             ) else { continue }
-
-            guard parsed.type == Constants.syncMessageType else { continue }
-
-            let oldExpected = stableChannel.expectedUSD.amount
-            let price = accountingBTCPrice
-            guard price > 0 else {
-                AuditService.log("SYNC_V1_DEFERRED", data: [
-                    "reason": "untrusted_price",
+            guard amountMsat == TradeProtocol.resultControlAmountMsat else {
+                AuditService.log("TRADE_RESULT_CONTROL_AMOUNT_INVALID", data: [
+                    "amount_msat": "\(amountMsat)",
                     "payment_hash": paymentHash
                 ])
-                return .retry
+                return .applied
             }
-            StabilityService.applyTrade(&stableChannel, newExpectedUSD: parsed.expectedUSD, price: price)
-            saveChannelToDB()
-
-            AuditService.log("SYNC_V1_APPLIED", data: [
-                "old_expected_usd": "\(oldExpected)",
-                "new_expected_usd": "\(parsed.expectedUSD)",
-                "btc_price": "\(price)",
-                "payment_hash": paymentHash
-            ])
-            return .applied
+            guard let databaseService else { return .retry }
+            let result: TradeControlApplyResult
+            switch message {
+            case .rejected(let rejection):
+                result = databaseService.channelRepo.applyTradeRejection(rejection)
+            case .sync(let sync):
+                if sync.correlation != nil {
+                    result = databaseService.channelRepo.applyCorrelatedTradeAcceptance(sync)
+                } else {
+                    let price = accountingBTCPrice
+                    guard price > 0 else {
+                        AuditService.log("SYNC_V1_DEFERRED", data: [
+                            "reason": "untrusted_price",
+                            "payment_hash": paymentHash
+                        ])
+                        return .retry
+                    }
+                    result = databaseService.channelRepo.applyUncorrelatedSyncIfNewer(
+                        sync,
+                        trustedPrice: price
+                    )
+                }
+            }
+            switch result.status {
+            case .retry:
+                _ = try? databaseService.channelRepo.markTradeResponseNotCommittable(message)
+                AuditService.log("TRADE_RESULT_DEFERRED", data: ["payment_hash": paymentHash])
+                return .retry
+            case .invalid:
+                AuditService.log("TRADE_RESULT_INVALID", data: ["payment_hash": paymentHash])
+                return .applied
+            case .duplicate:
+                if let paymentId = result.paymentId {
+                    pendingTradePayments.removeValue(forKey: paymentId)
+                }
+                guard let channel = try? databaseService.channelRepo.loadChannel(
+                    userChannelId: stableChannel.userChannelId
+                ) else { return .retry }
+                stableChannel.channelId = channel.channelId
+                stableChannel.expectedUSD = USD(amount: channel.expectedUSD)
+                stableChannel.backingSats = channel.backingSats
+                stableChannel.nativeSats = channel.nativeSats
+                stableChannel.nativeChannelBTC = Bitcoin(sats: channel.nativeSats)
+                stableChannel.latestPrice = channel.latestPrice
+                return .applied
+            case .applied:
+                if let paymentId = result.paymentId {
+                    pendingTradePayments.removeValue(forKey: paymentId)
+                }
+                guard let channel = try? databaseService.channelRepo.loadChannel(
+                    userChannelId: stableChannel.userChannelId
+                ) else { return .retry }
+                stableChannel.channelId = channel.channelId
+                stableChannel.expectedUSD = USD(amount: channel.expectedUSD)
+                stableChannel.backingSats = channel.backingSats
+                stableChannel.nativeSats = channel.nativeSats
+                stableChannel.nativeChannelBTC = Bitcoin(sats: channel.nativeSats)
+                stableChannel.latestPrice = channel.latestPrice
+                let diverged = result.localBackingSats != nil &&
+                    result.peerBackingSats != nil &&
+                    result.localBackingSats != result.peerBackingSats
+                AuditService.log("TRADE_RESULT_APPLIED", data: [
+                    "payment_hash": paymentHash,
+                    "local_backing_sats": result.localBackingSats.map { "\($0)" } ?? "nil",
+                    "peer_backing_sats": result.peerBackingSats.map { "\($0)" } ?? "nil",
+                    "allocation_diverged": "\(diverged)",
+                    "allocation_applied": result.allocationApplied.map { "\($0)" } ?? "nil"
+                ])
+                switch message {
+                case .rejected(let rejection):
+                    statusMessage = TradeProtocol.rejectionMessage(rejection.reasonCode)
+                case .sync:
+                    if result.paymentId != nil {
+                        statusMessage = "Order confirmed"
+                        paymentFlash = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                            self?.paymentFlash = false
+                        }
+                    }
+                }
+                return .applied
+            }
         }
         return .notSync
     }
@@ -1520,36 +1606,70 @@ class AppState {
     ) {
         let paymentHashStr = "\(paymentHash)"
 
-        // Check if this is a pending trade payment — apply trade now that payment confirmed
-        if let pid = paymentId, let trade = pendingTradePayments.removeValue(forKey: "\(pid)") {
-            // Apply the trade (deferred until confirmation — matches desktop)
-            StabilityService.applyTrade(
-                &stableChannel,
-                newExpectedUSD: trade.newExpectedUSD,
-                price: trade.price
-            )
-            saveChannelToDB()
+        // Fee settlement is not trade acceptance. Keep the durable correlation pending until a
+        // signed SYNC_V1 or TRADE_REJECTED_V1 commits the outcome.
+        if let pid = paymentId {
+            let paymentIdString = "\(pid)"
+            var trade = pendingTradePayments[paymentIdString]
+            var recognizedTrade = trade != nil
+            if let databaseService {
+                let marked: Bool
+                if let trade {
+                    marked = (try? databaseService.channelRepo.markKnownTradeFeePaid(
+                        tradeDbId: trade.tradeDbId,
+                        paymentId: paymentIdString
+                    )) == true
+                } else {
+                    marked = (try? databaseService.channelRepo.markTradeFeePaid(
+                        paymentId: paymentIdString
+                    )) == true
+                }
+                recognizedTrade = recognizedTrade || marked
 
-            try? databaseService?.paymentRepo.updateTradeStatus(trade.tradeDbId, status: "completed")
-
-            AuditService.log("TRADE_CONFIRMED", data: [
-                "payment_hash": paymentHashStr,
-                "action": trade.action,
-                "new_expected_usd": "\(trade.newExpectedUSD)",
-                "fee_paid_msat": feePaidMsat.map { "\($0)" } ?? "nil"
-            ])
-
-            refreshBalances()
-            updateStableBalances()
-
-            statusMessage = "Order confirmed"
-
-            // Flash so user notices the confirmation
-            paymentFlash = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
-                self?.paymentFlash = false
+                let paymentDetails = recognizedTrade ? nil : nodeService.node?.payment(paymentId: pid)
+                let eventAmountMsat = paymentDetails?.direction == .outbound
+                    ? paymentDetails?.amountMsat
+                    : nil
+                if !recognizedTrade, let eventAmountMsat {
+                    trade = try? databaseService.channelRepo.adoptUnattachedPreparedTrade(
+                        paymentId: paymentIdString,
+                        amountMsat: eventAmountMsat
+                    )
+                    recognizedTrade = trade != nil
+                }
+                if !recognizedTrade {
+                    recognizedTrade = (try? databaseService.channelRepo.tradePaymentExists(
+                        paymentId: paymentIdString
+                    )) == true
+                }
+                if !recognizedTrade, eventAmountMsat == nil,
+                   (try? databaseService.channelRepo.hasUnattachedPreparedTrade()) == true {
+                    statusMessage = "Payment confirmed; awaiting signed trade result"
+                    AuditService.log("TRADE_FEE_ID_UNRESOLVED", data: [
+                        "payment_id": paymentIdString
+                    ])
+                    return
+                }
             }
-            return
+            if recognizedTrade {
+                if let trade {
+                    pendingTradePayments[paymentIdString] = PendingTradePayment(
+                        newExpectedUSD: trade.newExpectedUSD,
+                        price: trade.price,
+                        tradeDbId: trade.tradeDbId,
+                        action: trade.action,
+                        status: "fee_paid"
+                    )
+                }
+                AuditService.log("TRADE_FEE_PAID", data: [
+                    "payment_hash": paymentHashStr,
+                    "action": trade?.action ?? "unknown",
+                    "new_expected_usd": trade.map { "\($0.newExpectedUSD)" } ?? "unknown",
+                    "fee_paid_msat": feePaidMsat.map { "\($0)" } ?? "nil"
+                ])
+                statusMessage = "Trade fee paid; awaiting signed result"
+                return
+            }
         }
 
         if handleStabilityPaymentSuccessful(paymentId: paymentId, feePaidMsat: feePaidMsat) {
@@ -2088,11 +2208,26 @@ class AppState {
 
                 await MainActor.run { [weak self] in
                     self?.recordCurrentPrice()
+                    self?.refreshTradeUncertainty()
                     self?.runStabilityCheck()
                     self?.detectOnchainDeposit()
                 }
             }
         }
+    }
+
+    private func refreshTradeUncertainty() {
+        guard let databaseService,
+              let changed = try? databaseService.channelRepo.markExpiredTradesUncertain(),
+              changed > 0 else { return }
+        if let restored = try? databaseService.channelRepo.unresolvedTradePayments() {
+            pendingTradePayments = restored
+        }
+        statusMessage = "Trade result delayed; it will still be accepted when received"
+        AuditService.log("TRADE_RESULT_UNCERTAIN", data: [
+            "reason": "no_response",
+            "count": "\(changed)"
+        ])
     }
 
     func ensureLSPConnected() {

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -179,6 +179,17 @@ class AppState {
     // Pending trade payments — deferred until PaymentSuccessful/PaymentFailed
     var pendingTradePayments: [String: PendingTradePayment] = [:]
 
+    /// Terminal result of a correlated trade, keyed by its fee payment id. Only a signed
+    /// acceptance or rejection lands here — the trade sheets read this instead of inferring
+    /// success from absence in the pending map (a rejection also clears pending; the old
+    /// absence heuristic showed "Order Confirmed" for rejected trades — e2e flow 13).
+    struct TradeOutcome: Equatable {
+        let accepted: Bool
+        let message: String
+    }
+
+    var tradeOutcomes: [String: TradeOutcome] = [:]
+
     // Pending splice info
     var pendingSplice: PendingSplice?
 
@@ -1545,6 +1556,14 @@ class AppState {
             case .duplicate:
                 if let paymentId = result.paymentId {
                     pendingTradePayments.removeValue(forKey: paymentId)
+                    if case .rejected(let rejection) = message {
+                        tradeOutcomes[paymentId] = TradeOutcome(
+                            accepted: false,
+                            message: TradeProtocol.rejectionMessage(rejection.reasonCode)
+                        )
+                    } else {
+                        tradeOutcomes[paymentId] = TradeOutcome(accepted: true, message: "")
+                    }
                 }
                 guard let channel = try? databaseService.channelRepo.loadChannel(
                     userChannelId: stableChannel.userChannelId
@@ -1559,6 +1578,14 @@ class AppState {
             case .applied:
                 if let paymentId = result.paymentId {
                     pendingTradePayments.removeValue(forKey: paymentId)
+                    if case .rejected(let rejection) = message {
+                        tradeOutcomes[paymentId] = TradeOutcome(
+                            accepted: false,
+                            message: TradeProtocol.rejectionMessage(rejection.reasonCode)
+                        )
+                    } else {
+                        tradeOutcomes[paymentId] = TradeOutcome(accepted: true, message: "")
+                    }
                 }
                 guard let channel = try? databaseService.channelRepo.loadChannel(
                     userChannelId: stableChannel.userChannelId

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -190,6 +190,29 @@ class AppState {
 
     var tradeOutcomes: [String: TradeOutcome] = [:]
 
+    /// Rehydrate a trade's terminal outcome from SQLite. The NSE and background handlers
+    /// commit accepted/rejected results directly to the database without touching this
+    /// in-memory map, so the trade sheets poll this while pending and it runs for every
+    /// known payment id on startup and foreground.
+    func refreshTradeOutcome(paymentId: String) {
+        guard tradeOutcomes[paymentId] == nil, let db = databaseService else { return }
+        guard let terminal =
+            (try? db.channelRepo.terminalTradeOutcome(paymentId: paymentId)) ?? nil else { return }
+        tradeOutcomes[paymentId] = terminal.accepted
+            ? TradeOutcome(accepted: true, message: "")
+            : TradeOutcome(
+                accepted: false,
+                message: TradeProtocol.rejectionMessage(terminal.reasonCode ?? "internal_failure")
+            )
+        pendingTradePayments.removeValue(forKey: paymentId)
+    }
+
+    private func refreshAllTradeOutcomes() {
+        for paymentId in Set(tradeOutcomes.keys).union(pendingTradePayments.keys) {
+            refreshTradeOutcome(paymentId: paymentId)
+        }
+    }
+
     // Pending splice info
     var pendingSplice: PendingSplice?
 
@@ -235,6 +258,7 @@ class AppState {
         tradeService = TradeService(nodeService: nodeService, databaseService: db)
         _ = try db.channelRepo.markExpiredTradesUncertain()
         pendingTradePayments = try db.channelRepo.unresolvedTradePayments()
+        refreshAllTradeOutcomes()
         let pollingService = databaseService.map { db in
             ConfirmationPollingService(
                 databaseService: db,
@@ -845,6 +869,9 @@ class AppState {
         // Payments received while backgrounded are recorded by the NSE, not the foreground
         // event loop — so refresh the banner from the newest DB row instead of leaving it stale.
         refreshLatestPaymentStatus()
+        // Same story for trade results: the NSE writes accepted/rejected to SQLite while
+        // we're backgrounded, so pull any terminal outcomes into the in-memory map.
+        refreshAllTradeOutcomes()
         if nodeService.isRunning {
             // Node never stopped, so gossip was never extracted — do NOT touch
             // ldk_node_data.sqlite while LDK has it open (a stale

--- a/ios/StableChannels/StableChannels/Domain/Trade.swift
+++ b/ios/StableChannels/StableChannels/Domain/Trade.swift
@@ -29,6 +29,39 @@ struct PendingTradePayment {
     let price: Double
     let tradeDbId: Int64
     let action: String // "buy" or "sell"
+    let status: String
+}
+
+enum TradeControlApplyStatus {
+    case applied
+    case duplicate
+    case invalid
+    case retry
+}
+
+struct TradeControlApplyResult {
+    let status: TradeControlApplyStatus
+    let localBackingSats: UInt64?
+    let peerBackingSats: UInt64?
+    let paymentId: String?
+    let action: String?
+    let allocationApplied: Bool?
+
+    init(
+        status: TradeControlApplyStatus,
+        localBackingSats: UInt64? = nil,
+        peerBackingSats: UInt64? = nil,
+        paymentId: String? = nil,
+        action: String? = nil,
+        allocationApplied: Bool? = nil
+    ) {
+        self.status = status
+        self.localBackingSats = localBackingSats
+        self.peerBackingSats = peerBackingSats
+        self.paymentId = paymentId
+        self.action = action
+        self.allocationApplied = allocationApplied
+    }
 }
 
 /// Outgoing splice awaiting confirmation.
@@ -49,6 +82,7 @@ struct ChannelRecord: Codable {
     let nativeSats: UInt64
     let receiverSats: UInt64
     let latestPrice: Double
+    let syncVersion: UInt64
 }
 
 struct TradeRecord: Codable, Identifiable {

--- a/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
@@ -190,14 +190,32 @@ struct BuyView: View {
         }
     }
 
-    private var tradeConfirmed: Bool {
-        guard let pid = pendingPaymentId else { return false }
-        return appState.pendingTradePayments[pid] == nil
+    // Only a signed, correlated acceptance confirms the order and only a signed
+    // rejection fails it. Absence from the pending map proves nothing — a rejection
+    // also clears it, and the old absence heuristic showed "Order Confirmed" for
+    // rejected trades (caught by e2e flow 13).
+    private var tradeOutcome: AppState.TradeOutcome? {
+        guard let pid = pendingPaymentId else { return nil }
+        return appState.tradeOutcomes[pid]
     }
+
+    private var tradeConfirmed: Bool { tradeOutcome?.accepted == true }
+    private var tradeRejected: Bool { tradeOutcome?.accepted == false }
 
     private var doneScreen: some View {
         VStack(spacing: 20) {
-            if tradeConfirmed {
+            if tradeRejected {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.red)
+
+                Text(String(localized: "status_trade_rejected", defaultValue: "Order Rejected"))
+                    .font(.title2.bold())
+
+                Text(tradeOutcome?.message ?? "The provider could not process the trade.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            } else if tradeConfirmed {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 64))
                     .foregroundStyle(.green)

--- a/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
@@ -275,26 +275,13 @@ struct BuyView: View {
                 return
             }
 
-            // Do NOT apply trade yet — wait for PaymentSuccessful event (matches desktop)
-
-            // Record trade in DB as pending
-            let tradeDbId = try appState.databaseService?.channelRepo.recordTrade(
-                channelId: sc.channelId,
-                action: "buy",
-                amountUSD: amountUSD,
-                amountBTC: result.btcAmount,
-                btcPrice: price,
-                feeUSD: feeUSD,
-                paymentId: result.paymentId,
-                status: "pending"
-            ) ?? 0
-
-            // Track so PaymentSuccessful/PaymentFailed can apply or revert
+            // View cache only; the prepared correlation was persisted before the fee send.
             appState.pendingTradePayments[result.paymentId] = PendingTradePayment(
                 newExpectedUSD: result.newExpectedUSD,
                 price: price,
-                tradeDbId: tradeDbId,
-                action: "buy"
+                tradeDbId: result.tradeDbId,
+                action: "buy",
+                status: "sent"
             )
 
             pendingPaymentId = result.paymentId

--- a/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
@@ -256,6 +256,16 @@ struct BuyView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
+        // The NSE commits results straight to SQLite without touching the in-memory
+        // outcome map, so poll the database while the result is unknown — otherwise a
+        // trade resolved while backgrounded stays "Order Pending".
+        .task(id: pendingPaymentId) {
+            guard let pid = pendingPaymentId else { return }
+            while !Task.isCancelled, appState.tradeOutcomes[pid] == nil {
+                appState.refreshTradeOutcome(paymentId: pid)
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+            }
+        }
     }
 
     private func confirmRow(_ label: String, _ value: String, bold: Bool = false) -> some View {

--- a/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
@@ -259,6 +259,16 @@ struct SellView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
+        // The NSE commits results straight to SQLite without touching the in-memory
+        // outcome map, so poll the database while the result is unknown — otherwise a
+        // trade resolved while backgrounded stays "Order Pending".
+        .task(id: pendingPaymentId) {
+            guard let pid = pendingPaymentId else { return }
+            while !Task.isCancelled, appState.tradeOutcomes[pid] == nil {
+                appState.refreshTradeOutcome(paymentId: pid)
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+            }
+        }
     }
 
     private func confirmRow(_ label: String, _ value: String, bold: Bool = false) -> some View {

--- a/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
@@ -280,26 +280,13 @@ struct SellView: View {
                 return
             }
 
-            // Do NOT apply trade yet — wait for PaymentSuccessful event (matches desktop)
-
-            // Record trade in DB as pending
-            let tradeDbId = try appState.databaseService?.channelRepo.recordTrade(
-                channelId: sc.channelId,
-                action: "sell",
-                amountUSD: amountUSD,
-                amountBTC: result.btcAmount,
-                btcPrice: price,
-                feeUSD: feeUSD,
-                paymentId: result.paymentId,
-                status: "pending"
-            ) ?? 0
-
-            // Track so PaymentSuccessful/PaymentFailed can apply or revert
+            // View cache only; the prepared correlation was persisted before the fee send.
             appState.pendingTradePayments[result.paymentId] = PendingTradePayment(
                 newExpectedUSD: result.newExpectedUSD,
                 price: price,
-                tradeDbId: tradeDbId,
-                action: "sell"
+                tradeDbId: result.tradeDbId,
+                action: "sell",
+                status: "sent"
             )
 
             pendingPaymentId = result.paymentId

--- a/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
@@ -193,14 +193,32 @@ struct SellView: View {
         }
     }
 
-    private var tradeConfirmed: Bool {
-        guard let pid = pendingPaymentId else { return false }
-        return appState.pendingTradePayments[pid] == nil
+    // Only a signed, correlated acceptance confirms the order and only a signed
+    // rejection fails it. Absence from the pending map proves nothing — a rejection
+    // also clears it, and the old absence heuristic showed "Order Confirmed" for
+    // rejected trades (caught by e2e flow 13).
+    private var tradeOutcome: AppState.TradeOutcome? {
+        guard let pid = pendingPaymentId else { return nil }
+        return appState.tradeOutcomes[pid]
     }
+
+    private var tradeConfirmed: Bool { tradeOutcome?.accepted == true }
+    private var tradeRejected: Bool { tradeOutcome?.accepted == false }
 
     private var doneScreen: some View {
         VStack(spacing: 20) {
-            if tradeConfirmed {
+            if tradeRejected {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.red)
+
+                Text(String(localized: "status_trade_rejected", defaultValue: "Order Rejected"))
+                    .font(.title2.bold())
+
+                Text(tradeOutcome?.message ?? "The provider could not process the trade.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            } else if tradeConfirmed {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 64))
                     .foregroundStyle(.green)

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -69,6 +69,7 @@ final class DatabaseService {
                 note TEXT,
                 receiver_sats INTEGER NOT NULL DEFAULT 0,
                 latest_price REAL NOT NULL DEFAULT 0.0,
+                sync_version INTEGER NOT NULL DEFAULT 0,
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
                 updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )
@@ -84,6 +85,21 @@ final class DatabaseService {
                 fee_usd REAL NOT NULL DEFAULT 0.0,
                 payment_id TEXT,
                 status TEXT NOT NULL DEFAULT 'pending',
+                user_channel_id TEXT,
+                trade_id TEXT,
+                request_hash TEXT,
+                request_payload TEXT,
+                trade_payment_id TEXT,
+                old_expected_usd REAL,
+                new_expected_usd REAL,
+                new_backing_sats INTEGER,
+                quote_price REAL,
+                fee_msat INTEGER NOT NULL DEFAULT 0,
+                expires_at INTEGER,
+                outcome TEXT,
+                reason_code TEXT,
+                uncertainty_reason TEXT,
+                resolved_at INTEGER,
                 created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )
             """,
@@ -213,6 +229,44 @@ final class DatabaseService {
         if !colNames.contains("native_sats") {
             try rawSQL.execute("ALTER TABLE channels ADD COLUMN native_sats INTEGER NOT NULL DEFAULT 0")
         }
+        if !colNames.contains("sync_version") {
+            try rawSQL.execute("ALTER TABLE channels ADD COLUMN sync_version INTEGER NOT NULL DEFAULT 0")
+        }
+
+        let tradeColumns = try rawSQL.query("PRAGMA table_info(trades)")
+            .compactMap { $0[1] as? String }
+        let tradeMigrations: [(String, String)] = [
+            ("user_channel_id", "TEXT"),
+            ("trade_id", "TEXT"),
+            ("request_hash", "TEXT"),
+            ("request_payload", "TEXT"),
+            ("trade_payment_id", "TEXT"),
+            ("old_expected_usd", "REAL"),
+            ("new_expected_usd", "REAL"),
+            ("new_backing_sats", "INTEGER"),
+            ("quote_price", "REAL"),
+            ("fee_msat", "INTEGER NOT NULL DEFAULT 0"),
+            ("expires_at", "INTEGER"),
+            ("outcome", "TEXT"),
+            ("reason_code", "TEXT"),
+            ("uncertainty_reason", "TEXT"),
+            ("resolved_at", "INTEGER")
+        ]
+        for (name, type) in tradeMigrations where !tradeColumns.contains(name) {
+            try rawSQL.execute("ALTER TABLE trades ADD COLUMN \(name) \(type)")
+        }
+        try rawSQL.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_trade_id_unique ON trades(trade_id) WHERE trade_id IS NOT NULL"
+        )
+        try rawSQL.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_request_hash_unique ON trades(request_hash) WHERE request_hash IS NOT NULL"
+        )
+        try rawSQL.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_payment_id_unique ON trades(trade_payment_id) WHERE trade_payment_id IS NOT NULL"
+        )
+        try rawSQL.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trades_unresolved_channel ON trades(channel_id, status)"
+        )
 
         // Migrate: add tx_block_height to payments if missing (on-chain confirmation tracking)
         let paymentsCols = try rawSQL.query("PRAGMA table_info(payments)")

--- a/ios/StableChannels/StableChannels/Services/Repositories/ChannelRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/ChannelRepository.swift
@@ -382,6 +382,23 @@ final class ChannelRepository {
         })
     }
 
+    /// Terminal outcome for a trade's fee payment id, straight from SQLite — the source
+    /// of truth that both the foreground handler and the NSE write. The in-memory outcome
+    /// map alone misses results committed while the app was backgrounded or before a
+    /// restart. Returns nil while the trade is unresolved.
+    func terminalTradeOutcome(paymentId: String) throws -> (accepted: Bool, reasonCode: String?)? {
+        let rows = try rawSQL.query(
+            """
+            SELECT status, reason_code FROM trades
+            WHERE trade_payment_id = ? AND status IN ('accepted','rejected')
+            ORDER BY id DESC LIMIT 1
+            """,
+            params: [.text(paymentId)]
+        )
+        guard let row = rows.first else { return nil }
+        return (row.string(0) == "accepted", row.optString(1))
+    }
+
     func applyCorrelatedTradeAcceptance(
         _ sync: TradeControlMessage.Sync
     ) -> TradeControlApplyResult {

--- a/ios/StableChannels/StableChannels/Services/Repositories/ChannelRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/ChannelRepository.swift
@@ -85,12 +85,12 @@ final class ChannelRepository {
         let sql: String
         let params: [SQLValue]
         if let id = userChannelId, !id.isEmpty {
-            sql = "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, receiver_sats, latest_price, native_sats FROM channels WHERE user_channel_id = ?"
+            sql = "SELECT channel_id, expected_usd, note, stable_sats, user_channel_id, receiver_sats, latest_price, native_sats, sync_version FROM channels WHERE user_channel_id = ?"
             params = [.text(id)]
         } else {
             sql = """
                 SELECT channel_id, expected_usd, note, stable_sats, user_channel_id,
-                       receiver_sats, latest_price, native_sats
+                       receiver_sats, latest_price, native_sats, sync_version
                 FROM channels
                 ORDER BY updated_at DESC, channel_id DESC
                 LIMIT 1
@@ -108,7 +108,8 @@ final class ChannelRepository {
             backingSats: row.uInt64(3),
             nativeSats: row.uInt64(7),
             receiverSats: row.uInt64(5),
-            latestPrice: row.double(6)
+            latestPrice: row.double(6),
+            syncVersion: row.uInt64(8)
         )
     }
 
@@ -136,6 +137,510 @@ final class ChannelRepository {
             paymentId.map { .text($0) } ?? .null, .text(status)
         ])
         return rawSQL.lastInsertRowId
+    }
+
+    func recordPreparedTrade(_ trade: PreparedMobileTrade) throws -> Int64 {
+        guard trade.feeMsat <= UInt64(Int64.max),
+              trade.newBackingSats <= UInt64(Int64.max),
+              trade.createdAt <= UInt64(Int64.max),
+              trade.expiresAt <= UInt64(Int64.max) else {
+            throw DatabaseError.executeFailed("Prepared trade values exceed SQLite integer range")
+        }
+        return try rawSQL.inTransaction {
+            let unresolved = try rawSQL.query(
+                "SELECT 1 FROM trades WHERE channel_id = ? AND status IN ('prepared','sent','fee_paid','uncertain') LIMIT 1",
+                params: [.text(trade.channelId)]
+            )
+            guard unresolved.isEmpty else {
+                throw DatabaseError.executeFailed("A previous trade is still awaiting its signed result")
+            }
+            try rawSQL.execute(
+                """
+                INSERT INTO trades (
+                    channel_id, user_channel_id, action, amount_usd, amount_btc, btc_price,
+                    fee_usd, status, trade_id, request_hash, request_payload,
+                    old_expected_usd, new_expected_usd, new_backing_sats, quote_price,
+                    fee_msat, expires_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'prepared', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                params: [
+                    .text(trade.channelId), .text(trade.userChannelId), .text(trade.action),
+                    .real(trade.amountUSD), .real(trade.amountBTC), .real(trade.quotePrice),
+                    .real(trade.feeUSD), .text(trade.tradeId), .text(trade.requestHash),
+                    .text(trade.requestPayload), .real(trade.oldExpectedUSD),
+                    .real(trade.newExpectedUSD), .integer(Int64(trade.newBackingSats)),
+                    .real(trade.quotePrice), .integer(Int64(trade.feeMsat)),
+                    .integer(Int64(trade.expiresAt)), .integer(Int64(trade.createdAt))
+                ]
+            )
+            return rawSQL.lastInsertRowId
+        }
+    }
+
+    func attachTradePaymentId(tradeDbId: Int64, paymentId: String) throws -> Bool {
+        guard TradeProtocol.isCanonicalIdentifier(paymentId) else { return false }
+        return try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades SET payment_id = ?, trade_payment_id = ?, status = 'sent'
+            WHERE id = ? AND status = 'prepared'
+            """,
+            params: [.text(paymentId), .text(paymentId), .integer(tradeDbId)]
+        ) == 1
+    }
+
+    func markTradeFeePaid(paymentId: String) throws -> Bool {
+        try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades SET status = 'fee_paid'
+            WHERE trade_payment_id = ? AND status IN ('prepared','sent','uncertain')
+            """,
+            params: [.text(paymentId)]
+        ) == 1
+    }
+
+    func markKnownTradeFeePaid(tradeDbId: Int64, paymentId: String) throws -> Bool {
+        guard TradeProtocol.isCanonicalIdentifier(paymentId) else { return false }
+        return try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades
+            SET payment_id = ?, trade_payment_id = ?, status = 'fee_paid'
+            WHERE id = ? AND status IN ('prepared','sent','uncertain')
+              AND (trade_payment_id IS NULL OR trade_payment_id = ?)
+            """,
+            params: [
+                .text(paymentId), .text(paymentId), .integer(tradeDbId), .text(paymentId)
+            ]
+        ) == 1
+    }
+
+    func tradePaymentExists(paymentId: String) throws -> Bool {
+        try !rawSQL.query(
+            "SELECT 1 FROM trades WHERE trade_payment_id = ? LIMIT 1",
+            params: [.text(paymentId)]
+        ).isEmpty
+    }
+
+    func hasUnattachedPreparedTrade() throws -> Bool {
+        try !rawSQL.query(
+            "SELECT 1 FROM trades WHERE trade_payment_id IS NULL AND status = 'prepared' LIMIT 1"
+        ).isEmpty
+    }
+
+    func adoptUnattachedPreparedTrade(
+        paymentId: String,
+        amountMsat: UInt64,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970)
+    ) throws -> PendingTradePayment? {
+        guard TradeProtocol.isCanonicalIdentifier(paymentId),
+              amountMsat <= UInt64(Int64.max), now <= UInt64(Int64.max) else { return nil }
+        return try rawSQL.inTransaction {
+            let cutoff = Int64(max(now, TradeProtocol.responseRetryWindowSecs)
+                - TradeProtocol.responseRetryWindowSecs)
+            let rows = try rawSQL.query(
+                """
+                SELECT id, new_expected_usd, quote_price, action
+                FROM trades
+                WHERE trade_payment_id IS NULL AND status = 'prepared'
+                  AND fee_msat = ? AND created_at >= ?
+                ORDER BY id DESC LIMIT 2
+                """,
+                params: [.integer(Int64(amountMsat)), .integer(cutoff)]
+            )
+            guard rows.count == 1, let row = rows.first else { return nil }
+            let tradeDbId = row.int64(0)
+            let changed = try rawSQL.executeReturningChanges(
+                """
+                UPDATE trades SET payment_id = ?, trade_payment_id = ?, status = 'fee_paid'
+                WHERE id = ? AND trade_payment_id IS NULL AND status = 'prepared'
+                """,
+                params: [.text(paymentId), .text(paymentId), .integer(tradeDbId)]
+            )
+            guard changed == 1 else {
+                throw DatabaseError.executeFailed("Prepared trade payment adoption lost its race")
+            }
+            return PendingTradePayment(
+                newExpectedUSD: row.double(1),
+                price: row.double(2),
+                tradeDbId: tradeDbId,
+                action: row.string(3),
+                status: "fee_paid"
+            )
+        }
+    }
+
+    func failUnattachedPreparedTrade(
+        paymentId: String,
+        amountMsat: UInt64,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970)
+    ) throws -> PendingTradePayment? {
+        guard TradeProtocol.isCanonicalIdentifier(paymentId),
+              amountMsat <= UInt64(Int64.max), now <= UInt64(Int64.max) else { return nil }
+        return try rawSQL.inTransaction {
+            let cutoff = Int64(max(now, TradeProtocol.responseRetryWindowSecs)
+                - TradeProtocol.responseRetryWindowSecs)
+            let rows = try rawSQL.query(
+                """
+                SELECT id, new_expected_usd, quote_price, action
+                FROM trades
+                WHERE trade_payment_id IS NULL AND status = 'prepared'
+                  AND fee_msat = ? AND created_at >= ?
+                ORDER BY id DESC LIMIT 2
+                """,
+                params: [.integer(Int64(amountMsat)), .integer(cutoff)]
+            )
+            guard rows.count == 1, let row = rows.first else { return nil }
+            let tradeDbId = row.int64(0)
+            let changed = try rawSQL.executeReturningChanges(
+                """
+                UPDATE trades
+                SET payment_id = ?, trade_payment_id = ?, status = 'send_failed',
+                    outcome = 'send_failed', resolved_at = strftime('%s', 'now')
+                WHERE id = ? AND trade_payment_id IS NULL AND status = 'prepared'
+                """,
+                params: [.text(paymentId), .text(paymentId), .integer(tradeDbId)]
+            )
+            guard changed == 1 else {
+                throw DatabaseError.executeFailed("Prepared trade failure adoption lost its race")
+            }
+            return PendingTradePayment(
+                newExpectedUSD: row.double(1),
+                price: row.double(2),
+                tradeDbId: tradeDbId,
+                action: row.string(3),
+                status: "send_failed"
+            )
+        }
+    }
+
+    func markTradeSendFailed(tradeDbId: Int64) throws -> Bool {
+        try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades SET status = 'send_failed', outcome = 'send_failed',
+                resolved_at = strftime('%s', 'now')
+            WHERE id = ? AND status IN ('prepared','sent','uncertain')
+            """,
+            params: [.integer(tradeDbId)]
+        ) == 1
+    }
+
+    func markExpiredTradesUncertain(now: UInt64 = UInt64(Date().timeIntervalSince1970)) throws -> Int {
+        guard now <= UInt64(Int64.max) else { return 0 }
+        return try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades SET status = 'uncertain', uncertainty_reason = 'no_response'
+            WHERE expires_at IS NOT NULL AND expires_at <= ?
+              AND status IN ('prepared','sent','fee_paid')
+            """,
+            params: [.integer(Int64(now))]
+        )
+    }
+
+    func markTradeResponseNotCommittable(_ message: TradeControlMessage) throws -> Bool {
+        let channelId: String
+        let correlation: TradeCorrelation
+        switch message {
+        case .sync(let sync):
+            guard let syncCorrelation = sync.correlation else { return false }
+            channelId = sync.channelId
+            correlation = syncCorrelation
+        case .rejected(let rejection):
+            channelId = rejection.channelId
+            correlation = rejection.correlation
+        }
+        return try rawSQL.executeReturningChanges(
+            """
+            UPDATE trades SET status = 'uncertain', uncertainty_reason = 'response_not_committable'
+            WHERE channel_id = ? AND trade_id = ? AND request_hash = ?
+              AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+              AND status IN ('prepared','sent','fee_paid','uncertain')
+            """,
+            params: [
+                .text(channelId), .text(correlation.tradeId), .text(correlation.requestHash),
+                .text(correlation.tradePaymentId)
+            ]
+        ) == 1
+    }
+
+    func unresolvedTradePayments() throws -> [String: PendingTradePayment] {
+        let rows = try rawSQL.query(
+            """
+            SELECT trade_payment_id, new_expected_usd, quote_price, id, action, status
+            FROM trades
+            WHERE trade_payment_id IS NOT NULL
+              AND status IN ('sent','fee_paid','uncertain')
+            ORDER BY id
+            """
+        )
+        return Dictionary(uniqueKeysWithValues: rows.map { row in
+            (row.string(0), PendingTradePayment(
+                newExpectedUSD: row.double(1),
+                price: row.double(2),
+                tradeDbId: row.int64(3),
+                action: row.string(4),
+                status: row.string(5)
+            ))
+        })
+    }
+
+    func applyCorrelatedTradeAcceptance(
+        _ sync: TradeControlMessage.Sync
+    ) -> TradeControlApplyResult {
+        guard let correlation = sync.correlation else {
+            return TradeControlApplyResult(status: .invalid)
+        }
+        do {
+            return try rawSQL.inTransaction {
+                let rows = try rawSQL.query(
+                    """
+                    SELECT id, channel_id, user_channel_id, trade_payment_id,
+                           new_expected_usd, new_backing_sats, status, action
+                    FROM trades
+                    WHERE trade_id = ? AND request_hash = ?
+                      AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+                    LIMIT 1
+                    """,
+                    params: [
+                        .text(correlation.tradeId), .text(correlation.requestHash),
+                        .text(correlation.tradePaymentId)
+                    ]
+                )
+                guard let trade = rows.first else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let storedPayment = trade.optString(3)
+                let storedExpected = trade.double(4)
+                guard trade.string(1) == sync.channelId,
+                      trade.string(2) == sync.userChannelId,
+                      storedPayment == nil || storedPayment == correlation.tradePaymentId,
+                      abs(storedExpected - sync.expectedUSD) <= 0.000000001,
+                      let storedBackingSigned = trade.optInt64(5), storedBackingSigned >= 0 else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let storedBacking = UInt64(storedBackingSigned)
+                let status = trade.string(6)
+                let action = trade.string(7)
+                if status == "accepted" {
+                    return TradeControlApplyResult(
+                        status: .duplicate,
+                        localBackingSats: storedBacking,
+                        peerBackingSats: sync.backingSats,
+                        paymentId: correlation.tradePaymentId,
+                        action: action
+                    )
+                }
+                guard status != "rejected", status != "send_failed" else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let channels = try rawSQL.query(
+                    "SELECT channel_id, receiver_sats, sync_version, stable_sats FROM channels WHERE user_channel_id = ?",
+                    params: [.text(sync.userChannelId)]
+                )
+                guard let channel = channels.first else {
+                    return TradeControlApplyResult(status: .retry)
+                }
+                guard channel.string(0) == sync.channelId else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let receiverSigned = channel.int64(1)
+                let currentVersion = channel.int64(2)
+                let currentBackingSigned = channel.int64(3)
+                guard receiverSigned >= 0, currentBackingSigned >= 0,
+                      sync.syncVersion <= UInt64(Int64.max) else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let allocationApplied = Int64(sync.syncVersion) > currentVersion
+                if allocationApplied {
+                    guard storedBacking <= UInt64(receiverSigned) else {
+                        return TradeControlApplyResult(status: .retry)
+                    }
+                    let native = UInt64(receiverSigned) - storedBacking
+                    let channelChanges = try rawSQL.executeReturningChanges(
+                        """
+                        UPDATE channels
+                        SET expected_usd = ?, stable_sats = ?, native_sats = ?, sync_version = ?,
+                            updated_at = strftime('%s', 'now')
+                        WHERE user_channel_id = ? AND channel_id = ? AND sync_version < ?
+                        """,
+                        params: [
+                            .real(sync.expectedUSD), .integer(Int64(storedBacking)),
+                            .integer(Int64(native)), .integer(Int64(sync.syncVersion)),
+                            .text(sync.userChannelId), .text(sync.channelId),
+                            .integer(Int64(sync.syncVersion))
+                        ]
+                    )
+                    guard channelChanges == 1 else {
+                        throw DatabaseError.executeFailed("Correlated sync channel update did not affect one row")
+                    }
+                }
+                let tradeChanges = try rawSQL.executeReturningChanges(
+                    """
+                    UPDATE trades
+                    SET payment_id = ?, trade_payment_id = ?, status = 'accepted',
+                        outcome = 'accepted', resolved_at = strftime('%s', 'now'),
+                        uncertainty_reason = NULL
+                    WHERE id = ?
+                    """,
+                    params: [
+                        .text(correlation.tradePaymentId), .text(correlation.tradePaymentId),
+                        .integer(trade.int64(0))
+                    ]
+                )
+                guard tradeChanges == 1 else {
+                    throw DatabaseError.executeFailed("Correlated sync trade update did not affect one row")
+                }
+                return TradeControlApplyResult(
+                    status: .applied,
+                    localBackingSats: allocationApplied ? storedBacking : UInt64(currentBackingSigned),
+                    peerBackingSats: sync.backingSats,
+                    paymentId: correlation.tradePaymentId,
+                    action: action,
+                    allocationApplied: allocationApplied
+                )
+            }
+        } catch {
+            return TradeControlApplyResult(status: .retry)
+        }
+    }
+
+    func applyTradeRejection(
+        _ rejection: TradeControlMessage.Rejected
+    ) -> TradeControlApplyResult {
+        do {
+            return try rawSQL.inTransaction {
+                let rows = try rawSQL.query(
+                    """
+                    SELECT id, channel_id, trade_payment_id, status, action
+                    FROM trades
+                    WHERE trade_id = ? AND request_hash = ?
+                      AND (trade_payment_id = ? OR trade_payment_id IS NULL)
+                    LIMIT 1
+                    """,
+                    params: [
+                        .text(rejection.correlation.tradeId),
+                        .text(rejection.correlation.requestHash),
+                        .text(rejection.correlation.tradePaymentId)
+                    ]
+                )
+                guard let trade = rows.first,
+                      trade.string(1) == rejection.channelId,
+                      trade.optString(2) == nil || trade.optString(2) == rejection.correlation.tradePaymentId else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                if trade.string(3) == "rejected" {
+                    return TradeControlApplyResult(
+                        status: .duplicate,
+                        paymentId: rejection.correlation.tradePaymentId,
+                        action: trade.string(4)
+                    )
+                }
+                guard trade.string(3) != "accepted", trade.string(3) != "send_failed",
+                      rejection.decidedAt <= UInt64(Int64.max) else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                let changes = try rawSQL.executeReturningChanges(
+                    """
+                    UPDATE trades
+                    SET payment_id = ?, trade_payment_id = ?, status = 'rejected',
+                        outcome = 'rejected', reason_code = ?, resolved_at = ?,
+                        uncertainty_reason = NULL
+                    WHERE id = ?
+                    """,
+                    params: [
+                        .text(rejection.correlation.tradePaymentId),
+                        .text(rejection.correlation.tradePaymentId),
+                        .text(rejection.reasonCode), .integer(Int64(rejection.decidedAt)),
+                        .integer(trade.int64(0))
+                    ]
+                )
+                guard changes == 1 else {
+                    throw DatabaseError.executeFailed("Trade rejection did not affect one row")
+                }
+                return TradeControlApplyResult(
+                    status: .applied,
+                    paymentId: rejection.correlation.tradePaymentId,
+                    action: trade.string(4)
+                )
+            }
+        } catch {
+            return TradeControlApplyResult(status: .retry)
+        }
+    }
+
+    func applyUncorrelatedSyncIfNewer(
+        _ sync: TradeControlMessage.Sync,
+        trustedPrice: Double
+    ) -> TradeControlApplyResult {
+        guard sync.correlation == nil, trustedPrice.isFinite, trustedPrice > 0,
+              sync.syncVersion <= UInt64(Int64.max) else {
+            return TradeControlApplyResult(status: .invalid)
+        }
+        do {
+            return try rawSQL.inTransaction {
+                let rows = try rawSQL.query(
+                    """
+                    SELECT channel_id, expected_usd, stable_sats, receiver_sats, sync_version
+                    FROM channels WHERE user_channel_id = ?
+                    """,
+                    params: [.text(sync.userChannelId)]
+                )
+                guard let channel = rows.first else {
+                    return TradeControlApplyResult(status: .retry)
+                }
+                guard channel.string(0) == sync.channelId else {
+                    return TradeControlApplyResult(status: .invalid)
+                }
+                if Int64(sync.syncVersion) <= channel.int64(4) {
+                    return TradeControlApplyResult(status: .duplicate)
+                }
+                let currentBackingSigned = channel.int64(2)
+                let receiverSigned = channel.int64(3)
+                guard currentBackingSigned >= 0, receiverSigned >= 0 else {
+                    return TradeControlApplyResult(status: .retry)
+                }
+                let currentBacking = UInt64(currentBackingSigned)
+                let receiver = UInt64(receiverSigned)
+                let localBacking: UInt64
+                if sync.expectedUSD == 0 {
+                    localBacking = 0
+                } else if currentBacking > 0, sync.expectedUSD == channel.double(1) {
+                    localBacking = min(currentBacking, receiver)
+                } else {
+                    guard let calculated = TradeProtocol.tradeBackingAfterDelta(
+                        receiverSats: receiver,
+                        currentBackingSats: currentBacking,
+                        currentExpectedUSD: channel.double(1),
+                        newExpectedUSD: sync.expectedUSD,
+                        price: trustedPrice
+                    ) else { return TradeControlApplyResult(status: .retry) }
+                    localBacking = calculated
+                }
+                let native = receiver - localBacking
+                let changes = try rawSQL.executeReturningChanges(
+                    """
+                    UPDATE channels
+                    SET expected_usd = ?, stable_sats = ?, native_sats = ?, sync_version = ?,
+                        latest_price = ?, updated_at = strftime('%s', 'now')
+                    WHERE user_channel_id = ? AND channel_id = ? AND sync_version < ?
+                    """,
+                    params: [
+                        .real(sync.expectedUSD), .integer(Int64(localBacking)),
+                        .integer(Int64(native)), .integer(Int64(sync.syncVersion)),
+                        .real(trustedPrice), .text(sync.userChannelId), .text(sync.channelId),
+                        .integer(Int64(sync.syncVersion))
+                    ]
+                )
+                guard changes == 1 else {
+                    throw DatabaseError.executeFailed("Uncorrelated sync did not affect one row")
+                }
+                return TradeControlApplyResult(
+                    status: .applied,
+                    localBackingSats: localBacking,
+                    peerBackingSats: sync.backingSats
+                )
+            }
+        } catch {
+            return TradeControlApplyResult(status: .retry)
+        }
     }
 
     func getRecentTrades(limit: Int) throws -> [TradeRecord] {

--- a/ios/StableChannels/StableChannels/Services/TradeService.swift
+++ b/ios/StableChannels/StableChannels/Services/TradeService.swift
@@ -1,168 +1,138 @@
 import Foundation
 import LDKNode
 
-/// Handles buy/sell BTC trades and custom TLV message protocol.
-class TradeService {
-    private let nodeService: NodeService
+struct TradeExecutionResult {
+    let paymentId: String
+    let newExpectedUSD: Double
+    let btcAmount: Double
+    let tradeDbId: Int64
+}
 
-    init(nodeService: NodeService) {
+/// Builds a durable, correlated TRADE_V1 request and sends its non-refundable fee.
+final class TradeService {
+    private let nodeService: NodeService
+    private let databaseService: DatabaseService
+
+    init(nodeService: NodeService, databaseService: DatabaseService) {
         self.nodeService = nodeService
+        self.databaseService = databaseService
     }
 
-    // MARK: - Trade Execution
-
-    /// Execute a buy BTC trade. Returns the PaymentId on success so the caller
-    /// can store a PendingTradePayment. Trade is NOT applied until payment confirms.
     func executeBuy(
         sc: StableChannel,
         amountUSD: Double,
         feeUSD: Double,
         price: Double
-    ) throws -> (paymentId: String, newExpectedUSD: Double, btcAmount: Double)? {
+    ) throws -> TradeExecutionResult? {
         guard amountUSD > 0, amountUSD <= sc.expectedUSD.amount, price > 0 else { return nil }
-
         let netAmount = amountUSD - feeUSD
-        let newExpectedUSD = max(sc.expectedUSD.amount - amountUSD, 0)
-        let btcAmount = netAmount / price
-
-        // Send trade message to counterparty — payment must succeed before we apply the trade
-        let paymentId = try sendTradeMessage(
-            expectedUSD: newExpectedUSD,
+        return try preparePersistAndSend(
+            sc: sc,
+            action: "buy",
+            amountUSD: amountUSD,
+            amountBTC: netAmount / price,
             feeUSD: feeUSD,
-            price: price,
-            channelId: sc.channelId,
-            userChannelId: sc.userChannelId,
-            counterparty: sc.counterparty
+            newExpectedUSD: max(sc.expectedUSD.amount - amountUSD, 0),
+            price: price
         )
-
-        return (paymentId: paymentId, newExpectedUSD: newExpectedUSD, btcAmount: btcAmount)
     }
 
-    /// Execute a sell BTC trade. Returns the PaymentId on success.
     func executeSell(
         sc: StableChannel,
         amountUSD: Double,
         feeUSD: Double,
         price: Double,
         maxUSD: Double
-    ) throws -> (paymentId: String, newExpectedUSD: Double, btcAmount: Double)? {
+    ) throws -> TradeExecutionResult? {
         guard amountUSD > 0, price > 0 else { return nil }
-
         let netAmount = amountUSD - feeUSD
-        let newExpectedUSD = min(sc.expectedUSD.amount + netAmount, maxUSD)
-        let btcAmount = netAmount / price
-
-        let paymentId = try sendTradeMessage(
-            expectedUSD: newExpectedUSD,
+        return try preparePersistAndSend(
+            sc: sc,
+            action: "sell",
+            amountUSD: amountUSD,
+            amountBTC: netAmount / price,
             feeUSD: feeUSD,
-            price: price,
+            newExpectedUSD: min(sc.expectedUSD.amount + netAmount, maxUSD),
+            price: price
+        )
+    }
+
+    private func preparePersistAndSend(
+        sc: StableChannel,
+        action: String,
+        amountUSD: Double,
+        amountBTC: Double,
+        feeUSD: Double,
+        newExpectedUSD: Double,
+        price: Double
+    ) throws -> TradeExecutionResult? {
+        guard let prepared = TradeProtocol.prepare(
             channelId: sc.channelId,
             userChannelId: sc.userChannelId,
-            counterparty: sc.counterparty
+            currentExpectedUSD: sc.expectedUSD.amount,
+            currentBackingSats: sc.backingSats,
+            receiverSats: sc.stableReceiverBTC.sats,
+            action: action,
+            amountUSD: amountUSD,
+            amountBTC: amountBTC,
+            feeUSD: feeUSD,
+            newExpectedUSD: newExpectedUSD,
+            quotePrice: price
+        ) else { return nil }
+
+        // Persist the exact signed payload and local allocation before the fee can leave.
+        let tradeDbId = try databaseService.channelRepo.recordPreparedTrade(prepared)
+        let paymentIdString: String
+        do {
+            let signature = try nodeService.signMessage(Array(prepared.requestPayload.utf8))
+            let envelope: [String: Any] = [
+                "payload": prepared.requestPayload,
+                "signature": signature
+            ]
+            let envelopeData = try JSONSerialization.data(
+                withJSONObject: envelope,
+                options: [.sortedKeys, .withoutEscapingSlashes]
+            )
+            let paymentId = try nodeService.sendKeysendWithTLV(
+                amountMsat: prepared.feeMsat,
+                to: sc.counterparty,
+                tlvs: [CustomTlvRecord(
+                    typeNum: Constants.stableChannelTLVType,
+                    value: envelopeData
+                )]
+            )
+            paymentIdString = "\(paymentId)"
+        } catch {
+            _ = try? databaseService.channelRepo.markTradeSendFailed(tradeDbId: tradeDbId)
+            throw error
+        }
+
+        // The payment has left the node at this point. A local bookkeeping failure must not
+        // report a send failure (or invite the user to pay the non-refundable fee twice).
+        let attached = (try? databaseService.channelRepo.attachTradePaymentId(
+            tradeDbId: tradeDbId,
+            paymentId: paymentIdString
+        )) == true
+        if !attached {
+            AuditService.log("TRADE_PAYMENT_ID_PERSIST_FAILED", data: [
+                "trade_db_id": "\(tradeDbId)",
+                "trade_id": prepared.tradeId,
+                "payment_id": paymentIdString
+            ])
+        }
+        AuditService.log("TRADE_MESSAGE_SENT", data: [
+            "trade_id": prepared.tradeId,
+            "request_hash": prepared.requestHash,
+            "payment_id": paymentIdString,
+            "fee_msat": "\(prepared.feeMsat)",
+            "new_expected_usd": "\(prepared.newExpectedUSD)",
+            "new_backing_sats": "\(prepared.newBackingSats)"
+        ])
+        return TradeExecutionResult(
+            paymentId: paymentIdString,
+            newExpectedUSD: prepared.newExpectedUSD,
+            btcAmount: amountBTC,
+            tradeDbId: tradeDbId
         )
-
-        return (paymentId: paymentId, newExpectedUSD: newExpectedUSD, btcAmount: btcAmount)
-    }
-
-    // MARK: - Custom TLV Messages
-
-    /// Send a TRADE_V1 message to the counterparty. Returns the PaymentId string.
-    /// The fee is sent as the keysend payment amount (matching desktop behavior).
-    @discardableResult
-    func sendTradeMessage(
-        expectedUSD: Double,
-        feeUSD: Double = 0,
-        price: Double = 0,
-        channelId: String,
-        userChannelId: String,
-        counterparty: String
-    ) throws -> String {
-        let payload: [String: Any] = [
-            "type": Constants.tradeMessageType,
-            "channel_id": channelId,
-            "user_channel_id": "\(userChannelId)",
-            "expected_usd": expectedUSD
-        ]
-
-        guard let payloadData = try? JSONSerialization.data(withJSONObject: payload),
-              let payloadStr = String(data: payloadData, encoding: .utf8) else {
-            throw TradeError.encodingFailed
-        }
-
-        let signature = try nodeService.signMessage(Array(payloadStr.utf8))
-
-        let envelope: [String: Any] = [
-            "payload": payloadStr,
-            "signature": signature
-        ]
-
-        guard let envelopeData = try? JSONSerialization.data(withJSONObject: envelope),
-              let envelopeStr = String(data: envelopeData, encoding: .utf8) else {
-            throw TradeError.encodingFailed
-        }
-
-        let tlv = CustomTlvRecord(
-            typeNum: Constants.stableChannelTLVType,
-            value: Data(envelopeStr.utf8)
-        )
-
-        // Send fee as payment amount (matches desktop: fee_msats.max(1))
-        let feeMsat: UInt64
-        if price > 0 && feeUSD > 0 {
-            let feeBtc = feeUSD / price
-            let feeSats = UInt64(feeBtc * 100_000_000)
-            feeMsat = max(feeSats * 1000, 1)
-        } else {
-            feeMsat = 1
-        }
-
-        let paymentId = try nodeService.sendKeysendWithTLV(
-            amountMsat: feeMsat,
-            to: counterparty,
-            tlvs: [tlv]
-        )
-        return "\(paymentId)"
-    }
-
-    /// Parse and verify an incoming TLV message (TRADE_V1 or SYNC_V1).
-    static func parseIncomingTLV(
-        data: [UInt8],
-        expectedCounterparty: String,
-        verifySignature: ([UInt8], String, String) -> Bool
-    ) -> (type: String, expectedUSD: Double, userChannelId: String)? {
-        guard let envelopeStr = String(bytes: data, encoding: .utf8),
-              let envelopeData = envelopeStr.data(using: .utf8),
-              let envelope = try? JSONSerialization.jsonObject(with: envelopeData) as? [String: Any],
-              let payloadStr = envelope["payload"] as? String,
-              let signature = envelope["signature"] as? String else {
-            return nil
-        }
-
-        // Verify signature
-        guard verifySignature(Array(payloadStr.utf8), signature, expectedCounterparty) else {
-            return nil
-        }
-
-        // Parse payload
-        guard let payloadData = payloadStr.data(using: .utf8),
-              let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
-              let msgType = payload["type"] as? String,
-              let expectedUSD = payload["expected_usd"] as? Double else {
-            return nil
-        }
-
-        let userChannelId = payload["user_channel_id"] as? String ?? ""
-
-        return (type: msgType, expectedUSD: expectedUSD, userChannelId: userChannelId)
-    }
-}
-
-enum TradeError: LocalizedError {
-    case encodingFailed
-
-    var errorDescription: String? {
-        switch self {
-        case .encodingFailed: return "Failed to encode trade message"
-        }
     }
 }

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -845,6 +845,106 @@ final class DatabaseServiceTests: XCTestCase {
         ))
     }
 
+    func testTerminalTradeOutcomeReflectsResultsCommittedOutsideTheHandler() throws {
+        let channelId = String(repeating: "ab", count: 32)
+        try service.channelRepo.saveChannel(
+            channelId: channelId,
+            userChannelId: "7",
+            expectedUSD: 50,
+            backingSats: 55_000,
+            nativeSats: 45_000,
+            note: nil,
+            receiverSats: 100_000,
+            latestPrice: 100_000
+        )
+
+        // Rejected trade: outcome must surface with the persisted reason code.
+        let rejectedTrade = try XCTUnwrap(TradeProtocol.prepare(
+            channelId: channelId,
+            userChannelId: "7",
+            currentExpectedUSD: 50,
+            currentBackingSats: 55_000,
+            receiverSats: 100_000,
+            action: "sell",
+            amountUSD: 10,
+            amountBTC: 0.000099,
+            feeUSD: 0.1,
+            newExpectedUSD: 59.9,
+            quotePrice: 100_000,
+            now: 1_786_310_000,
+            tradeId: String(repeating: "ef", count: 32)
+        ))
+        let rejectedDbId = try service.channelRepo.recordPreparedTrade(rejectedTrade)
+        let rejectedPaymentId = String(repeating: "cd", count: 32)
+        XCTAssertTrue(try service.channelRepo.attachTradePaymentId(
+            tradeDbId: rejectedDbId, paymentId: rejectedPaymentId
+        ))
+        XCTAssertNil(try service.channelRepo.terminalTradeOutcome(paymentId: rejectedPaymentId))
+
+        let rejection = TradeControlMessage.Rejected(
+            channelId: channelId,
+            correlation: TradeCorrelation(
+                tradeId: rejectedTrade.tradeId,
+                tradePaymentId: rejectedPaymentId,
+                requestHash: rejectedTrade.requestHash
+            ),
+            reasonCode: "quote_deviation",
+            decidedAt: 1_786_310_002
+        )
+        guard case .applied = service.channelRepo.applyTradeRejection(rejection).status else {
+            return XCTFail("Expected rejection to commit")
+        }
+        let rejectedOutcome = try XCTUnwrap(
+            service.channelRepo.terminalTradeOutcome(paymentId: rejectedPaymentId)
+        )
+        XCTAssertFalse(rejectedOutcome.accepted)
+        XCTAssertEqual(rejectedOutcome.reasonCode, "quote_deviation")
+
+        // Accepted trade: outcome must flip to accepted with no reason code.
+        let acceptedTrade = try XCTUnwrap(TradeProtocol.prepare(
+            channelId: channelId,
+            userChannelId: "7",
+            currentExpectedUSD: 50,
+            currentBackingSats: 55_000,
+            receiverSats: 100_000,
+            action: "sell",
+            amountUSD: 10,
+            amountBTC: 0.000099,
+            feeUSD: 0.1,
+            newExpectedUSD: 59.9,
+            quotePrice: 100_000,
+            now: 1_786_310_003,
+            tradeId: String(repeating: "aa", count: 32)
+        ))
+        let acceptedDbId = try service.channelRepo.recordPreparedTrade(acceptedTrade)
+        let acceptedPaymentId = String(repeating: "bb", count: 32)
+        XCTAssertTrue(try service.channelRepo.attachTradePaymentId(
+            tradeDbId: acceptedDbId, paymentId: acceptedPaymentId
+        ))
+        XCTAssertNil(try service.channelRepo.terminalTradeOutcome(paymentId: acceptedPaymentId))
+
+        let sync = TradeControlMessage.Sync(
+            channelId: channelId,
+            userChannelId: "7",
+            expectedUSD: acceptedTrade.newExpectedUSD,
+            backingSats: acceptedTrade.newBackingSats,
+            syncVersion: 1,
+            correlation: TradeCorrelation(
+                tradeId: acceptedTrade.tradeId,
+                tradePaymentId: acceptedPaymentId,
+                requestHash: acceptedTrade.requestHash
+            )
+        )
+        guard case .applied = service.channelRepo.applyCorrelatedTradeAcceptance(sync).status else {
+            return XCTFail("Expected correlated acceptance to commit")
+        }
+        let acceptedOutcome = try XCTUnwrap(
+            service.channelRepo.terminalTradeOutcome(paymentId: acceptedPaymentId)
+        )
+        XCTAssertTrue(acceptedOutcome.accepted)
+        XCTAssertNil(acceptedOutcome.reasonCode)
+    }
+
     func testPreparedTradeWaitsForCorrelatedAcceptanceBeforeUpdatingAllocation() throws {
         let channelId = String(repeating: "ab", count: 32)
         let paymentId = String(repeating: "cd", count: 32)

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -729,4 +729,332 @@ final class DatabaseServiceTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Mobile trade-result protocol
+
+    func testTradeProtocolHashAndFeeVectorsMatchRust() {
+        let payload = #"{"type":"TRADE_V1","user_channel_id":"7","expected_usd":25.0}"#
+        XCTAssertEqual(
+            TradeProtocol.requestHash(Data(payload.utf8)),
+            "c07dcdff3aae2fc7ebd4fb19a7f1cd60b8e61c94a89acd35c5c600935d671602"
+        )
+
+        XCTAssertEqual(
+            TradeProtocol.expectedTradeFeeMsat(
+                oldExpectedUSD: 50, newExpectedUSD: 99.5, quotePrice: 100_000
+            ),
+            500_000
+        )
+        XCTAssertEqual(
+            TradeProtocol.expectedTradeFeeMsat(
+                oldExpectedUSD: 100, newExpectedUSD: 50, quotePrice: 100_000
+            ),
+            500_000
+        )
+        XCTAssertEqual(
+            TradeProtocol.expectedTradeFeeMsat(
+                oldExpectedUSD: 1, newExpectedUSD: 0, quotePrice: 1_000_000
+            ),
+            1_000
+        )
+        XCTAssertEqual(
+            TradeProtocol.expectedTradeFeeMsat(
+                oldExpectedUSD: 1, newExpectedUSD: 0.1, quotePrice: 1_000_000
+            ),
+            1
+        )
+        XCTAssertEqual(TradeProtocol.normalizeExpectedUSD(0.009), 0)
+        XCTAssertEqual(
+            TradeProtocol.expectedTradeFeeMsat(
+                oldExpectedUSD: 0, newExpectedUSD: 0, quotePrice: 100_000
+            ),
+            1
+        )
+    }
+
+    func testSignedTradeControlRequiresExactBytesAndCompleteCorrelation() throws {
+        let identifier = String(repeating: "ab", count: 32)
+        let payload = """
+        {"type":"SYNC_V1","channel_id":"\(
+            identifier
+        )","user_channel_id":"7","expected_usd":25.0,"backing_sats":31250,"sync_version":4,"trade_id":"\(
+            identifier
+        )","trade_payment_id":"\(identifier)","request_hash":"\(identifier)"}
+        """
+        let envelope = try JSONSerialization.data(withJSONObject: [
+            "payload": payload,
+            "signature": "valid"
+        ])
+        let parsed = TradeProtocol.parseSignedControl(
+            data: envelope,
+            expectedCounterparty: "peer",
+            verifySignature: { bytes, signature, peer in
+                bytes == Array(payload.utf8) && signature == "valid" && peer == "peer"
+            }
+        )
+        guard case .sync(let sync) = parsed else {
+            return XCTFail("Expected correlated SYNC_V1")
+        }
+        XCTAssertEqual(sync.correlation?.tradeId, identifier)
+
+        let partialPayload = payload.replacingOccurrences(
+            of: ",\"request_hash\":\"\(identifier)\"",
+            with: ""
+        )
+        let partialEnvelope = try JSONSerialization.data(withJSONObject: [
+            "payload": partialPayload,
+            "signature": "valid"
+        ])
+        XCTAssertNil(TradeProtocol.parseSignedControl(
+            data: partialEnvelope,
+            expectedCounterparty: "peer",
+            verifySignature: { _, _, _ in true }
+        ))
+        XCTAssertNil(TradeProtocol.parseSignedControl(
+            data: envelope,
+            expectedCounterparty: "peer",
+            verifySignature: { _, _, _ in false }
+        ))
+
+        let fractionalPayload = payload.replacingOccurrences(
+            of: "\"sync_version\":4",
+            with: "\"sync_version\":1.5"
+        )
+        let fractionalEnvelope = try JSONSerialization.data(withJSONObject: [
+            "payload": fractionalPayload,
+            "signature": "valid"
+        ])
+        XCTAssertNil(TradeProtocol.parseSignedControl(
+            data: fractionalEnvelope,
+            expectedCounterparty: "peer",
+            verifySignature: { _, _, _ in true }
+        ))
+
+        let booleanPayload = payload.replacingOccurrences(
+            of: "\"expected_usd\":25.0",
+            with: "\"expected_usd\":true"
+        )
+        let booleanEnvelope = try JSONSerialization.data(withJSONObject: [
+            "payload": booleanPayload,
+            "signature": "valid"
+        ])
+        XCTAssertNil(TradeProtocol.parseSignedControl(
+            data: booleanEnvelope,
+            expectedCounterparty: "peer",
+            verifySignature: { _, _, _ in true }
+        ))
+    }
+
+    func testPreparedTradeWaitsForCorrelatedAcceptanceBeforeUpdatingAllocation() throws {
+        let channelId = String(repeating: "ab", count: 32)
+        let paymentId = String(repeating: "cd", count: 32)
+        let tradeId = String(repeating: "ef", count: 32)
+        try service.channelRepo.saveChannel(
+            channelId: channelId,
+            userChannelId: "7",
+            expectedUSD: 50,
+            backingSats: 55_000,
+            nativeSats: 45_000,
+            note: nil,
+            receiverSats: 100_000,
+            latestPrice: 100_000
+        )
+        let prepared = try XCTUnwrap(TradeProtocol.prepare(
+            channelId: channelId,
+            userChannelId: "7",
+            currentExpectedUSD: 50,
+            currentBackingSats: 55_000,
+            receiverSats: 100_000,
+            action: "sell",
+            amountUSD: 10,
+            amountBTC: 0.000099,
+            feeUSD: 0.1,
+            newExpectedUSD: 59.9,
+            quotePrice: 100_000,
+            now: 1_786_310_000,
+            tradeId: tradeId
+        ))
+        let tradeDbId = try service.channelRepo.recordPreparedTrade(prepared)
+        let adopted = try XCTUnwrap(service.channelRepo.adoptUnattachedPreparedTrade(
+            paymentId: paymentId,
+            amountMsat: prepared.feeMsat,
+            now: 1_786_310_001
+        ))
+        XCTAssertEqual(adopted.tradeDbId, tradeDbId)
+        XCTAssertTrue(try service.channelRepo.tradePaymentExists(paymentId: paymentId))
+
+        let beforeAcceptance = try XCTUnwrap(
+            service.channelRepo.loadChannel(userChannelId: "7")
+        )
+        XCTAssertEqual(beforeAcceptance.expectedUSD, 50)
+        XCTAssertEqual(beforeAcceptance.backingSats, 55_000)
+        XCTAssertEqual(
+            try service.channelRepo.unresolvedTradePayments()[paymentId]?.status,
+            "fee_paid"
+        )
+
+        let sync = TradeControlMessage.Sync(
+            channelId: channelId,
+            userChannelId: "7",
+            expectedUSD: prepared.newExpectedUSD,
+            backingSats: prepared.newBackingSats + 1,
+            syncVersion: 1,
+            correlation: TradeCorrelation(
+                tradeId: tradeId,
+                tradePaymentId: paymentId,
+                requestHash: prepared.requestHash
+            )
+        )
+        XCTAssertTrue(try service.channelRepo.markTradeResponseNotCommittable(.sync(sync)))
+        XCTAssertEqual(
+            try service.channelRepo.unresolvedTradePayments()[paymentId]?.status,
+            "uncertain"
+        )
+        let accepted = service.channelRepo.applyCorrelatedTradeAcceptance(sync)
+        guard case .applied = accepted.status else {
+            return XCTFail("Expected correlated acceptance to commit")
+        }
+        XCTAssertEqual(accepted.localBackingSats, prepared.newBackingSats)
+        XCTAssertEqual(accepted.peerBackingSats, prepared.newBackingSats + 1)
+
+        let afterAcceptance = try XCTUnwrap(
+            service.channelRepo.loadChannel(userChannelId: "7")
+        )
+        XCTAssertEqual(afterAcceptance.expectedUSD, prepared.newExpectedUSD, accuracy: 0.000000001)
+        XCTAssertEqual(afterAcceptance.backingSats, prepared.newBackingSats)
+        XCTAssertEqual(afterAcceptance.syncVersion, 1)
+        XCTAssertNil(try service.channelRepo.unresolvedTradePayments()[paymentId])
+
+        let duplicate = service.channelRepo.applyCorrelatedTradeAcceptance(sync)
+        guard case .duplicate = duplicate.status else {
+            return XCTFail("Expected accepted response replay to be idempotent")
+        }
+
+        let superseded = try XCTUnwrap(TradeProtocol.prepare(
+            channelId: channelId,
+            userChannelId: "7",
+            currentExpectedUSD: prepared.newExpectedUSD,
+            currentBackingSats: prepared.newBackingSats,
+            receiverSats: 100_000,
+            action: "buy",
+            amountUSD: 1,
+            amountBTC: 0.0000099,
+            feeUSD: 0.01,
+            newExpectedUSD: prepared.newExpectedUSD - 1,
+            quotePrice: 100_000,
+            now: 1_786_310_001,
+            tradeId: String(repeating: "aa", count: 32)
+        ))
+        let supersededDbId = try service.channelRepo.recordPreparedTrade(superseded)
+        let supersededPaymentId = String(repeating: "bb", count: 32)
+        XCTAssertTrue(try service.channelRepo.attachTradePaymentId(
+            tradeDbId: supersededDbId,
+            paymentId: supersededPaymentId
+        ))
+        let staleAcceptance = TradeControlMessage.Sync(
+            channelId: channelId,
+            userChannelId: "7",
+            expectedUSD: superseded.newExpectedUSD,
+            backingSats: superseded.newBackingSats,
+            syncVersion: 1,
+            correlation: TradeCorrelation(
+                tradeId: superseded.tradeId,
+                tradePaymentId: supersededPaymentId,
+                requestHash: superseded.requestHash
+            )
+        )
+        let staleResult = service.channelRepo.applyCorrelatedTradeAcceptance(staleAcceptance)
+        guard case .applied = staleResult.status else {
+            return XCTFail("A superseded acceptance must still resolve its trade")
+        }
+        XCTAssertEqual(staleResult.allocationApplied, false)
+        let afterSuperseded = try XCTUnwrap(
+            service.channelRepo.loadChannel(userChannelId: "7")
+        )
+        XCTAssertEqual(afterSuperseded.expectedUSD, prepared.newExpectedUSD, accuracy: 0.000000001)
+        XCTAssertEqual(afterSuperseded.backingSats, prepared.newBackingSats)
+        XCTAssertEqual(afterSuperseded.syncVersion, 1)
+        XCTAssertNil(try service.channelRepo.unresolvedTradePayments()[supersededPaymentId])
+    }
+
+    func testFailedPaymentRecoversPreparedTradeWhenPaymentIdAttachmentWasLost() throws {
+        let channelId = String(repeating: "12", count: 32)
+        let paymentId = String(repeating: "34", count: 32)
+        let prepared = try XCTUnwrap(TradeProtocol.prepare(
+            channelId: channelId,
+            userChannelId: "9",
+            currentExpectedUSD: 25,
+            currentBackingSats: 25_000,
+            receiverSats: 100_000,
+            action: "buy",
+            amountUSD: 5,
+            amountBTC: 0.0000495,
+            feeUSD: 0.05,
+            newExpectedUSD: 20,
+            quotePrice: 100_000,
+            now: 1_786_310_000,
+            tradeId: String(repeating: "56", count: 32)
+        ))
+        let tradeDbId = try service.channelRepo.recordPreparedTrade(prepared)
+
+        let failed = try XCTUnwrap(service.channelRepo.failUnattachedPreparedTrade(
+            paymentId: paymentId,
+            amountMsat: prepared.feeMsat,
+            now: 1_786_310_001
+        ))
+
+        XCTAssertEqual(failed.tradeDbId, tradeDbId)
+        XCTAssertEqual(failed.status, "send_failed")
+        XCTAssertTrue(try service.channelRepo.tradePaymentExists(paymentId: paymentId))
+        XCTAssertNil(try service.channelRepo.unresolvedTradePayments()[paymentId])
+    }
+
+    func testLegacyTradeSchemaMigratesWithoutLosingRows() throws {
+        let legacyDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_trade_migration_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: legacyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: legacyDir) }
+
+        var legacyDB: OpaquePointer?
+        let path = legacyDir.appendingPathComponent(DatabaseService.dbFilename).path
+        XCTAssertEqual(sqlite3_open(path, &legacyDB), SQLITE_OK)
+        let legacySQL = """
+        CREATE TABLE channels (
+            channel_id TEXT PRIMARY KEY, user_channel_id TEXT UNIQUE,
+            expected_usd REAL NOT NULL DEFAULT 0.0, stable_sats INTEGER NOT NULL DEFAULT 0,
+            note TEXT, created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+            updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+        CREATE TABLE trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, channel_id TEXT NOT NULL,
+            action TEXT NOT NULL, amount_usd REAL NOT NULL, amount_btc REAL NOT NULL DEFAULT 0.0,
+            btc_price REAL NOT NULL, fee_usd REAL NOT NULL DEFAULT 0.0,
+            payment_id TEXT, status TEXT NOT NULL DEFAULT 'pending',
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+        INSERT INTO channels (channel_id, user_channel_id, expected_usd, stable_sats)
+            VALUES ('legacy-channel', 'legacy-user-channel', 25.0, 25000);
+        INSERT INTO trades (channel_id, action, amount_usd, btc_price, status)
+            VALUES ('legacy-channel', 'buy', 5.0, 100000.0, 'pending');
+        """
+        XCTAssertEqual(sqlite3_exec(legacyDB, legacySQL, nil, nil, nil), SQLITE_OK)
+        sqlite3_close(legacyDB)
+
+        let upgraded = try DatabaseService(dataDir: legacyDir)
+        let channelColumns = try upgraded.rawSQL.query("PRAGMA table_info(channels)")
+            .compactMap { $0[1] as? String }
+        let tradeColumns = try upgraded.rawSQL.query("PRAGMA table_info(trades)")
+            .compactMap { $0[1] as? String }
+        XCTAssertTrue(channelColumns.contains("sync_version"))
+        XCTAssertTrue(tradeColumns.contains("trade_id"))
+        XCTAssertTrue(tradeColumns.contains("uncertainty_reason"))
+
+        let legacyChannel = try XCTUnwrap(
+            upgraded.channelRepo.loadChannel(userChannelId: "legacy-user-channel")
+        )
+        XCTAssertEqual(legacyChannel.expectedUSD, 25)
+        XCTAssertEqual(legacyChannel.backingSats, 25_000)
+        let legacyTradeCount = try upgraded.rawSQL.query("SELECT COUNT(*) FROM trades")
+        XCTAssertEqual(legacyTradeCount.first?.first as? Int64, 1)
+    }
 }

--- a/ios/StableChannels/StableChannelsTests/MempoolWebSocketServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/MempoolWebSocketServiceTests.swift
@@ -403,6 +403,21 @@ final class MempoolWebSocketServiceTests: XCTestCase {
 
     // MARK: - Connect / Disconnect Lifecycle
 
+    /// The delegate callback flips `isConnected` on an async MainActor hop, so a single
+    /// fixed sleep flakes on loaded CI runners (the hop simply hasn't run yet). Poll
+    /// until the flag turns true or a generous deadline passes, then assert.
+    private func waitForConnected(file: StaticString = #filePath, line: UInt = #line) {
+        let exp = expectation(description: "isConnected becomes true")
+        Task { @MainActor in
+            for _ in 0..<300 where !service.isConnected {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+        XCTAssertTrue(service.isConnected, "service never reported connected", file: file, line: line)
+    }
+
     func testConnectDoesNotSetIsConnectedSynchronously() {
         XCTAssertFalse(service.isConnected)
 
@@ -422,16 +437,7 @@ final class MempoolWebSocketServiceTests: XCTestCase {
             didOpenWithProtocol: nil
         )
 
-        // The delegate fires an async task on MainActor, so we need to wait a beat
-        let exp = expectation(description: "isConnected becomes true")
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            if service.isConnected {
-                exp.fulfill()
-            }
-        }
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(service.isConnected)
+        waitForConnected()
     }
 
     func testDisconnectClearsIsConnected() throws {
@@ -441,15 +447,7 @@ final class MempoolWebSocketServiceTests: XCTestCase {
             didOpenWithProtocol: nil
         )
 
-        let exp = expectation(description: "isConnected becomes true")
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            if service.isConnected {
-                exp.fulfill()
-            }
-        }
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(service.isConnected)
+        waitForConnected()
 
         service.disconnect()
 
@@ -540,15 +538,7 @@ final class MempoolWebSocketServiceTests: XCTestCase {
             didOpenWithProtocol: nil
         )
 
-        let exp = expectation(description: "isConnected becomes true")
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 10_000_000)
-            if service.isConnected {
-                exp.fulfill()
-            }
-        }
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertTrue(service.isConnected)
+        waitForConnected()
 
         service.trackAddress("bc1qmore")
 

--- a/ios/StableChannels/project.yml
+++ b/ios/StableChannels/project.yml
@@ -26,6 +26,7 @@ targets:
     platform: iOS
     sources:
       - path: StableChannels
+      - path: NotificationService/Services/TradeProtocol.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.stablechannels.app

--- a/mobile-trade-sync-parity-plan.md
+++ b/mobile-trade-sync-parity-plan.md
@@ -1,0 +1,399 @@
+# Plan — Harden the mobile trade handshake (#204)
+
+## Branch and pull request
+
+- **Branch:** `mobile/trade-sync-handshake`
+- **PR title:** `Harden Android and iOS trade-result accounting`
+- **Base:** a clean worktree from the latest `origin/main`
+- **Closes:** [#204](https://github.com/toneloc/stable-channels/issues/204)
+
+Do not build this on the current `autotest` checkout or mix in the unmerged iOS
+`fix/authenticated-stability-settlements-ios` branch. That branch contains broad, unrelated
+refactors. Port only small pieces after verifying them against the current desktop/LSP contract.
+
+## Outcome
+
+Bring Android and iOS to parity with the current desktop/LSP `TRADE_V1` → signed result
+handshake:
+
+1. The mobile wallet validates and durably records a trade before paying the non-refundable fee.
+2. The signed `TRADE_V1` binds the current channel, target, quote, timestamp and random trade ID.
+3. `PaymentSuccessful` confirms only that the fee moved; it does **not** apply the trade.
+4. A signed, correlated `SYNC_V1` is the only accepted result that changes the mobile allocation.
+5. A signed `TRADE_REJECTED_V1` records a terminal rejection and shows a useful reason.
+6. Every accepted sync is channel-bound, ordered by persisted `sync_version`, atomic, and
+   drift-preserving in both foreground and background execution.
+
+Android and iOS must implement the same protocol and state transitions. Platform-specific code
+may differ, but the accepted payloads, database states, audit outcomes and tests should match.
+
+## Protocol invariants
+
+These are requirements, not implementation suggestions:
+
+- Sign and verify the exact UTF-8 payload bytes received on the wire. Do not parse and
+  re-serialize before signature verification or request hashing.
+- Generate `trade_id` as 32 random bytes encoded as 64 lowercase hexadecimal characters.
+- Compute `request_hash` as plain, forward-order, lowercase SHA-256 hex of the exact signed
+  `TRADE_V1` payload bytes. Do not reverse the digest as a Bitcoin display hash.
+- Include `type`, `channel_id`, `user_channel_id`, `trade_id`, `expected_usd`, `quote_price` and
+  `ts` in mobile `TRADE_V1`.
+- Persist the prepared trade and proposed local allocation before sending its fee.
+- Attach the returned Lightning payment ID after the send. A failure to attach it must leave a
+  recoverable durable record rather than silently applying or forgetting the trade.
+- Treat a trade as unresolved until a valid correlated acceptance or rejection is committed.
+- Correlate results by `trade_id`, `trade_payment_id` and `request_hash`; also require the current
+  `channel_id`.
+- Require accepted/rejected correlated result payments to be exactly 1 msat, the protocol control
+  amount used by the current LSP.
+- Treat correlated request timestamps as fresh for 15 minutes (`TRADE_RESULT_TIMEOUT_SECS`). The
+  five-minute `TRADE_SIG_WINDOW_SECS` applies only to legacy, uncorrelated compatibility traffic.
+- Require `sync_version > 0` and strictly newer than the version persisted for that
+  `user_channel_id` before changing allocation. Duplicate or older versions never roll allocation
+  back; a matched delayed acceptance may still close its trade as accepted, matching desktop.
+- Preserve accumulated drift. A trade acceptance uses the locally prepared post-fee allocation;
+  a non-trade sync preserves an unchanged target or applies only the locally priced target delta.
+- Never blindly adopt the LSP's `backing_sats`. Require it in `SYNC_V1`, compare it with the
+  locally derived state, and emit structured divergence telemetry.
+- Commit the channel allocation, sync version and trade outcome in one database transaction.
+- A missing trusted price, unavailable channel state or database failure must defer event
+  acknowledgement so the control payment can be retried. Invalid signatures, malformed payloads,
+  wrong channels and replayed terminal results must not mutate accounting.
+- A 15-minute local timeout may mark the UI/result as uncertain, but it must not delete the
+  correlation record. Retain it for at least the server's 14-day response retry window; the
+  server retains response detail for 30 days. A later valid signed response remains authoritative.
+- Match the Rust fee calculation exactly. Increases gross up the target delta by `1 / (1 -
+  fee_rate)`; decreases do not. Convert valid non-negative finite fee sats by truncating toward
+  zero, then multiply by 1,000 and clamp to at least 1 msat. Guard Swift conversions against NaN,
+  negative and out-of-range values before constructing `UInt64`; never round to the nearest sat.
+- A signed-quote fee may differ from the server's expected fee by at most exactly 1,000 msat in
+  either direction. Material overpayment is rejected just like underpayment.
+
+## Scope
+
+### Included
+
+- Hardened `TRADE_V1` creation and local preflight on Android and iOS.
+- Durable prepared/sent/fee-paid/accepted/rejected/uncertain trade states.
+- Signed correlated `SYNC_V1` acceptance.
+- Signed `TRADE_REJECTED_V1` handling and user-facing reason mapping.
+- Ordered, drift-preserving uncorrelated `SYNC_V1` for spend, splice and recovery updates.
+- Foreground and background/notification-extension handlers.
+- Database creation, upgrades, indexes and atomic transition helpers.
+- Equivalent Android/iOS fixtures, migration tests and behavior tests.
+- Small LSP/Rust fixture or contract tests only if needed to prove byte-level compatibility; no
+  server behavior redesign.
+
+### Not included
+
+- Signed `STABILITY_PAYMENT_V1` on mobile.
+- Removal of the legacy `[1]` stability marker.
+- A two-phase trade protocol or fee refund.
+- New sync reason/delta fields for spend, splice or recovery.
+- Price-oracle redesign, UI redesign or broad repository/refactor work.
+- Adopting the LSP's backing as canonical wallet state.
+
+## 1. Pin cross-platform contract fixtures first
+
+Before changing either app, add compact fixtures that describe:
+
+- one canonical `TRADE_V1` payload and its exact request hash, including this literal byte-order
+  check:
+
+  ```text
+  payload: {"type":"TRADE_V1","user_channel_id":"7","expected_usd":25.0}
+  sha256:  c07dcdff3aae2fc7ebd4fb19a7f1cd60b8e61c94a89acd35c5c600935d671602
+  ```
+
+- literal fee-amount vectors generated from Rust `expected_trade_fee_msat`, covering an increase,
+  a decrease, sub-cent normalization, an exact-sat boundary and a value just below one;
+- one correlated accepted `SYNC_V1`;
+- one correlated `TRADE_REJECTED_V1` for each supported reason code;
+- one uncorrelated newer sync and one duplicate/older sync;
+- wrong-channel, incomplete-correlation, malformed-number and bad-signature cases.
+
+Use the current Rust builders/parsers as the source of truth. Check the same literal payload bytes,
+identifiers and expected outcomes into Android and iOS tests. This catches JSON-number, field-name,
+hex and hashing differences before they can become live protocol bugs.
+
+Do not require a canonical JSON field order across implementations. Require only that each sender
+sign and hash the exact bytes it actually sends, and that the receiver verifies those exact bytes.
+This rule is message-specific: `RegisterPushSigned` still requires declaration-order
+serialization, so do not generalize this behavior to every signed protocol message.
+
+## 2. Add durable mobile schema and migrations
+
+### Channel state
+
+Add `sync_version INTEGER NOT NULL DEFAULT 0` to `channels` on both platforms. Indexing is not
+needed for the single active-channel lookup, but every foreground/background query must address the
+row by `user_channel_id` and verify `channel_id`.
+
+### Trade state
+
+Extend `trades` with the minimum durable protocol fields:
+
+- `trade_id` — unique lowercase-hex ID;
+- `request_hash` — hash of exact signed payload bytes;
+- `request_payload` — exact payload retained for audit/recovery;
+- `trade_payment_id` — attached after the fee send;
+- `old_expected_usd` and `new_expected_usd`;
+- `new_backing_sats` — wallet's prepared drift-preserving allocation;
+- `quote_price`, `fee_msat` and `expires_at`;
+- `outcome`/`reason_code` and result timestamps.
+
+Use a constrained status model such as:
+
+`prepared → sent → fee_paid → accepted | rejected | uncertain | send_failed`
+
+`uncertain` is locally non-terminal: a later matching signed response may transition it to
+`accepted` or `rejected`. Record whether uncertainty means `no_response` or
+`response_not_committable` so acknowledgement/retry behavior remains observable. Do not allow two
+unresolved trades for the same channel.
+
+### Migration rules
+
+- Android: increment `DatabaseService.DB_VERSION`, make `onUpgrade` additive and preserve all
+  existing channel, payment and trade rows.
+- iOS: extend the existing `PRAGMA table_info` migration pattern; the main app owns schema
+  creation, while the notification extension must fail/defer safely when it encounters an old
+  schema during an upgrade race.
+- Add uniqueness/index constraints for non-null `trade_id`, `request_hash` and payment ID where
+  compatible with legacy rows.
+- Test a real version-2 Android database and a representative pre-change iOS database, not only a
+  fresh database.
+
+Implement transaction methods rather than distributing SQL across UI/event handlers:
+
+- `recordPreparedTrade`
+- `attachTradePaymentId`
+- `markTradeFeePaid`
+- `applyCorrelatedTradeAcceptance`
+- `applyTradeRejection`
+- `applyUncorrelatedSyncIfNewer`
+- `markExpiredTradesUncertain`
+
+Each result method must be idempotent and compare the stored correlation/channel before mutation.
+
+## 3. Extract pure allocation and parser logic
+
+Replace the mobile `applyTrade` full-repricing call with a pure drift-preserving allocator matching
+the current Rust behavior:
+
+- normalize sub-cent targets;
+- value the target delta at the wallet's trusted local quote;
+- account for the non-refundable fee and live post-fee receiver capacity;
+- reject underflow, backing exhaustion, unsafe full exits and target-over-capacity results;
+- preserve existing backing drift and native balance;
+- use the same rounding rules on Android and iOS.
+
+Replace Android's `Triple<String, Double, String>` and the equivalent loose iOS dictionaries at the
+business boundary with typed models:
+
+- `TradeV1`
+- `SyncV1`
+- `TradeRejectedV1`
+- `SignedEnvelope`
+- `TradeCorrelation`
+
+Parsing must reject missing/partial correlation, non-finite values, invalid lowercase-hex IDs,
+zero/out-of-range versions and unknown rejection reasons. Signature verification happens before
+payload interpretation.
+
+## 4. Android implementation
+
+### Send path
+
+Update `TradeService.kt`, trade view models/screens and `DatabaseService.kt`:
+
+1. Obtain the admitted accounting quote and current channel snapshot.
+2. Run the shared preflight/allocator before any payment.
+3. Generate the payload, trade ID and exact-byte request hash.
+4. Persist the prepared trade.
+5. Send the fee carrying the signed TLV.
+6. Attach the Lightning payment ID and expose the durable pending state to the UI.
+
+Remove the in-memory map as the authority. It may remain only as a view cache derived from SQLite.
+
+### Result path
+
+Update `AppState.kt` so `PaymentSuccessful` only marks the fee paid. It must not call
+`StabilityService.applyTrade`, update the stable target, or show the trade as accepted.
+
+Replace `handleSyncMessage` with a signed-result dispatcher:
+
+- correlated `SYNC_V1` → validate, atomically apply stored allocation/version and accept trade;
+- `TRADE_REJECTED_V1` → validate, atomically reject and show mapped reason;
+- uncorrelated `SYNC_V1` → derive local delta and apply only if version is newer.
+
+Update `StabilityProcessingService.kt` to use the same typed parsing and transactional database
+methods. Background code must not maintain a second accounting algorithm in raw SQL. If code
+sharing with the main process is impractical, share pure models/calculators and keep equivalent
+tests over both adapters.
+
+On startup, rebuild pending UI state from the database and mark expired unresolved rows uncertain;
+do not apply them or automatically resend the trade fee.
+
+## 5. iOS implementation
+
+### Send path
+
+Update `TradeService.swift`, `Trade.swift`, Buy/Sell views and the repository layer using the same
+ordering as Android: preflight → exact payload/hash → durable prepared row → send → attach payment
+ID. Replace `pendingTradePayments` as the source of truth with repository-backed state.
+
+`PaymentSuccessful` in `AppState.swift` marks the fee paid only. It must not call
+`StabilityService.applyTrade` or complete the trade.
+
+### Result path
+
+Create one typed signed-control parser shared in behavior by the app and Notification Service
+Extension. Update:
+
+- `AppState.handleSyncMessage`
+- `StableControlParser`
+- `PaymentDatabase` protocol
+- `SQLitePaymentDatabase`
+
+The main app and extension must call the same transaction semantics for accepted, rejected,
+duplicate, stale, retryable and invalid results. The extension must use the trusted-price rules
+already shared through the app group and return `deferToForeground` when it cannot safely derive or
+commit the allocation.
+
+Add any new Swift files to both the Xcode project and `project.yml` deliberately. Do not run
+XcodeGen over the existing hand-maintained project as an incidental rewrite.
+
+On launch/foreground recovery, reload unresolved trades, reconcile any known LDK payment outcome,
+and keep late signed responses applicable.
+
+## 6. Tests
+
+Add equivalent Android and iOS suites for:
+
+### Wire contract
+
+- exact payload signature verification and request hash fixture;
+- literal forward-order SHA-256 fixture matches on Rust, Kotlin and Swift;
+- all required hardened trade fields;
+- complete correlation required together;
+- accepted and rejected response parsing;
+- invalid signature/channel/amount/version/identifier rejection.
+
+### Allocation
+
+- literal fee-amount vectors match Rust on Kotlin and Swift for increase, decrease,
+  sub-cent normalization and sat-boundary cases;
+- signed-quote fee tolerance accepts exactly ±1,000 msat and rejects values beyond it;
+- increase and decrease preserve pre-existing drift;
+- unchanged target leaves backing unchanged;
+- safe full exit and settlement-required full exit;
+- fee-aware capacity boundary and rounding edges;
+- LSP `backing_sats` divergence audits but does not overwrite local state.
+
+### Persistence and ordering
+
+- fresh database and upgrade from the current production schema;
+- prepared intent exists before the send seam is invoked;
+- `PaymentSuccessful` does not change allocation;
+- correlated acceptance updates trade, channel and `sync_version` atomically;
+- rejection leaves allocation unchanged and is idempotent;
+- duplicate/stale sync is a no-op;
+- newer uncorrelated sync applies the local delta once;
+- database failure defers acknowledgement and retry succeeds exactly once;
+- restart reconstructs pending/uncertain state and accepts a late response;
+- foreground/background processors produce the same database result.
+
+### LSP compatibility
+
+- current LSP accepts hardened Android and iOS fixtures;
+- accepted responses carry exact stored correlation;
+- rejection reason codes map consistently on both apps;
+- legacy mobile traffic remains accepted during rollout.
+
+## 7. Verification
+
+Run locally before pushing:
+
+```text
+cd android
+./gradlew --no-daemon testDebugUnitTest
+
+xcodebuild test \
+  -project ios/StableChannels/StableChannels.xcodeproj \
+  -scheme StableChannels \
+  -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' \
+  -parallel-testing-enabled NO
+
+cd ios
+swiftformat --lint . --strict
+```
+
+Also run the relevant Rust/LSP tests if contract fixtures or server code change.
+If Rust fixtures or server code are touched, add or enable a pull-request CI job that runs
+`cargo test --locked` and `cargo build --locked`; local-only Rust verification is insufficient.
+
+Confirm that every new iOS test source is a member of the Xcode test target and appears in the
+`xcodebuild test` log. Presence on disk or in `project.yml` alone does not count as execution.
+
+Use the local E2E stack for one accepted and one rejected trade per platform. Assert database and
+audit state, not only UI text. Then perform the physical-device checks that automation cannot
+prove:
+
+- Android foreground and background delivery;
+- iOS foreground and Notification Service Extension delivery;
+- app killed/restarted while fee is paid but result is pending;
+- delayed and replayed response;
+- stale price and stale Lightning-sync deferral;
+- device upgrade with existing channel/trade history.
+
+No production or meaningful-value mainnet trade should be used until regtest/simulator and small
+controlled test cases are green.
+
+## 8. Rollout and compatibility
+
+- Keep the LSP's legacy mobile compatibility path during the release window.
+- Add audit counters for hardened versus legacy mobile trade requests before the first mobile
+  release. Missing `trade_id` silently selects the legacy parser path, so this counter must make a
+  malformed hardened client visible. Also count accepted/rejected/uncertain outcomes,
+  stale/duplicate syncs and allocation divergence.
+- Release Android and iOS with the same protocol behavior before tightening the server.
+- Watch result-delivery retries, rejection rates, sync-version conflicts and unresolved trade age.
+- Remove legacy trade tolerance only in a separate change after deployed-version telemetry shows
+  legacy use is no longer significant.
+- Signed mobile stability settlement and legacy `[1]` removal remain a separate follow-up.
+
+## Commit sequence
+
+Keep reviewable commits in this order on the requested single feature branch. Treat the Android
+and iOS protocol transitions as independent review units even though they ship in one PR:
+
+1. `test: pin mobile trade-result protocol fixtures`
+2. `db: add durable mobile trade and sync state`
+3. `android: harden TRADE_V1 and signed result handling`
+4. `ios: harden TRADE_V1 and signed result handling`
+5. `test: cover mobile migrations, replay, recovery and LSP compatibility`
+6. `docs: describe the hardened mobile trade handshake`
+
+Do not merge a commit state that sends hardened correlated `TRADE_V1` while still applying the
+trade on `PaymentSuccessful`. If intermediate commits cannot compile and test safely on their own,
+squash the protocol transition per platform before review.
+
+## Definition of done
+
+- Android and iOS send the complete hardened `TRADE_V1` payload.
+- A literal cross-language fee-amount vector table passes in Rust, Kotlin and Swift.
+- The request-hash fixture asserts
+  `c07dcdff3aae2fc7ebd4fb19a7f1cd60b8e61c94a89acd35c5c600935d671602`.
+- Correlated freshness is tested and documented as 15 minutes; the five-minute legacy window and
+  issue #234 are documented accurately.
+- The fee payment never applies the target by itself.
+- Both platforms accept only correctly signed, channel-bound, correlated and ordered trade results.
+- Accepted trades use the prepared local drift-preserving allocation.
+- Rejections are durable, idempotent and understandable to the user.
+- Foreground and background paths share the same state-transition rules.
+- Production database upgrades preserve existing wallet history and channel state.
+- All Android, iOS and affected Rust/LSP tests pass.
+- New iOS tests are members of the Xcode test target and visibly execute under `xcodebuild test`.
+- LSP hardened-versus-legacy request counters are live before the first mobile release.
+- Physical-device results and audit evidence are attached to the PR before it is marked ready.
+- The PR contains no signed-stability work, legacy-marker removal or unrelated refactor.

--- a/server/stable-channels-lsp/src/stable_manager.rs
+++ b/server/stable-channels-lsp/src/stable_manager.rs
@@ -438,6 +438,7 @@ impl StableChannelManager {
             Ok(true) => stable_channels::audit::audit_event(
                 "TRADE_REJECTION_QUEUED",
                 serde_json::json!({
+                    "protocol_path": "hardened",
                     "trade_id": trade_id,
                     "trade_payment_id": inbound_payment_id,
                     "request_hash": request_hash,
@@ -2628,6 +2629,14 @@ impl StableChannelManager {
             "TRADE_SIGNATURE_VALID",
             serde_json::json!({ "channel_id": chan.channel_id, "user_channel_id": chan.user_channel_id.clone() }),
         );
+        stable_channels::audit::audit_event(
+            "TRADE_PROTOCOL_PATH",
+            serde_json::json!({
+                "path": if payload.trade_id.is_some() { "hardened" } else { "legacy" },
+                "channel_id": chan.channel_id,
+                "user_channel_id": chan.user_channel_id.clone(),
+            }),
+        );
 
         // Verify-then-write: the settlement row is recorded only now that the envelope's
         // signature is verified against the channel counterparty. An unauthenticated peer's
@@ -2888,6 +2897,7 @@ impl StableChannelManager {
                     stable_channels::audit::audit_event(
                         "TRADE_ACCEPTED",
                         serde_json::json!({
+                            "protocol_path": "hardened",
                             "trade_id": trade_id,
                             "trade_payment_id": inbound_payment_id,
                             "request_hash": request_hash,
@@ -3103,6 +3113,7 @@ impl StableChannelManager {
         stable_channels::audit::audit_event(
             "TRADE_APPLIED",
             serde_json::json!({
+                "protocol_path": "legacy",
                 "channel_id": channel_id_hex,
                 "user_channel_id": ucid_str,
                 "new_expected_usd": expected_usd_f,
@@ -4810,6 +4821,8 @@ mod tests {
             expected_trade_fee_msat(50.0, 50.0, 100_000.0),
             Some(1)
         );
+        assert_eq!(expected_trade_fee_msat(1.0, 0.0, 1_000_000.0), Some(1_000));
+        assert_eq!(expected_trade_fee_msat(1.0, 0.1, 1_000_000.0), Some(1));
         assert_eq!(trade_fee_tolerance_msat(114_000, true), 1_000);
 
         // At this boundary the wallet's original gross fee floors to 113 sats, while recovering

--- a/src/trade.rs
+++ b/src/trade.rs
@@ -150,6 +150,12 @@ mod tests {
             "53842fe0ffc7d71ad4b6f9d0940152f9803eba24ba30de840b8967c410acbcd4"
         );
         assert_ne!(request_hash(compact), request_hash(spaced));
+
+        let mobile_fixture = br#"{"type":"TRADE_V1","user_channel_id":"7","expected_usd":25.0}"#;
+        assert_eq!(
+            request_hash(mobile_fixture),
+            "c07dcdff3aae2fc7ebd4fb19a7f1cd60b8e61c94a89acd35c5c600935d671602"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Send fully correlated, signed `TRADE_V1` requests from Android and iOS.
- Persist the trade before paying its non-refundable fee; fee success alone no longer applies the trade.
- Apply only signed, channel-bound, ordered acceptances/rejections in foreground and background paths.
- Preserve the wallet’s local allocation, recover across crashes/restarts, and keep delayed results auditable.
- Pin literal SHA-256 and fee vectors across Rust, Kotlin, and Swift; add Rust pull-request CI and hardened/legacy telemetry.
- Incorporate the plan review corrections: correlated freshness is 15 minutes; legacy compatibility remains 5 minutes.

## Verification

- `./gradlew test assembleDebug` — 88 debug and 88 release tests passed; APK built.
- iOS simulator — 217 tests passed.
- Generic iOS device build — app and Notification Service Extension built successfully.
- SwiftFormat 0.62.1 strict lint passed.
- `cargo test --workspace --locked` passed.
- `cargo build --workspace --locked` passed.

## Before marking ready

- Run accepted, rejected, delayed, replay, and restart scenarios on physical Android and iPhone devices with the LSP.
- Attach the resulting audit evidence to this PR.

Closes #204

Related accuracy correction: #234
