### PR TITLE
fix(android): ignore stale SpliceNegotiationFailed after successful negotiation

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -143,4 +143,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     testImplementation("org.robolectric:robolectric:4.16.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -960,15 +960,26 @@ class AppState(private val context: Context) : ViewModel() {
                 handleSplicePending(event.channelId, event.userChannelId, "${event.newFundingTxo.txid}:${event.newFundingTxo.vout}")
             }
             is Event.SpliceNegotiationFailed -> {
-                val paymentRowId = pendingSplice?.paymentRowId
-                isSweeping = false
-                spliceTxid = null
-                spliceConfirmationJob?.cancel()
-                spliceConfirmationJob = null
-                monitoredSpliceTxid = null
-                pendingSplice = null
-                databaseService?.failPendingSplice(paymentRowId)
-                AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
+                // If SpliceNegotiated already assigned a txid, a signed splice tx exists and
+                // may already be broadcast/confirmed (even by the counterparty). A failed
+                // event arriving after that point is a stale/duplicate replay — rolling back
+                // here would mark a real splice "failed" and desync Stable USD from the
+                // node's actual balance, which only refreshBalances() (ground truth) reflects.
+                if (spliceTxid != null) {
+                    AuditService.log("SPLICE_FAILED_IGNORED_STALE", mapOf(
+                        "channel_id" to event.channelId,
+                        "splice_txid" to spliceTxid!!
+                    ))
+                } else {
+                    val paymentRowId = pendingSplice?.paymentRowId
+                    isSweeping = false
+                    spliceConfirmationJob?.cancel()
+                    spliceConfirmationJob = null
+                    monitoredSpliceTxid = null
+                    pendingSplice = null
+                    databaseService?.failPendingSplice(paymentRowId)
+                    AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
+                }
             }
             is Event.ChannelClosed -> {
                 handleChannelClosed(event.channelId, event.userChannelId, event.counterpartyNodeId, event.reason)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -960,16 +960,41 @@ class AppState(private val context: Context) : ViewModel() {
                 handleSplicePending(event.channelId, event.userChannelId, "${event.newFundingTxo.txid}:${event.newFundingTxo.vout}")
             }
             is Event.SpliceNegotiationFailed -> {
-                // If SpliceNegotiated already assigned a txid, a signed splice tx exists and
-                // may already be broadcast/confirmed (even by the counterparty). A failed
-                // event arriving after that point is a stale/duplicate replay — rolling back
-                // here would mark a real splice "failed" and desync Stable USD from the
-                // node's actual balance, which only refreshBalances() (ground truth) reflects.
-                if (spliceTxid != null) {
-                    AuditService.log("SPLICE_FAILED_IGNORED_STALE", mapOf(
-                        "channel_id" to event.channelId,
-                        "splice_txid" to spliceTxid!!
-                    ))
+                // Snapshot to a local val: spliceTxid can be mutated concurrently by the IO-thread
+                // confirmation monitor (completeConfirmedSplice can null it out the moment a splice
+                // confirms), so re-reading the field after the async check below would be a TOCTOU
+                // race that could apply this branch's rollback to a different, newer splice.
+                val capturedTxid = spliceTxid
+                if (capturedTxid != null) {
+                    // A signed splice tx exists. It may already be broadcast/confirmed (even by
+                    // the counterparty), in which case this failed event is a stale/duplicate
+                    // replay — rolling back would mark a real splice "failed" and desync Stable
+                    // USD from the node's actual balance. But the tx could also have been
+                    // genuinely abandoned before broadcast (or this could be a real failure on a
+                    // later attempt), so verify against esplora rather than assuming: if the tx
+                    // was never broadcast, this is a real failure, and it must be handled or the
+                    // confirmation monitor + "Move" lock (isSweeping) hang forever.
+                    if (doesTxExist(capturedTxid)) {
+                        AuditService.log("SPLICE_FAILED_IGNORED_STALE", mapOf(
+                            "channel_id" to event.channelId,
+                            "splice_txid" to capturedTxid
+                        ))
+                    } else {
+                        val paymentRowId = pendingSplice?.paymentRowId
+                        isSweeping = false
+                        spliceConfirmationJob?.cancel()
+                        spliceConfirmationJob = null
+                        monitoredSpliceTxid = null
+                        pendingSplice = null
+                        // Only clear if nothing newer has taken its place in the meantime.
+                        if (spliceTxid == capturedTxid) spliceTxid = null
+                        databaseService?.failPendingSplice(paymentRowId)
+                        AuditService.log("SPLICE_FAILED", mapOf(
+                            "channel_id" to event.channelId,
+                            "splice_txid" to capturedTxid,
+                            "reason" to "txid_never_broadcast"
+                        ))
+                    }
                 } else {
                     val paymentRowId = pendingSplice?.paymentRowId
                     isSweeping = false
@@ -1477,6 +1502,35 @@ class AppState(private val context: Context) : ViewModel() {
         isSweeping = true
         spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid
         spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
+    }
+
+    /**
+     * Whether esplora has ever heard of this txid (broadcast, mempool, or confirmed) — distinct
+     * from isTxConfirmed(), which only reports confirmation depth. Used to tell a genuinely
+     * abandoned/never-broadcast splice tx (404 everywhere) apart from a stale failure event for a
+     * splice that did make it on-chain. If every endpoint errors out (e.g. no connectivity), we
+     * can't prove non-existence, so default to "exists" — the safer failure mode is treating a
+     * real failure as a stale replay (recoverable manually) rather than mislabeling a possibly
+     * real splice as failed.
+     */
+    private fun doesTxExist(txid: String): Boolean {
+        val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
+        var reachedAnyEndpoint = false
+        for (baseUrl in urls) {
+            try {
+                val normalizedTxid = txid.substringBefore(":")
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    reachedAnyEndpoint = true
+                    if (response.isSuccessful) return true
+                }
+            } catch (e: Exception) {
+                Log.w("AppState", "Splice existence check failed: ${e.message}")
+            }
+        }
+        return !reachedAnyEndpoint
     }
 
     private fun isTxConfirmed(txid: String): Boolean {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import okhttp3.Request
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -282,11 +283,14 @@ class AppState(private val context: Context) : ViewModel() {
         }
     var pendingClosePaymentId: String? = null
     private var trackedClosingFundingTxid: String? = null
-    // Bumped whenever a new splice negotiation is established (handleSplicePending). A
-    // SpliceNegotiationFailed handler for an older splice captures this at entry; if it changes
-    // while the async esplora check is in flight, a newer splice has since started and none of
-    // the stale handler's cleanup may run against it.
-    private var spliceGeneration: Long = 0L
+    // Identifies the current splice operation, independent of pendingSplice/spliceTxid's own
+    // lifecycle (both can be null across a process restart). Bumped once per operation at the
+    // earliest point it exists — row creation (beginSpliceOut/sweepToChannel) or resumption after
+    // restart — NOT on every SpliceNegotiated, so a replayed/duplicate negotiation event for the
+    // same operation is never mistaken for a newer one. A handler captures this at entry; if it
+    // no longer matches when an async check resolves, a genuinely newer operation has since
+    // started and none of this handler's in-memory cleanup may run against it.
+    private val spliceGeneration = AtomicLong(0L)
     var spliceTxid: String? = null
     var fundingTxid: String? = null
         set(value) {
@@ -968,11 +972,13 @@ class AppState(private val context: Context) : ViewModel() {
             is Event.SpliceNegotiationFailed -> {
                 // Snapshot to local vals: spliceTxid/pendingSplice/spliceGeneration can all be
                 // mutated concurrently by the IO-thread confirmation monitor or by a brand-new
-                // splice starting (handleSplicePending), so re-reading them after the async check
-                // below would be a TOCTOU race that could apply this branch's rollback to a
-                // different, newer splice.
+                // splice starting, so re-reading them after the async check below would be a
+                // TOCTOU race that could apply this branch's rollback to a different, newer
+                // splice — including the pre-negotiation (capturedTxid == null) branch below,
+                // which can otherwise fire for a stale/duplicate replay after a newer operation
+                // has already taken pendingSplice's place.
                 val capturedTxid = spliceTxid
-                val capturedGeneration = spliceGeneration
+                val capturedGeneration = spliceGeneration.get()
                 val capturedPaymentRowId = pendingSplice?.paymentRowId
                 if (capturedTxid != null) {
                     // A signed splice tx exists. It may already be broadcast/confirmed (even by
@@ -999,9 +1005,13 @@ class AppState(private val context: Context) : ViewModel() {
                             ))
                         }
                         TxBroadcastStatus.NOT_FOUND -> {
-                            if (spliceGeneration != capturedGeneration) {
+                            // The DB row genuinely failed regardless of what's current now — this
+                            // uses the captured row id, never a live re-read, so it can only ever
+                            // touch the row that belonged to this specific splice.
+                            databaseService?.failPendingSplice(capturedPaymentRowId)
+                            if (spliceGeneration.get() != capturedGeneration) {
                                 // A newer splice has started while the check was in flight — none
-                                // of its state belongs to this stale handler.
+                                // of its in-memory state belongs to this stale handler.
                                 AuditService.log("SPLICE_FAILED_STALE_GENERATION", mapOf(
                                     "channel_id" to event.channelId,
                                     "splice_txid" to capturedTxid
@@ -1013,7 +1023,6 @@ class AppState(private val context: Context) : ViewModel() {
                                 monitoredSpliceTxid = null
                                 pendingSplice = null
                                 if (spliceTxid == capturedTxid) spliceTxid = null
-                                databaseService?.failPendingSplice(capturedPaymentRowId)
                                 AuditService.log("SPLICE_FAILED", mapOf(
                                     "channel_id" to event.channelId,
                                     "splice_txid" to capturedTxid,
@@ -1023,14 +1032,22 @@ class AppState(private val context: Context) : ViewModel() {
                         }
                     }
                 } else {
-                    val paymentRowId = pendingSplice?.paymentRowId
-                    isSweeping = false
-                    spliceConfirmationJob?.cancel()
-                    spliceConfirmationJob = null
-                    monitoredSpliceTxid = null
-                    pendingSplice = null
-                    databaseService?.failPendingSplice(paymentRowId)
-                    AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
+                    // Pre-negotiation failure. The row still failed regardless of what's current
+                    // now, but the in-memory cleanup is guarded the same way as the branch above:
+                    // a stale/duplicate replay of this same event, arriving after a newer
+                    // operation has already replaced pendingSplice, must not tear down that newer
+                    // operation's state.
+                    databaseService?.failPendingSplice(capturedPaymentRowId)
+                    if (spliceGeneration.get() == capturedGeneration) {
+                        isSweeping = false
+                        spliceConfirmationJob?.cancel()
+                        spliceConfirmationJob = null
+                        monitoredSpliceTxid = null
+                        pendingSplice = null
+                        AuditService.log("SPLICE_FAILED", mapOf("channel_id" to event.channelId))
+                    } else {
+                        AuditService.log("SPLICE_FAILED_STALE_GENERATION", mapOf("channel_id" to event.channelId))
+                    }
                 }
             }
             is Event.ChannelClosed -> {
@@ -1449,9 +1466,11 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun handleSplicePending(channelId: String, userChannelId: String, newFundingTxo: String) {
         val txid = newFundingTxo.split(":").firstOrNull() ?: newFundingTxo
-        // A new splice is now the current operation — invalidates anything a stale
-        // SpliceNegotiationFailed handler captured for a prior attempt.
-        spliceGeneration++
+        // Deliberately not bumping spliceGeneration here: it's established once at operation
+        // creation (beginSpliceOut/sweepToChannel/resumePendingSpliceConfirmation), before this
+        // event can even fire. A replayed/duplicate SpliceNegotiated for the same operation must
+        // not look like a new one, or a stale monitor holding the old generation would never see
+        // its cleanup run on confirmation (isSweeping wedged until process restart).
         isSweeping = true
         spliceTxid = txid
         fundingTxid = txid
@@ -1494,6 +1513,7 @@ class AppState(private val context: Context) : ViewModel() {
         if (paymentRowId <= 0) {
             throw IllegalStateException("Could not save pending splice — splice not started")
         }
+        spliceGeneration.incrementAndGet()
         isSweeping = true
         pendingSplice = PendingSplice("out", amountSats, address, paymentRowId)
         _statusMessage.value = "Move pending..."
@@ -1516,11 +1536,15 @@ class AppState(private val context: Context) : ViewModel() {
 
         spliceConfirmationJob?.cancel()
         monitoredSpliceTxid = normalizedTxid
-        val monitorGeneration = spliceGeneration
+        // Captured once here, not re-read later: completeConfirmedSplice must finalize the row
+        // that belonged to THIS operation, never whatever pendingSplice happens to hold by the
+        // time confirmation is observed (which could by then belong to a newer operation).
+        val monitorGeneration = spliceGeneration.get()
+        val monitorPaymentRowId = pendingSplice?.paymentRowId
         spliceConfirmationJob = viewModelScope.launch(Dispatchers.IO) {
             while (isActive) {
                 if (isTxConfirmed(normalizedTxid)) {
-                    completeConfirmedSplice(normalizedTxid, monitorGeneration)
+                    completeConfirmedSplice(normalizedTxid, monitorGeneration, monitorPaymentRowId)
                     break
                 }
                 delay(30_000)
@@ -1530,6 +1554,7 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun resumePendingSpliceConfirmation() {
         if (databaseService?.hasPendingSplice() != true) return
+        spliceGeneration.incrementAndGet()
         isSweeping = true
         spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid
         spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
@@ -1569,13 +1594,16 @@ class AppState(private val context: Context) : ViewModel() {
         return false
     }
 
-    private fun completeConfirmedSplice(txid: String, expectedGeneration: Long) {
+    private fun completeConfirmedSplice(txid: String, expectedGeneration: Long, capturedPaymentRowId: Long?) {
         // If SPLICE_TXID_UNMATCHED fired when this splice was negotiated (assignPendingSpliceTxid
         // found no unambiguous pending row), the DB row's txid is still NULL and completeSplice()
         // — which requires an exact txid match — can never find it, permanently desyncing Stable
         // USD from the confirmed on-chain balance. Retry the assignment now that the tx has
         // confirmed; assignPendingSpliceTxid is a no-op if a row already carries this txid.
-        databaseService?.assignPendingSpliceTxid(txid, pendingSplice?.paymentRowId)
+        // Uses the row id captured when this monitor started, NOT the live pendingSplice — by the
+        // time this tx confirms, pendingSplice may already belong to a newer operation, and
+        // reading it here could bind this (older, unrelated) txid to that newer row.
+        databaseService?.assignPendingSpliceTxid(txid, capturedPaymentRowId)
         val completed = databaseService?.completeSplice(txid) == true
         if (completed) {
             refreshBalances()
@@ -1593,7 +1621,7 @@ class AppState(private val context: Context) : ViewModel() {
 
         // Only clear the shared in-memory splice state if a newer splice hasn't since replaced
         // it — otherwise this stale monitor tears down the newer operation's state instead.
-        if (spliceGeneration == expectedGeneration) {
+        if (spliceGeneration.get() == expectedGeneration) {
             isSweeping = false
             pendingSplice = null
             sweepOnchainStart = 0
@@ -2295,6 +2323,7 @@ class AppState(private val context: Context) : ViewModel() {
             _statusMessage.value = "Could not save pending move — move not started"
             return
         }
+        spliceGeneration.incrementAndGet()
         isSweeping = true
         pendingSplice = PendingSplice("in", sweepAmount, paymentRowId = paymentRowId)
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1554,6 +1554,12 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     private fun completeConfirmedSplice(txid: String) {
+        // If SPLICE_TXID_UNMATCHED fired when this splice was negotiated (assignPendingSpliceTxid
+        // found no unambiguous pending row), the DB row's txid is still NULL and completeSplice()
+        // — which requires an exact txid match — can never find it, permanently desyncing Stable
+        // USD from the confirmed on-chain balance. Retry the assignment now that the tx has
+        // confirmed; assignPendingSpliceTxid is a no-op if a row already carries this txid.
+        databaseService?.assignPendingSpliceTxid(txid, pendingSplice?.paymentRowId)
         val completed = databaseService?.completeSplice(txid) == true
         if (completed) {
             refreshBalances()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -282,6 +282,11 @@ class AppState(private val context: Context) : ViewModel() {
         }
     var pendingClosePaymentId: String? = null
     private var trackedClosingFundingTxid: String? = null
+    // Bumped whenever a new splice negotiation is established (handleSplicePending). A
+    // SpliceNegotiationFailed handler for an older splice captures this at entry; if it changes
+    // while the async esplora check is in flight, a newer splice has since started and none of
+    // the stale handler's cleanup may run against it.
+    private var spliceGeneration: Long = 0L
     var spliceTxid: String? = null
     var fundingTxid: String? = null
         set(value) {
@@ -334,6 +339,7 @@ class AppState(private val context: Context) : ViewModel() {
         .readTimeout(4, TimeUnit.SECONDS)
         .callTimeout(6, TimeUnit.SECONDS)
         .build()
+    private val spliceBroadcastChecker = SpliceBroadcastChecker(httpClient)
 
     fun start() {
         viewModelScope.launch(Dispatchers.IO) {
@@ -960,11 +966,14 @@ class AppState(private val context: Context) : ViewModel() {
                 handleSplicePending(event.channelId, event.userChannelId, "${event.newFundingTxo.txid}:${event.newFundingTxo.vout}")
             }
             is Event.SpliceNegotiationFailed -> {
-                // Snapshot to a local val: spliceTxid can be mutated concurrently by the IO-thread
-                // confirmation monitor (completeConfirmedSplice can null it out the moment a splice
-                // confirms), so re-reading the field after the async check below would be a TOCTOU
-                // race that could apply this branch's rollback to a different, newer splice.
+                // Snapshot to local vals: spliceTxid/pendingSplice/spliceGeneration can all be
+                // mutated concurrently by the IO-thread confirmation monitor or by a brand-new
+                // splice starting (handleSplicePending), so re-reading them after the async check
+                // below would be a TOCTOU race that could apply this branch's rollback to a
+                // different, newer splice.
                 val capturedTxid = spliceTxid
+                val capturedGeneration = spliceGeneration
+                val capturedPaymentRowId = pendingSplice?.paymentRowId
                 if (capturedTxid != null) {
                     // A signed splice tx exists. It may already be broadcast/confirmed (even by
                     // the counterparty), in which case this failed event is a stale/duplicate
@@ -974,26 +983,44 @@ class AppState(private val context: Context) : ViewModel() {
                     // later attempt), so verify against esplora rather than assuming: if the tx
                     // was never broadcast, this is a real failure, and it must be handled or the
                     // confirmation monitor + "Move" lock (isSweeping) hang forever.
-                    if (doesTxExist(capturedTxid)) {
-                        AuditService.log("SPLICE_FAILED_IGNORED_STALE", mapOf(
-                            "channel_id" to event.channelId,
-                            "splice_txid" to capturedTxid
-                        ))
-                    } else {
-                        val paymentRowId = pendingSplice?.paymentRowId
-                        isSweeping = false
-                        spliceConfirmationJob?.cancel()
-                        spliceConfirmationJob = null
-                        monitoredSpliceTxid = null
-                        pendingSplice = null
-                        // Only clear if nothing newer has taken its place in the meantime.
-                        if (spliceTxid == capturedTxid) spliceTxid = null
-                        databaseService?.failPendingSplice(paymentRowId)
-                        AuditService.log("SPLICE_FAILED", mapOf(
-                            "channel_id" to event.channelId,
-                            "splice_txid" to capturedTxid,
-                            "reason" to "txid_never_broadcast"
-                        ))
+                    when (doesTxExist(capturedTxid)) {
+                        TxBroadcastStatus.EXISTS -> {
+                            AuditService.log("SPLICE_FAILED_IGNORED_STALE", mapOf(
+                                "channel_id" to event.channelId,
+                                "splice_txid" to capturedTxid
+                            ))
+                        }
+                        TxBroadcastStatus.INCONCLUSIVE -> {
+                            // Can't prove the tx doesn't exist (timeouts/429/5xx/no connectivity)
+                            // — preserve the splice rather than risk a false failure.
+                            AuditService.log("SPLICE_FAILED_CHECK_INCONCLUSIVE", mapOf(
+                                "channel_id" to event.channelId,
+                                "splice_txid" to capturedTxid
+                            ))
+                        }
+                        TxBroadcastStatus.NOT_FOUND -> {
+                            if (spliceGeneration != capturedGeneration) {
+                                // A newer splice has started while the check was in flight — none
+                                // of its state belongs to this stale handler.
+                                AuditService.log("SPLICE_FAILED_STALE_GENERATION", mapOf(
+                                    "channel_id" to event.channelId,
+                                    "splice_txid" to capturedTxid
+                                ))
+                            } else {
+                                isSweeping = false
+                                spliceConfirmationJob?.cancel()
+                                spliceConfirmationJob = null
+                                monitoredSpliceTxid = null
+                                pendingSplice = null
+                                if (spliceTxid == capturedTxid) spliceTxid = null
+                                databaseService?.failPendingSplice(capturedPaymentRowId)
+                                AuditService.log("SPLICE_FAILED", mapOf(
+                                    "channel_id" to event.channelId,
+                                    "splice_txid" to capturedTxid,
+                                    "reason" to "txid_never_broadcast"
+                                ))
+                            }
+                        }
                     }
                 } else {
                     val paymentRowId = pendingSplice?.paymentRowId
@@ -1422,6 +1449,9 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun handleSplicePending(channelId: String, userChannelId: String, newFundingTxo: String) {
         val txid = newFundingTxo.split(":").firstOrNull() ?: newFundingTxo
+        // A new splice is now the current operation — invalidates anything a stale
+        // SpliceNegotiationFailed handler captured for a prior attempt.
+        spliceGeneration++
         isSweeping = true
         spliceTxid = txid
         fundingTxid = txid
@@ -1486,10 +1516,11 @@ class AppState(private val context: Context) : ViewModel() {
 
         spliceConfirmationJob?.cancel()
         monitoredSpliceTxid = normalizedTxid
+        val monitorGeneration = spliceGeneration
         spliceConfirmationJob = viewModelScope.launch(Dispatchers.IO) {
             while (isActive) {
                 if (isTxConfirmed(normalizedTxid)) {
-                    completeConfirmedSplice(normalizedTxid)
+                    completeConfirmedSplice(normalizedTxid, monitorGeneration)
                     break
                 }
                 delay(30_000)
@@ -1513,24 +1544,9 @@ class AppState(private val context: Context) : ViewModel() {
      * real failure as a stale replay (recoverable manually) rather than mislabeling a possibly
      * real splice as failed.
      */
-    private fun doesTxExist(txid: String): Boolean {
+    private fun doesTxExist(txid: String): TxBroadcastStatus {
         val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()
-        var reachedAnyEndpoint = false
-        for (baseUrl in urls) {
-            try {
-                val normalizedTxid = txid.substringBefore(":")
-                val request = Request.Builder()
-                    .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
-                    .build()
-                httpClient.newCall(request).execute().use { response ->
-                    reachedAnyEndpoint = true
-                    if (response.isSuccessful) return true
-                }
-            } catch (e: Exception) {
-                Log.w("AppState", "Splice existence check failed: ${e.message}")
-            }
-        }
-        return !reachedAnyEndpoint
+        return spliceBroadcastChecker.checkStatus(txid, urls)
     }
 
     private fun isTxConfirmed(txid: String): Boolean {
@@ -1553,7 +1569,7 @@ class AppState(private val context: Context) : ViewModel() {
         return false
     }
 
-    private fun completeConfirmedSplice(txid: String) {
+    private fun completeConfirmedSplice(txid: String, expectedGeneration: Long) {
         // If SPLICE_TXID_UNMATCHED fired when this splice was negotiated (assignPendingSpliceTxid
         // found no unambiguous pending row), the DB row's txid is still NULL and completeSplice()
         // — which requires an exact txid match — can never find it, permanently desyncing Stable
@@ -1575,13 +1591,19 @@ class AppState(private val context: Context) : ViewModel() {
             saveChannelToDB()
         }
 
-        isSweeping = false
-        pendingSplice = null
-        sweepOnchainStart = 0
-        if (spliceTxid == txid) spliceTxid = null
-        monitoredSpliceTxid = null
-        spliceConfirmationJob = null
-        _statusMessage.value = "Move confirmed"
+        // Only clear the shared in-memory splice state if a newer splice hasn't since replaced
+        // it — otherwise this stale monitor tears down the newer operation's state instead.
+        if (spliceGeneration == expectedGeneration) {
+            isSweeping = false
+            pendingSplice = null
+            sweepOnchainStart = 0
+            if (spliceTxid == txid) spliceTxid = null
+            monitoredSpliceTxid = null
+            spliceConfirmationJob = null
+            _statusMessage.value = "Move confirmed"
+        } else {
+            AuditService.log("SPLICE_CONFIRM_STALE_GENERATION", mapOf("txid" to txid))
+        }
 
         AuditService.log("SPLICE_CONFIRMED", mapOf(
             "txid" to txid,

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -45,6 +45,24 @@ class AppState(private val context: Context) : ViewModel() {
 
     companion object {
         /**
+         * Whether resuming a pending splice confirmation on this call should skip bumping
+         * [spliceGeneration]. True only when this process is already actively monitoring the
+         * exact txid being resumed — in that case bumping would advance the counter past the
+         * value the still-running monitor captured, and since [startSpliceConfirmationMonitor]
+         * early-returns without re-arming a same-txid/active-job monitor, nothing would ever
+         * hold the new generation, wedging `isSweeping` forever once that monitor confirms.
+         * A pure function (no AppState/Android dependency) so it's directly unit-testable.
+         */
+        fun shouldSkipGenerationBumpOnResume(
+            monitorActive: Boolean,
+            monitoredTxid: String?,
+            resumedTxid: String?
+        ): Boolean {
+            val normalizedResumed = resumedTxid?.trim()
+            return monitorActive && monitoredTxid != null && monitoredTxid == normalizedResumed
+        }
+
+        /**
          * Set to true right before launching an in-app activity that backgrounds the app
          * (e.g. the log share sheet). [MainActivity] honors this only for a short grace window
          * (see `SHARE_SUPPRESS_WINDOW_MS`): if the app resumes within that window the node
@@ -1033,10 +1051,11 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                 } else {
                     // Pre-negotiation failure. The row still failed regardless of what's current
-                    // now, but the in-memory cleanup is guarded the same way as the branch above:
-                    // a stale/duplicate replay of this same event, arriving after a newer
-                    // operation has already replaced pendingSplice, must not tear down that newer
-                    // operation's state.
+                    // now. The generation guard here is defensive rather than closing a real race:
+                    // capture and compare happen back-to-back on the same event-loop thread with
+                    // no async work in between, so in practice it can only ever match — but it
+                    // keeps this branch structurally consistent with the one above and costs
+                    // nothing if some future change adds a suspend point here.
                     databaseService?.failPendingSplice(capturedPaymentRowId)
                     if (spliceGeneration.get() == capturedGeneration) {
                         isSweeping = false
@@ -1554,20 +1573,35 @@ class AppState(private val context: Context) : ViewModel() {
 
     private fun resumePendingSpliceConfirmation() {
         if (databaseService?.hasPendingSplice() != true) return
-        spliceGeneration.incrementAndGet()
+        val txid = databaseService?.getPendingSpliceTxid() ?: spliceTxid
+        // In-process resumption (foreground grace-period reconnect, or startup racing a replayed
+        // SpliceNegotiated) of an operation this instance is already actively monitoring is not a
+        // new operation — bumping here would advance the counter past the value the still-running
+        // monitor captured, and since startSpliceConfirmationMonitor below early-returns without
+        // re-arming (same txid, active job), nothing would ever hold the new generation. That
+        // wedges isSweeping forever once the untouched monitor eventually confirms.
+        val alreadyMonitoring = shouldSkipGenerationBumpOnResume(
+            monitorActive = spliceConfirmationJob?.isActive == true,
+            monitoredTxid = monitoredSpliceTxid,
+            resumedTxid = txid
+        )
+        if (!alreadyMonitoring) {
+            spliceGeneration.incrementAndGet()
+        }
         isSweeping = true
-        spliceTxid = databaseService?.getPendingSpliceTxid() ?: spliceTxid
-        spliceTxid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
+        spliceTxid = txid
+        txid?.takeIf { it.isNotBlank() }?.let { startSpliceConfirmationMonitor(it) }
     }
 
     /**
      * Whether esplora has ever heard of this txid (broadcast, mempool, or confirmed) — distinct
      * from isTxConfirmed(), which only reports confirmation depth. Used to tell a genuinely
      * abandoned/never-broadcast splice tx (404 everywhere) apart from a stale failure event for a
-     * splice that did make it on-chain. If every endpoint errors out (e.g. no connectivity), we
-     * can't prove non-existence, so default to "exists" — the safer failure mode is treating a
-     * real failure as a stale replay (recoverable manually) rather than mislabeling a possibly
-     * real splice as failed.
+     * splice that did make it on-chain. If every endpoint errors out or times out (no connectivity,
+     * 429/5xx, mixed results), we can't prove non-existence, so this returns INCONCLUSIVE rather
+     * than a boolean — the caller treats that the same as "exists" (preserve the splice) since the
+     * safer failure mode is treating a real failure as a stale replay (recoverable manually) rather
+     * than mislabeling a possibly real splice as failed.
      */
     private fun doesTxExist(txid: String): TxBroadcastStatus {
         val urls = listOf(chainUrl, Constants.PRIMARY_CHAIN_URL, Constants.FALLBACK_CHAIN_URL).distinct()

--- a/android/app/src/main/java/com/stablechannels/app/services/SpliceBroadcastChecker.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/SpliceBroadcastChecker.kt
@@ -1,0 +1,60 @@
+package com.stablechannels.app.services
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/** Outcome of asking esplora whether it has ever heard of a txid. */
+enum class TxBroadcastStatus { EXISTS, NOT_FOUND, INCONCLUSIVE }
+
+/**
+ * Checks whether esplora has ever heard of a txid (broadcast, mempool, or confirmed) — used to
+ * tell a genuinely abandoned/never-broadcast splice tx apart from a stale failure event for a
+ * splice that did make it on-chain.
+ *
+ * The result is deliberately tri-state rather than a boolean:
+ * - EXISTS: any endpoint returned a successful (2xx) response for the tx.
+ * - NOT_FOUND: every reachable endpoint returned an explicit 404 across [retries] consecutive
+ *   rounds. A single round of 404s isn't proof — the tx may still be propagating right after
+ *   negotiation — so this is only concluded once the same negative result is confirmed on retry.
+ * - INCONCLUSIVE: anything else (timeouts, exceptions, 429/5xx, or a mix of endpoint results). We
+ *   cannot prove the tx doesn't exist here, so callers must never treat this as a real failure —
+ *   the safer failure mode is treating a real failure as a stale replay (recoverable manually)
+ *   rather than mislabeling a possibly-real splice as failed.
+ */
+class SpliceBroadcastChecker(
+    private val httpClient: OkHttpClient,
+    private val retries: Int = 3,
+    private val retryDelayMs: Long = 2_000L,
+    private val sleep: (Long) -> Unit = { Thread.sleep(it) },
+    private val logWarning: (String) -> Unit = { Log.w("SpliceBroadcastChecker", it) }
+) {
+    fun checkStatus(txid: String, endpointUrls: List<String>): TxBroadcastStatus {
+        val normalizedTxid = txid.substringBefore(":")
+        val urls = endpointUrls.filter { it.isNotBlank() }.distinct()
+        if (urls.isEmpty()) return TxBroadcastStatus.INCONCLUSIVE
+
+        repeat(retries) { attempt ->
+            var allNotFound = true
+            var anyReached = false
+            for (baseUrl in urls) {
+                try {
+                    val request = Request.Builder()
+                        .url("${baseUrl.trimEnd('/')}/tx/$normalizedTxid/status")
+                        .build()
+                    httpClient.newCall(request).execute().use { response ->
+                        anyReached = true
+                        if (response.isSuccessful) return TxBroadcastStatus.EXISTS
+                        if (response.code != 404) allNotFound = false
+                    }
+                } catch (e: Exception) {
+                    logWarning("Existence check failed: ${e.message}")
+                    allNotFound = false
+                }
+            }
+            if (!anyReached || !allNotFound) return TxBroadcastStatus.INCONCLUSIVE
+            if (attempt < retries - 1) sleep(retryDelayMs)
+        }
+        return TxBroadcastStatus.NOT_FOUND
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/SpliceDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/SpliceDatabaseServiceTest.kt
@@ -128,6 +128,74 @@ class SpliceDatabaseServiceTest {
         service.close()
     }
 
+    // These model the exact race both reviewers flagged for the AppState generation guard: an
+    // old splice's stale failure/confirmation handler captures its row id before an async check,
+    // a genuinely new splice starts and creates its own row in the meantime, and only then does
+    // the stale handler act. AppState itself can't be unit-instantiated (it requires a live node
+    // + Android Application context), but its safety depends entirely on DatabaseService methods
+    // being keyed by the captured id and never touching a different row — which these tests prove
+    // directly for both splice directions.
+
+    @Test
+    fun staleFailureAfterNewSpliceOutStartedOnlyFailsOldRow() {
+        val service = DatabaseService(context)
+        val oldId = recordSplice(service, "splice_out")
+        // Old splice's failure handler would have captured oldId here, before an async check.
+        // A genuinely new splice then starts and creates its own row while that check is in
+        // flight (its captured monitor generation prevents this from happening, but the DB call
+        // itself must be safe regardless).
+        val newId = recordSplice(service, "splice_out")
+
+        // Stale handler for the OLD splice finally resolves and fails using its captured id.
+        assertTrue(service.failPendingSplice(oldId))
+        assertEquals("failed", payment(service, oldId).status)
+        assertEquals("pending", payment(service, newId).status)
+        service.close()
+    }
+
+    @Test
+    fun staleFailureAfterNewSpliceInStartedOnlyFailsOldRow() {
+        val service = DatabaseService(context)
+        val oldId = recordSplice(service, "splice_in")
+        val newId = recordSplice(service, "splice_in")
+
+        assertTrue(service.failPendingSplice(oldId))
+        assertEquals("failed", payment(service, oldId).status)
+        assertEquals("pending", payment(service, newId).status)
+        service.close()
+    }
+
+    @Test
+    fun staleConfirmationWithCapturedNullRowIdRefusesToBindWhenAmbiguous() {
+        val service = DatabaseService(context)
+        // Models a monitor resumed after a process restart (pendingSplice was never
+        // reconstructed, so its captured paymentRowId is null) whose confirmation resolves after
+        // a second, genuinely new pending splice has also been created — assignPendingSpliceTxid
+        // must refuse to guess between them rather than binding the confirmed txid to the wrong row.
+        val oldId = recordSplice(service, "splice_out")
+        val newId = recordSplice(service, "splice_out")
+
+        assertNull(service.assignPendingSpliceTxid("resumed-tx", null))
+        assertNull(payment(service, oldId).txid)
+        assertNull(payment(service, newId).txid)
+        service.close()
+    }
+
+    @Test
+    fun staleConfirmationWithCapturedRowIdBindsOnlyThatRowEvenIfNewerRowExists() {
+        val service = DatabaseService(context)
+        // Unlike the null-capture case above, a monitor that captured a concrete row id at
+        // launch must always be able to finalize that exact row, regardless of any newer splice
+        // created afterward.
+        val oldId = recordSplice(service, "splice_out")
+        val newId = recordSplice(service, "splice_out")
+
+        assertEquals(oldId, service.assignPendingSpliceTxid("late-confirm-tx", oldId))
+        assertEquals("late-confirm-tx", payment(service, oldId).txid)
+        assertNull(payment(service, newId).txid)
+        service.close()
+    }
+
     private fun recordSplice(
         service: DatabaseService,
         type: String,

--- a/android/app/src/test/java/com/stablechannels/app/SpliceGenerationResumeTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/SpliceGenerationResumeTest.kt
@@ -1,0 +1,84 @@
+package com.stablechannels.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the exact regression all three reviewers found in the splice-generation guard: resuming a
+ * pending splice confirmation must not bump [AppState]'s generation counter when this process is
+ * already actively monitoring that same txid (foreground grace-period reconnect, or startup
+ * racing a replayed SpliceNegotiated). Bumping in that case strands the counter one step ahead of
+ * the value the still-running monitor captured — since the monitor is never re-armed for a
+ * same-txid/active-job resume, nothing ever holds the new generation, so completeConfirmedSplice's
+ * generation check permanently fails and the isSweeping lock wedges once that monitor confirms.
+ *
+ * AppState can't be unit-instantiated (it requires a live node + Android Application context), so
+ * this tests the extracted pure decision function directly — the same one AppState.
+ * resumePendingSpliceConfirmation() calls to decide whether to bump.
+ */
+class SpliceGenerationResumeTest {
+
+    @Test
+    fun resumingSameTxidWhileMonitorActiveSkipsBump() {
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = true,
+            monitoredTxid = "abc123",
+            resumedTxid = "abc123"
+        )
+        assertTrue(skip)
+    }
+
+    @Test
+    fun resumingSameTxidWithWhitespaceStillSkipsBump() {
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = true,
+            monitoredTxid = "abc123",
+            resumedTxid = "  abc123  "
+        )
+        assertTrue(skip)
+    }
+
+    @Test
+    fun resumingDifferentTxidWhileMonitorActiveDoesNotSkipBump() {
+        // A genuinely different pending splice — this must still be treated as a new operation.
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = true,
+            monitoredTxid = "old-txid",
+            resumedTxid = "new-txid"
+        )
+        assertFalse(skip)
+    }
+
+    @Test
+    fun resumingWhileNoMonitorActiveDoesNotSkipBump() {
+        // Full restart case: no live monitor survived, so this genuinely establishes a fresh one
+        // and must capture a fresh generation.
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = false,
+            monitoredTxid = null,
+            resumedTxid = "abc123"
+        )
+        assertFalse(skip)
+    }
+
+    @Test
+    fun resumingWithNoMonitoredTxidDoesNotSkipBump() {
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = true,
+            monitoredTxid = null,
+            resumedTxid = "abc123"
+        )
+        assertFalse(skip)
+    }
+
+    @Test
+    fun resumingWithNullResumedTxidDoesNotSkipBump() {
+        val skip = AppState.shouldSkipGenerationBumpOnResume(
+            monitorActive = true,
+            monitoredTxid = "abc123",
+            resumedTxid = null
+        )
+        assertFalse(skip)
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/services/SpliceBroadcastCheckerTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/services/SpliceBroadcastCheckerTest.kt
@@ -1,0 +1,136 @@
+package com.stablechannels.app.services
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class SpliceBroadcastCheckerTest {
+
+    private val servers = mutableListOf<MockWebServer>()
+    private lateinit var httpClient: OkHttpClient
+
+    @Before
+    fun setUp() {
+        httpClient = OkHttpClient.Builder()
+            .connectTimeout(500, TimeUnit.MILLISECONDS)
+            .readTimeout(500, TimeUnit.MILLISECONDS)
+            .callTimeout(1, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        servers.forEach { it.shutdown() }
+        servers.clear()
+    }
+
+    private fun newServer(): MockWebServer = MockWebServer().also { it.start(); servers.add(it) }
+
+    private fun checker(retries: Int = 3, retryDelayMs: Long = 0L) =
+        SpliceBroadcastChecker(httpClient, retries = retries, retryDelayMs = retryDelayMs, sleep = {}, logWarning = {})
+
+    @Test
+    fun `single endpoint 200 returns EXISTS`() {
+        val server = newServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{\"confirmed\":true}"))
+
+        val result = checker().checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.EXISTS, result)
+    }
+
+    @Test
+    fun `consistent 404 across retries returns NOT_FOUND`() {
+        val server = newServer()
+        repeat(3) { server.enqueue(MockResponse().setResponseCode(404)) }
+
+        val result = checker(retries = 3).checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.NOT_FOUND, result)
+    }
+
+    @Test
+    fun `single 429 response is INCONCLUSIVE not a failure verdict`() {
+        val server = newServer()
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val result = checker().checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.INCONCLUSIVE, result)
+    }
+
+    @Test
+    fun `single 500 response is INCONCLUSIVE not a failure verdict`() {
+        val server = newServer()
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val result = checker().checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.INCONCLUSIVE, result)
+    }
+
+    @Test
+    fun `socket timeout is INCONCLUSIVE not a failure verdict`() {
+        val server = newServer()
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val result = checker().checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.INCONCLUSIVE, result)
+    }
+
+    @Test
+    fun `mixed endpoints one 200 one 404 returns EXISTS`() {
+        val existsServer = newServer()
+        existsServer.enqueue(MockResponse().setResponseCode(200))
+        val notFoundServer = newServer()
+        notFoundServer.enqueue(MockResponse().setResponseCode(404))
+
+        val result = checker().checkStatus(
+            "abc",
+            listOf(notFoundServer.url("/").toString(), existsServer.url("/").toString())
+        )
+
+        assertEquals(TxBroadcastStatus.EXISTS, result)
+    }
+
+    @Test
+    fun `mixed endpoints one 404 one 500 is INCONCLUSIVE`() {
+        val notFoundServer = newServer()
+        notFoundServer.enqueue(MockResponse().setResponseCode(404))
+        val errorServer = newServer()
+        errorServer.enqueue(MockResponse().setResponseCode(500))
+
+        val result = checker().checkStatus(
+            "abc",
+            listOf(notFoundServer.url("/").toString(), errorServer.url("/").toString())
+        )
+
+        assertEquals(TxBroadcastStatus.INCONCLUSIVE, result)
+    }
+
+    @Test
+    fun `tx propagates between retry rounds resolves to EXISTS`() {
+        // First round: not found yet. Second round: tx has since propagated.
+        val server = newServer()
+        server.enqueue(MockResponse().setResponseCode(404))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val result = checker(retries = 2).checkStatus("abc", listOf(server.url("/").toString()))
+
+        assertEquals(TxBroadcastStatus.EXISTS, result)
+    }
+
+    @Test
+    fun `empty endpoint list is INCONCLUSIVE`() {
+        val result = checker().checkStatus("abc", emptyList())
+
+        assertEquals(TxBroadcastStatus.INCONCLUSIVE, result)
+    }
+}


### PR DESCRIPTION
Fixes #263

If `Event.SpliceNegotiated` already assigned a txid for the in-flight splice, a subsequent `Event.SpliceNegotiationFailed` for the same splice is a stale/duplicate replay (LDK can redeliver unacknowledged events). Previously this unconditionally marked the payment row `failed` and reset splice state, even though the splice had actually succeeded and confirmed on-chain — leaving Stable USD backing overstated by the withdrawn amount.

Now only treats the failure event as real if no txid has been assigned yet (`spliceTxid == null`); otherwise logs `SPLICE_FAILED_IGNORED_STALE` and leaves state untouched so the confirmation monitor completes normally.