### PR TITLE
fix(android): synchronize status and navigation bar icon contrast with light and dark themes

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/home/HomeScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.stablechannels.app.ui.theme.LocalDarkTheme
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
@@ -636,7 +637,8 @@ private fun PendingRow(text: String, txid: String?, context: android.content.Con
 @Composable
 private fun SheetEdgeToEdgeEffect() {
     val view = LocalView.current
-    DisposableEffect(view) {
+    val isDark = LocalDarkTheme.current
+    DisposableEffect(view, isDark) {
         var context = view.context
         var dialog: android.app.Dialog? = null
         while (context is android.content.ContextWrapper) {
@@ -649,6 +651,9 @@ private fun SheetEdgeToEdgeEffect() {
         val window = dialog?.window
         if (window != null) {
             WindowCompat.setDecorFitsSystemWindows(window, false)
+            val insetsController = WindowCompat.getInsetsController(window, view)
+            insetsController.isAppearanceLightStatusBars = !isDark
+            insetsController.isAppearanceLightNavigationBars = !isDark
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                 @Suppress("DEPRECATION")
                 window.navigationBarColor = android.graphics.Color.TRANSPARENT

--- a/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/theme/Theme.kt
@@ -1,6 +1,8 @@
 package com.stablechannels.app.ui.theme
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.SharedPreferences
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
@@ -11,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,6 +21,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 // ─── Branded Color Palette ───────────────────────────────────────────────────
 
@@ -175,6 +180,10 @@ val LocalSemanticColors = staticCompositionLocalOf {
     LightSemanticColors
 }
 
+val LocalDarkTheme = staticCompositionLocalOf {
+    false
+}
+
 // ─── Theme Preference ────────────────────────────────────────────────────────
 
 enum class ThemePreference(val label: String) {
@@ -225,6 +234,12 @@ private fun rememberThemePreference(): ThemePreference {
     return preference
 }
 
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
 @Composable
 fun StableChannelsTheme(
     content: @Composable () -> Unit
@@ -240,7 +255,22 @@ fun StableChannelsTheme(
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
     val semanticColors = if (darkTheme) DarkSemanticColors else LightSemanticColors
 
-    CompositionLocalProvider(LocalSemanticColors provides semanticColors) {
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = view.context.findActivity()?.window
+            if (window != null) {
+                val insetsController = WindowCompat.getInsetsController(window, view)
+                insetsController.isAppearanceLightStatusBars = !darkTheme
+                insetsController.isAppearanceLightNavigationBars = !darkTheme
+            }
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalSemanticColors provides semanticColors,
+        LocalDarkTheme provides darkTheme
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             content = content


### PR DESCRIPTION
## Summary

Fixes invisible status bar icons (battery %, clock, Wi-Fi, cellular signal, DND, notifications) and navigation bar handles when the Android app is running in light mode. Integrates dynamic `WindowInsetsControllerCompat` synchronization into `StableChannelsTheme` and modal bottom sheet windows via `LocalDarkTheme`.

---

## Motivation & Problem

When light mode is active, the app background and top surface render in pure white (`#FFFFFF`). 

In Android, the operating system controls status bar icon colors via window appearance flags (`isAppearanceLightStatusBars` and `isAppearanceLightNavigationBars`). Because these flags were previously never set, the OS defaulted to light/white icons. This caused all status bar indicators (clock, battery level, network strength, Do Not Disturb, and notification badges) to disappear against the white background.

Furthermore, switching themes in **Settings -> Appearance** dynamically updated Compose colors, but left the system window flags unchanged.

---

## Key Changes

1. **Dynamic Insets Synchronization in `Theme.kt`**:
   - Added a Compose `SideEffect` inside `StableChannelsTheme` that immediately updates `WindowCompat.getInsetsController(window, view)` whenever `darkTheme` state changes:
     - **Light Mode (`darkTheme = false`)**: Sets `isAppearanceLightStatusBars = true` and `isAppearanceLightNavigationBars = true` -> OS paints dark/black status bar icons and dark navigation handles.
     - **Dark Mode (`darkTheme = true`)**: Sets `isAppearanceLightStatusBars = false` and `isAppearanceLightNavigationBars = false` -> OS paints light/white status bar icons and light navigation handles.
   - Provided `LocalDarkTheme` as the authoritative single source of truth across the entire composable hierarchy.
   - Added a safe `Context.findActivity()` unwrapper to resolve the host `Activity` window across `ContextWrapper` chains.

2. **Modal Bottom Sheet Window Synchronization in `HomeScreen.kt`**:
   - Updated `SheetEdgeToEdgeEffect` to consume `LocalDarkTheme.current` directly, synchronizing the dialog window's insets controller with the active theme state when bottom sheets (Send, Receive, Buy, Sell) are opened.

---

## System Bars Theme Pipeline

<img width="800" alt="System Bars Theme Pipeline" src="https://github.com/user-attachments/assets/5131446e-024f-47b1-bd8e-7d05f4c8ebd8" />

---

## Screenshots (Tested on physical iQOO 13)

### System Bars Contrast (Before vs. After)

| Before (Light Mode) | After (Light Mode) | Before (Dark Mode) | After (Dark Mode) |
| :---: | :---: | :---: | :---: |
| <img width="200" alt="Before Light Mode (Invisible Icons)" src="https://github.com/user-attachments/assets/53f5862d-a276-4cfa-86d8-4cb35501c0ed" /> | <img width="200" alt="After Light Mode (Synced Dark Icons)" src="https://github.com/user-attachments/assets/ab3582bb-09ee-4e35-9f80-78db0b999566" /> | <img width="200" alt="Before Dark Mode" src="https://github.com/user-attachments/assets/f7ca64e1-deae-4880-8d98-a37c51845fa0" /> | <img width="200" alt="After Dark Mode (Synced Light Icons)" src="https://github.com/user-attachments/assets/79569366-e93e-48f6-897c-59230ad6815c" /> |

---

## Verification & Testing

- **Physical Device Verification (iQOO 13)**:
  - Validated on a physical **iQOO 13** (6.82" 2K AMOLED, Funtouch OS, Android 16).
  - Confirmed status bar indicators (clock, battery %, Wi-Fi, cellular signal, DND, notifications) and navigation gesture handles switch between black and white immediately upon theme change without app restart.
  - Confirmed modal bottom sheets (`SendScreen`, `ReceiveScreen`, `BuyScreen`, `SellScreen`) preserve high-contrast dark system bar icons over light sheet surfaces.
- **Automated Tests**: Ran `./gradlew compileDebugKotlin testDebugUnitTest` — all 28 unit tests passed cleanly in 9s.
- **Runtime Theme Toggling**: Verified dynamic toggling across **Light**, **Dark**, and **System** modes in **Settings -> Appearance**.

---

## Related
- Closes #255

