### PR TITLE
Fix Android node-start race and clarify activation copy

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -653,6 +653,18 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     private fun handleNodeStartFailure(e: Exception, fallbackMessage: String) {
+        if (e is NodeService.AlreadyRunningException && nodeService.isRunning) {
+            Log.w("AppState", "Ignoring duplicate node start after another start succeeded", e)
+            _phase.value = Phase.WALLET
+            _isSyncing.value = false
+            _errorMessage.value = ""
+            AuditService.log(
+                "NODE_START_DUPLICATE",
+                mapOf("error" to (e.message ?: fallbackMessage))
+            )
+            return
+        }
+
         if (isRetryableNodeStartFailure(e)) {
             _phase.value = Phase.SYNCING
             _errorMessage.value = ""

--- a/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
@@ -46,9 +46,10 @@ class NodeService(private val context: Context) {
     private val _eventChannel = Channel<Pair<Event, CompletableDeferred<Boolean>>>(Channel.RENDEZVOUS)
     val eventChannel: ReceiveChannel<Pair<Event, CompletableDeferred<Boolean>>> = _eventChannel
 
+    @Synchronized
     fun start(network: Network, esploraURL: String, mnemonic: String?, strictLspConnect: Boolean = false) {
         if (node != null || _isRunning.value) {
-            throw IllegalStateException("LDK node already running")
+            throw AlreadyRunningException()
         }
         if (!LdkNodeOwner.tryAcquire(LdkNodeOwner.MAIN_APP)) {
             throw IllegalStateException(
@@ -56,12 +57,12 @@ class NodeService(private val context: Context) {
             )
         }
 
-        val dataDir = Constants.userDataDir(context)
-        val lspPubkey = LspPreferencesManager.getLspPubkey(context)
-        val lspAddress = LspPreferencesManager.getLspAddress(context)
         var ldkNode: Node? = null
 
         try {
+            val dataDir = Constants.userDataDir(context)
+            val lspPubkey = LspPreferencesManager.getLspPubkey(context)
+            val lspAddress = LspPreferencesManager.getLspAddress(context)
             val anchorConfig = AnchorChannelsConfig(
                 trustedPeersNoReserve = listOf(lspPubkey),
                 perChannelReserveSats = 25_000UL
@@ -171,6 +172,10 @@ class NodeService(private val context: Context) {
     }
 
     fun stop() {
+        // A start that has acquired the process-wide owner may still be building the node.
+        // Do not release that owner until start() either succeeds or cleans up its own failure.
+        if (node == null && !_isRunning.value) return
+
         try {
             eventJob?.cancel()
             eventJob = null
@@ -401,6 +406,8 @@ class NodeService(private val context: Context) {
     }
 
     class NodeServiceError : Exception("Node not running")
+
+    class AlreadyRunningException : IllegalStateException("LDK node already running")
 
     /** Thrown by [sendStabilityPayment] when the Lightning wallet's chain sync is too old
      *  to safely pay. [syncAgeSecs] is null when the wallet has never synced. */

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -400,14 +400,14 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             }
                             PendingRow(text, effectiveTxid, context)
                             if (!hasReadyChannel) {
-                                Text("Receive a payment over Lightning to activate your Lightning account.",
+                                Text("Receive a payment over Lightning to activate your account.",
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                         } else {
                             // 4. No channel, confirmed deposit — just needs Lightning
                             Spacer(Modifier.height(4.dp))
-                            Text("Receive a payment over Lightning to activate your Lightning account.",
+                            Text("Receive a payment over Lightning to activate your account.",
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -400,14 +400,14 @@ fun HomeScreen(appState: AppState, modifier: Modifier = Modifier) {
                             }
                             PendingRow(text, effectiveTxid, context)
                             if (!hasReadyChannel) {
-                                Text("Get your first payment over Lightning to activate your account",
+                                Text("Receive a payment over Lightning to activate your Lightning account.",
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                         } else {
                             // 4. No channel, confirmed deposit — just needs Lightning
                             Spacer(Modifier.height(4.dp))
-                            Text("Get your first payment over Lightning to activate your account",
+                            Text("Receive a payment over Lightning to activate your Lightning account.",
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/ReceiveScreen.kt
@@ -164,7 +164,7 @@ fun ReceiveScreen(appState: AppState, onDismiss: () -> Unit) {
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        "Get your first payment over Lightning to activate your account",
+                        "Receive a payment over Lightning to activate your Lightning account.",
                         modifier = Modifier.padding(12.dp),
                         style = MaterialTheme.typography.bodySmall
                     )


### PR DESCRIPTION
## Summary
- serialize Android `NodeService.start()` so overlapping foreground/retry starts cannot collide with the app’s own LDK owner
- release the LDK owner on every post-acquire configuration failure and avoid dropping an in-flight start’s owner from an idle stop
- recover only the typed duplicate-start case; unrelated post-start failures still surface normally
- clarify the Android Lightning activation copy on Home and Receive

## Testing
- `ANDROID_HOME=/Users/t/Library/Android/sdk ./gradlew --no-daemon testDebugUnitTest`

## Manual follow-up
- Rapid background/foreground device reproduction during cold-start syncing is still recommended before release.
