### PR TITLE
fix(android): graced onDestroy stop + splice-out payment tracking

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -262,12 +262,6 @@ class AppState(private val context: Context) : ViewModel() {
         paymentIds.forEach { refreshTradeOutcome(it) }
     }
     var pendingSplice: PendingSplice? = null
-    // LDK redelivers the same unhandled event until eventHandled() is called, so a sync message
-    // that can never commit (e.g. no give-up path for an uncorrelated RETRY) would otherwise
-    // wedge the entire event pipeline behind it forever. Caps retries per payment hash per
-    // process lifetime; resets on restart.
-    private val syncRetryCounts = mutableMapOf<String, Int>()
-    private val MAX_SYNC_RETRIES = 20
     private val _isChannelClosing = MutableStateFlow(false)
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
     var isChannelClosing: Boolean
@@ -401,12 +395,13 @@ class AppState(private val context: Context) : ViewModel() {
                     nodeStartRetryJob = null
                     _phase.value = Phase.WALLET
                     _isSyncing.value = false
+                    // Restore the known funding txid before the first live balance refresh so
+                    // an ordinary cold start is not mistaken for a funding transition.
+                    fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
+                        .getString("funding_txid", null)
                     refreshBalances()
                     pollPaymentConfirmations(force = true)
                     connectMempoolWebSocket()
-                    // Restore fundingTxid
-                    fundingTxid = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
-                        .getString("funding_txid", null)
                     resumePendingSpliceConfirmation()
                     // Restore channel-closing state if a close is still pending on-chain
                     val pendingCloseId = databaseService?.getPendingChannelClosePaymentId()
@@ -965,13 +960,14 @@ class AppState(private val context: Context) : ViewModel() {
                 handleSplicePending(event.channelId, event.userChannelId, "${event.newFundingTxo.txid}:${event.newFundingTxo.vout}")
             }
             is Event.SpliceNegotiationFailed -> {
+                val paymentRowId = pendingSplice?.paymentRowId
                 isSweeping = false
                 spliceTxid = null
                 spliceConfirmationJob?.cancel()
                 spliceConfirmationJob = null
                 monitoredSpliceTxid = null
                 pendingSplice = null
-                databaseService?.failLatestPendingSplice()
+                databaseService?.failPendingSplice(paymentRowId)
                 AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
             }
             is Event.ChannelClosed -> {
@@ -1113,14 +1109,7 @@ class AppState(private val context: Context) : ViewModel() {
         when (result.status) {
             TradeControlApplyStatus.RETRY -> {
                 try { db.markTradeResponseNotCommittable(message) } catch (_: Exception) {}
-                val attempts = (syncRetryCounts[paymentHash] ?: 0) + 1
-                syncRetryCounts[paymentHash] = attempts
-                if (attempts > MAX_SYNC_RETRIES) {
-                    syncRetryCounts.remove(paymentHash)
-                    AuditService.log("TRADE_RESULT_GAVE_UP", mapOf("payment_hash" to paymentHash, "attempts" to attempts))
-                    return true
-                }
-                AuditService.log("TRADE_RESULT_DEFERRED", mapOf("payment_hash" to paymentHash, "attempt" to attempts))
+                AuditService.log("TRADE_RESULT_DEFERRED", mapOf("payment_hash" to paymentHash))
                 throw RetryableSyncException("Signed trade result could not be committed")
             }
             TradeControlApplyStatus.INVALID -> {
@@ -1400,37 +1389,56 @@ class AppState(private val context: Context) : ViewModel() {
         isSweeping = true
         spliceTxid = txid
         fundingTxid = txid
-        // Both directions persist their pending row up front, so stamping the txid here also
-        // recovers a restart-replay (pendingSplice lost in memory across relaunch).
-        databaseService?.setPendingSpliceTxid(txid)
+        // Prefer the exact in-memory row. After a process restart the LDK event can be replayed;
+        // the database then accepts only one recent pending candidate and never a failed row.
+        val assignedRowId = databaseService?.assignPendingSpliceTxid(
+            txid = txid,
+            paymentRowId = pendingSplice?.paymentRowId
+        )
+        if (assignedRowId == null) {
+            AuditService.log("SPLICE_TXID_UNMATCHED", mapOf(
+                "channel_id" to channelId,
+                "user_channel_id" to userChannelId,
+                "txid" to txid
+            ))
+        }
         refreshBalances()
         updateStableBalances()
         _statusMessage.value = "Move pending confirmation"
         startSpliceConfirmationMonitor(txid)
     }
 
-    fun beginSpliceOut(amountSats: Long, address: String) {
+    fun beginSpliceOut(amountSats: Long, address: String, accountingPrice: Double) {
         if (isSweeping) {
             throw IllegalStateException("A splice is already in progress — try again shortly")
         }
-        isSweeping = true
-        pendingSplice = PendingSplice("out", amountSats, address)
-        // Persisted immediately (txid unknown yet) so this survives a restart before negotiation completes.
-        val price = priceService.currentPrice.value
-        databaseService?.recordPayment(
+        val db = databaseService
+            ?: throw IllegalStateException("Payment history is unavailable — splice not started")
+        // Persist before the native call so the operation survives a process restart.
+        val paymentRowId = db.recordPayment(
             paymentId = null, paymentType = "splice_out", direction = "sent",
             amountMsat = amountSats * 1000,
-            amountUSD = if (price > 0) (amountSats.toDouble() / Constants.SATS_IN_BTC) * price else null,
-            btcPrice = price.takeIf { it > 0 }, status = "pending", address = address
+            amountUSD = if (accountingPrice > 0) {
+                (amountSats.toDouble() / Constants.SATS_IN_BTC) * accountingPrice
+            } else null,
+            btcPrice = accountingPrice.takeIf { it > 0 },
+            status = "pending",
+            address = address
         )
+        if (paymentRowId <= 0) {
+            throw IllegalStateException("Could not save pending splice — splice not started")
+        }
+        isSweeping = true
+        pendingSplice = PendingSplice("out", amountSats, address, paymentRowId)
         _statusMessage.value = "Move pending..."
     }
 
     fun cancelPendingSpliceStart() {
         if (spliceTxid == null) {
+            val paymentRowId = pendingSplice?.paymentRowId
             isSweeping = false
             pendingSplice = null
-            databaseService?.failPendingSpliceOutWithoutTxid()
+            databaseService?.failPendingSplice(paymentRowId)
             _statusMessage.value = ""
         }
     }
@@ -1456,7 +1464,7 @@ class AppState(private val context: Context) : ViewModel() {
     private fun resumePendingSpliceConfirmation() {
         if (databaseService?.hasPendingSplice() != true) return
         isSweeping = true
-        spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid ?: fundingTxid
+        spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid
         spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
     }
 
@@ -2175,24 +2183,32 @@ class AppState(private val context: Context) : ViewModel() {
         }
         val sweepAmount = spendable
 
-        // Set isSweeping=true BEFORE calling spliceInWithAll so that if LDK fires
-        // a ChannelReady event synchronously during the call, the event handler
-        // correctly identifies it as still in-flight and does not prematurely clear
-        // the sweep state and re-show the Swap button.
+        val db = databaseService ?: run {
+            _statusMessage.value = "Payment history is unavailable — move not started"
+            return
+        }
+        val price = priceService.currentAccountingPrice()
+        val amountUSD = if (price > 0) {
+            (sweepAmount.toDouble() / Constants.SATS_IN_BTC) * price
+        } else null
+        // Persist before the native call so SpliceNegotiated always has a row to update,
+        // even if the event is delivered before spliceInWithAll returns.
+        val paymentRowId = db.recordPayment(
+            paymentId = null, paymentType = "splice_in", direction = "received",
+            amountMsat = sweepAmount * 1000,
+            amountUSD = amountUSD, btcPrice = price.takeIf { it > 0 }, status = "pending"
+        )
+        if (paymentRowId <= 0) {
+            _statusMessage.value = "Could not save pending move — move not started"
+            return
+        }
         isSweeping = true
-        pendingSplice = PendingSplice("in", sweepAmount)
+        pendingSplice = PendingSplice("in", sweepAmount, paymentRowId = paymentRowId)
 
         try {
             nodeService.spliceInWithAll(channel.userChannelId, channel.counterpartyNodeId)
             sweepOnchainStart = spendable
             _statusMessage.value = "Moving all onchain funds to channel..."
-            val price = priceService.currentPrice.value
-            val amountUSD = if (price > 0) (sweepAmount.toDouble() / Constants.SATS_IN_BTC) * price else null
-            databaseService?.recordPayment(
-                paymentId = null, paymentType = "splice_in", direction = "received",
-                amountMsat = sweepAmount * 1000,
-                amountUSD = amountUSD, btcPrice = price.takeIf { it > 0 }, status = "pending"
-            )
             AuditService.log("SWEEP_TO_CHANNEL", mapOf(
                 "amount_sats" to sweepAmount,
                 "mode" to "splice_in_with_all"
@@ -2200,6 +2216,7 @@ class AppState(private val context: Context) : ViewModel() {
         } catch (e: Exception) {
             isSweeping = false
             pendingSplice = null
+            db.failPendingSplice(paymentRowId)
             _statusMessage.value = "Sweep failed: ${e.message}"
             AuditService.log("SWEEP_FAILED", mapOf("error" to (e.message ?: "")))
             return
@@ -2438,8 +2455,6 @@ class AppState(private val context: Context) : ViewModel() {
                 val currentTxid = txo.txid
                 if (currentTxid != fundingTxid) {
                     fundingTxid = currentTxid
-                    // Recovers a splice row stuck without a txid if its SpliceNegotiated event was lost.
-                    databaseService?.recoverStuckSpliceTxid(currentTxid)
                 }
             }
             // Derive the authoritative counterparty from the live channel. For an open channel

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -262,6 +262,12 @@ class AppState(private val context: Context) : ViewModel() {
         paymentIds.forEach { refreshTradeOutcome(it) }
     }
     var pendingSplice: PendingSplice? = null
+    // LDK redelivers the same unhandled event until eventHandled() is called, so a sync message
+    // that can never commit (e.g. no give-up path for an uncorrelated RETRY) would otherwise
+    // wedge the entire event pipeline behind it forever. Caps retries per payment hash per
+    // process lifetime; resets on restart.
+    private val syncRetryCounts = mutableMapOf<String, Int>()
+    private val MAX_SYNC_RETRIES = 20
     private val _isChannelClosing = MutableStateFlow(false)
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
     var isChannelClosing: Boolean
@@ -1107,7 +1113,14 @@ class AppState(private val context: Context) : ViewModel() {
         when (result.status) {
             TradeControlApplyStatus.RETRY -> {
                 try { db.markTradeResponseNotCommittable(message) } catch (_: Exception) {}
-                AuditService.log("TRADE_RESULT_DEFERRED", mapOf("payment_hash" to paymentHash))
+                val attempts = (syncRetryCounts[paymentHash] ?: 0) + 1
+                syncRetryCounts[paymentHash] = attempts
+                if (attempts > MAX_SYNC_RETRIES) {
+                    syncRetryCounts.remove(paymentHash)
+                    AuditService.log("TRADE_RESULT_GAVE_UP", mapOf("payment_hash" to paymentHash, "attempts" to attempts))
+                    return true
+                }
+                AuditService.log("TRADE_RESULT_DEFERRED", mapOf("payment_hash" to paymentHash, "attempt" to attempts))
                 throw RetryableSyncException("Signed trade result could not be committed")
             }
             TradeControlApplyStatus.INVALID -> {
@@ -1387,29 +1400,9 @@ class AppState(private val context: Context) : ViewModel() {
         isSweeping = true
         spliceTxid = txid
         fundingTxid = txid
-        val splice = pendingSplice
-        if (splice != null) {
-            when (splice.direction) {
-                "in" -> databaseService?.setPendingSpliceTxid(txid)
-                "out" -> {
-                    val price = priceService.currentPrice.value
-                    databaseService?.recordPayment(
-                        paymentId = null, paymentType = "splice_out", direction = "sent",
-                        amountMsat = splice.amountSats * 1000,
-                        amountUSD = (splice.amountSats.toDouble() / Constants.SATS_IN_BTC) * price,
-                        // bare txid (not the "txid:vout" outpoint) so completeSplice
-                        // txid lookups match this row
-                        btcPrice = price, status = "pending", txid = txid, address = splice.address
-                    )
-                }
-            }
-        } else {
-            // pendingSplice is in-memory and lost across relaunch. If this event
-            // is a restart replay, the latest NULL-txid splice row is this
-            // splice's initiation row — stamp it so ChannelReady can complete it
-            // and the no-txid expiry can't mark it failed.
-            databaseService?.setPendingSpliceTxid(txid)
-        }
+        // Both directions persist their pending row up front, so stamping the txid here also
+        // recovers a restart-replay (pendingSplice lost in memory across relaunch).
+        databaseService?.setPendingSpliceTxid(txid)
         refreshBalances()
         updateStableBalances()
         _statusMessage.value = "Move pending confirmation"
@@ -1422,6 +1415,14 @@ class AppState(private val context: Context) : ViewModel() {
         }
         isSweeping = true
         pendingSplice = PendingSplice("out", amountSats, address)
+        // Persisted immediately (txid unknown yet) so this survives a restart before negotiation completes.
+        val price = priceService.currentPrice.value
+        databaseService?.recordPayment(
+            paymentId = null, paymentType = "splice_out", direction = "sent",
+            amountMsat = amountSats * 1000,
+            amountUSD = if (price > 0) (amountSats.toDouble() / Constants.SATS_IN_BTC) * price else null,
+            btcPrice = price.takeIf { it > 0 }, status = "pending", address = address
+        )
         _statusMessage.value = "Move pending..."
     }
 
@@ -1429,6 +1430,7 @@ class AppState(private val context: Context) : ViewModel() {
         if (spliceTxid == null) {
             isSweeping = false
             pendingSplice = null
+            databaseService?.failPendingSpliceOutWithoutTxid()
             _statusMessage.value = ""
         }
     }
@@ -2436,6 +2438,8 @@ class AppState(private val context: Context) : ViewModel() {
                 val currentTxid = txo.txid
                 if (currentTxid != fundingTxid) {
                     fundingTxid = currentTxid
+                    // Recovers a splice row stuck without a txid if its SpliceNegotiated event was lost.
+                    databaseService?.recoverStuckSpliceTxid(currentTxid)
                 }
             }
             // Derive the authoritative counterparty from the live channel. For an open channel

--- a/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
@@ -128,9 +128,10 @@ class MainActivity : FragmentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (::appState.isInitialized) {
-            appState.stop()
-        }
+        if (!::appState.isInitialized) return
+        // Route through the graced stop (like onPause()) instead of stopping immediately,
+        // since the OS can destroy/recreate this Activity on plain backgrounding, not just a real close.
+        appState.stopNodeForBackground()
     }
 
     @Composable

--- a/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
+++ b/android/app/src/main/java/com/stablechannels/app/MainActivity.kt
@@ -128,10 +128,9 @@ class MainActivity : FragmentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (!::appState.isInitialized) return
-        // Route through the graced stop (like onPause()) instead of stopping immediately,
-        // since the OS can destroy/recreate this Activity on plain backgrounding, not just a real close.
-        appState.stopNodeForBackground()
+        if (::appState.isInitialized) {
+            appState.stop()
+        }
     }
 
     @Composable

--- a/android/app/src/main/java/com/stablechannels/app/models/Trade.kt
+++ b/android/app/src/main/java/com/stablechannels/app/models/Trade.kt
@@ -37,7 +37,8 @@ data class PendingTradePayment(
 data class PendingSplice(
     val direction: String, // "in" or "out"
     val amountSats: Long,
-    val address: String? = null
+    val address: String? = null,
+    val paymentRowId: Long
 )
 
 data class ChannelRecord(

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -1330,8 +1330,25 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
 
     fun setPendingSpliceTxid(txid: String) {
         writableDatabase.execSQL(
-            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'splice_in' AND status IN ('pending','failed') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)",
+            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status IN ('pending','failed') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)",
             arrayOf(txid)
+        )
+    }
+
+    /** Stamps a txid onto a splice row stuck at NULL (event lost across a restart) and un-fails
+     *  it, using the live channel's funding txid as the restart-proof source of truth. */
+    fun recoverStuckSpliceTxid(txid: String): Boolean {
+        val stmt = writableDatabase.compileStatement(
+            "UPDATE payments SET txid = ?, status = 'pending' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)"
+        )
+        stmt.bindString(1, txid)
+        return stmt.executeUpdateDelete() > 0
+    }
+
+    /** Fails a splice-out row if negotiation never even started (no txid assigned yet). */
+    fun failPendingSpliceOutWithoutTxid() {
+        writableDatabase.execSQL(
+            "UPDATE payments SET status = 'failed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'splice_out' AND status = 'pending' AND txid IS NULL ORDER BY created_at DESC LIMIT 1)"
         )
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import androidx.core.database.sqlite.transaction
 import com.stablechannels.app.models.*
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.HistoricalPrices
@@ -49,6 +50,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     companion object {
         private const val DB_FILENAME = "stablechannels.db"
         internal const val DB_VERSION = 3
+        internal const val PENDING_SPLICE_WITHOUT_TXID_TIMEOUT_SECS = 10 * 60L
     }
 
     override fun onCreate(db: SQLiteDatabase) {
@@ -1328,40 +1330,88 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         return cursor.use { if (it.moveToFirst()) it.getString(0) else null }
     }
 
-    fun setPendingSpliceTxid(txid: String) {
-        writableDatabase.execSQL(
-            "UPDATE payments SET txid = ? WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status IN ('pending','failed') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)",
-            arrayOf(txid)
+    private fun SQLiteDatabase.queryIds(sql: String, args: Array<String>): List<Long> =
+        rawQuery(sql, args).use { cursor ->
+            buildList { while (cursor.moveToNext()) add(cursor.getLong(0)) }
+        }
+
+    private fun SQLiteDatabase.recentPendingSpliceIds(paymentRowId: Long?, cutoff: Long): List<Long> {
+        val idClause = if (paymentRowId == null) "" else "AND id = ?"
+        val args = buildList {
+            if (paymentRowId != null) add(paymentRowId.toString())
+            add(cutoff.toString())
+        }.toTypedArray()
+        return queryIds(
+            """
+            SELECT id FROM payments
+            WHERE payment_type IN ('splice_in','splice_out')
+              AND status = 'pending' AND txid IS NULL
+              $idClause AND created_at >= ?
+            LIMIT 2
+            """.trimIndent(),
+            args
         )
     }
 
-    /** Stamps a txid onto a splice row stuck at NULL (event lost across a restart) and un-fails
-     *  it, using the live channel's funding txid as the restart-proof source of truth. */
-    fun recoverStuckSpliceTxid(txid: String): Boolean {
-        val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET txid = ?, status = 'pending' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND txid IS NULL ORDER BY created_at DESC LIMIT 1)"
-        )
-        stmt.bindString(1, txid)
-        return stmt.executeUpdateDelete() > 0
-    }
+    /** Assigns a negotiated txid to one pending splice without guessing from payment history.
+     *  The exact row is preferred. After a process restart, where that in-memory id is gone,
+     *  exactly one recent pending NULL-txid splice must exist or no row is changed. */
+    fun assignPendingSpliceTxid(
+        txid: String,
+        paymentRowId: Long? = null,
+        nowEpochSecs: Long = System.currentTimeMillis() / 1000L
+    ): Long? {
+        val normalizedTxid = txid.trim()
+        if (normalizedTxid.isEmpty()) return null
 
-    /** Fails a splice-out row if negotiation never even started (no txid assigned yet). */
-    fun failPendingSpliceOutWithoutTxid() {
-        writableDatabase.execSQL(
-            "UPDATE payments SET status = 'failed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type = 'splice_out' AND status = 'pending' AND txid IS NULL ORDER BY created_at DESC LIMIT 1)"
-        )
-    }
-
-    fun completeLatestSplice(txid: String?) {
-        if (txid.isNullOrBlank()) {
-            writableDatabase.execSQL(
-                "UPDATE payments SET status = 'completed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status IN ('pending','failed') ORDER BY created_at DESC LIMIT 1)"
+        return writableDatabase.transaction {
+            val existing = queryIds(
+                "SELECT id FROM payments WHERE txid = ? AND payment_type IN ('splice_in','splice_out') AND status = 'pending' LIMIT 2",
+                arrayOf(normalizedTxid)
             )
-        } else {
-            writableDatabase.execSQL(
-                "UPDATE payments SET status = 'completed' WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status IN ('pending','failed')",
-                arrayOf(txid)
+            if (existing.isNotEmpty()) {
+                return@transaction existing.singleOrNull()
+                    ?.takeIf { paymentRowId == null || it == paymentRowId }
+            }
+            val txidInUse = rawQuery(
+                "SELECT 1 FROM payments WHERE txid = ? LIMIT 1",
+                arrayOf(normalizedTxid)
+            ).use { it.moveToFirst() }
+            if (txidInUse) return@transaction null
+
+            val cutoff = nowEpochSecs - PENDING_SPLICE_WITHOUT_TXID_TIMEOUT_SECS
+            val candidates = recentPendingSpliceIds(paymentRowId, cutoff)
+            val candidateId = candidates.singleOrNull() ?: return@transaction null
+            val values = ContentValues().apply { put("txid", normalizedTxid) }
+            val updated = update(
+                "payments",
+                values,
+                """
+                id = ? AND status = 'pending' AND txid IS NULL
+                  AND NOT EXISTS (SELECT 1 FROM payments WHERE txid = ? AND id != ?)
+                """.trimIndent(),
+                arrayOf(candidateId.toString(), normalizedTxid, candidateId.toString())
             )
+            if (updated == 1) candidateId else null
+        }
+    }
+
+    /** Marks one pre-negotiation splice failed. Failed rows are terminal. */
+    fun failPendingSplice(
+        paymentRowId: Long? = null,
+        nowEpochSecs: Long = System.currentTimeMillis() / 1000L
+    ): Boolean {
+        return writableDatabase.transaction {
+            val cutoff = nowEpochSecs - PENDING_SPLICE_WITHOUT_TXID_TIMEOUT_SECS
+            val candidates = recentPendingSpliceIds(paymentRowId, cutoff)
+            val candidateId = candidates.singleOrNull() ?: return@transaction false
+            val values = ContentValues().apply { put("status", "failed") }
+            update(
+                "payments",
+                values,
+                "id = ? AND status = 'pending' AND txid IS NULL",
+                arrayOf(candidateId.toString())
+            ) == 1
         }
     }
 
@@ -1369,24 +1419,20 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
      *  so callers can use the result as the "this ChannelReady was a splice" signal. */
     fun completeSplice(txid: String): Boolean {
         val stmt = writableDatabase.compileStatement(
-            "UPDATE payments SET status = 'completed', confirmations = 1 WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status IN ('pending','failed')"
+            "UPDATE payments SET status = 'completed', confirmations = 1 WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status = 'pending'"
         )
         stmt.bindString(1, txid)
         return stmt.executeUpdateDelete() > 0
     }
 
-    fun failLatestPendingSplice() {
-        writableDatabase.execSQL(
-            "UPDATE payments SET status = 'failed' WHERE rowid = (SELECT rowid FROM payments WHERE payment_type IN ('splice_in','splice_out') AND status = 'pending' ORDER BY created_at DESC LIMIT 1)"
-        )
-    }
-
     fun getPendingSpliceTxid(): String? {
-        val cursor = readableDatabase.rawQuery(
-            "SELECT txid FROM payments WHERE status = 'pending' AND payment_type IN ('splice_in','splice_out') AND txid IS NOT NULL ORDER BY created_at DESC LIMIT 1",
+        val txids = readableDatabase.rawQuery(
+            "SELECT txid FROM payments WHERE status = 'pending' AND payment_type IN ('splice_in','splice_out') AND txid IS NOT NULL LIMIT 2",
             null
-        )
-        return cursor.use { if (it.moveToFirst()) it.getString(0) else null }
+        ).use { cursor ->
+            buildList { while (cursor.moveToNext()) add(cursor.getString(0)) }
+        }
+        return txids.singleOrNull()
     }
 
     fun hasPendingSplice(): Boolean {
@@ -1394,7 +1440,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         // durable in-flight splice to wait for. Let that pre-negotiation lock heal.
         // Keep with-txid rows pending: confirmation can outlive the app process,
         // and the splice confirmation monitor completes them after 1 conf.
-        val noTxidCutoff = System.currentTimeMillis() / 1000 - 600
+        val noTxidCutoff = System.currentTimeMillis() / 1000 - PENDING_SPLICE_WITHOUT_TXID_TIMEOUT_SECS
         writableDatabase.execSQL(
             "UPDATE payments SET status = 'failed' WHERE status = 'pending' AND payment_type IN ('splice_in','splice_out') AND txid IS NULL AND created_at < ?",
             arrayOf(noTxidCutoff)

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -313,7 +313,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                 if (hasChannel) {
                                     if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
                                     val sc = appState.stableChannel.value
-                                    appState.beginSpliceOut(sats, addr)
+                                    appState.beginSpliceOut(sats, addr, accountingPrice)
                                     try {
                                         appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
                                     } catch (e: Exception) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -716,7 +716,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         if (hasChannel) {
                                             if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
                                             val sc = appState.stableChannel.value
-                                            appState.beginSpliceOut(sats, trimmed)
+                                            appState.beginSpliceOut(sats, trimmed, accountingPrice)
                                             try {
                                                 appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, trimmed, sats)
                                             } catch (e: Exception) {

--- a/android/app/src/test/java/com/stablechannels/app/SpliceDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/SpliceDatabaseServiceTest.kt
@@ -1,0 +1,151 @@
+package com.stablechannels.app
+
+import android.content.Context
+import com.stablechannels.app.models.PaymentRecord
+import com.stablechannels.app.services.DatabaseService
+import com.stablechannels.app.util.Constants
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SpliceDatabaseServiceTest {
+    private lateinit var context: Context
+    private lateinit var dbFile: File
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        dbFile = File(Constants.userDataDir(context), "stablechannels.db")
+        deleteDatabaseFiles()
+    }
+
+    @After
+    fun tearDown() {
+        deleteDatabaseFiles()
+    }
+
+    @Test
+    fun negotiatedTxidUpdatesExactPendingRowAndReplayIsIdempotent() {
+        val service = DatabaseService(context)
+        val targetId = recordSplice(service, "splice_out")
+        val otherId = recordSplice(service, "splice_in")
+
+        assertEquals(targetId, service.assignPendingSpliceTxid("tx-target", targetId))
+        assertEquals("tx-target", payment(service, targetId).txid)
+        assertNull(payment(service, otherId).txid)
+        assertEquals(targetId, service.assignPendingSpliceTxid("tx-target", targetId))
+        service.close()
+    }
+
+    @Test
+    fun restartRecoveryRequiresExactlyOneRecentPendingRow() {
+        val service = DatabaseService(context)
+        val firstId = recordSplice(service, "splice_out")
+        val secondId = recordSplice(service, "splice_in")
+
+        assertNull(service.assignPendingSpliceTxid("ambiguous-tx"))
+        assertNull(payment(service, firstId).txid)
+        assertNull(payment(service, secondId).txid)
+
+        assertTrue(service.failPendingSplice(secondId))
+        assertEquals(firstId, service.assignPendingSpliceTxid("single-tx"))
+        assertEquals("single-tx", payment(service, firstId).txid)
+        service.close()
+    }
+
+    @Test
+    fun failedSpliceCannotBeReassignedOrCompleted() {
+        val service = DatabaseService(context)
+        val failedId = recordSplice(service, "splice_out", status = "failed")
+
+        assertNull(service.assignPendingSpliceTxid("new-tx", failedId))
+        service.writableDatabase.execSQL(
+            "UPDATE payments SET txid = ? WHERE id = ?",
+            arrayOf<Any>("failed-tx", failedId)
+        )
+        assertFalse(service.completeSplice("failed-tx"))
+        assertEquals("failed", payment(service, failedId).status)
+        service.close()
+    }
+
+    @Test
+    fun expiredPendingSpliceIsNotRecoveredOrFailedByAnEvent() {
+        val service = DatabaseService(context)
+        val now = 2_000_000L
+        val expiredId = recordSplice(service, "splice_out")
+        service.writableDatabase.execSQL(
+            "UPDATE payments SET created_at = ? WHERE id = ?",
+            arrayOf<Any>(
+                now - DatabaseService.PENDING_SPLICE_WITHOUT_TXID_TIMEOUT_SECS - 1,
+                expiredId
+            )
+        )
+
+        assertNull(service.assignPendingSpliceTxid("late-tx", expiredId, now))
+        assertFalse(service.failPendingSplice(expiredId, now))
+        assertEquals("pending", payment(service, expiredId).status)
+        assertNull(payment(service, expiredId).txid)
+        service.close()
+    }
+
+    @Test
+    fun txidAlreadyUsedByAnotherPaymentIsNotReassigned() {
+        val service = DatabaseService(context)
+        service.recordPayment(
+            paymentId = "existing-payment",
+            paymentType = "onchain",
+            direction = "sent",
+            amountMsat = 1_000,
+            txid = "used-tx"
+        )
+        val pendingId = recordSplice(service, "splice_out")
+
+        assertNull(service.assignPendingSpliceTxid("used-tx", pendingId))
+        assertNull(payment(service, pendingId).txid)
+        service.close()
+    }
+
+    @Test
+    fun failingByIdChangesOnlyThatPendingSplice() {
+        val service = DatabaseService(context)
+        val targetId = recordSplice(service, "splice_out")
+        val otherId = recordSplice(service, "splice_in")
+
+        assertTrue(service.failPendingSplice(targetId))
+        assertEquals("failed", payment(service, targetId).status)
+        assertEquals("pending", payment(service, otherId).status)
+        service.close()
+    }
+
+    private fun recordSplice(
+        service: DatabaseService,
+        type: String,
+        status: String = "pending"
+    ): Long = service.recordPayment(
+        paymentId = null,
+        paymentType = type,
+        direction = if (type == "splice_out") "sent" else "received",
+        amountMsat = 10_000,
+        status = status
+    )
+
+    private fun payment(service: DatabaseService, id: Long): PaymentRecord =
+        service.getRecentPayments(100).single { it.id == id }
+
+    private fun deleteDatabaseFiles() {
+        listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
+            .forEach { file -> if (file.exists()) assertTrue(file.delete()) }
+        assertFalse(dbFile.exists())
+    }
+}


### PR DESCRIPTION
## Fixes

**1. Frequent cold node restarts on quick app open/close**
`onDestroy()` called `appState.stop()` directly, bypassing the graced stop already scheduled by `onPause()`. Since the OS can destroy/recreate the Activity on plain backgrounding (not just a real close), this forced an immediate hard stop far more often than intended, causing a resync flash on quick app-switches. Now routes through the same graced stop path as `onPause()`.

**2. Splice-out missing from History / Home screen**
Splice-out tracking relied on an in-memory flag and a DB helper hardcoded to `splice_in` only, so a restart mid-splice lost all tracking (unlike splice-in, which already persisted its row immediately). `beginSpliceOut()` now persists a `pending` row immediately, and the txid-stamping query covers both directions.

**3. Splice-out stuck showing "Failed" despite succeeding on-chain**
The one-shot LDK event that stamps the txid onto a splice-out row could be lost across a restart, and a 10-minute stale-pending cleanup would then mark the still-txid-less row as failed — even if the splice itself succeeded and confirmed on-chain. `refreshBalances()` already reads the live channel's current funding txid every call (restart-proof); it now also reconciles any stuck NULL-txid splice row against that txid and un-fails it. Verified against a real splice-out that had gotten stuck this way — the row is now correctly `completed`.

## Testing
Built, installed on a physical device, and verified against real on-chain splice-out transactions (cross-checked via blockstream.info).