### PR TITLE
Fix(cross): Instant On-Chain Send Balance Deduction, Send-Max Ghost Balance Elimination, and Dynamic Confirmation Policy

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -78,6 +78,31 @@ class AppState(private val context: Context) : ViewModel() {
         // Covers ordinary quick app-switches without keeping an unserviced cached Android
         // process in control of the node for longer than the common return window.
         private const val QUICK_SWITCH_GRACE_MS = 10_000L
+
+        fun calculateTotalBalance(
+            lightning: Long,
+            onchain: Long,
+            hasReady: Boolean,
+            isChannelClosing: Boolean,
+            isSweeping: Boolean,
+            pendingSweep: Long = 0L,
+            isOpeningChannel: Boolean = false
+        ): Long {
+            return when {
+                isChannelClosing -> onchain
+                isOpeningChannel -> if (lightning > 0) lightning else onchain
+                isSweeping -> lightning
+                !hasReady -> onchain + pendingSweep
+                else -> lightning + onchain
+            }
+        }
+
+        fun requiredConfirmationsForType(paymentType: String): Int {
+            return when (paymentType) {
+                "splice_in", "splice_out" -> 1
+                else -> 6
+            }
+        }
     }
 
     val nodeService = NodeService(context)
@@ -132,6 +157,8 @@ class AppState(private val context: Context) : ViewModel() {
     val totalBalanceSats: StateFlow<Long> get() = _totalBalanceSats
     private val _hasReadyChannel = MutableStateFlow(false)
     val hasReadyChannel: StateFlow<Boolean> get() = _hasReadyChannel
+    private val _pendingSweepBalanceSats = MutableStateFlow(0L)
+    val pendingSweepBalanceSats: StateFlow<Long> get() = _pendingSweepBalanceSats
 
     private val _onchainReceiveAddress = MutableStateFlow<String?>(null)
     val onchainReceiveAddress: StateFlow<String?> get() = _onchainReceiveAddress
@@ -1827,12 +1854,6 @@ class AppState(private val context: Context) : ViewModel() {
         }
     }
 
-    private fun requiredConfirmationsForType(paymentType: String): Int {
-        return when (paymentType) {
-            "splice_in", "splice_out" -> 1
-            else -> 6
-        }
-    }
 
     private data class TxConfirmationStatus(
         val confirmed: Boolean,
@@ -1984,6 +2005,10 @@ class AppState(private val context: Context) : ViewModel() {
 
             if (anyUpdated) {
                 _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
+                try {
+                    nodeService.syncWallets()
+                } catch (_: Exception) {}
+                refreshBalances()
             }
             lastConfirmationPollAtMs = now
         } finally {
@@ -2623,6 +2648,18 @@ class AppState(private val context: Context) : ViewModel() {
                 _stableChannel.value = _stableChannel.value.copy(counterparty = liveCounterparty)
             }
         }
+        // Pending sweep: count PendingBroadcast and BroadcastAwaitingConfirmation
+        // These funds are NOT yet in total_onchain_balance_sats
+        var sweepSats = 0L
+        for (pending in balances.pendingBalancesFromChannelClosures) {
+            when (pending) {
+                is PendingSweepBalance.PendingBroadcast -> sweepSats += pending.amountSatoshis.toLong()
+                is PendingSweepBalance.BroadcastAwaitingConfirmation -> sweepSats += pending.amountSatoshis.toLong()
+                else -> {}
+            }
+        }
+        _pendingSweepBalanceSats.value = sweepSats
+
         _lightningBalanceSats.value = lightning
         _onchainBalanceSats.value = onchain
         _hasReadyChannel.value = hasReady
@@ -2637,14 +2674,14 @@ class AppState(private val context: Context) : ViewModel() {
             isChannelClosing = false
         }
 
-        _totalBalanceSats.value = when {
-            isChannelClosing -> onchain
-            isSweeping -> lightning
-            // No open channel but both balances present: lightning is pending-close claimable
-            // that overlaps with on-chain — avoid double-count
-            !hasReady && lightning > 0 && onchain > 0 -> onchain
-            else -> lightning + onchain
-        }
+        _totalBalanceSats.value = calculateTotalBalance(
+            lightning = lightning,
+            onchain = onchain,
+            hasReady = hasReady,
+            isChannelClosing = isChannelClosing,
+            isSweeping = isSweeping,
+            pendingSweep = sweepSats
+        )
 
         // Calculate native sats (lightning minus stable portion) for slider position
         // On-chain funds excluded — they're not in the channel yet
@@ -2661,6 +2698,42 @@ class AppState(private val context: Context) : ViewModel() {
             .putLong("cached_spendable_sats", spendable)
             .putLong("cached_native_sats", native)
             .apply()
+    }
+
+    fun onchainSendBroadcasted(amountSats: Long, isSendAll: Boolean) {
+        val currentOnchain = _onchainBalanceSats.value
+        val currentSpendable = _spendableOnchainSats.value
+        val newOnchain = if (isSendAll) 0L else (currentOnchain - amountSats).coerceAtLeast(0L)
+        val newSpendable = if (isSendAll) 0L else (currentSpendable - amountSats).coerceAtLeast(0L)
+
+        _onchainBalanceSats.value = newOnchain
+        _spendableOnchainSats.value = newSpendable
+
+        val lightning = _lightningBalanceSats.value
+        val hasReady = _hasReadyChannel.value
+        _totalBalanceSats.value = calculateTotalBalance(
+            lightning = lightning,
+            onchain = newOnchain,
+            hasReady = hasReady,
+            isChannelClosing = isChannelClosing,
+            isSweeping = isSweeping,
+            pendingSweep = _pendingSweepBalanceSats.value
+        )
+
+        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+            .putLong("cached_onchain_sats", newOnchain)
+            .putLong("cached_spendable_sats", newSpendable)
+        if (!hasReady) {
+            editor.putLong("cached_lightning_sats", 0L)
+        }
+        editor.apply()
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                nodeService.syncWallets()
+            } catch (_: Exception) {}
+            refreshBalances()
+        }
     }
 
     fun updateStableBalances() {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -131,10 +131,46 @@ class AppState(private val context: Context) : ViewModel() {
             }
         }
 
+        object BalanceCacheKey {
+            const val PREFS_NAME = "balance_cache"
+            const val LIGHTNING = "cached_lightning_sats"
+            const val ONCHAIN = "cached_onchain_sats"
+            const val SPENDABLE = "cached_spendable_sats"
+            const val NATIVE = "cached_native_sats"
+            const val PENDING_AMOUNT = "pending_outbound_onchain_sats"
+            const val PENDING_IS_SEND_ALL = "pending_outbound_is_send_all"
+            const val PENDING_BASELINE = "pending_outbound_baseline_sats"
+            const val PENDING_TIMESTAMP = "pending_outbound_timestamp_secs"
+            const val RECEIVE_ADDRESS = "onchain_receive_address"
+            const val LAST_RECEIVE_TXID = "last_receive_txid"
+            const val LAST_RECEIVE_TXID_ADDRESS = "last_receive_txid_address"
+            const val LAST_CLOSE_TXID = "last_close_txid"
+            const val LAST_CLOSE_TXID_AT = "last_close_txid_at"
+            const val FUNDING_TXID = "funding_txid"
+            const val CLOSING_FUNDING_TXID = "closing_funding_txid"
+            const val CACHED_CHANNEL_ID = "cached_channel_id"
+            const val CACHED_USER_CHANNEL_ID = "cached_user_channel_id"
+            const val CACHED_EXPECTED_USD = "cached_expected_usd"
+
+            fun clearPendingOutbound(context: Context) {
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
+                    .remove(PENDING_AMOUNT)
+                    .remove(PENDING_IS_SEND_ALL)
+                    .remove(PENDING_BASELINE)
+                    .remove(PENDING_TIMESTAMP)
+                    .apply()
+            }
+
+            fun clearAll(context: Context) {
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().apply()
+            }
+        }
+
         data class PendingOutboundSend(
             val amountSats: Long = 0L,
             val isSendAll: Boolean = false,
-            val baselineOnchainSats: Long = 0L
+            val baselineOnchainSats: Long = 0L,
+            val timestampSecs: Long = System.currentTimeMillis() / 1000L
         )
 
         /**
@@ -161,13 +197,23 @@ class AppState(private val context: Context) : ViewModel() {
          * Resolves pending outbound send state against a fresh raw on-chain balance observation.
          * Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
          * to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
+         * Includes a TTL backstop (default 600s) to prevent unobserved transactions or incoming deposits
+         * from permanently stranding pending state.
          */
         fun resolvePendingOutboundSend(
             rawOnchain: Long,
-            pending: PendingOutboundSend
+            pending: PendingOutboundSend,
+            currentTimestampSecs: Long = System.currentTimeMillis() / 1000L,
+            ttlSecs: Long = 600L
         ): PendingOutboundSend {
+            if (pending.amountSats == 0L && !pending.isSendAll) {
+                return pending
+            }
+            if (pending.timestampSecs > 0L && (currentTimestampSecs - pending.timestampSecs) >= ttlSecs) {
+                return PendingOutboundSend()
+            }
             if (pending.isSendAll) {
-                if (rawOnchain == 0L || (pending.baselineOnchainSats > 0L && rawOnchain < pending.baselineOnchainSats)) {
+                if (rawOnchain == 0L) {
                     return PendingOutboundSend()
                 }
                 return pending
@@ -250,13 +296,13 @@ class AppState(private val context: Context) : ViewModel() {
 
     fun setLastCloseTxid(txid: String?) {
         _lastCloseTxid.value = txid
-        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        val editor = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
         if (txid != null) {
-            editor.putString("last_close_txid", txid)
-            editor.putLong("last_close_txid_at", System.currentTimeMillis())
+            editor.putString(BalanceCacheKey.LAST_CLOSE_TXID, txid)
+            editor.putLong(BalanceCacheKey.LAST_CLOSE_TXID_AT, System.currentTimeMillis())
         } else {
-            editor.remove("last_close_txid")
-            editor.remove("last_close_txid_at")
+            editor.remove(BalanceCacheKey.LAST_CLOSE_TXID)
+            editor.remove(BalanceCacheKey.LAST_CLOSE_TXID_AT)
         }
         editor.apply()
     }
@@ -265,27 +311,32 @@ class AppState(private val context: Context) : ViewModel() {
         _lastReceiveTxid.value = txid
         lastReceiveTxidAddress = address
 
-        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
+        val editor = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
         if (txid.isNullOrBlank()) {
-            editor.remove("last_receive_txid")
-            editor.remove("last_receive_txid_address")
+            editor.remove(BalanceCacheKey.LAST_RECEIVE_TXID)
+            editor.remove(BalanceCacheKey.LAST_RECEIVE_TXID_ADDRESS)
         } else {
-            editor.putString("last_receive_txid", txid)
+            editor.putString(BalanceCacheKey.LAST_RECEIVE_TXID, txid)
             if (!address.isNullOrBlank()) {
-                editor.putString("last_receive_txid_address", address)
+                editor.putString(BalanceCacheKey.LAST_RECEIVE_TXID_ADDRESS, address)
             } else {
-                editor.remove("last_receive_txid_address")
+                editor.remove(BalanceCacheKey.LAST_RECEIVE_TXID_ADDRESS)
             }
         }
         editor.apply()
     }
 
+    fun resetInMemoryWalletState() {
+        pendingOutboundSend = PendingOutboundSend()
+        BalanceCacheKey.clearAll(context)
+    }
 
     private val _spendableOnchainSats = MutableStateFlow(
-        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).getLong("cached_spendable_sats", 0L)
+        context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).getLong(BalanceCacheKey.SPENDABLE, 0L)
     )
     val spendableOnchainSats: StateFlow<Long> = _spendableOnchainSats
 
+    @Volatile
     var pendingOutboundSend: PendingOutboundSend = PendingOutboundSend()
         private set
 
@@ -293,40 +344,41 @@ class AppState(private val context: Context) : ViewModel() {
     val nativeSats: StateFlow<Long> get() = _nativeSats
 
     init {
-        val prefs = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
-        val cachedLightning = prefs.getLong("cached_lightning_sats", 0L)
-        val cachedOnchain = prefs.getLong("cached_onchain_sats", 0L)
-        val pendingAmount = prefs.getLong("pending_outbound_onchain_sats", 0L)
-        val pendingIsSendAll = prefs.getBoolean("pending_outbound_is_send_all", false)
-        val pendingBaseline = prefs.getLong("pending_outbound_baseline_sats", 0L)
+        val prefs = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
+        val cachedLightning = prefs.getLong(BalanceCacheKey.LIGHTNING, 0L)
+        val cachedOnchain = prefs.getLong(BalanceCacheKey.ONCHAIN, 0L)
+        val pendingAmount = prefs.getLong(BalanceCacheKey.PENDING_AMOUNT, 0L)
+        val pendingIsSendAll = prefs.getBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, false)
+        val pendingBaseline = prefs.getLong(BalanceCacheKey.PENDING_BASELINE, 0L)
+        val pendingTimestamp = prefs.getLong(BalanceCacheKey.PENDING_TIMESTAMP, 0L)
         pendingOutboundSend = PendingOutboundSend(
             amountSats = pendingAmount,
             isSendAll = pendingIsSendAll,
-            baselineOnchainSats = pendingBaseline
+            baselineOnchainSats = pendingBaseline,
+            timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L)
         )
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
         _totalBalanceSats = MutableStateFlow(cachedLightning + cachedOnchain)
-                _nativeSats = MutableStateFlow(prefs.getLong("cached_native_sats", 0L))
-        _onchainReceiveAddress.value = prefs.getString("onchain_receive_address", null)
-        _lastReceiveTxid.value = prefs.getString("last_receive_txid", null)
-        lastReceiveTxidAddress = prefs.getString("last_receive_txid_address", null)
+        _nativeSats = MutableStateFlow(prefs.getLong(BalanceCacheKey.NATIVE, 0L))
+        _onchainReceiveAddress.value = prefs.getString(BalanceCacheKey.RECEIVE_ADDRESS, null)
+        _lastReceiveTxid.value = prefs.getString(BalanceCacheKey.LAST_RECEIVE_TXID, null)
+        lastReceiveTxidAddress = prefs.getString(BalanceCacheKey.LAST_RECEIVE_TXID_ADDRESS, null)
 
-        val closeAt = prefs.getLong("last_close_txid_at", 0L)
+        val closeAt = prefs.getLong(BalanceCacheKey.LAST_CLOSE_TXID_AT, 0L)
         if (System.currentTimeMillis() - closeAt < 7 * 86400 * 1000L) {
-            _lastCloseTxid.value = prefs.getString("last_close_txid", null)
+            _lastCloseTxid.value = prefs.getString(BalanceCacheKey.LAST_CLOSE_TXID, null)
         } else {
             prefs.edit()
-                .remove("last_close_txid")
-                .remove("last_close_txid_at")
+                .remove(BalanceCacheKey.LAST_CLOSE_TXID)
+                .remove(BalanceCacheKey.LAST_CLOSE_TXID_AT)
                 .apply()
         }
 
-
         // Restore cached channel state so UI shows correct slider position immediately
-        val cachedChannelId = prefs.getString("cached_channel_id", null)
-        val cachedUserChannelId = prefs.getString("cached_user_channel_id", null)
-        val cachedExpectedUsd = prefs.getFloat("cached_expected_usd", 0f)
+        val cachedChannelId = prefs.getString(BalanceCacheKey.CACHED_CHANNEL_ID, null)
+        val cachedUserChannelId = prefs.getString(BalanceCacheKey.CACHED_USER_CHANNEL_ID, null)
+        val cachedExpectedUsd = prefs.getFloat(BalanceCacheKey.CACHED_EXPECTED_USD, 0f)
         if (cachedUserChannelId != null) {
             _stableChannel.value = StableChannel.defaultWithLsp(context).copy(
                 channelId = cachedChannelId ?: "",
@@ -2795,14 +2847,15 @@ class AppState(private val context: Context) : ViewModel() {
         _nativeSats.value = native
 
         // Cache for instant display on next launch
-        context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-            .putLong("cached_lightning_sats", lightning)
-            .putLong("cached_onchain_sats", onchain)
-            .putLong("cached_spendable_sats", spendable)
-            .putLong("cached_native_sats", native)
-            .putLong("pending_outbound_onchain_sats", pendingOutboundSend.amountSats)
-            .putBoolean("pending_outbound_is_send_all", pendingOutboundSend.isSendAll)
-            .putLong("pending_outbound_baseline_sats", pendingOutboundSend.baselineOnchainSats)
+        context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
+            .putLong(BalanceCacheKey.LIGHTNING, lightning)
+            .putLong(BalanceCacheKey.ONCHAIN, onchain)
+            .putLong(BalanceCacheKey.SPENDABLE, spendable)
+            .putLong(BalanceCacheKey.NATIVE, native)
+            .putLong(BalanceCacheKey.PENDING_AMOUNT, pendingOutboundSend.amountSats)
+            .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
+            .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
+            .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
             .apply()
     }
 
@@ -2810,21 +2863,30 @@ class AppState(private val context: Context) : ViewModel() {
         val currentOnchain = _onchainBalanceSats.value
         val currentSpendable = _spendableOnchainSats.value
 
+        val newOnchain = if (isSendAll) 0L else (currentOnchain - amountSats).coerceAtLeast(0L)
+        val newSpendable = if (isSendAll) 0L else (currentSpendable - amountSats).coerceAtLeast(0L)
+
+        val newBaseline = if (pendingOutboundSend.baselineOnchainSats == 0L) {
+            currentOnchain
+        } else {
+            pendingOutboundSend.baselineOnchainSats
+        }
+
         pendingOutboundSend = if (isSendAll) {
             PendingOutboundSend(
-                amountSats = currentOnchain,
+                amountSats = pendingOutboundSend.amountSats + currentOnchain,
                 isSendAll = true,
-                baselineOnchainSats = currentOnchain
+                baselineOnchainSats = newBaseline,
+                timestampSecs = System.currentTimeMillis() / 1000L
             )
         } else {
             PendingOutboundSend(
                 amountSats = pendingOutboundSend.amountSats + amountSats,
                 isSendAll = false,
-                baselineOnchainSats = if (pendingOutboundSend.baselineOnchainSats == 0L) currentOnchain else pendingOutboundSend.baselineOnchainSats
+                baselineOnchainSats = newBaseline,
+                timestampSecs = System.currentTimeMillis() / 1000L
             )
         }
-
-        val (newOnchain, newSpendable) = calculateEffectiveBalances(currentOnchain, currentSpendable, pendingOutboundSend)
 
         _onchainBalanceSats.value = newOnchain
         _spendableOnchainSats.value = newSpendable
@@ -2843,22 +2905,31 @@ class AppState(private val context: Context) : ViewModel() {
             hasAnyChannel = hasAnyChannel
         )
 
-        val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
-            .putLong("cached_onchain_sats", newOnchain)
-            .putLong("cached_spendable_sats", newSpendable)
-            .putLong("pending_outbound_onchain_sats", pendingOutboundSend.amountSats)
-            .putBoolean("pending_outbound_is_send_all", pendingOutboundSend.isSendAll)
-            .putLong("pending_outbound_baseline_sats", pendingOutboundSend.baselineOnchainSats)
+        val editor = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
+            .putLong(BalanceCacheKey.ONCHAIN, newOnchain)
+            .putLong(BalanceCacheKey.SPENDABLE, newSpendable)
+            .putLong(BalanceCacheKey.PENDING_AMOUNT, pendingOutboundSend.amountSats)
+            .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
+            .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
+            .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
         if (!hasReady && !hasAnyChannel) {
-            editor.putLong("cached_lightning_sats", 0L)
+            editor.putLong(BalanceCacheKey.LIGHTNING, 0L)
         }
         editor.apply()
 
         viewModelScope.launch(Dispatchers.IO) {
-            try {
+            val syncSuccess = try {
                 nodeService.syncWallets()
-            } catch (_: Exception) {}
-            refreshBalances()
+                true
+            } catch (_: Exception) {
+                false
+            }
+            withContext(Dispatchers.Main) {
+                if (syncSuccess) {
+                    pendingOutboundSend = PendingOutboundSend()
+                }
+                refreshBalances()
+            }
         }
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1,6 +1,7 @@
 package com.stablechannels.app
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -211,27 +212,20 @@ class AppState(private val context: Context) : ViewModel() {
             val txid: String? get() = entries.firstOrNull()?.txid
 
             companion object {
-                /** Backward-compatible constructor: distributes aggregate across flat txids. */
+                /** Backward-compatible factory: delegates to legacy constructor. */
                 fun fromLegacy(
                     amountSats: Long,
                     isSendAll: Boolean,
                     baselineOnchainSats: Long,
                     timestampSecs: Long,
                     txids: List<String>
-                ): PendingOutboundSend {
-                    val entries = if (txids.isNotEmpty() && amountSats > 0L) {
-                        val perTx = amountSats / txids.size
-                        val remainder = amountSats % txids.size
-                        txids.mapIndexed { i, tid ->
-                            TxEntry(tid, perTx + if (i < remainder) 1L else 0L)
-                        }
-                    } else if (amountSats > 0L) {
-                        listOf(TxEntry("", amountSats))
-                    } else {
-                        emptyList()
-                    }
-                    return PendingOutboundSend(isSendAll, baselineOnchainSats, timestampSecs, entries)
-                }
+                ): PendingOutboundSend = PendingOutboundSend(
+                    amountSats = amountSats,
+                    isSendAll = isSendAll,
+                    baselineOnchainSats = baselineOnchainSats,
+                    timestampSecs = timestampSecs,
+                    txids = txids
+                )
             }
         }
 
@@ -348,6 +342,115 @@ class AppState(private val context: Context) : ViewModel() {
             syncSuccess: Boolean
         ): Boolean {
             return syncSuccess && expectedGeneration == currentGeneration
+        }
+
+        /**
+         * Records an immediate outbound send broadcast and returns the updated pending state.
+         * Pure helper ensuring architectural parity with iOS BalanceCalculator.recordBroadcast.
+         */
+        fun recordBroadcast(
+            currentPending: PendingOutboundSend,
+            amountSats: Long,
+            isSendAll: Boolean,
+            currentOnchain: Long,
+            timestampSecs: Long = System.currentTimeMillis() / 1000L,
+            txid: String? = null
+        ): PendingOutboundSend {
+            val baseline = if (currentPending.baselineOnchainSats == 0L) {
+                currentOnchain
+            } else {
+                currentPending.baselineOnchainSats
+            }
+            val sendAmount = if (isSendAll) currentOnchain else amountSats
+            val updatedEntries = currentPending.entries.toMutableList()
+            if (!txid.isNullOrBlank()) {
+                if (updatedEntries.none { it.txid == txid }) {
+                    updatedEntries.add(TxEntry(txid, sendAmount))
+                }
+            } else {
+                // No txid available yet; append an anonymous entry.
+                updatedEntries.add(TxEntry("", sendAmount))
+            }
+
+            return PendingOutboundSend(
+                isSendAll = isSendAll || currentPending.isSendAll,
+                baselineOnchainSats = baseline,
+                timestampSecs = timestampSecs,
+                entries = updatedEntries
+            )
+        }
+
+        /**
+         * Deserializes cached pending outbound send state from SharedPreferences.
+         * Supports per-txid colon-delimited format as well as legacy flat comma-delimited txid lists.
+         */
+        fun loadCachedPendingOutboundSend(prefs: SharedPreferences): PendingOutboundSend {
+            val pendingAmount = prefs.getLong(BalanceCacheKey.PENDING_AMOUNT, 0L)
+            val pendingIsSendAll = prefs.getBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, false)
+            val pendingBaseline = prefs.getLong(BalanceCacheKey.PENDING_BASELINE, 0L)
+            val pendingTimestamp = prefs.getLong(BalanceCacheKey.PENDING_TIMESTAMP, 0L)
+            val pendingTxidsStr = prefs.getString(BalanceCacheKey.PENDING_TXIDS, "") ?: ""
+
+            if (pendingAmount == 0L && !pendingIsSendAll) {
+                return PendingOutboundSend(
+                    isSendAll = false,
+                    baselineOnchainSats = 0L,
+                    timestampSecs = 0L,
+                    entries = emptyList()
+                )
+            }
+
+            val parts = if (pendingTxidsStr.isNotBlank()) {
+                pendingTxidsStr.split(",").filter { it.isNotBlank() }
+            } else {
+                emptyList()
+            }
+            val hasEntryFormat = parts.any { it.contains(":") }
+
+            val entries: List<TxEntry> = if (hasEntryFormat) {
+                parts.mapNotNull { part ->
+                    val components = part.split(":", limit = 2)
+                    if (components.size == 2) {
+                        val amt = components[1].toLongOrNull() ?: return@mapNotNull null
+                        TxEntry(components[0], amt)
+                    } else null
+                }
+            } else {
+                // Legacy path: distribute stored aggregate across txids.
+                if (parts.isNotEmpty() && pendingAmount > 0L) {
+                    val perTx = pendingAmount / parts.size
+                    val remainder = pendingAmount % parts.size
+                    parts.mapIndexed { i, tid ->
+                        TxEntry(tid, perTx + if (i.toLong() < remainder) 1L else 0L)
+                    }
+                } else if (pendingAmount > 0L) {
+                    listOf(TxEntry("", pendingAmount))
+                } else {
+                    emptyList()
+                }
+            }
+
+            return PendingOutboundSend(
+                isSendAll = pendingIsSendAll,
+                baselineOnchainSats = pendingBaseline,
+                timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L),
+                entries = entries
+            )
+        }
+
+        /**
+         * Serializes pending outbound send state to SharedPreferences.
+         */
+        fun persistPendingOutboundSend(editor: SharedPreferences.Editor, pending: PendingOutboundSend) {
+            editor
+                .putLong(BalanceCacheKey.PENDING_AMOUNT, pending.amountSats)
+                .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pending.isSendAll)
+                .putLong(BalanceCacheKey.PENDING_BASELINE, pending.baselineOnchainSats)
+                .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pending.timestampSecs)
+                .putString(
+                    BalanceCacheKey.PENDING_TXIDS,
+                    pending.entries.joinToString(",") { "${it.txid}:${it.amountSats}" }
+                )
         }
     }
 
@@ -475,47 +578,7 @@ class AppState(private val context: Context) : ViewModel() {
         val prefs = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
         val cachedLightning = prefs.getLong(BalanceCacheKey.LIGHTNING, 0L)
         val cachedOnchain = prefs.getLong(BalanceCacheKey.ONCHAIN, 0L)
-        val pendingAmount = prefs.getLong(BalanceCacheKey.PENDING_AMOUNT, 0L)
-        val pendingIsSendAll = prefs.getBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, false)
-        val pendingBaseline = prefs.getLong(BalanceCacheKey.PENDING_BASELINE, 0L)
-        val pendingTimestamp = prefs.getLong(BalanceCacheKey.PENDING_TIMESTAMP, 0L)
-        val pendingTxidsStr = prefs.getString(BalanceCacheKey.PENDING_TXIDS, "") ?: ""
-
-        // If no pending amount was cached and it is not send-all, no send is pending.
-        val parts = if (pendingTxidsStr.isNotBlank()) pendingTxidsStr.split(",").filter { it.isNotBlank() } else emptyList()
-        val hasEntryFormat = parts.any { it.contains(":") }
-
-        val entries: List<TxEntry> = if (pendingAmount == 0L && !pendingIsSendAll) {
-            emptyList()
-        } else if (hasEntryFormat) {
-            parts.mapNotNull { part ->
-                val components = part.split(":", limit = 2)
-                if (components.size == 2) {
-                    val amt = components[1].toLongOrNull() ?: return@mapNotNull null
-                    TxEntry(components[0], amt)
-                } else null
-            }
-        } else {
-            // Legacy path: distribute stored aggregate across txids.
-            if (parts.isNotEmpty() && pendingAmount > 0L) {
-                val perTx = pendingAmount / parts.size
-                val remainder = pendingAmount % parts.size
-                parts.mapIndexed { i, tid ->
-                    TxEntry(tid, perTx + if (i < remainder) 1L else 0L)
-                }
-            } else if (pendingAmount > 0L) {
-                listOf(TxEntry("", pendingAmount))
-            } else {
-                emptyList()
-            }
-        }
-
-        pendingOutboundSend = PendingOutboundSend(
-            isSendAll = pendingIsSendAll,
-            baselineOnchainSats = pendingBaseline,
-            timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L),
-            entries = entries
-        )
+        pendingOutboundSend = loadCachedPendingOutboundSend(prefs)
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
         _totalBalanceSats = MutableStateFlow(cachedLightning + cachedOnchain)
@@ -2941,6 +3004,9 @@ class AppState(private val context: Context) : ViewModel() {
             // the wallet's raw balance already reflects the spend. Any positive balance delta
             // is a genuine incoming deposit, not a masked deduction. This fixes the relaunch+deposit
             // scenario where the old "succeeded-only" check left funds stuck until 6 confirmations.
+            // Invariant note: ldk-node creates Onchain payment rows strictly from wallet events
+            // (TxUnconfirmed/TxConfirmed) diffing the wallet's tx graph, ensuring raw balances
+            // already incorporate the spend when PENDING is reached.
             val incorporatedPredicate: (String) -> Boolean = { tid ->
                 nodeService.node?.listPayments()?.any { p ->
                     val kind = p.kind
@@ -3031,17 +3097,13 @@ class AppState(private val context: Context) : ViewModel() {
         _nativeSats.value = native
 
         // Cache for instant display on next launch
-        context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
+        val editor = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
             .putLong(BalanceCacheKey.LIGHTNING, lightning)
             .putLong(BalanceCacheKey.ONCHAIN, onchain)
             .putLong(BalanceCacheKey.SPENDABLE, spendable)
             .putLong(BalanceCacheKey.NATIVE, native)
-            .putLong(BalanceCacheKey.PENDING_AMOUNT, pendingOutboundSend.amountSats)
-            .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
-            .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
-            .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
-            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.entries.joinToString(",") { "${it.txid}:${it.amountSats}" })
-            .apply()
+        persistPendingOutboundSend(editor, pendingOutboundSend)
+        editor.apply()
     }
 
     fun onchainSendBroadcasted(amountSats: Long, isSendAll: Boolean, txid: String? = null) {
@@ -3052,27 +3114,12 @@ class AppState(private val context: Context) : ViewModel() {
         val newSpendable = if (isSendAll) 0L else (currentSpendable - amountSats).coerceAtLeast(0L)
 
         val gen = synchronized(pendingLock) {
-            val newBaseline = if (pendingOutboundSend.baselineOnchainSats == 0L) {
-                currentOnchain
-            } else {
-                pendingOutboundSend.baselineOnchainSats
-            }
-            val sendAmount = if (isSendAll) currentOnchain else amountSats
-            val updatedEntries = pendingOutboundSend.entries.toMutableList()
-            if (!txid.isNullOrBlank()) {
-                if (updatedEntries.none { it.txid == txid }) {
-                    updatedEntries.add(TxEntry(txid, sendAmount))
-                }
-            } else {
-                // No txid available yet; append an anonymous entry.
-                updatedEntries.add(TxEntry("", sendAmount))
-            }
-
-            pendingOutboundSend = PendingOutboundSend(
-                isSendAll = isSendAll || pendingOutboundSend.isSendAll,
-                baselineOnchainSats = newBaseline,
-                timestampSecs = System.currentTimeMillis() / 1000L,
-                entries = updatedEntries
+            pendingOutboundSend = recordBroadcast(
+                currentPending = pendingOutboundSend,
+                amountSats = amountSats,
+                isSendAll = isSendAll,
+                currentOnchain = currentOnchain,
+                txid = txid
             )
             ++sendGeneration
         }
@@ -3097,11 +3144,7 @@ class AppState(private val context: Context) : ViewModel() {
         val editor = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).edit()
             .putLong(BalanceCacheKey.ONCHAIN, newOnchain)
             .putLong(BalanceCacheKey.SPENDABLE, newSpendable)
-            .putLong(BalanceCacheKey.PENDING_AMOUNT, pendingOutboundSend.amountSats)
-            .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
-            .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
-            .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
-            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.entries.joinToString(",") { "${it.txid}:${it.amountSats}" })
+        persistPendingOutboundSend(editor, pendingOutboundSend)
         if (!hasReady && !hasAnyChannel) {
             editor.putLong(BalanceCacheKey.LIGHTNING, 0L)
         }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -3007,18 +3007,22 @@ class AppState(private val context: Context) : ViewModel() {
             // Invariant note: ldk-node creates Onchain payment rows strictly from wallet events
             // (TxUnconfirmed/TxConfirmed) diffing the wallet's tx graph, ensuring raw balances
             // already incorporate the spend when PENDING is reached.
-            val incorporatedPredicate: (String) -> Boolean = { tid ->
-                nodeService.node?.listPayments()?.any { p ->
+            val paymentStatusMap by lazy {
+                val map = mutableMapOf<String, PaymentStatus>()
+                nodeService.node?.listPayments()?.forEach { p ->
                     val kind = p.kind
-                    kind is PaymentKind.Onchain && kind.txid == tid &&
-                        (p.status == PaymentStatus.SUCCEEDED || p.status == PaymentStatus.PENDING)
-                } ?: false
+                    if (kind is PaymentKind.Onchain) {
+                        map[kind.txid] = p.status
+                    }
+                }
+                map
+            }
+            val incorporatedPredicate: (String) -> Boolean = { tid ->
+                val status = paymentStatusMap[tid]
+                status == PaymentStatus.SUCCEEDED || status == PaymentStatus.PENDING
             }
             val failedPredicate: (String) -> Boolean = { tid ->
-                nodeService.node?.listPayments()?.any { p ->
-                    val kind = p.kind
-                    kind is PaymentKind.Onchain && kind.txid == tid && p.status == PaymentStatus.FAILED
-                } ?: false
+                paymentStatusMap[tid] == PaymentStatus.FAILED
             }
             pendingOutboundSend = resolvePendingOutboundSend(
                 rawOnchain = rawOnchain,

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -79,23 +79,50 @@ class AppState(private val context: Context) : ViewModel() {
         // process in control of the node for longer than the common return window.
         private const val QUICK_SWITCH_GRACE_MS = 10_000L
 
+        data class ChannelState(
+            val hasReady: Boolean,
+            val hasAnyChannel: Boolean = false,
+            val isChannelClosing: Boolean = false,
+            val isOpeningChannel: Boolean = false,
+            val isSweeping: Boolean = false
+        )
+
+        fun calculateTotalBalance(
+            lightning: Long,
+            onchain: Long,
+            pendingSweep: Long = 0L,
+            channelState: ChannelState
+        ): Long {
+            return when {
+                channelState.isChannelClosing -> onchain
+                channelState.isOpeningChannel -> if (lightning > 0) lightning else onchain
+                channelState.isSweeping -> lightning
+                !channelState.hasReady && !channelState.hasAnyChannel -> onchain + pendingSweep
+                else -> lightning + onchain
+            }
+        }
+
         fun calculateTotalBalance(
             lightning: Long,
             onchain: Long,
             hasReady: Boolean,
-            isChannelClosing: Boolean,
-            isSweeping: Boolean,
+            isChannelClosing: Boolean = false,
+            isSweeping: Boolean = false,
             pendingSweep: Long = 0L,
-            isOpeningChannel: Boolean = false
-        ): Long {
-            return when {
-                isChannelClosing -> onchain
-                isOpeningChannel -> if (lightning > 0) lightning else onchain
-                isSweeping -> lightning
-                !hasReady -> onchain + pendingSweep
-                else -> lightning + onchain
-            }
-        }
+            isOpeningChannel: Boolean = false,
+            hasAnyChannel: Boolean = false
+        ): Long = calculateTotalBalance(
+            lightning = lightning,
+            onchain = onchain,
+            pendingSweep = pendingSweep,
+            channelState = ChannelState(
+                hasReady = hasReady,
+                hasAnyChannel = hasAnyChannel,
+                isChannelClosing = isChannelClosing,
+                isOpeningChannel = isOpeningChannel,
+                isSweeping = isSweeping
+            )
+        )
 
         fun requiredConfirmationsForType(paymentType: String): Int {
             return when (paymentType) {
@@ -308,6 +335,13 @@ class AppState(private val context: Context) : ViewModel() {
         paymentIds.forEach { refreshTradeOutcome(it) }
     }
     var pendingSplice: PendingSplice? = null
+    private val _isOpeningChannel = MutableStateFlow(false)
+    val isOpeningChannelFlow: StateFlow<Boolean> = _isOpeningChannel
+    var isOpeningChannel: Boolean
+        get() = _isOpeningChannel.value
+        set(value) {
+            _isOpeningChannel.value = value
+        }
     private val _isChannelClosing = MutableStateFlow(false)
     val isChannelClosingFlow: StateFlow<Boolean> = _isChannelClosing
     var isChannelClosing: Boolean
@@ -2674,13 +2708,16 @@ class AppState(private val context: Context) : ViewModel() {
             isChannelClosing = false
         }
 
+        val hasAnyChannel = nodeService.channels.isNotEmpty()
         _totalBalanceSats.value = calculateTotalBalance(
             lightning = lightning,
             onchain = onchain,
             hasReady = hasReady,
             isChannelClosing = isChannelClosing,
             isSweeping = isSweeping,
-            pendingSweep = sweepSats
+            pendingSweep = sweepSats,
+            isOpeningChannel = isOpeningChannel,
+            hasAnyChannel = hasAnyChannel
         )
 
         // Calculate native sats (lightning minus stable portion) for slider position
@@ -2711,19 +2748,22 @@ class AppState(private val context: Context) : ViewModel() {
 
         val lightning = _lightningBalanceSats.value
         val hasReady = _hasReadyChannel.value
+        val hasAnyChannel = nodeService.channels.isNotEmpty()
         _totalBalanceSats.value = calculateTotalBalance(
             lightning = lightning,
             onchain = newOnchain,
             hasReady = hasReady,
             isChannelClosing = isChannelClosing,
             isSweeping = isSweeping,
-            pendingSweep = _pendingSweepBalanceSats.value
+            pendingSweep = _pendingSweepBalanceSats.value,
+            isOpeningChannel = isOpeningChannel,
+            hasAnyChannel = hasAnyChannel
         )
 
         val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
             .putLong("cached_onchain_sats", newOnchain)
             .putLong("cached_spendable_sats", newSpendable)
-        if (!hasReady) {
+        if (!hasReady && !hasAnyChannel) {
             editor.putLong("cached_lightning_sats", 0L)
         }
         editor.apply()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -130,6 +130,57 @@ class AppState(private val context: Context) : ViewModel() {
                 else -> 6
             }
         }
+
+        data class PendingOutboundSend(
+            val amountSats: Long = 0L,
+            val isSendAll: Boolean = false,
+            val baselineOnchainSats: Long = 0L
+        )
+
+        /**
+         * Derives user-facing on-chain and spendable balances by subtracting any pending
+         * outbound send that has not yet been incorporated into LDK/BDK's raw wallet view.
+         */
+        fun calculateEffectiveBalances(
+            rawOnchain: Long,
+            rawSpendable: Long,
+            pending: PendingOutboundSend
+        ): Pair<Long, Long> {
+            if (pending.isSendAll) {
+                return Pair(0L, 0L)
+            }
+            if (pending.amountSats > 0L) {
+                val onchain = (rawOnchain - pending.amountSats).coerceAtLeast(0L)
+                val spendable = (rawSpendable - pending.amountSats).coerceAtLeast(0L)
+                return Pair(onchain, spendable)
+            }
+            return Pair(rawOnchain, rawSpendable)
+        }
+
+        /**
+         * Resolves pending outbound send state against a fresh raw on-chain balance observation.
+         * Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
+         * to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
+         */
+        fun resolvePendingOutboundSend(
+            rawOnchain: Long,
+            pending: PendingOutboundSend
+        ): PendingOutboundSend {
+            if (pending.isSendAll) {
+                if (rawOnchain == 0L || (pending.baselineOnchainSats > 0L && rawOnchain < pending.baselineOnchainSats)) {
+                    return PendingOutboundSend()
+                }
+                return pending
+            }
+            if (pending.amountSats > 0L) {
+                val expectedRemaining = (pending.baselineOnchainSats - pending.amountSats).coerceAtLeast(0L)
+                if (rawOnchain <= expectedRemaining) {
+                    return PendingOutboundSend()
+                }
+                return pending
+            }
+            return pending
+        }
     }
 
     val nodeService = NodeService(context)
@@ -235,6 +286,9 @@ class AppState(private val context: Context) : ViewModel() {
     )
     val spendableOnchainSats: StateFlow<Long> = _spendableOnchainSats
 
+    var pendingOutboundSend: PendingOutboundSend = PendingOutboundSend()
+        private set
+
     private val _nativeSats: MutableStateFlow<Long>
     val nativeSats: StateFlow<Long> get() = _nativeSats
 
@@ -242,6 +296,14 @@ class AppState(private val context: Context) : ViewModel() {
         val prefs = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE)
         val cachedLightning = prefs.getLong("cached_lightning_sats", 0L)
         val cachedOnchain = prefs.getLong("cached_onchain_sats", 0L)
+        val pendingAmount = prefs.getLong("pending_outbound_onchain_sats", 0L)
+        val pendingIsSendAll = prefs.getBoolean("pending_outbound_is_send_all", false)
+        val pendingBaseline = prefs.getLong("pending_outbound_baseline_sats", 0L)
+        pendingOutboundSend = PendingOutboundSend(
+            amountSats = pendingAmount,
+            isSendAll = pendingIsSendAll,
+            baselineOnchainSats = pendingBaseline
+        )
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
         _totalBalanceSats = MutableStateFlow(cachedLightning + cachedOnchain)
@@ -2658,8 +2720,13 @@ class AppState(private val context: Context) : ViewModel() {
         nodeService.refreshChannels()
         val balances = nodeService.balances() ?: return
         val lightning = balances.totalLightningBalanceSats.toLong()
-        val onchain = balances.totalOnchainBalanceSats.toLong()
+        val rawOnchain = balances.totalOnchainBalanceSats.toLong()
+        val rawSpendable = balances.spendableOnchainBalanceSats.toLong()
         val hasReady = nodeService.channels.any { it.isChannelReady }
+
+        // Resolve pending outbound deduction against raw wallet observation
+        pendingOutboundSend = resolvePendingOutboundSend(rawOnchain, pendingOutboundSend)
+        val (onchain, spendable) = calculateEffectiveBalances(rawOnchain, rawSpendable, pendingOutboundSend)
 
         // Sync fundingTxid directly from the LDK node's channel details
         // to gracefully handle out-of-band splices (e.g. LSP-initiated)
@@ -2697,7 +2764,6 @@ class AppState(private val context: Context) : ViewModel() {
         _lightningBalanceSats.value = lightning
         _onchainBalanceSats.value = onchain
         _hasReadyChannel.value = hasReady
-        val spendable = balances.spendableOnchainBalanceSats.toLong()
         _spendableOnchainSats.value = spendable
 
 
@@ -2734,14 +2800,31 @@ class AppState(private val context: Context) : ViewModel() {
             .putLong("cached_onchain_sats", onchain)
             .putLong("cached_spendable_sats", spendable)
             .putLong("cached_native_sats", native)
+            .putLong("pending_outbound_onchain_sats", pendingOutboundSend.amountSats)
+            .putBoolean("pending_outbound_is_send_all", pendingOutboundSend.isSendAll)
+            .putLong("pending_outbound_baseline_sats", pendingOutboundSend.baselineOnchainSats)
             .apply()
     }
 
     fun onchainSendBroadcasted(amountSats: Long, isSendAll: Boolean) {
         val currentOnchain = _onchainBalanceSats.value
         val currentSpendable = _spendableOnchainSats.value
-        val newOnchain = if (isSendAll) 0L else (currentOnchain - amountSats).coerceAtLeast(0L)
-        val newSpendable = if (isSendAll) 0L else (currentSpendable - amountSats).coerceAtLeast(0L)
+
+        pendingOutboundSend = if (isSendAll) {
+            PendingOutboundSend(
+                amountSats = currentOnchain,
+                isSendAll = true,
+                baselineOnchainSats = currentOnchain
+            )
+        } else {
+            PendingOutboundSend(
+                amountSats = pendingOutboundSend.amountSats + amountSats,
+                isSendAll = false,
+                baselineOnchainSats = if (pendingOutboundSend.baselineOnchainSats == 0L) currentOnchain else pendingOutboundSend.baselineOnchainSats
+            )
+        }
+
+        val (newOnchain, newSpendable) = calculateEffectiveBalances(currentOnchain, currentSpendable, pendingOutboundSend)
 
         _onchainBalanceSats.value = newOnchain
         _spendableOnchainSats.value = newSpendable
@@ -2763,6 +2846,9 @@ class AppState(private val context: Context) : ViewModel() {
         val editor = context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
             .putLong("cached_onchain_sats", newOnchain)
             .putLong("cached_spendable_sats", newSpendable)
+            .putLong("pending_outbound_onchain_sats", pendingOutboundSend.amountSats)
+            .putBoolean("pending_outbound_is_send_all", pendingOutboundSend.isSendAll)
+            .putLong("pending_outbound_baseline_sats", pendingOutboundSend.baselineOnchainSats)
         if (!hasReady && !hasAnyChannel) {
             editor.putLong("cached_lightning_sats", 0L)
         }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -151,6 +151,7 @@ class AppState(private val context: Context) : ViewModel() {
             const val CACHED_CHANNEL_ID = "cached_channel_id"
             const val CACHED_USER_CHANNEL_ID = "cached_user_channel_id"
             const val CACHED_EXPECTED_USD = "cached_expected_usd"
+            const val PENDING_TXIDS = "pending_outbound_txids"
 
             fun clearPendingOutbound(context: Context) {
                 context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
@@ -158,6 +159,7 @@ class AppState(private val context: Context) : ViewModel() {
                     .remove(PENDING_IS_SEND_ALL)
                     .remove(PENDING_BASELINE)
                     .remove(PENDING_TIMESTAMP)
+                    .remove(PENDING_TXIDS)
                     .apply()
             }
 
@@ -170,8 +172,11 @@ class AppState(private val context: Context) : ViewModel() {
             val amountSats: Long = 0L,
             val isSendAll: Boolean = false,
             val baselineOnchainSats: Long = 0L,
-            val timestampSecs: Long = System.currentTimeMillis() / 1000L
-        )
+            val timestampSecs: Long = System.currentTimeMillis() / 1000L,
+            val txids: List<String> = emptyList()
+        ) {
+            val txid: String? get() = txids.firstOrNull()
+        }
 
         /**
          * Derives user-facing on-chain and spendable balances by subtracting any pending
@@ -207,21 +212,36 @@ class AppState(private val context: Context) : ViewModel() {
          * Resolves pending outbound send state against a fresh raw on-chain balance observation.
          * Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
          * to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
-         * Includes a TTL backstop (default 600s) to prevent unobserved transactions or incoming deposits
-         * from permanently stranding pending state.
+         * If the balance has not dropped (e.g. masked by an incoming deposit), authoritative transaction
+         * reconciliation (via isTxConfirmed or isTxFailed) resolves the state without re-exposing spent funds.
+         * If indexer/node sync is degraded beyond TTL, it fails closed by retaining the deduction.
          */
         fun resolvePendingOutboundSend(
             rawOnchain: Long,
             pending: PendingOutboundSend,
             currentTimestampSecs: Long = System.currentTimeMillis() / 1000L,
-            ttlSecs: Long = 600L
+            ttlSecs: Long = 600L,
+            isTxConfirmed: ((String) -> Boolean)? = null,
+            isTxFailed: ((String) -> Boolean)? = null
         ): PendingOutboundSend {
             if (pending.amountSats == 0L && !pending.isSendAll) {
                 return pending
             }
-            if (pending.timestampSecs > 0L && (currentTimestampSecs - pending.timestampSecs) >= ttlSecs) {
+
+            // 1. Authoritative transaction status check:
+            // If all pending broadcast transactions failed and were rejected, safely release the deduction.
+            if (isTxFailed != null && pending.txids.isNotEmpty() && pending.txids.all { isTxFailed(it) }) {
                 return PendingOutboundSend()
             }
+
+            // 2. Authoritative confirmation check:
+            // If all pending broadcast txids are confirmed, then even if an incoming deposit
+            // masked the raw balance drop, we know the spend was incorporated into the wallet.
+            if (isTxConfirmed != null && pending.txids.isNotEmpty() && pending.txids.all { isTxConfirmed(it) }) {
+                return PendingOutboundSend()
+            }
+
+            // 3. Raw balance drop check:
             if (pending.isSendAll) {
                 if (rawOnchain == 0L) {
                     return PendingOutboundSend()
@@ -233,9 +253,23 @@ class AppState(private val context: Context) : ViewModel() {
                 if (rawOnchain <= expectedRemaining) {
                     return PendingOutboundSend()
                 }
+                // When balance hasn't dropped and authoritative checks haven't completed,
+                // fail closed even if beyond TTL to never re-expose spent broadcast funds.
                 return pending
             }
             return pending
+        }
+
+        /**
+         * Pure helper to evaluate if a background wallet sync completion owns the active send generation
+         * and succeeded, preventing older out-of-order syncs from clearing newer pending broadcasts.
+         */
+        fun shouldClearPendingOnSyncCompletion(
+            expectedGeneration: Long,
+            currentGeneration: Long,
+            syncSuccess: Boolean
+        ): Boolean {
+            return syncSuccess && expectedGeneration == currentGeneration
         }
     }
 
@@ -367,11 +401,14 @@ class AppState(private val context: Context) : ViewModel() {
         val pendingIsSendAll = prefs.getBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, false)
         val pendingBaseline = prefs.getLong(BalanceCacheKey.PENDING_BASELINE, 0L)
         val pendingTimestamp = prefs.getLong(BalanceCacheKey.PENDING_TIMESTAMP, 0L)
+        val pendingTxidsStr = prefs.getString(BalanceCacheKey.PENDING_TXIDS, "") ?: ""
+        val pendingTxids = if (pendingTxidsStr.isNotBlank()) pendingTxidsStr.split(",").filter { it.isNotBlank() } else emptyList()
         pendingOutboundSend = PendingOutboundSend(
             amountSats = pendingAmount,
             isSendAll = pendingIsSendAll,
             baselineOnchainSats = pendingBaseline,
-            timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L)
+            timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L),
+            txids = pendingTxids
         )
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
@@ -2794,7 +2831,24 @@ class AppState(private val context: Context) : ViewModel() {
 
         // Resolve pending outbound deduction against raw wallet observation
         val effectivePending = synchronized(pendingLock) {
-            pendingOutboundSend = resolvePendingOutboundSend(rawOnchain, pendingOutboundSend)
+            val confirmedPredicate: (String) -> Boolean = { tid ->
+                nodeService.node?.listPayments()?.any { p ->
+                    val kind = p.kind
+                    kind is PaymentKind.Onchain && kind.txid == tid && p.status == PaymentStatus.SUCCEEDED
+                } ?: false
+            }
+            val failedPredicate: (String) -> Boolean = { tid ->
+                nodeService.node?.listPayments()?.any { p ->
+                    val kind = p.kind
+                    kind is PaymentKind.Onchain && kind.txid == tid && p.status == PaymentStatus.FAILED
+                } ?: false
+            }
+            pendingOutboundSend = resolvePendingOutboundSend(
+                rawOnchain = rawOnchain,
+                pending = pendingOutboundSend,
+                isTxConfirmed = confirmedPredicate,
+                isTxFailed = failedPredicate
+            )
             pendingOutboundSend
         }
         val (onchain, spendable) = calculateEffectiveBalances(rawOnchain, rawSpendable, effectivePending)
@@ -2875,10 +2929,11 @@ class AppState(private val context: Context) : ViewModel() {
             .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
             .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
             .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
+            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.txids.joinToString(","))
             .apply()
     }
 
-    fun onchainSendBroadcasted(amountSats: Long, isSendAll: Boolean) {
+    fun onchainSendBroadcasted(amountSats: Long, isSendAll: Boolean, txid: String? = null) {
         val currentOnchain = _onchainBalanceSats.value
         val currentSpendable = _spendableOnchainSats.value
 
@@ -2891,20 +2946,28 @@ class AppState(private val context: Context) : ViewModel() {
             } else {
                 pendingOutboundSend.baselineOnchainSats
             }
+            val currentTxids = pendingOutboundSend.txids
+            val updatedTxids = if (!txid.isNullOrBlank() && !currentTxids.contains(txid)) {
+                currentTxids + txid
+            } else {
+                currentTxids
+            }
 
             pendingOutboundSend = if (isSendAll) {
                 PendingOutboundSend(
                     amountSats = pendingOutboundSend.amountSats + currentOnchain,
                     isSendAll = true,
                     baselineOnchainSats = newBaseline,
-                    timestampSecs = System.currentTimeMillis() / 1000L
+                    timestampSecs = System.currentTimeMillis() / 1000L,
+                    txids = updatedTxids
                 )
             } else {
                 PendingOutboundSend(
                     amountSats = pendingOutboundSend.amountSats + amountSats,
                     isSendAll = false,
                     baselineOnchainSats = newBaseline,
-                    timestampSecs = System.currentTimeMillis() / 1000L
+                    timestampSecs = System.currentTimeMillis() / 1000L,
+                    txids = updatedTxids
                 )
             }
             ++sendGeneration
@@ -2934,20 +2997,25 @@ class AppState(private val context: Context) : ViewModel() {
             .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
             .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
             .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
+            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.txids.joinToString(","))
         if (!hasReady && !hasAnyChannel) {
             editor.putLong(BalanceCacheKey.LIGHTNING, 0L)
         }
         editor.apply()
 
         viewModelScope.launch(Dispatchers.IO) {
-            val syncSuccess = try {
-                nodeService.syncWallets()
-                true
-            } catch (_: Exception) {
-                false
+            var syncSuccess = false
+            for (attempt in 0..2) {
+                try {
+                    nodeService.syncWallets()
+                    syncSuccess = true
+                    break
+                } catch (_: Exception) {
+                    delay(500L * (attempt + 1))
+                }
             }
             withContext(Dispatchers.Main) {
-                if (syncSuccess) {
+                if (shouldClearPendingOnSyncCompletion(gen, sendGeneration, syncSuccess)) {
                     synchronized(pendingLock) {
                         if (gen == sendGeneration) {
                             pendingOutboundSend = PendingOutboundSend()

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -186,8 +186,18 @@ class AppState(private val context: Context) : ViewModel() {
                 return Pair(0L, 0L)
             }
             if (pending.amountSats > 0L) {
-                val onchain = (rawOnchain - pending.amountSats).coerceAtLeast(0L)
-                val spendable = (rawSpendable - pending.amountSats).coerceAtLeast(0L)
+                val rawDrop = if (rawOnchain < pending.baselineOnchainSats) {
+                    pending.baselineOnchainSats - rawOnchain
+                } else {
+                    0L
+                }
+                val pendingToDeduct = if (pending.amountSats > rawDrop) {
+                    pending.amountSats - rawDrop
+                } else {
+                    0L
+                }
+                val onchain = (rawOnchain - pendingToDeduct).coerceAtLeast(0L)
+                val spendable = (rawSpendable - pendingToDeduct).coerceAtLeast(0L)
                 return Pair(onchain, spendable)
             }
             return Pair(rawOnchain, rawSpendable)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -168,14 +168,71 @@ class AppState(private val context: Context) : ViewModel() {
             }
         }
 
+        /** A single pending broadcast entry pairing a transaction id with its sent amount.
+         * Enables per-transaction resolution so mixed succeeded/failed batches release
+         * only the resolved portion instead of blocking the entire aggregate. */
+        data class TxEntry(val txid: String, val amountSats: Long)
+
         data class PendingOutboundSend(
-            val amountSats: Long = 0L,
             val isSendAll: Boolean = false,
             val baselineOnchainSats: Long = 0L,
             val timestampSecs: Long = System.currentTimeMillis() / 1000L,
-            val txids: List<String> = emptyList()
+            val entries: List<TxEntry> = emptyList()
         ) {
-            val txid: String? get() = txids.firstOrNull()
+            /** Backward-compatible constructor accepting aggregate amount and flat txid list. */
+            constructor(
+                amountSats: Long,
+                isSendAll: Boolean = false,
+                baselineOnchainSats: Long = 0L,
+                timestampSecs: Long = System.currentTimeMillis() / 1000L,
+                txids: List<String> = emptyList()
+            ) : this(
+                isSendAll = isSendAll,
+                baselineOnchainSats = baselineOnchainSats,
+                timestampSecs = timestampSecs,
+                entries = if (txids.isNotEmpty() && amountSats > 0L) {
+                    val perTx = amountSats / txids.size
+                    val remainder = amountSats % txids.size
+                    txids.mapIndexed { i, tid ->
+                        TxEntry(tid, perTx + if (i.toLong() < remainder) 1L else 0L)
+                    }
+                } else if (amountSats > 0L) {
+                    listOf(TxEntry("", amountSats))
+                } else {
+                    emptyList()
+                }
+            )
+
+            /** Aggregate pending amount across all unresolved entries. */
+            val amountSats: Long get() = entries.sumOf { it.amountSats }
+            /** All pending txids for predicate checks. */
+            val txids: List<String> get() = entries.map { it.txid }
+            /** First broadcast txid, if any. */
+            val txid: String? get() = entries.firstOrNull()?.txid
+
+            companion object {
+                /** Backward-compatible constructor: distributes aggregate across flat txids. */
+                fun fromLegacy(
+                    amountSats: Long,
+                    isSendAll: Boolean,
+                    baselineOnchainSats: Long,
+                    timestampSecs: Long,
+                    txids: List<String>
+                ): PendingOutboundSend {
+                    val entries = if (txids.isNotEmpty() && amountSats > 0L) {
+                        val perTx = amountSats / txids.size
+                        val remainder = amountSats % txids.size
+                        txids.mapIndexed { i, tid ->
+                            TxEntry(tid, perTx + if (i < remainder) 1L else 0L)
+                        }
+                    } else if (amountSats > 0L) {
+                        listOf(TxEntry("", amountSats))
+                    } else {
+                        emptyList()
+                    }
+                    return PendingOutboundSend(isSendAll, baselineOnchainSats, timestampSecs, entries)
+                }
+            }
         }
 
         /**
@@ -190,14 +247,15 @@ class AppState(private val context: Context) : ViewModel() {
             if (pending.isSendAll) {
                 return Pair(0L, 0L)
             }
-            if (pending.amountSats > 0L) {
+            val amount = pending.amountSats
+            if (amount > 0L) {
                 val rawDrop = if (rawOnchain < pending.baselineOnchainSats) {
                     pending.baselineOnchainSats - rawOnchain
                 } else {
                     0L
                 }
-                val pendingToDeduct = if (pending.amountSats > rawDrop) {
-                    pending.amountSats - rawDrop
+                val pendingToDeduct = if (amount > rawDrop) {
+                    amount - rawDrop
                 } else {
                     0L
                 }
@@ -210,51 +268,71 @@ class AppState(private val context: Context) : ViewModel() {
 
         /**
          * Resolves pending outbound send state against a fresh raw on-chain balance observation.
-         * Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
-         * to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
-         * If the balance has not dropped (e.g. masked by an incoming deposit), authoritative transaction
-         * reconciliation (via isTxConfirmed or isTxFailed) resolves the state without re-exposing spent funds.
-         * If indexer/node sync is degraded beyond TTL, it fails closed by retaining the deduction.
+         * Performs per-txid resolution: transactions whose authoritative status is known
+         * (incorporated or failed) are removed individually, allowing partial clearing of
+         * mixed-status batches instead of all-or-nothing.
+         * Fails closed during extended indexer/node outages to prevent re-exposing spent funds.
          */
         fun resolvePendingOutboundSend(
             rawOnchain: Long,
             pending: PendingOutboundSend,
             currentTimestampSecs: Long = System.currentTimeMillis() / 1000L,
             ttlSecs: Long = 600L,
-            isTxConfirmed: ((String) -> Boolean)? = null,
-            isTxFailed: ((String) -> Boolean)? = null
+            isTxIncorporated: ((String) -> Boolean)? = null,
+            isTxFailed: ((String) -> Boolean)? = null,
+            isTxConfirmed: ((String) -> Boolean)? = null
         ): PendingOutboundSend {
+            val incorporated = isTxIncorporated ?: isTxConfirmed
             if (pending.amountSats == 0L && !pending.isSendAll) {
                 return pending
             }
 
-            // 1. Authoritative transaction status check:
-            // If all pending broadcast transactions failed and were rejected, safely release the deduction.
-            if (isTxFailed != null && pending.txids.isNotEmpty() && pending.txids.all { isTxFailed(it) }) {
-                return PendingOutboundSend()
-            }
-
-            // 2. Authoritative confirmation check:
-            // If all pending broadcast txids are confirmed, then even if an incoming deposit
-            // masked the raw balance drop, we know the spend was incorporated into the wallet.
-            if (isTxConfirmed != null && pending.txids.isNotEmpty() && pending.txids.all { isTxConfirmed(it) }) {
-                return PendingOutboundSend()
-            }
-
-            // 3. Raw balance drop check:
-            if (pending.isSendAll) {
-                if (rawOnchain == 0L) {
+            // 1. Per-txid resolution: remove entries whose txid has a terminal or incorporated status.
+            var unresolvedEntries = pending.entries
+            if (unresolvedEntries.isNotEmpty()) {
+                unresolvedEntries = unresolvedEntries.filter { entry ->
+                    if (entry.txid.isBlank()) return@filter true
+                    // Failed transactions: release the deduction (funds were never spent).
+                    if (isTxFailed != null && isTxFailed(entry.txid)) return@filter false
+                    // Incorporated transactions: wallet already reflects the spend.
+                    if (incorporated != null && incorporated(entry.txid)) return@filter false
+                    true
+                }
+                // If all entries resolved, clear the entire record.
+                if (unresolvedEntries.isEmpty()) {
                     return PendingOutboundSend()
                 }
+                // If some entries resolved, re-check raw balance drop against the reduced aggregate.
+                if (unresolvedEntries.size < pending.entries.size) {
+                    val resolved = PendingOutboundSend(
+                        isSendAll = pending.isSendAll,
+                        baselineOnchainSats = pending.baselineOnchainSats,
+                        timestampSecs = pending.timestampSecs,
+                        entries = unresolvedEntries
+                    )
+                    return resolveByBalanceDrop(rawOnchain, resolved)
+                }
+            }
+
+            // 2. No per-txid resolution occurred; check raw balance drop.
+            return resolveByBalanceDrop(rawOnchain, pending)
+        }
+
+        /** Checks whether the raw on-chain balance has dropped enough to account for the
+         * remaining pending deduction. Pure helper for resolvePendingOutboundSend. */
+        private fun resolveByBalanceDrop(
+            rawOnchain: Long,
+            pending: PendingOutboundSend
+        ): PendingOutboundSend {
+            if (pending.isSendAll) {
+                if (rawOnchain == 0L) return PendingOutboundSend()
                 return pending
             }
-            if (pending.amountSats > 0L) {
-                val expectedRemaining = (pending.baselineOnchainSats - pending.amountSats).coerceAtLeast(0L)
-                if (rawOnchain <= expectedRemaining) {
-                    return PendingOutboundSend()
-                }
-                // When balance hasn't dropped and authoritative checks haven't completed,
-                // fail closed even if beyond TTL to never re-expose spent broadcast funds.
+            val amount = pending.amountSats
+            if (amount > 0L) {
+                val expectedRemaining = (pending.baselineOnchainSats - amount).coerceAtLeast(0L)
+                if (rawOnchain <= expectedRemaining) return PendingOutboundSend()
+                // Fail closed: retain deduction until authoritative reconciliation.
                 return pending
             }
             return pending
@@ -402,13 +480,41 @@ class AppState(private val context: Context) : ViewModel() {
         val pendingBaseline = prefs.getLong(BalanceCacheKey.PENDING_BASELINE, 0L)
         val pendingTimestamp = prefs.getLong(BalanceCacheKey.PENDING_TIMESTAMP, 0L)
         val pendingTxidsStr = prefs.getString(BalanceCacheKey.PENDING_TXIDS, "") ?: ""
-        val pendingTxids = if (pendingTxidsStr.isNotBlank()) pendingTxidsStr.split(",").filter { it.isNotBlank() } else emptyList()
+
+        // If no pending amount was cached and it is not send-all, no send is pending.
+        val parts = if (pendingTxidsStr.isNotBlank()) pendingTxidsStr.split(",").filter { it.isNotBlank() } else emptyList()
+        val hasEntryFormat = parts.any { it.contains(":") }
+
+        val entries: List<TxEntry> = if (pendingAmount == 0L && !pendingIsSendAll) {
+            emptyList()
+        } else if (hasEntryFormat) {
+            parts.mapNotNull { part ->
+                val components = part.split(":", limit = 2)
+                if (components.size == 2) {
+                    val amt = components[1].toLongOrNull() ?: return@mapNotNull null
+                    TxEntry(components[0], amt)
+                } else null
+            }
+        } else {
+            // Legacy path: distribute stored aggregate across txids.
+            if (parts.isNotEmpty() && pendingAmount > 0L) {
+                val perTx = pendingAmount / parts.size
+                val remainder = pendingAmount % parts.size
+                parts.mapIndexed { i, tid ->
+                    TxEntry(tid, perTx + if (i < remainder) 1L else 0L)
+                }
+            } else if (pendingAmount > 0L) {
+                listOf(TxEntry("", pendingAmount))
+            } else {
+                emptyList()
+            }
+        }
+
         pendingOutboundSend = PendingOutboundSend(
-            amountSats = pendingAmount,
             isSendAll = pendingIsSendAll,
             baselineOnchainSats = pendingBaseline,
             timestampSecs = if (pendingTimestamp > 0L) pendingTimestamp else (System.currentTimeMillis() / 1000L),
-            txids = pendingTxids
+            entries = entries
         )
         _lightningBalanceSats = MutableStateFlow(cachedLightning)
         _onchainBalanceSats = MutableStateFlow(cachedOnchain)
@@ -2831,10 +2937,15 @@ class AppState(private val context: Context) : ViewModel() {
 
         // Resolve pending outbound deduction against raw wallet observation
         val effectivePending = synchronized(pendingLock) {
-            val confirmedPredicate: (String) -> Boolean = { tid ->
+            // Wallet-incorporation predicate: once LDK tracks the txid (pending or succeeded),
+            // the wallet's raw balance already reflects the spend. Any positive balance delta
+            // is a genuine incoming deposit, not a masked deduction. This fixes the relaunch+deposit
+            // scenario where the old "succeeded-only" check left funds stuck until 6 confirmations.
+            val incorporatedPredicate: (String) -> Boolean = { tid ->
                 nodeService.node?.listPayments()?.any { p ->
                     val kind = p.kind
-                    kind is PaymentKind.Onchain && kind.txid == tid && p.status == PaymentStatus.SUCCEEDED
+                    kind is PaymentKind.Onchain && kind.txid == tid &&
+                        (p.status == PaymentStatus.SUCCEEDED || p.status == PaymentStatus.PENDING)
                 } ?: false
             }
             val failedPredicate: (String) -> Boolean = { tid ->
@@ -2846,7 +2957,7 @@ class AppState(private val context: Context) : ViewModel() {
             pendingOutboundSend = resolvePendingOutboundSend(
                 rawOnchain = rawOnchain,
                 pending = pendingOutboundSend,
-                isTxConfirmed = confirmedPredicate,
+                isTxIncorporated = incorporatedPredicate,
                 isTxFailed = failedPredicate
             )
             pendingOutboundSend
@@ -2929,7 +3040,7 @@ class AppState(private val context: Context) : ViewModel() {
             .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
             .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
             .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
-            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.txids.joinToString(","))
+            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.entries.joinToString(",") { "${it.txid}:${it.amountSats}" })
             .apply()
     }
 
@@ -2946,30 +3057,23 @@ class AppState(private val context: Context) : ViewModel() {
             } else {
                 pendingOutboundSend.baselineOnchainSats
             }
-            val currentTxids = pendingOutboundSend.txids
-            val updatedTxids = if (!txid.isNullOrBlank() && !currentTxids.contains(txid)) {
-                currentTxids + txid
+            val sendAmount = if (isSendAll) currentOnchain else amountSats
+            val updatedEntries = pendingOutboundSend.entries.toMutableList()
+            if (!txid.isNullOrBlank()) {
+                if (updatedEntries.none { it.txid == txid }) {
+                    updatedEntries.add(TxEntry(txid, sendAmount))
+                }
             } else {
-                currentTxids
+                // No txid available yet; append an anonymous entry.
+                updatedEntries.add(TxEntry("", sendAmount))
             }
 
-            pendingOutboundSend = if (isSendAll) {
-                PendingOutboundSend(
-                    amountSats = pendingOutboundSend.amountSats + currentOnchain,
-                    isSendAll = true,
-                    baselineOnchainSats = newBaseline,
-                    timestampSecs = System.currentTimeMillis() / 1000L,
-                    txids = updatedTxids
-                )
-            } else {
-                PendingOutboundSend(
-                    amountSats = pendingOutboundSend.amountSats + amountSats,
-                    isSendAll = false,
-                    baselineOnchainSats = newBaseline,
-                    timestampSecs = System.currentTimeMillis() / 1000L,
-                    txids = updatedTxids
-                )
-            }
+            pendingOutboundSend = PendingOutboundSend(
+                isSendAll = isSendAll || pendingOutboundSend.isSendAll,
+                baselineOnchainSats = newBaseline,
+                timestampSecs = System.currentTimeMillis() / 1000L,
+                entries = updatedEntries
+            )
             ++sendGeneration
         }
 
@@ -2997,7 +3101,7 @@ class AppState(private val context: Context) : ViewModel() {
             .putBoolean(BalanceCacheKey.PENDING_IS_SEND_ALL, pendingOutboundSend.isSendAll)
             .putLong(BalanceCacheKey.PENDING_BASELINE, pendingOutboundSend.baselineOnchainSats)
             .putLong(BalanceCacheKey.PENDING_TIMESTAMP, pendingOutboundSend.timestampSecs)
-            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.txids.joinToString(","))
+            .putString(BalanceCacheKey.PENDING_TXIDS, pendingOutboundSend.entries.joinToString(",") { "${it.txid}:${it.amountSats}" })
         if (!hasReady && !hasAnyChannel) {
             editor.putLong(BalanceCacheKey.LIGHTNING, 0L)
         }

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -337,7 +337,10 @@ class AppState(private val context: Context) : ViewModel() {
     }
 
     fun resetInMemoryWalletState() {
-        pendingOutboundSend = PendingOutboundSend()
+        synchronized(pendingLock) {
+            sendGeneration++
+            pendingOutboundSend = PendingOutboundSend()
+        }
         BalanceCacheKey.clearAll(context)
     }
 
@@ -345,6 +348,9 @@ class AppState(private val context: Context) : ViewModel() {
         context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE).getLong(BalanceCacheKey.SPENDABLE, 0L)
     )
     val spendableOnchainSats: StateFlow<Long> = _spendableOnchainSats
+
+    private val pendingLock = Any()
+    private var sendGeneration: Long = 0L
 
     @Volatile
     var pendingOutboundSend: PendingOutboundSend = PendingOutboundSend()
@@ -2787,8 +2793,11 @@ class AppState(private val context: Context) : ViewModel() {
         val hasReady = nodeService.channels.any { it.isChannelReady }
 
         // Resolve pending outbound deduction against raw wallet observation
-        pendingOutboundSend = resolvePendingOutboundSend(rawOnchain, pendingOutboundSend)
-        val (onchain, spendable) = calculateEffectiveBalances(rawOnchain, rawSpendable, pendingOutboundSend)
+        val effectivePending = synchronized(pendingLock) {
+            pendingOutboundSend = resolvePendingOutboundSend(rawOnchain, pendingOutboundSend)
+            pendingOutboundSend
+        }
+        val (onchain, spendable) = calculateEffectiveBalances(rawOnchain, rawSpendable, effectivePending)
 
         // Sync fundingTxid directly from the LDK node's channel details
         // to gracefully handle out-of-band splices (e.g. LSP-initiated)
@@ -2876,26 +2885,29 @@ class AppState(private val context: Context) : ViewModel() {
         val newOnchain = if (isSendAll) 0L else (currentOnchain - amountSats).coerceAtLeast(0L)
         val newSpendable = if (isSendAll) 0L else (currentSpendable - amountSats).coerceAtLeast(0L)
 
-        val newBaseline = if (pendingOutboundSend.baselineOnchainSats == 0L) {
-            currentOnchain
-        } else {
-            pendingOutboundSend.baselineOnchainSats
-        }
+        val gen = synchronized(pendingLock) {
+            val newBaseline = if (pendingOutboundSend.baselineOnchainSats == 0L) {
+                currentOnchain
+            } else {
+                pendingOutboundSend.baselineOnchainSats
+            }
 
-        pendingOutboundSend = if (isSendAll) {
-            PendingOutboundSend(
-                amountSats = pendingOutboundSend.amountSats + currentOnchain,
-                isSendAll = true,
-                baselineOnchainSats = newBaseline,
-                timestampSecs = System.currentTimeMillis() / 1000L
-            )
-        } else {
-            PendingOutboundSend(
-                amountSats = pendingOutboundSend.amountSats + amountSats,
-                isSendAll = false,
-                baselineOnchainSats = newBaseline,
-                timestampSecs = System.currentTimeMillis() / 1000L
-            )
+            pendingOutboundSend = if (isSendAll) {
+                PendingOutboundSend(
+                    amountSats = pendingOutboundSend.amountSats + currentOnchain,
+                    isSendAll = true,
+                    baselineOnchainSats = newBaseline,
+                    timestampSecs = System.currentTimeMillis() / 1000L
+                )
+            } else {
+                PendingOutboundSend(
+                    amountSats = pendingOutboundSend.amountSats + amountSats,
+                    isSendAll = false,
+                    baselineOnchainSats = newBaseline,
+                    timestampSecs = System.currentTimeMillis() / 1000L
+                )
+            }
+            ++sendGeneration
         }
 
         _onchainBalanceSats.value = newOnchain
@@ -2936,7 +2948,11 @@ class AppState(private val context: Context) : ViewModel() {
             }
             withContext(Dispatchers.Main) {
                 if (syncSuccess) {
-                    pendingOutboundSend = PendingOutboundSend()
+                    synchronized(pendingLock) {
+                        if (gen == sendGeneration) {
+                            pendingOutboundSend = PendingOutboundSend()
+                        }
+                    }
                 }
                 refreshBalances()
             }

--- a/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/NodeService.kt
@@ -325,6 +325,11 @@ class NodeService(private val context: Context) {
         return n.onchainPayment().sendAllToAddress(address, false, null)
     }
 
+    fun syncWallets() {
+        val n = node ?: throw NodeServiceError()
+        n.syncWallets()
+    }
+
     fun balances(): BalanceDetails? = node?.listBalances()
 
     fun spendableOnchainSats(): Long {

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/HistoryScreen.kt
@@ -32,9 +32,6 @@ import com.stablechannels.app.util.relativeString
 import com.stablechannels.app.util.satsFormatted
 import com.stablechannels.app.util.usdFormatted
 
-private const val REQUIRED_CONFIRMATIONS = 6
-private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen(appState: AppState, modifier: Modifier = Modifier) {
@@ -360,10 +357,7 @@ private fun PaymentRecord.historyStatusColor(): Color {
 }
 
 private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
-    return when (paymentType) {
-        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
-        else -> REQUIRED_CONFIRMATIONS
-    }
+    return AppState.requiredConfirmationsForType(paymentType)
 }
 
 @Composable

--- a/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/history/PaymentDetailDialog.kt
@@ -20,9 +20,8 @@ import com.stablechannels.app.util.Constants
 import androidx.compose.ui.platform.LocalContext
 import android.content.Intent
 import android.net.Uri
+import com.stablechannels.app.AppState
 
-private const val REQUIRED_CONFIRMATIONS = 6
-private const val SPLICE_REQUIRED_CONFIRMATIONS = 1
 private val TXID_REGEX = Regex("^[0-9a-fA-F]{64}$")
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -201,10 +200,7 @@ private fun PaymentRecord.detailStatusLabel(): String {
 }
 
 private fun PaymentRecord.requiredConfirmationsForDisplay(): Int {
-    return when (paymentType) {
-        "splice_in", "splice_out" -> SPLICE_REQUIRED_CONFIRMATIONS
-        else -> REQUIRED_CONFIRMATIONS
-    }
+    return AppState.requiredConfirmationsForType(paymentType)
 }
 
 private fun PaymentRecord.explorerTxid(): String? {

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreen(appState: AppState, modifier: Modifier = Modifier) {
                     showRestore = false
                     restoreMnemonic = ""
                     restoreError = null
+                    appState.resetInMemoryWalletState()
                     appState.refreshBalances()
                 }
             } catch (e: Exception) {

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -293,6 +293,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                             if (sendAll) {
                                 val txid = appState.nodeService.sendAllOnchain(addr)
                                 val sendSats = onchainSats
+                                appState.onchainSendBroadcasted(sendSats, isSendAll = true)
                                 appState.databaseService?.recordPayment(
                                     paymentId = txid, paymentType = "onchain", direction = "sent",
                                     amountMsat = sendSats * 1000,
@@ -324,6 +325,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                     successTxid = null
                                 } else {
                                     val txid = appState.nodeService.sendOnchain(addr, sats)
+                                    appState.onchainSendBroadcasted(sats, isSendAll = false)
                                     appState.databaseService?.recordPayment(
                                         paymentId = txid, paymentType = "onchain", direction = "sent",
                                         amountMsat = sats * 1000,
@@ -331,7 +333,6 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                         btcPrice = accountingPrice,
                                         txid = txid, address = addr
                                     )
-                                    appState.refreshBalances()
                                     result = "Sent successfully."
                                     successTxid = txid
                                 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -293,7 +293,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                             if (sendAll) {
                                 val txid = appState.nodeService.sendAllOnchain(addr)
                                 val sendSats = onchainSats
-                                appState.onchainSendBroadcasted(sendSats, isSendAll = true)
+                                appState.onchainSendBroadcasted(sendSats, isSendAll = true, txid = txid)
                                 appState.databaseService?.recordPayment(
                                     paymentId = txid, paymentType = "onchain", direction = "sent",
                                     amountMsat = sendSats * 1000,
@@ -325,7 +325,7 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                                     successTxid = null
                                 } else {
                                     val txid = appState.nodeService.sendOnchain(addr, sats)
-                                    appState.onchainSendBroadcasted(sats, isSendAll = false)
+                                    appState.onchainSendBroadcasted(sats, isSendAll = false, txid = txid)
                                     appState.databaseService?.recordPayment(
                                         paymentId = txid, paymentType = "onchain", direction = "sent",
                                         amountMsat = sats * 1000,

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -731,6 +731,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             } else {
                                                 appState.nodeService.sendOnchain(trimmed, sats)
                                             }
+                                            appState.onchainSendBroadcasted(sats, isSendAll = isSendMax)
                                             appState.databaseService?.recordPayment(
                                                 paymentId = null, paymentType = "onchain",
                                                 direction = "sent", amountMsat = sats * 1000,

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -731,7 +731,7 @@ fun SendScreen(appState: AppState, onDismiss: () -> Unit) {
                                             } else {
                                                 appState.nodeService.sendOnchain(trimmed, sats)
                                             }
-                                            appState.onchainSendBroadcasted(sats, isSendAll = isSendMax)
+                                            appState.onchainSendBroadcasted(sats, isSendAll = isSendMax, txid = txid)
                                             appState.databaseService?.recordPayment(
                                                 paymentId = null, paymentType = "onchain",
                                                 direction = "sent", amountMsat = sats * 1000,

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -1,0 +1,85 @@
+package com.stablechannels.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OnChainSendBalanceTest {
+
+    @Test
+    fun `total balance with active ready channel returns lightning plus onchain`() {
+        val total = AppState.calculateTotalBalance(
+            lightning = 100_000L,
+            onchain = 50_000L,
+            hasReady = true,
+            isChannelClosing = false,
+            isSweeping = false,
+            pendingSweep = 0L
+        )
+        assertEquals(150_000L, total)
+    }
+
+    @Test
+    fun `total balance during channel closing returns onchain only`() {
+        val total = AppState.calculateTotalBalance(
+            lightning = 100_000L,
+            onchain = 50_000L,
+            hasReady = false,
+            isChannelClosing = true,
+            isSweeping = false,
+            pendingSweep = 0L
+        )
+        assertEquals(50_000L, total)
+    }
+
+    @Test
+    fun `total balance during sweeping returns lightning`() {
+        val total = AppState.calculateTotalBalance(
+            lightning = 100_000L,
+            onchain = 50_000L,
+            hasReady = true,
+            isChannelClosing = false,
+            isSweeping = true,
+            pendingSweep = 0L
+        )
+        assertEquals(100_000L, total)
+    }
+
+    @Test
+    fun `total balance without ready channel includes onchain and pending sweep`() {
+        val total = AppState.calculateTotalBalance(
+            lightning = 80_000L, // Stale claimable from closed channel
+            onchain = 45_000L,
+            hasReady = false,
+            isChannelClosing = false,
+            isSweeping = false,
+            pendingSweep = 15_000L
+        )
+        // Stale lightning is ignored, only onchain + pending sweep counted
+        assertEquals(60_000L, total)
+    }
+
+    @Test
+    fun `total balance without ready channel zeroes on send max and never resurrects stale lightning (Issue 260)`() {
+        // Bug reproduction: Channel closed, user sent max onchain so onchain drops to 0.
+        // LDK continues reporting stale lightning balance.
+        // Total balance must be 0, not resurrect the stale lightning balance.
+        val total = AppState.calculateTotalBalance(
+            lightning = 120_000L, // Stale closed-channel lightning claimables
+            onchain = 0L,
+            hasReady = false,
+            isChannelClosing = false,
+            isSweeping = false,
+            pendingSweep = 0L
+        )
+        assertEquals(0L, total)
+    }
+
+    @Test
+    fun `required confirmations policy returns 1 for splices and 6 for direct onchain sends`() {
+        assertEquals(1, AppState.requiredConfirmationsForType("splice_in"))
+        assertEquals(1, AppState.requiredConfirmationsForType("splice_out"))
+        assertEquals(6, AppState.requiredConfirmationsForType("onchain"))
+        assertEquals(6, AppState.requiredConfirmationsForType("channel_close"))
+        assertEquals(6, AppState.requiredConfirmationsForType("unknown"))
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -140,4 +140,132 @@ class OnChainSendBalanceTest {
         assertEquals(6, AppState.requiredConfirmationsForType("channel_close"))
         assertEquals(6, AppState.requiredConfirmationsForType("unknown"))
     }
+
+    @Test
+    fun `calculate effective balances deducts pending outbound send`() {
+        val pendingPartial = AppState.Companion.PendingOutboundSend(
+            amountSats = 30_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L
+        )
+        val (onchainPartial, spendablePartial) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = pendingPartial
+        )
+        assertEquals(70_000L, onchainPartial)
+        assertEquals(65_000L, spendablePartial)
+
+        val pendingAll = AppState.Companion.PendingOutboundSend(
+            amountSats = 100_000L,
+            isSendAll = true,
+            baselineOnchainSats = 100_000L
+        )
+        val (onchainAll, spendableAll) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = pendingAll
+        )
+        assertEquals(0L, onchainAll)
+        assertEquals(0L, spendableAll)
+
+        val pendingNone = AppState.Companion.PendingOutboundSend()
+        val (onchainNone, spendableNone) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = pendingNone
+        )
+        assertEquals(100_000L, onchainNone)
+        assertEquals(95_000L, spendableNone)
+    }
+
+    @Test
+    fun `resolve pending outbound send clears only after spend is incorporated`() {
+        val pending = AppState.Companion.PendingOutboundSend(
+            amountSats = 30_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L
+        )
+
+        // Before wallet sync incorporates the spend: raw balance is still 100k
+        val stillPending = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending
+        )
+        assertEquals(30_000L, stillPending.amountSats)
+        assertEquals(false, stillPending.isSendAll)
+
+        // After wallet sync incorporates the spend: raw balance dropped to 70k or less
+        val incorporated = AppState.resolvePendingOutboundSend(
+            rawOnchain = 69_850L,
+            pending = pending
+        )
+        assertEquals(0L, incorporated.amountSats)
+
+        // Send All incorporation
+        val pendingAll = AppState.Companion.PendingOutboundSend(
+            amountSats = 100_000L,
+            isSendAll = true,
+            baselineOnchainSats = 100_000L
+        )
+        val allStillPending = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pendingAll
+        )
+        assertEquals(true, allStillPending.isSendAll)
+
+        val allIncorporated = AppState.resolvePendingOutboundSend(
+            rawOnchain = 0L,
+            pending = pendingAll
+        )
+        assertEquals(false, allIncorporated.isSendAll)
+        assertEquals(0L, allIncorporated.amountSats)
+    }
+
+    @Test
+    fun `interleaving balance refresh before wallet sync completes preserves deduction and prevents ghost balance resurrection`() {
+        // Simulates:
+        // 1. Broadcast send of 30,000 sats when raw balance is 100,000 sats.
+        // 2. Intervening refresh receives old 100,000 balance from LDK before sync incorporates the spend.
+        // 3. Invariant: effective balance MUST remain 70,000 and never resurrect the pre-send 100,000.
+        val rawPreSend = 100_000L
+        val rawSpendablePreSend = 95_000L
+        val sendAmount = 30_000L
+
+        var pending = AppState.Companion.PendingOutboundSend(
+            amountSats = sendAmount,
+            isSendAll = false,
+            baselineOnchainSats = rawPreSend
+        )
+
+        // Intervening refresh: LDK still reports old 100k balance
+        val rawDuringSync = rawPreSend
+        val rawSpendableDuringSync = rawSpendablePreSend
+
+        pending = AppState.resolvePendingOutboundSend(rawOnchain = rawDuringSync, pending = pending)
+        assertEquals(30_000L, pending.amountSats)
+
+        val (effOnchainDuringSync, effSpendableDuringSync) = AppState.calculateEffectiveBalances(
+            rawOnchain = rawDuringSync,
+            rawSpendable = rawSpendableDuringSync,
+            pending = pending
+        )
+        assertEquals(70_000L, effOnchainDuringSync)
+        assertEquals(65_000L, effSpendableDuringSync)
+
+        // Once sync completes and LDK reports the incorporated balance:
+        val rawPostSync = 69_850L
+        val rawSpendablePostSync = 64_850L
+
+        pending = AppState.resolvePendingOutboundSend(rawOnchain = rawPostSync, pending = pending)
+        assertEquals(0L, pending.amountSats)
+
+        val (effOnchainPostSync, effSpendablePostSync) = AppState.calculateEffectiveBalances(
+            rawOnchain = rawPostSync,
+            rawSpendable = rawSpendablePostSync,
+            pending = pending
+        )
+        assertEquals(69_850L, effOnchainPostSync)
+        assertEquals(64_850L, effSpendablePostSync)
+    }
 }

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -69,9 +69,67 @@ class OnChainSendBalanceTest {
             hasReady = false,
             isChannelClosing = false,
             isSweeping = false,
-            pendingSweep = 0L
+            pendingSweep = 0L,
+            hasAnyChannel = false
         )
         assertEquals(0L, total)
+    }
+
+    @Test
+    fun `total balance with pending channel when hasReady is false preserves lightning balance`() {
+        // A channel exists (hasAnyChannel = true) but is not ready yet (funding pending)
+        val total = AppState.calculateTotalBalance(
+            lightning = 80_000L,
+            onchain = 20_000L,
+            hasReady = false,
+            isChannelClosing = false,
+            isSweeping = false,
+            pendingSweep = 0L,
+            hasAnyChannel = true
+        )
+        assertEquals(100_000L, total)
+    }
+
+    @Test
+    fun `total balance during channel opening returns lightning if non-zero else onchain`() {
+        val totalWithLightning = AppState.calculateTotalBalance(
+            lightning = 50_000L,
+            onchain = 0L,
+            hasReady = false,
+            isChannelClosing = false,
+            isSweeping = false,
+            isOpeningChannel = true
+        )
+        assertEquals(50_000L, totalWithLightning)
+
+        val totalWithOnchain = AppState.calculateTotalBalance(
+            lightning = 0L,
+            onchain = 70_000L,
+            hasReady = false,
+            isChannelClosing = false,
+            isSweeping = false,
+            isOpeningChannel = true
+        )
+        assertEquals(70_000L, totalWithOnchain)
+    }
+
+    @Test
+    fun `total balance using ChannelState parameter object adheres to Open Closed Principle`() {
+        val state = AppState.Companion.ChannelState(
+            hasReady = false,
+            hasAnyChannel = false,
+            isChannelClosing = false,
+            isOpeningChannel = false,
+            isSweeping = false
+        )
+        val total = AppState.calculateTotalBalance(
+            lightning = 50_000L,
+            onchain = 20_000L,
+            pendingSweep = 5_000L,
+            channelState = state
+        )
+        // Without ready or existing channel, stale lightning is excluded
+        assertEquals(25_000L, total)
     }
 
     @Test

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -268,4 +268,196 @@ class OnChainSendBalanceTest {
         assertEquals(69_850L, effOnchainPostSync)
         assertEquals(64_850L, effSpendablePostSync)
     }
+
+    @Test
+    fun `overlapping consecutive sends does not double deduct`() {
+        val initialRaw = 100_000L
+        val initialSpendable = 95_000L
+
+        // Send 1: 30,000 sats
+        val send1 = 30_000L
+        val pending1 = AppState.Companion.PendingOutboundSend(
+            amountSats = send1,
+            isSendAll = false,
+            baselineOnchainSats = initialRaw
+        )
+        val (eff1Onchain, eff1Spendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = initialRaw,
+            rawSpendable = initialSpendable,
+            pending = pending1
+        )
+        assertEquals(70_000L, eff1Onchain)
+        assertEquals(65_000L, eff1Spendable)
+
+        // Send 2: 20,000 sats issued while Send 1 is still pending
+        val send2 = 20_000L
+        val cumulativePending = AppState.Companion.PendingOutboundSend(
+            amountSats = pending1.amountSats + send2,
+            isSendAll = false,
+            baselineOnchainSats = pending1.baselineOnchainSats
+        )
+        assertEquals(50_000L, cumulativePending.amountSats)
+        assertEquals(initialRaw, cumulativePending.baselineOnchainSats)
+
+        // Incremental deduction from published balance yields correct 50k (not 20k)
+        val incrementalOnchain = (eff1Onchain - send2).coerceAtLeast(0L)
+        val incrementalSpendable = (eff1Spendable - send2).coerceAtLeast(0L)
+        assertEquals(50_000L, incrementalOnchain)
+        assertEquals(45_000L, incrementalSpendable)
+
+        // And effective balance calculation against the raw baseline is consistent
+        val (eff2Onchain, eff2Spendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = initialRaw,
+            rawSpendable = initialSpendable,
+            pending = cumulativePending
+        )
+        assertEquals(50_000L, eff2Onchain)
+        assertEquals(45_000L, eff2Spendable)
+
+        // After wallet sync incorporates both sends (raw on-chain drops to 49,850 sats):
+        val rawAfterBothSync = 49_850L
+        val resolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = rawAfterBothSync,
+            pending = cumulativePending
+        )
+        assertEquals(0L, resolved.amountSats)
+        val (finalOnchain, _) = AppState.calculateEffectiveBalances(
+            rawOnchain = rawAfterBothSync,
+            rawSpendable = 44_850L,
+            pending = resolved
+        )
+        assertEquals(49_850L, finalOnchain)
+    }
+
+    @Test
+    fun `pending outbound send expires after TTL backstop`() {
+        val sendTimestamp = 1_700_000_000L
+        val pending = AppState.Companion.PendingOutboundSend(
+            amountSats = 30_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = sendTimestamp
+        )
+
+        // Before TTL (e.g. at 300 seconds): still pending if raw balance hasn't dropped
+        val active = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            currentTimestampSecs = sendTimestamp + 300L,
+            ttlSecs = 600L
+        )
+        assertEquals(30_000L, active.amountSats)
+
+        // After TTL (at 601 seconds): expired to prevent permanent balance suppression
+        val expired = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            currentTimestampSecs = sendTimestamp + 601L,
+            ttlSecs = 600L
+        )
+        assertEquals(0L, expired.amountSats)
+    }
+
+    @Test
+    fun `incoming deposit during pending window clears via TTL without stranding balance`() {
+        // Baseline 100k, send 30k. Expected remaining = 70k.
+        // But a 50k deposit lands concurrently, raising raw balance to 120k.
+        val sendTimestamp = 1_700_000_000L
+        val pending = AppState.Companion.PendingOutboundSend(
+            amountSats = 30_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = sendTimestamp
+        )
+
+        val rawWithDeposit = 120_000L
+
+        // Prior to TTL, the balance predicate alone cannot clear because 120k > 70k
+        val pendingBeforeTtl = AppState.resolvePendingOutboundSend(
+            rawOnchain = rawWithDeposit,
+            pending = pending,
+            currentTimestampSecs = sendTimestamp + 100L,
+            ttlSecs = 600L
+        )
+        assertEquals(30_000L, pendingBeforeTtl.amountSats)
+
+        // Once TTL expires, pending clears and user sees the true updated deposit balance
+        val pendingAfterTtl = AppState.resolvePendingOutboundSend(
+            rawOnchain = rawWithDeposit,
+            pending = pending,
+            currentTimestampSecs = sendTimestamp + 650L,
+            ttlSecs = 600L
+        )
+        assertEquals(0L, pendingAfterTtl.amountSats)
+        val (effOnchain, _) = AppState.calculateEffectiveBalances(
+            rawOnchain = rawWithDeposit,
+            rawSpendable = rawWithDeposit,
+            pending = pendingAfterTtl
+        )
+        assertEquals(120_000L, effOnchain)
+    }
+
+    @Test
+    fun `partial then send all sequence preserves baseline and clears on zero`() {
+        val initialRaw = 100_000L
+        val initialSpendable = 95_000L
+
+        // Send 1: partial 20k
+        val pending1 = AppState.Companion.PendingOutboundSend(
+            amountSats = 20_000L,
+            isSendAll = false,
+            baselineOnchainSats = initialRaw
+        )
+        val (eff1Onchain, eff1Spendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = initialRaw,
+            rawSpendable = initialSpendable,
+            pending = pending1
+        )
+        assertEquals(80_000L, eff1Onchain)
+        assertEquals(75_000L, eff1Spendable)
+
+        // Send 2: send all (remaining 80k)
+        val pendingSendAll = AppState.Companion.PendingOutboundSend(
+            amountSats = pending1.amountSats + eff1Onchain,
+            isSendAll = true,
+            baselineOnchainSats = pending1.baselineOnchainSats
+        )
+        assertEquals(100_000L, pendingSendAll.amountSats)
+        assertEquals(initialRaw, pendingSendAll.baselineOnchainSats)
+
+        val (effAllOnchain, effAllSpendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = initialRaw,
+            rawSpendable = initialSpendable,
+            pending = pendingSendAll
+        )
+        assertEquals(0L, effAllOnchain)
+        assertEquals(0L, effAllSpendable)
+
+        // Wallet refresh incorporating only partial send 1 (raw drops to 80k) MUST NOT clear send all
+        val refreshAfterPartialOnly = AppState.resolvePendingOutboundSend(
+            rawOnchain = 80_000L,
+            pending = pendingSendAll
+        )
+        assertEquals(true, refreshAfterPartialOnly.isSendAll)
+
+        // Once send-all is incorporated (raw drops to 0):
+        val fullyResolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = 0L,
+            pending = pendingSendAll
+        )
+        assertEquals(false, fullyResolved.isSendAll)
+        assertEquals(0L, fullyResolved.amountSats)
+    }
+
+    @Test
+    fun `centralized balance cache keys match expected preferences schema`() {
+        assertEquals("balance_cache", AppState.Companion.BalanceCacheKey.PREFS_NAME)
+        assertEquals("cached_lightning_sats", AppState.Companion.BalanceCacheKey.LIGHTNING)
+        assertEquals("cached_onchain_sats", AppState.Companion.BalanceCacheKey.ONCHAIN)
+        assertEquals("cached_spendable_sats", AppState.Companion.BalanceCacheKey.SPENDABLE)
+        assertEquals("pending_outbound_onchain_sats", AppState.Companion.BalanceCacheKey.PENDING_AMOUNT)
+        assertEquals("pending_outbound_is_send_all", AppState.Companion.BalanceCacheKey.PENDING_IS_SEND_ALL)
+        assertEquals("pending_outbound_baseline_sats", AppState.Companion.BalanceCacheKey.PENDING_BASELINE)
+        assertEquals("pending_outbound_timestamp_secs", AppState.Companion.BalanceCacheKey.PENDING_TIMESTAMP)
+    }
 }

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -578,4 +578,114 @@ class OnChainSendBalanceTest {
         assertEquals(100_000L, effOnchain)
         assertEquals(95_000L, effSpendable)
     }
+
+    @Test
+    fun `mixed succeeded and failed batch partial release releases only resolved amount`() {
+        // Two sends aggregated: tx_fail (30k) and tx_success (20k). Total = 50k.
+        val pending = AppState.Companion.PendingOutboundSend(
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = 1_000_000L,
+            entries = listOf(
+                AppState.Companion.TxEntry("tx_fail", 30_000L),
+                AppState.Companion.TxEntry("tx_success", 20_000L)
+            )
+        )
+        assertEquals(50_000L, pending.amountSats)
+        assertEquals(listOf("tx_fail", "tx_success"), pending.txids)
+
+        // Case 1: tx_fail fails; tx_success is not yet incorporated.
+        // The failed 30k must be released, retaining only 20k for tx_success.
+        val partialFail = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            isTxIncorporated = { false },
+            isTxFailed = { it == "tx_fail" }
+        )
+        assertEquals(20_000L, partialFail.amountSats)
+        assertEquals(1, partialFail.entries.size)
+        assertEquals("tx_success", partialFail.entries.first().txid)
+
+        val (effOnchainFail, effSpendableFail) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = partialFail
+        )
+        assertEquals(80_000L, effOnchainFail)
+        assertEquals(75_000L, effSpendableFail)
+
+        // Case 2: tx_success is incorporated; tx_fail is still pending.
+        val partialSuccess = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            isTxIncorporated = { it == "tx_success" },
+            isTxFailed = { false }
+        )
+        assertEquals(30_000L, partialSuccess.amountSats)
+        assertEquals(1, partialSuccess.entries.size)
+        assertEquals("tx_fail", partialSuccess.entries.first().txid)
+
+        // Case 3: Both resolve (one failed, one incorporated). Entire record clears.
+        val bothResolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            isTxIncorporated = { it == "tx_success" },
+            isTxFailed = { it == "tx_fail" }
+        )
+        assertEquals(0L, bothResolved.amountSats)
+        assertTrue(bothResolved.entries.isEmpty())
+    }
+
+    @Test
+    fun `relaunch with concurrent deposit clears on incorporation`() {
+        // gpt-6-astra P1 scenario:
+        // App was killed before sync, restored on relaunch from cache.
+        // During relaunch, an incoming deposit raised raw onchain to 120_000 (baseline was 100_000).
+        // Since rawOnchain > baseline, rawDrop is 0.
+        // The broadcast tx ("tx_mempool") is tracked in LDK with PENDING status (not SUCCEEDED).
+        val pending = AppState.Companion.PendingOutboundSend(
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = 1_000_000L,
+            entries = listOf(
+                AppState.Companion.TxEntry("tx_mempool", 50_000L)
+            )
+        )
+
+        // Under new policy, isTxIncorporated returns true for PENDING or SUCCEEDED status.
+        val resolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = 120_000L,
+            pending = pending,
+            isTxIncorporated = { it == "tx_mempool" },
+            isTxFailed = { false }
+        )
+        assertEquals(0L, resolved.amountSats)
+
+        // Effective balance immediately displays full deposit without stuck deduction.
+        val (effOnchain, effSpendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = 120_000L,
+            rawSpendable = 115_000L,
+            pending = resolved
+        )
+        assertEquals(120_000L, effOnchain)
+        assertEquals(115_000L, effSpendable)
+    }
+
+    @Test
+    fun `per txid entry from legacy deserialization distributes aggregate`() {
+        val legacy = AppState.Companion.PendingOutboundSend.fromLegacy(
+            amountSats = 50_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = 1_000_000L,
+            txids = listOf("legacy_tx1", "legacy_tx2")
+        )
+        assertEquals(50_000L, legacy.amountSats)
+        assertEquals(2, legacy.entries.size)
+        assertEquals("legacy_tx1", legacy.entries[0].txid)
+        assertEquals(25_000L, legacy.entries[0].amountSats)
+        assertEquals("legacy_tx2", legacy.entries[1].txid)
+        assertEquals(25_000L, legacy.entries[1].amountSats)
+    }
 }
+

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -460,4 +460,52 @@ class OnChainSendBalanceTest {
         assertEquals("pending_outbound_baseline_sats", AppState.Companion.BalanceCacheKey.PENDING_BASELINE)
         assertEquals("pending_outbound_timestamp_secs", AppState.Companion.BalanceCacheKey.PENDING_TIMESTAMP)
     }
+
+    @Test
+    fun `partial incorporation of multiple sends does not double deduct`() {
+        // Baseline 100k, spendable 95k. User performs two sends: 30k, then 20k (total pending = 50k).
+        val pending = AppState.Companion.PendingOutboundSend(
+            amountSats = 50_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            timestampSecs = 1_000_000L
+        )
+
+        // Stage 1: No sends incorporated into raw yet (rawOnchain = 100k)
+        val (onchain1, spendable1) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = pending
+        )
+        assertEquals(50_000L, onchain1)
+        assertEquals(45_000L, spendable1)
+
+        // Stage 2: Intermediate state - send 1 (30k) has landed in raw balance (rawOnchain = 70k),
+        // but send 2 (20k) is still unincorporated.
+        // Effective balance must remain 50k, NOT drop to 20k from double-deduction.
+        val (onchain2, spendable2) = AppState.calculateEffectiveBalances(
+            rawOnchain = 70_000L,
+            rawSpendable = 65_000L,
+            pending = pending
+        )
+        assertEquals(50_000L, onchain2)
+        assertEquals(45_000L, spendable2)
+
+        // Stage 3: Both sends incorporated into raw balance (rawOnchain = 50k)
+        val (onchain3, spendable3) = AppState.calculateEffectiveBalances(
+            rawOnchain = 50_000L,
+            rawSpendable = 45_000L,
+            pending = pending
+        )
+        assertEquals(50_000L, onchain3)
+        assertEquals(45_000L, spendable3)
+
+        val resolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = 50_000L,
+            pending = pending,
+            currentTimestampSecs = 1_000_100L,
+            ttlSecs = 600L
+        )
+        assertEquals(0L, resolved.amountSats)
+    }
 }

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -1,6 +1,8 @@
 package com.stablechannels.app
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class OnChainSendBalanceTest {
@@ -330,16 +332,17 @@ class OnChainSendBalanceTest {
     }
 
     @Test
-    fun `pending outbound send expires after TTL backstop`() {
+    fun `pending outbound send fails closed past TTL without balance drop or confirmation`() {
         val sendTimestamp = 1_700_000_000L
         val pending = AppState.Companion.PendingOutboundSend(
             amountSats = 30_000L,
             isSendAll = false,
             baselineOnchainSats = 100_000L,
-            timestampSecs = sendTimestamp
+            timestampSecs = sendTimestamp,
+            txids = listOf("tx1")
         )
 
-        // Before TTL (e.g. at 300 seconds): still pending if raw balance hasn't dropped
+        // Before TTL (at 300 seconds): retains pending send
         val active = AppState.resolvePendingOutboundSend(
             rawOnchain = 100_000L,
             pending = pending,
@@ -348,18 +351,18 @@ class OnChainSendBalanceTest {
         )
         assertEquals(30_000L, active.amountSats)
 
-        // After TTL (at 601 seconds): expired to prevent permanent balance suppression
-        val expired = AppState.resolvePendingOutboundSend(
+        // Past TTL (at 601 seconds): fails closed and retains deduction during indexer/node outage
+        val pastTtl = AppState.resolvePendingOutboundSend(
             rawOnchain = 100_000L,
             pending = pending,
             currentTimestampSecs = sendTimestamp + 601L,
             ttlSecs = 600L
         )
-        assertEquals(0L, expired.amountSats)
+        assertEquals(30_000L, pastTtl.amountSats)
     }
 
     @Test
-    fun `incoming deposit during pending window clears via TTL without stranding balance`() {
+    fun `incoming deposit with authoritative tx confirmation clears pending without stranding balance`() {
         // Baseline 100k, send 30k. Expected remaining = 70k.
         // But a 50k deposit lands concurrently, raising raw balance to 120k.
         val sendTimestamp = 1_700_000_000L
@@ -367,32 +370,45 @@ class OnChainSendBalanceTest {
             amountSats = 30_000L,
             isSendAll = false,
             baselineOnchainSats = 100_000L,
-            timestampSecs = sendTimestamp
+            timestampSecs = sendTimestamp,
+            txids = listOf("tx1")
         )
 
         val rawWithDeposit = 120_000L
 
-        // Prior to TTL, the balance predicate alone cannot clear because 120k > 70k
-        val pendingBeforeTtl = AppState.resolvePendingOutboundSend(
+        // Prior to confirmation, balance predicate alone does not clear because 120k > 70k (fails closed)
+        val pendingUnconfirmed = AppState.resolvePendingOutboundSend(
             rawOnchain = rawWithDeposit,
             pending = pending,
             currentTimestampSecs = sendTimestamp + 100L,
-            ttlSecs = 600L
+            ttlSecs = 600L,
+            isTxConfirmed = { false }
         )
-        assertEquals(30_000L, pendingBeforeTtl.amountSats)
+        assertEquals(30_000L, pendingUnconfirmed.amountSats)
 
-        // Once TTL expires, pending clears and user sees the true updated deposit balance
-        val pendingAfterTtl = AppState.resolvePendingOutboundSend(
+        // Even past TTL, if unconfirmed it fails closed
+        val pendingPastTtlUnconfirmed = AppState.resolvePendingOutboundSend(
             rawOnchain = rawWithDeposit,
             pending = pending,
             currentTimestampSecs = sendTimestamp + 650L,
-            ttlSecs = 600L
+            ttlSecs = 600L,
+            isTxConfirmed = { false }
         )
-        assertEquals(0L, pendingAfterTtl.amountSats)
+        assertEquals(30_000L, pendingPastTtlUnconfirmed.amountSats)
+
+        // Once authoritative confirmation verifies tx1 is incorporated, pending clears
+        val pendingConfirmed = AppState.resolvePendingOutboundSend(
+            rawOnchain = rawWithDeposit,
+            pending = pending,
+            currentTimestampSecs = sendTimestamp + 100L,
+            ttlSecs = 600L,
+            isTxConfirmed = { it == "tx1" }
+        )
+        assertEquals(0L, pendingConfirmed.amountSats)
         val (effOnchain, _) = AppState.calculateEffectiveBalances(
             rawOnchain = rawWithDeposit,
             rawSpendable = rawWithDeposit,
-            pending = pendingAfterTtl
+            pending = pendingConfirmed
         )
         assertEquals(120_000L, effOnchain)
     }
@@ -459,6 +475,7 @@ class OnChainSendBalanceTest {
         assertEquals("pending_outbound_is_send_all", AppState.Companion.BalanceCacheKey.PENDING_IS_SEND_ALL)
         assertEquals("pending_outbound_baseline_sats", AppState.Companion.BalanceCacheKey.PENDING_BASELINE)
         assertEquals("pending_outbound_timestamp_secs", AppState.Companion.BalanceCacheKey.PENDING_TIMESTAMP)
+        assertEquals("pending_outbound_txids", AppState.Companion.BalanceCacheKey.PENDING_TXIDS)
     }
 
     @Test
@@ -507,5 +524,58 @@ class OnChainSendBalanceTest {
             ttlSecs = 600L
         )
         assertEquals(0L, resolved.amountSats)
+    }
+
+    @Test
+    fun `out of order sync completion cannot clear newer broadcast generation`() {
+        // Generation 1 (older broadcast) finishes after Generation 2 was broadcast
+        val shouldClearOlder = AppState.shouldClearPendingOnSyncCompletion(
+            expectedGeneration = 1L,
+            currentGeneration = 2L,
+            syncSuccess = true
+        )
+        assertFalse(shouldClearOlder)
+
+        // Generation 2 (current broadcast) finishes and clears
+        val shouldClearCurrent = AppState.shouldClearPendingOnSyncCompletion(
+            expectedGeneration = 2L,
+            currentGeneration = 2L,
+            syncSuccess = true
+        )
+        assertTrue(shouldClearCurrent)
+    }
+
+    @Test
+    fun `all sync attempts fail preserves pending deduction`() {
+        val shouldClearFailedSync = AppState.shouldClearPendingOnSyncCompletion(
+            expectedGeneration = 1L,
+            currentGeneration = 1L,
+            syncSuccess = false
+        )
+        assertFalse(shouldClearFailedSync)
+    }
+
+    @Test
+    fun `authoritative tx failure clears pending and restores spendable balance`() {
+        val pending = AppState.Companion.PendingOutboundSend(
+            amountSats = 30_000L,
+            isSendAll = false,
+            baselineOnchainSats = 100_000L,
+            txids = listOf("tx_failed")
+        )
+
+        val resolved = AppState.resolvePendingOutboundSend(
+            rawOnchain = 100_000L,
+            pending = pending,
+            isTxFailed = { it == "tx_failed" }
+        )
+        assertEquals(0L, resolved.amountSats)
+        val (effOnchain, effSpendable) = AppState.calculateEffectiveBalances(
+            rawOnchain = 100_000L,
+            rawSpendable = 95_000L,
+            pending = resolved
+        )
+        assertEquals(100_000L, effOnchain)
+        assertEquals(95_000L, effSpendable)
     }
 }

--- a/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/OnChainSendBalanceTest.kt
@@ -687,5 +687,217 @@ class OnChainSendBalanceTest {
         assertEquals("legacy_tx2", legacy.entries[1].txid)
         assertEquals(25_000L, legacy.entries[1].amountSats)
     }
+
+    @Test
+    fun `recordBroadcast accumulates entries idempotently and maintains sticky sendAll`() {
+        var pending = AppState.Companion.PendingOutboundSend()
+
+        // 1. Initial send records entry and sets baseline
+        pending = AppState.Companion.recordBroadcast(
+            currentPending = pending,
+            amountSats = 20_000L,
+            isSendAll = false,
+            currentOnchain = 100_000L,
+            txid = "tx1"
+        )
+        assertEquals(20_000L, pending.amountSats)
+        assertEquals(100_000L, pending.baselineOnchainSats)
+        assertEquals(1, pending.entries.size)
+        assertEquals("tx1", pending.entries[0].txid)
+        assertFalse(pending.isSendAll)
+
+        // 2. Second send appends distinct entry, baseline remains unchanged
+        pending = AppState.Companion.recordBroadcast(
+            currentPending = pending,
+            amountSats = 30_000L,
+            isSendAll = false,
+            currentOnchain = 80_000L,
+            txid = "tx2"
+        )
+        assertEquals(50_000L, pending.amountSats)
+        assertEquals(100_000L, pending.baselineOnchainSats)
+        assertEquals(2, pending.entries.size)
+        assertEquals("tx2", pending.entries[1].txid)
+
+        // 3. Repeated broadcast with same txid is idempotent
+        pending = AppState.Companion.recordBroadcast(
+            currentPending = pending,
+            amountSats = 30_000L,
+            isSendAll = false,
+            currentOnchain = 80_000L,
+            txid = "tx2"
+        )
+        assertEquals(50_000L, pending.amountSats)
+        assertEquals(2, pending.entries.size)
+
+        // 4. Send all sets isSendAll and records send amount
+        var sendAllPending = AppState.Companion.recordBroadcast(
+            currentPending = AppState.Companion.PendingOutboundSend(),
+            amountSats = 0L,
+            isSendAll = true,
+            currentOnchain = 100_000L,
+            txid = "tx_all"
+        )
+        assertTrue(sendAllPending.isSendAll)
+        assertEquals(100_000L, sendAllPending.amountSats)
+
+        // 5. Subsequent send preserves sticky isSendAll
+        sendAllPending = AppState.Companion.recordBroadcast(
+            currentPending = sendAllPending,
+            amountSats = 10_000L,
+            isSendAll = false,
+            currentOnchain = 0L,
+            txid = "tx_after"
+        )
+        assertTrue(sendAllPending.isSendAll)
+
+        // 6. Anonymous entry when txid is null
+        val anon = AppState.Companion.recordBroadcast(
+            currentPending = AppState.Companion.PendingOutboundSend(),
+            amountSats = 15_000L,
+            isSendAll = false,
+            currentOnchain = 50_000L,
+            txid = null
+        )
+        assertEquals(1, anon.entries.size)
+        assertEquals("", anon.entries[0].txid)
+        assertEquals(15_000L, anon.entries[0].amountSats)
+    }
+
+    @Test
+    fun `cached pending outbound send roundtrips across formats`() {
+        val fakePrefs = FakeSharedPreferences()
+        val editor = fakePrefs.edit()
+
+        // 1. New colon format roundtrip
+        val original = AppState.Companion.PendingOutboundSend(
+            isSendAll = false,
+            baselineOnchainSats = 80_000L,
+            timestampSecs = 1_700_000_000L,
+            entries = listOf(
+                AppState.Companion.TxEntry("tx_a", 25_000L),
+                AppState.Companion.TxEntry("tx_b", 35_000L)
+            )
+        )
+        AppState.Companion.persistPendingOutboundSend(editor, original)
+        editor.apply()
+
+        val loaded = AppState.Companion.loadCachedPendingOutboundSend(fakePrefs)
+        assertEquals(original.isSendAll, loaded.isSendAll)
+        assertEquals(original.baselineOnchainSats, loaded.baselineOnchainSats)
+        assertEquals(original.timestampSecs, loaded.timestampSecs)
+        assertEquals(original.amountSats, loaded.amountSats)
+        assertEquals(2, loaded.entries.size)
+        assertEquals("tx_a", loaded.entries[0].txid)
+        assertEquals(25_000L, loaded.entries[0].amountSats)
+        assertEquals("tx_b", loaded.entries[1].txid)
+        assertEquals(35_000L, loaded.entries[1].amountSats)
+
+        // 2. Anonymous entry roundtrip
+        val anonOriginal = AppState.Companion.PendingOutboundSend(
+            isSendAll = false,
+            baselineOnchainSats = 50_000L,
+            timestampSecs = 1_700_000_000L,
+            entries = listOf(AppState.Companion.TxEntry("", 50_000L))
+        )
+        AppState.Companion.persistPendingOutboundSend(editor, anonOriginal)
+        editor.apply()
+        val loadedAnon = AppState.Companion.loadCachedPendingOutboundSend(fakePrefs)
+        assertEquals(1, loadedAnon.entries.size)
+        assertEquals("", loadedAnon.entries[0].txid)
+        assertEquals(50_000L, loadedAnon.entries[0].amountSats)
+
+        // 3. Legacy comma-delimited fallback without colons
+        fakePrefs.clear()
+        editor.putLong(AppState.Companion.BalanceCacheKey.PENDING_AMOUNT, 40_000L)
+        editor.putBoolean(AppState.Companion.BalanceCacheKey.PENDING_IS_SEND_ALL, false)
+        editor.putLong(AppState.Companion.BalanceCacheKey.PENDING_BASELINE, 100_000L)
+        editor.putLong(AppState.Companion.BalanceCacheKey.PENDING_TIMESTAMP, 1_700_000_000L)
+        editor.putString(AppState.Companion.BalanceCacheKey.PENDING_TXIDS, "leg1,leg2")
+        editor.apply()
+
+        val loadedLegacy = AppState.Companion.loadCachedPendingOutboundSend(fakePrefs)
+        assertEquals(40_000L, loadedLegacy.amountSats)
+        assertEquals(2, loadedLegacy.entries.size)
+        assertEquals("leg1", loadedLegacy.entries[0].txid)
+        assertEquals(20_000L, loadedLegacy.entries[0].amountSats)
+        assertEquals("leg2", loadedLegacy.entries[1].txid)
+        assertEquals(20_000L, loadedLegacy.entries[1].amountSats)
+
+        // 4. Zero pending amount when not send-all yields empty entries
+        fakePrefs.clear()
+        editor.putLong(AppState.Companion.BalanceCacheKey.PENDING_AMOUNT, 0L)
+        editor.putBoolean(AppState.Companion.BalanceCacheKey.PENDING_IS_SEND_ALL, false)
+        editor.putString(AppState.Companion.BalanceCacheKey.PENDING_TXIDS, "stale_tx")
+        editor.apply()
+        val loadedZero = AppState.Companion.loadCachedPendingOutboundSend(fakePrefs)
+        assertEquals(0L, loadedZero.amountSats)
+        assertTrue(loadedZero.entries.isEmpty())
+    }
+
+    private class FakeSharedPreferences : android.content.SharedPreferences {
+        private val data = mutableMapOf<String, Any>()
+
+        fun clear() {
+            data.clear()
+        }
+
+        override fun getAll(): Map<String, *> = data
+        override fun getString(key: String, defValue: String?): String? = data[key] as? String ?: defValue
+        override fun getStringSet(key: String, defValues: Set<String>?): Set<String>? = null
+        override fun getInt(key: String, defValue: Int): Int = (data[key] as? Number)?.toInt() ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = (data[key] as? Number)?.toLong() ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = (data[key] as? Number)?.toFloat() ?: defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = (data[key] as? Boolean) ?: defValue
+        override fun contains(key: String): Boolean = data.containsKey(key)
+        override fun edit(): android.content.SharedPreferences.Editor = FakeEditor(data)
+        override fun registerOnSharedPreferenceChangeListener(listener: android.content.SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(listener: android.content.SharedPreferences.OnSharedPreferenceChangeListener?) {}
+
+        private class FakeEditor(private val data: MutableMap<String, Any>) : android.content.SharedPreferences.Editor {
+            private val temp = mutableMapOf<String, Any>()
+            private val removals = mutableSetOf<String>()
+            private var clearRequested = false
+
+            override fun putString(key: String, value: String?): android.content.SharedPreferences.Editor {
+                if (value != null) temp[key] = value else removals.add(key)
+                return this
+            }
+            override fun putStringSet(key: String, values: Set<String>?): android.content.SharedPreferences.Editor = this
+            override fun putInt(key: String, value: Int): android.content.SharedPreferences.Editor {
+                temp[key] = value
+                return this
+            }
+            override fun putLong(key: String, value: Long): android.content.SharedPreferences.Editor {
+                temp[key] = value
+                return this
+            }
+            override fun putFloat(key: String, value: Float): android.content.SharedPreferences.Editor {
+                temp[key] = value
+                return this
+            }
+            override fun putBoolean(key: String, value: Boolean): android.content.SharedPreferences.Editor {
+                temp[key] = value
+                return this
+            }
+            override fun remove(key: String): android.content.SharedPreferences.Editor {
+                removals.add(key)
+                return this
+            }
+            override fun clear(): android.content.SharedPreferences.Editor {
+                clearRequested = true
+                return this
+            }
+            override fun commit(): Boolean {
+                apply()
+                return true
+            }
+            override fun apply() {
+                if (clearRequested) data.clear()
+                removals.forEach { data.remove(it) }
+                data.putAll(temp)
+            }
+        }
+    }
 }
 

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		6FC18A5668E49E3CD5E990A8 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB261201C1C656BAAED5283 /* SettingsView.swift */; };
 		7001A102AAC41DA0BAF0EFF8 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F22F6639A59D4B86A959586 /* Constants.swift */; };
 		7015C73934B1CDBCEF48751A /* LSPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D4B3FBC893E4863B95AB9 /* LSPService.swift */; };
+		70CCF0022F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CCF0012F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift */; };
 		76D934F4495402F7B4944BE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8811E90D4B2B5C5C51093A95 /* Assets.xcassets */; };
 		8173B7F0205744685F9E67E6 /* NodeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB0D1D623E0794FC1ED6ED /* NodeService.swift */; };
 		88769D82377C43BCF549A52C /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702A9339F75D1A3A7B5313C7 /* HistoryView.swift */; };
@@ -304,6 +305,7 @@
 		6DDD82B198645873A6F492F2 /* StableChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StableChannel.swift; sourceTree = "<group>"; };
 		6E44DC584AB4E87B5F6A2921 /* BackupPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupPromptView.swift; sourceTree = "<group>"; };
 		702A9339F75D1A3A7B5313C7 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
+		70CCF0012F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChainConfirmationPolicyTests.swift; sourceTree = "<group>"; };
 		786B669FA976C4646AF0D206 /* PriceChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChartView.swift; sourceTree = "<group>"; };
 		7DB261201C1C656BAAED5283 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		7E0FAABBD08BCBF20220C850 /* SendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendView.swift; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				49DAFB3B2FDB6587003BE0EB /* FeeRateServiceTests.swift */,
 				49FEF36C30124CEE0089850F /* MempoolWebSocketServiceTests.swift */,
 				D1A60F120000000000000010 /* NodeStartupFailoverTests.swift */,
+				70CCF0012F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift */,
 				499DBE732FD2DADF003E89F9 /* OnchainTxidResolverTests.swift */,
 				499B40AB2F9D46C70004CB73 /* PendingPushPaymentTests.swift */,
 				490224CB302F90A500DF84AA /* PriceServiceTests.swift */,
@@ -874,6 +877,7 @@
 				49DAFB3C2FDB6587003BE0EB /* FeeRateServiceTests.swift in Sources */,
 				49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */,
 				499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */,
+				70CCF0022F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift in Sources */,
 				1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */,
 				D1A60F120000000000000011 /* NodeStartupFailoverTests.swift in Sources */,
 			);

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -102,12 +102,21 @@ class AppState {
     var isChannelClosing: Bool = false
     var isOpeningChannel: Bool = false
     var isSyncing: Bool = false
+    private enum BalanceCacheKey {
+        static let lightning = "cached_lightning_sats"
+        static let onchain = "cached_onchain_sats"
+        static let spendable = "cached_spendable_onchain_sats"
+        static let pendingAmount = "pending_outbound_onchain_sats"
+        static let pendingIsSendAll = "pending_outbound_is_send_all"
+        static let pendingBaseline = "pending_outbound_baseline_sats"
+    }
+
     var spendableOnchainSats: UInt64 = {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        if let val = ud?.object(forKey: "cached_spendable_onchain_sats") as? Int {
+        if let val = ud?.object(forKey: BalanceCacheKey.spendable) as? Int {
             return UInt64(bitPattern: Int64(val))
         }
-        return UInt64(bitPattern: Int64(ud?.integer(forKey: "cached_onchain_sats") ?? 0))
+        return UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.onchain) ?? 0))
     }()
 
     var pendingSweepBalanceSats: UInt64 = 0
@@ -115,26 +124,19 @@ class AppState {
     // Balance (derived) — initialized from cache for instant display
     var lightningBalanceSats: UInt64 = {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        return UInt64(bitPattern: Int64(ud?.integer(forKey: "cached_lightning_sats") ?? 0))
+        return UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.lightning) ?? 0))
     }()
 
     var onchainBalanceSats: UInt64 = {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        return UInt64(bitPattern: Int64(ud?.integer(forKey: "cached_onchain_sats") ?? 0))
+        return UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.onchain) ?? 0))
     }()
 
     var hasReadyChannel: Bool = false
 
     var pendingOutboundSend: BalanceCalculator.PendingOutboundSend = {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        let amount = UInt64(bitPattern: Int64(ud?.integer(forKey: "pending_outbound_onchain_sats") ?? 0))
-        let isSendAll = ud?.bool(forKey: "pending_outbound_is_send_all") ?? false
-        let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: "pending_outbound_baseline_sats") ?? 0))
-        return BalanceCalculator.PendingOutboundSend(
-            amountSats: amount,
-            isSendAll: isSendAll,
-            baselineOnchainSats: baseline
-        )
+        return AppState.loadCachedPendingOutboundSend(from: ud)
     }()
 
     /// The active LSP configuration managed by `LSPService`.
@@ -153,8 +155,8 @@ class AppState {
         )
     }
 
-    /// Static calculation entry point adhering to Single Responsibility Principle,
-    /// enabling pure functional testing without initializing full AppState graph.
+    /// Static calculation entry point enabling pure functional testing
+    /// without initializing the full AppState graph.
     static func calculateTotalBalance(
         lightning: UInt64,
         onchain: UInt64,
@@ -199,6 +201,43 @@ class AppState {
             rawOnchain: rawOnchain,
             pending: pending
         )
+    }
+
+    static func recordBroadcast(
+        currentPending: BalanceCalculator.PendingOutboundSend,
+        amountSats: UInt64,
+        isSendAll: Bool,
+        currentOnchain: UInt64
+    ) -> BalanceCalculator.PendingOutboundSend {
+        BalanceCalculator.recordBroadcast(
+            currentPending: currentPending,
+            amountSats: amountSats,
+            isSendAll: isSendAll,
+            currentOnchain: currentOnchain
+        )
+    }
+
+    static func loadCachedPendingOutboundSend(from ud: UserDefaults?) -> BalanceCalculator.PendingOutboundSend {
+        let amount = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingAmount) ?? 0))
+        let isSendAll = ud?.bool(forKey: BalanceCacheKey.pendingIsSendAll) ?? false
+        let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingBaseline) ?? 0))
+        return BalanceCalculator.PendingOutboundSend(
+            amountSats: amount,
+            isSendAll: isSendAll,
+            baselineOnchainSats: baseline
+        )
+    }
+
+    private func persistPendingOutboundSend(to ud: UserDefaults?) {
+        ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: BalanceCacheKey.pendingAmount)
+        ud?.set(pendingOutboundSend.isSendAll, forKey: BalanceCacheKey.pendingIsSendAll)
+        ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: BalanceCacheKey.pendingBaseline)
+    }
+
+    private func clearPendingOutboundSendCache(from ud: UserDefaults?) {
+        ud?.removeObject(forKey: BalanceCacheKey.pendingAmount)
+        ud?.removeObject(forKey: BalanceCacheKey.pendingIsSendAll)
+        ud?.removeObject(forKey: BalanceCacheKey.pendingBaseline)
     }
 
     var totalBalanceUSD: Double {
@@ -503,7 +542,7 @@ class AppState {
         }
     }
 
-    private func resetInMemoryWalletState() {
+    func resetInMemoryWalletState() {
         stableChannel = .default
         statusMessage = ""
         paymentFlash = false
@@ -523,6 +562,7 @@ class AppState {
         hasReadyChannel = false
         spendableOnchainSats = 0
         pendingSweepBalanceSats = 0
+        pendingOutboundSend = BalanceCalculator.PendingOutboundSend()
         transactionLinkService.onchainReceiveAddress = nil
         transactionLinkService.clearCloseTxid()
         transactionLinkService.clearReceiveTxid()
@@ -532,9 +572,10 @@ class AppState {
         let shared = UserDefaults(suiteName: Constants.appGroupIdentifier)
         shared?.removeObject(forKey: "funding_txid")
         shared?.removeObject(forKey: "node_id")
-        shared?.set(Int64(0), forKey: "cached_lightning_sats")
-        shared?.set(Int64(0), forKey: "cached_onchain_sats")
-        shared?.set(Int64(0), forKey: "cached_spendable_onchain_sats")
+        shared?.set(Int64(0), forKey: BalanceCacheKey.lightning)
+        shared?.set(Int64(0), forKey: BalanceCacheKey.onchain)
+        shared?.set(Int64(0), forKey: BalanceCacheKey.spendable)
+        clearPendingOutboundSendCache(from: shared)
         shared?.set(false, forKey: "pending_push_payment")
     }
 
@@ -3010,12 +3051,10 @@ class AppState {
 
         // Cache for instant display on next launch
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        ud?.set(Int64(bitPattern: lightning), forKey: "cached_lightning_sats")
-        ud?.set(Int64(bitPattern: onchain), forKey: "cached_onchain_sats")
-        ud?.set(Int64(bitPattern: spendable), forKey: "cached_spendable_onchain_sats")
-        ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: "pending_outbound_onchain_sats")
-        ud?.set(pendingOutboundSend.isSendAll, forKey: "pending_outbound_is_send_all")
-        ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: "pending_outbound_baseline_sats")
+        ud?.set(Int64(bitPattern: lightning), forKey: BalanceCacheKey.lightning)
+        ud?.set(Int64(bitPattern: onchain), forKey: BalanceCacheKey.onchain)
+        ud?.set(Int64(bitPattern: spendable), forKey: BalanceCacheKey.spendable)
+        persistPendingOutboundSend(to: ud)
     }
 
     /// Deducts sent on-chain amount immediately from cached and in-memory balances
@@ -3024,20 +3063,12 @@ class AppState {
         let currentOnchain = onchainBalanceSats
         let currentSpendable = spendableOnchainSats
 
-        if isSendAll {
-            pendingOutboundSend = BalanceCalculator.PendingOutboundSend(
-                amountSats: currentOnchain,
-                isSendAll: true,
-                baselineOnchainSats: currentOnchain
-            )
-        } else {
-            pendingOutboundSend = BalanceCalculator.PendingOutboundSend(
-                amountSats: pendingOutboundSend.amountSats + amountSats,
-                isSendAll: false,
-                baselineOnchainSats: pendingOutboundSend.baselineOnchainSats == 0 ? currentOnchain : pendingOutboundSend
-                    .baselineOnchainSats
-            )
-        }
+        pendingOutboundSend = BalanceCalculator.recordBroadcast(
+            currentPending: pendingOutboundSend,
+            amountSats: amountSats,
+            isSendAll: isSendAll,
+            currentOnchain: currentOnchain
+        )
 
         let effective = BalanceCalculator.calculateEffectiveBalances(
             rawOnchain: currentOnchain,
@@ -3048,11 +3079,9 @@ class AppState {
         spendableOnchainSats = effective.spendable
 
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
-        ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: "cached_onchain_sats")
-        ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
-        ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: "pending_outbound_onchain_sats")
-        ud?.set(pendingOutboundSend.isSendAll, forKey: "pending_outbound_is_send_all")
-        ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: "pending_outbound_baseline_sats")
+        ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: BalanceCacheKey.onchain)
+        ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: BalanceCacheKey.spendable)
+        persistPendingOutboundSend(to: ud)
 
         syncWalletsInBackground()
     }

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -102,7 +102,15 @@ class AppState {
     var isChannelClosing: Bool = false
     var isOpeningChannel: Bool = false
     var isSyncing: Bool = false
-    var spendableOnchainSats: UInt64 = 0
+    var spendableOnchainSats: UInt64 = {
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        if let val = ud?.object(forKey: "cached_spendable_onchain_sats") as? Int {
+            return UInt64(bitPattern: Int64(val))
+        }
+        return UInt64(bitPattern: Int64(ud?.integer(forKey: "cached_onchain_sats") ?? 0))
+    }()
+
+    var pendingSweepBalanceSats: UInt64 = 0
 
     // Balance (derived) — initialized from cache for instant display
     var lightningBalanceSats: UInt64 = {
@@ -130,10 +138,10 @@ class AppState {
         if isSweeping {
             return lightningBalanceSats
         }
-        // If no open channels but both balances exist, lightning balance is
-        // pending-close claimable that overlaps with on-chain — avoid double-count.
-        if !hasReadyChannel && lightningBalanceSats > 0 && onchainBalanceSats > 0 {
-            return onchainBalanceSats
+        // If no ready channel, lightning balance contains stale claimables from
+        // closed channels — never count it, even when onchainBalanceSats reaches 0 (Issue #260).
+        if !hasReadyChannel {
+            return onchainBalanceSats + pendingSweepBalanceSats
         }
         return lightningBalanceSats + onchainBalanceSats
     }
@@ -268,7 +276,15 @@ class AppState {
         }
         confirmationPollingService = pollingService
         pollingService?.onUpdate = { [weak self] in
-            self?.confirmationUpdateEpoch += 1
+            guard let self else { return }
+            self.confirmationUpdateEpoch += 1
+            self.refreshBalances()
+            Task.detached { [weak self] in
+                try? self?.nodeService.syncWallets()
+                await MainActor.run {
+                    self?.refreshBalances()
+                }
+            }
         }
         if let db = databaseService, let polling = pollingService {
             let spvService = SPVHeaderChainService(
@@ -456,6 +472,7 @@ class AppState {
         onchainBalanceSats = 0
         hasReadyChannel = false
         spendableOnchainSats = 0
+        pendingSweepBalanceSats = 0
         transactionLinkService.onchainReceiveAddress = nil
         transactionLinkService.clearCloseTxid()
         transactionLinkService.clearReceiveTxid()
@@ -467,6 +484,7 @@ class AppState {
         shared?.removeObject(forKey: "node_id")
         shared?.set(Int64(0), forKey: "cached_lightning_sats")
         shared?.set(Int64(0), forKey: "cached_onchain_sats")
+        shared?.set(Int64(0), forKey: "cached_spendable_onchain_sats")
         shared?.set(false, forKey: "pending_push_payment")
     }
 
@@ -2900,6 +2918,22 @@ class AppState {
         let onchain = balances.totalOnchainBalanceSats
         let lightning = balances.totalLightningBalanceSats
 
+        // Pending sweep: count PendingBroadcast and BroadcastAwaitingConfirmation
+        // These funds are NOT yet in total_onchain_balance_sats
+        // (Desktop src/user.rs lines 5989-6002 parity)
+        var sweepSats: UInt64 = 0
+        for pending in balances.pendingBalancesFromChannelClosures {
+            switch pending {
+            case let .pendingBroadcast(_, amountSatoshis):
+                sweepSats += amountSatoshis
+            case let .broadcastAwaitingConfirmation(_, _, _, amountSatoshis):
+                sweepSats += amountSatoshis
+            default:
+                break
+            }
+        }
+        pendingSweepBalanceSats = sweepSats
+
         lightningBalanceSats = lightning
         onchainBalanceSats = onchain
         hasReadyChannel = nodeService.channels.contains { $0.isChannelReady }
@@ -2914,6 +2948,30 @@ class AppState {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
         ud?.set(Int64(bitPattern: lightning), forKey: "cached_lightning_sats")
         ud?.set(Int64(bitPattern: onchain), forKey: "cached_onchain_sats")
+        ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
+    }
+
+    /// Deducts sent on-chain amount immediately from cached and in-memory balances
+    /// so the UI updates with zero lag, then triggers wallet sync in the background.
+    func onchainSendBroadcasted(amountSats: UInt64, isSendAll: Bool) {
+        if isSendAll {
+            onchainBalanceSats = 0
+            spendableOnchainSats = 0
+        } else {
+            onchainBalanceSats = onchainBalanceSats >= amountSats ? onchainBalanceSats - amountSats : 0
+            spendableOnchainSats = spendableOnchainSats >= amountSats ? spendableOnchainSats - amountSats : 0
+        }
+
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: "cached_onchain_sats")
+        ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
+
+        Task.detached { [weak self] in
+            try? self?.nodeService.syncWallets()
+            await MainActor.run {
+                self?.refreshBalances()
+            }
+        }
     }
 
     /// Update the StableChannel struct from current LDK channel data + price.

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -129,21 +129,42 @@ class AppState {
     var activeLSP: LSPConfig { lspService.activeLSP }
 
     var totalBalanceSats: UInt64 {
-        if isChannelClosing {
-            return onchainBalanceSats
-        }
-        if isOpeningChannel {
-            return lightningBalanceSats > 0 ? lightningBalanceSats : onchainBalanceSats
-        }
-        if isSweeping {
-            return lightningBalanceSats
-        }
-        // If no ready channel, lightning balance contains stale claimables from
-        // closed channels — never count it, even when onchainBalanceSats reaches 0 (Issue #260).
-        if !hasReadyChannel {
-            return onchainBalanceSats + pendingSweepBalanceSats
-        }
-        return lightningBalanceSats + onchainBalanceSats
+        AppState.calculateTotalBalance(
+            lightning: lightningBalanceSats,
+            onchain: onchainBalanceSats,
+            hasReadyChannel: hasReadyChannel,
+            hasAnyChannel: !nodeService.channels.isEmpty,
+            isChannelClosing: isChannelClosing,
+            isOpeningChannel: isOpeningChannel,
+            isSweeping: isSweeping,
+            pendingSweep: pendingSweepBalanceSats
+        )
+    }
+
+    /// Static calculation entry point adhering to Single Responsibility Principle,
+    /// enabling pure functional testing without initializing full AppState graph.
+    static func calculateTotalBalance(
+        lightning: UInt64,
+        onchain: UInt64,
+        hasReadyChannel: Bool,
+        hasAnyChannel: Bool = false,
+        isChannelClosing: Bool = false,
+        isOpeningChannel: Bool = false,
+        isSweeping: Bool = false,
+        pendingSweep: UInt64 = 0
+    ) -> UInt64 {
+        BalanceCalculator.calculateTotalBalance(
+            lightning: lightning,
+            onchain: onchain,
+            pendingSweep: pendingSweep,
+            channelState: BalanceCalculator.ChannelState(
+                hasReadyChannel: hasReadyChannel,
+                hasAnyChannel: hasAnyChannel,
+                isChannelClosing: isChannelClosing,
+                isOpeningChannel: isOpeningChannel,
+                isSweeping: isSweeping
+            )
+        )
     }
 
     var totalBalanceUSD: Double {
@@ -279,8 +300,9 @@ class AppState {
             guard let self else { return }
             self.confirmationUpdateEpoch += 1
             self.refreshBalances()
+            let nodeService = self.nodeService
             Task.detached { [weak self] in
-                try? self?.nodeService.syncWallets()
+                try? nodeService.syncWallets()
                 await MainActor.run {
                     self?.refreshBalances()
                 }
@@ -2966,8 +2988,9 @@ class AppState {
         ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: "cached_onchain_sats")
         ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
 
+        let nodeService = self.nodeService
         Task.detached { [weak self] in
-            try? self?.nodeService.syncWallets()
+            try? nodeService.syncWallets()
             await MainActor.run {
                 self?.refreshBalances()
             }

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -109,6 +109,7 @@ class AppState {
         static let pendingAmount = "pending_outbound_onchain_sats"
         static let pendingIsSendAll = "pending_outbound_is_send_all"
         static let pendingBaseline = "pending_outbound_baseline_sats"
+        static let pendingTimestamp = "pending_outbound_timestamp_secs"
     }
 
     var spendableOnchainSats: UInt64 = {
@@ -221,10 +222,12 @@ class AppState {
         let amount = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingAmount) ?? 0))
         let isSendAll = ud?.bool(forKey: BalanceCacheKey.pendingIsSendAll) ?? false
         let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingBaseline) ?? 0))
+        let timestamp = Int64(ud?.integer(forKey: BalanceCacheKey.pendingTimestamp) ?? 0)
         return BalanceCalculator.PendingOutboundSend(
             amountSats: amount,
             isSendAll: isSendAll,
-            baselineOnchainSats: baseline
+            baselineOnchainSats: baseline,
+            timestampSecs: timestamp
         )
     }
 
@@ -232,12 +235,14 @@ class AppState {
         ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: BalanceCacheKey.pendingAmount)
         ud?.set(pendingOutboundSend.isSendAll, forKey: BalanceCacheKey.pendingIsSendAll)
         ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: BalanceCacheKey.pendingBaseline)
+        ud?.set(pendingOutboundSend.timestampSecs, forKey: BalanceCacheKey.pendingTimestamp)
     }
 
     private func clearPendingOutboundSendCache(from ud: UserDefaults?) {
         ud?.removeObject(forKey: BalanceCacheKey.pendingAmount)
         ud?.removeObject(forKey: BalanceCacheKey.pendingIsSendAll)
         ud?.removeObject(forKey: BalanceCacheKey.pendingBaseline)
+        ud?.removeObject(forKey: BalanceCacheKey.pendingTimestamp)
     }
 
     var totalBalanceUSD: Double {
@@ -3063,20 +3068,22 @@ class AppState {
         let currentOnchain = onchainBalanceSats
         let currentSpendable = spendableOnchainSats
 
+        // Immediately update UI balances with exact incremental deduction,
+        // avoiding compounded subtraction if multiple sends occur before sync finishes.
+        if isSendAll {
+            onchainBalanceSats = 0
+            spendableOnchainSats = 0
+        } else {
+            onchainBalanceSats = currentOnchain >= amountSats ? currentOnchain - amountSats : 0
+            spendableOnchainSats = currentSpendable >= amountSats ? currentSpendable - amountSats : 0
+        }
+
         pendingOutboundSend = BalanceCalculator.recordBroadcast(
             currentPending: pendingOutboundSend,
             amountSats: amountSats,
             isSendAll: isSendAll,
             currentOnchain: currentOnchain
         )
-
-        let effective = BalanceCalculator.calculateEffectiveBalances(
-            rawOnchain: currentOnchain,
-            rawSpendable: currentSpendable,
-            pending: pendingOutboundSend
-        )
-        onchainBalanceSats = effective.onchain
-        spendableOnchainSats = effective.spendable
 
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
         ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: BalanceCacheKey.onchain)
@@ -3089,11 +3096,14 @@ class AppState {
     /// Synchronizes wallets off the main actor and refreshes balances upon completion.
     private func syncWalletsInBackground() {
         let nodeService = self.nodeService
-        Task { [weak self] in
-            await Task.detached(priority: .utility) {
-                try? nodeService.syncWallets()
-            }.value
-            self?.refreshBalances()
+        Task.detached(priority: .utility) { [weak self] in
+            let syncSuccess = (try? nodeService.syncWallets()) != nil
+            await MainActor.run {
+                if syncSuccess {
+                    self?.pendingOutboundSend = BalanceCalculator.PendingOutboundSend(timestampSecs: 0)
+                }
+                self?.refreshBalances()
+            }
         }
     }
 

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -125,6 +125,18 @@ class AppState {
 
     var hasReadyChannel: Bool = false
 
+    var pendingOutboundSend: BalanceCalculator.PendingOutboundSend = {
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        let amount = UInt64(bitPattern: Int64(ud?.integer(forKey: "pending_outbound_onchain_sats") ?? 0))
+        let isSendAll = ud?.bool(forKey: "pending_outbound_is_send_all") ?? false
+        let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: "pending_outbound_baseline_sats") ?? 0))
+        return BalanceCalculator.PendingOutboundSend(
+            amountSats: amount,
+            isSendAll: isSendAll,
+            baselineOnchainSats: baseline
+        )
+    }()
+
     /// The active LSP configuration managed by `LSPService`.
     var activeLSP: LSPConfig { lspService.activeLSP }
 
@@ -164,6 +176,28 @@ class AppState {
                 isOpeningChannel: isOpeningChannel,
                 isSweeping: isSweeping
             )
+        )
+    }
+
+    static func calculateEffectiveBalances(
+        rawOnchain: UInt64,
+        rawSpendable: UInt64,
+        pending: BalanceCalculator.PendingOutboundSend
+    ) -> (onchain: UInt64, spendable: UInt64) {
+        BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: rawOnchain,
+            rawSpendable: rawSpendable,
+            pending: pending
+        )
+    }
+
+    static func resolvePendingOutboundSend(
+        rawOnchain: UInt64,
+        pending: BalanceCalculator.PendingOutboundSend
+    ) -> BalanceCalculator.PendingOutboundSend {
+        BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: rawOnchain,
+            pending: pending
         )
     }
 
@@ -300,13 +334,7 @@ class AppState {
             guard let self else { return }
             self.confirmationUpdateEpoch += 1
             self.refreshBalances()
-            let nodeService = self.nodeService
-            Task.detached { [weak self] in
-                try? nodeService.syncWallets()
-                await MainActor.run {
-                    self?.refreshBalances()
-                }
-            }
+            self.syncWalletsInBackground()
         }
         if let db = databaseService, let polling = pollingService {
             let spvService = SPVHeaderChainService(
@@ -2937,8 +2965,22 @@ class AppState {
     func refreshBalances() {
         nodeService.refreshChannels()
         guard let balances = nodeService.balances() else { return }
-        let onchain = balances.totalOnchainBalanceSats
+        let rawOnchain = balances.totalOnchainBalanceSats
+        let rawSpendable = balances.spendableOnchainBalanceSats
         let lightning = balances.totalLightningBalanceSats
+
+        // Resolve pending outbound deduction against raw wallet observation
+        pendingOutboundSend = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: rawOnchain,
+            pending: pendingOutboundSend
+        )
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: rawOnchain,
+            rawSpendable: rawSpendable,
+            pending: pendingOutboundSend
+        )
+        let onchain = effective.onchain
+        let spendable = effective.spendable
 
         // Pending sweep: count PendingBroadcast and BroadcastAwaitingConfirmation
         // These funds are NOT yet in total_onchain_balance_sats
@@ -2959,7 +3001,7 @@ class AppState {
         lightningBalanceSats = lightning
         onchainBalanceSats = onchain
         hasReadyChannel = nodeService.channels.contains { $0.isChannelReady }
-        spendableOnchainSats = balances.spendableOnchainBalanceSats
+        spendableOnchainSats = spendable
 
         // Clear closing flag once lightning balance fully resolves
         if isChannelClosing && lightning == 0 {
@@ -2970,30 +3012,59 @@ class AppState {
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
         ud?.set(Int64(bitPattern: lightning), forKey: "cached_lightning_sats")
         ud?.set(Int64(bitPattern: onchain), forKey: "cached_onchain_sats")
-        ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
+        ud?.set(Int64(bitPattern: spendable), forKey: "cached_spendable_onchain_sats")
+        ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: "pending_outbound_onchain_sats")
+        ud?.set(pendingOutboundSend.isSendAll, forKey: "pending_outbound_is_send_all")
+        ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: "pending_outbound_baseline_sats")
     }
 
     /// Deducts sent on-chain amount immediately from cached and in-memory balances
     /// so the UI updates with zero lag, then triggers wallet sync in the background.
     func onchainSendBroadcasted(amountSats: UInt64, isSendAll: Bool) {
+        let currentOnchain = onchainBalanceSats
+        let currentSpendable = spendableOnchainSats
+
         if isSendAll {
-            onchainBalanceSats = 0
-            spendableOnchainSats = 0
+            pendingOutboundSend = BalanceCalculator.PendingOutboundSend(
+                amountSats: currentOnchain,
+                isSendAll: true,
+                baselineOnchainSats: currentOnchain
+            )
         } else {
-            onchainBalanceSats = onchainBalanceSats >= amountSats ? onchainBalanceSats - amountSats : 0
-            spendableOnchainSats = spendableOnchainSats >= amountSats ? spendableOnchainSats - amountSats : 0
+            pendingOutboundSend = BalanceCalculator.PendingOutboundSend(
+                amountSats: pendingOutboundSend.amountSats + amountSats,
+                isSendAll: false,
+                baselineOnchainSats: pendingOutboundSend.baselineOnchainSats == 0 ? currentOnchain : pendingOutboundSend
+                    .baselineOnchainSats
+            )
         }
+
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: currentOnchain,
+            rawSpendable: currentSpendable,
+            pending: pendingOutboundSend
+        )
+        onchainBalanceSats = effective.onchain
+        spendableOnchainSats = effective.spendable
 
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
         ud?.set(Int64(bitPattern: onchainBalanceSats), forKey: "cached_onchain_sats")
         ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: "cached_spendable_onchain_sats")
+        ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: "pending_outbound_onchain_sats")
+        ud?.set(pendingOutboundSend.isSendAll, forKey: "pending_outbound_is_send_all")
+        ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: "pending_outbound_baseline_sats")
 
+        syncWalletsInBackground()
+    }
+
+    /// Synchronizes wallets off the main actor and refreshes balances upon completion.
+    private func syncWalletsInBackground() {
         let nodeService = self.nodeService
-        Task.detached { [weak self] in
-            try? nodeService.syncWallets()
-            await MainActor.run {
-                self?.refreshBalances()
-            }
+        Task { [weak self] in
+            await Task.detached(priority: .utility) {
+                try? nodeService.syncWallets()
+            }.value
+            self?.refreshBalances()
         }
     }
 

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -3066,24 +3066,30 @@ class AppState {
         // Invariant note: ldk-node creates Onchain payment rows strictly from wallet events
         // (TxUnconfirmed/TxConfirmed) diffing the wallet's tx graph, ensuring raw balances
         // already incorporate the spend when .pending is reached.
-        let incorporatedPredicate: (String) -> Bool = { [weak self] tid in
-            guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
-            return payments.contains { p in
-                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid {
-                    if case .succeeded = p.status { return true }
-                    if case .pending = p.status { return true }
+        var paymentStatusMap: [String: PaymentStatus]?
+        let getPaymentStatus: (String) -> PaymentStatus? = { [weak self] tid in
+            if paymentStatusMap == nil {
+                guard let self, let payments = self.nodeService.node?.listPayments() else { return nil }
+                var map: [String: PaymentStatus] = [:]
+                for p in payments {
+                    if case let .onchain(paymentTxid, _) = p.kind {
+                        map[paymentTxid] = p.status
+                    }
                 }
-                return false
+                paymentStatusMap = map
             }
+            return paymentStatusMap?[tid]
         }
-        let failedPredicate: (String) -> Bool = { [weak self] tid in
-            guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
-            return payments.contains { p in
-                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid, case .failed = p.status {
-                    return true
-                }
-                return false
-            }
+        let incorporatedPredicate: (String) -> Bool = { tid in
+            guard let status = getPaymentStatus(tid) else { return false }
+            if case .succeeded = status { return true }
+            if case .pending = status { return true }
+            return false
+        }
+        let failedPredicate: (String) -> Bool = { tid in
+            guard let status = getPaymentStatus(tid) else { return false }
+            if case .failed = status { return true }
+            return false
         }
         pendingOutboundSend = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: rawOnchain,

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -140,6 +140,8 @@ class AppState {
         return AppState.loadCachedPendingOutboundSend(from: ud)
     }()
 
+    private var sendGeneration: Int64 = 0
+
     /// The active LSP configuration managed by `LSPService`.
     var activeLSP: LSPConfig { lspService.activeLSP }
 
@@ -567,6 +569,7 @@ class AppState {
         hasReadyChannel = false
         spendableOnchainSats = 0
         pendingSweepBalanceSats = 0
+        sendGeneration += 1
         pendingOutboundSend = BalanceCalculator.PendingOutboundSend()
         transactionLinkService.onchainReceiveAddress = nil
         transactionLinkService.clearCloseTxid()
@@ -3090,17 +3093,21 @@ class AppState {
         ud?.set(Int64(bitPattern: spendableOnchainSats), forKey: BalanceCacheKey.spendable)
         persistPendingOutboundSend(to: ud)
 
-        syncWalletsInBackground()
+        sendGeneration += 1
+        let currentGen = sendGeneration
+        syncWalletsInBackground(expectedGeneration: currentGen)
     }
 
     /// Synchronizes wallets off the main actor and refreshes balances upon completion.
-    private func syncWalletsInBackground() {
+    /// If expectedGeneration is provided, the pending outbound send is only cleared if
+    /// no subsequent sends have been broadcast while the sync was in-flight.
+    private func syncWalletsInBackground(expectedGeneration: Int64? = nil) {
         let nodeService = self.nodeService
         Task { @MainActor in
             let syncSuccess = await Task.detached(priority: .utility) {
                 (try? nodeService.syncWallets()) != nil
             }.value
-            if syncSuccess {
+            if syncSuccess, let expected = expectedGeneration, expected == self.sendGeneration {
                 self.pendingOutboundSend = BalanceCalculator.PendingOutboundSend(timestampSecs: 0)
             }
             self.refreshBalances()

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -110,6 +110,7 @@ class AppState {
         static let pendingIsSendAll = "pending_outbound_is_send_all"
         static let pendingBaseline = "pending_outbound_baseline_sats"
         static let pendingTimestamp = "pending_outbound_timestamp_secs"
+        static let pendingTxids = "pending_outbound_txids"
     }
 
     var spendableOnchainSats: UInt64 = {
@@ -225,11 +226,14 @@ class AppState {
         let isSendAll = ud?.bool(forKey: BalanceCacheKey.pendingIsSendAll) ?? false
         let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingBaseline) ?? 0))
         let timestamp = Int64(ud?.integer(forKey: BalanceCacheKey.pendingTimestamp) ?? 0)
+        let txidsStr = ud?.string(forKey: BalanceCacheKey.pendingTxids) ?? ""
+        let txids = txidsStr.split(separator: ",").map(String.init).filter { !$0.isEmpty }
         return BalanceCalculator.PendingOutboundSend(
             amountSats: amount,
             isSendAll: isSendAll,
             baselineOnchainSats: baseline,
-            timestampSecs: timestamp
+            timestampSecs: timestamp,
+            txids: txids
         )
     }
 
@@ -238,6 +242,7 @@ class AppState {
         ud?.set(pendingOutboundSend.isSendAll, forKey: BalanceCacheKey.pendingIsSendAll)
         ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: BalanceCacheKey.pendingBaseline)
         ud?.set(pendingOutboundSend.timestampSecs, forKey: BalanceCacheKey.pendingTimestamp)
+        ud?.set(pendingOutboundSend.txids.joined(separator: ","), forKey: BalanceCacheKey.pendingTxids)
     }
 
     private func clearPendingOutboundSendCache(from ud: UserDefaults?) {
@@ -245,6 +250,7 @@ class AppState {
         ud?.removeObject(forKey: BalanceCacheKey.pendingIsSendAll)
         ud?.removeObject(forKey: BalanceCacheKey.pendingBaseline)
         ud?.removeObject(forKey: BalanceCacheKey.pendingTimestamp)
+        ud?.removeObject(forKey: BalanceCacheKey.pendingTxids)
     }
 
     var totalBalanceUSD: Double {
@@ -3019,9 +3025,29 @@ class AppState {
         let lightning = balances.totalLightningBalanceSats
 
         // Resolve pending outbound deduction against raw wallet observation
+        let confirmedPredicate: (String) -> Bool = { [weak self] tid in
+            guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
+            return payments.contains { p in
+                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid, case .succeeded = p.status {
+                    return true
+                }
+                return false
+            }
+        }
+        let failedPredicate: (String) -> Bool = { [weak self] tid in
+            guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
+            return payments.contains { p in
+                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid, case .failed = p.status {
+                    return true
+                }
+                return false
+            }
+        }
         pendingOutboundSend = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: rawOnchain,
-            pending: pendingOutboundSend
+            pending: pendingOutboundSend,
+            isTxConfirmed: confirmedPredicate,
+            isTxFailed: failedPredicate
         )
         let effective = BalanceCalculator.calculateEffectiveBalances(
             rawOnchain: rawOnchain,
@@ -3067,7 +3093,7 @@ class AppState {
 
     /// Deducts sent on-chain amount immediately from cached and in-memory balances
     /// so the UI updates with zero lag, then triggers wallet sync in the background.
-    func onchainSendBroadcasted(amountSats: UInt64, isSendAll: Bool) {
+    func onchainSendBroadcasted(amountSats: UInt64, isSendAll: Bool, txid: String? = nil) {
         let currentOnchain = onchainBalanceSats
         let currentSpendable = spendableOnchainSats
 
@@ -3085,7 +3111,8 @@ class AppState {
             currentPending: pendingOutboundSend,
             amountSats: amountSats,
             isSendAll: isSendAll,
-            currentOnchain: currentOnchain
+            currentOnchain: currentOnchain,
+            txid: txid
         )
 
         let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
@@ -3104,10 +3131,22 @@ class AppState {
     private func syncWalletsInBackground(expectedGeneration: Int64? = nil) {
         let nodeService = self.nodeService
         Task { @MainActor in
-            let syncSuccess = await Task.detached(priority: .utility) {
-                (try? nodeService.syncWallets()) != nil
-            }.value
-            if syncSuccess, let expected = expectedGeneration, expected == self.sendGeneration {
+            var syncSuccess = false
+            for attempt in 0 ..< 3 {
+                let success = await Task.detached(priority: .utility) {
+                    (try? nodeService.syncWallets()) != nil
+                }.value
+                if success {
+                    syncSuccess = true
+                    break
+                }
+                try? await Task.sleep(nanoseconds: UInt64(500_000_000 * (attempt + 1)))
+            }
+            if let expected = expectedGeneration, BalanceCalculator.shouldClearPendingOnSyncCompletion(
+                expectedGeneration: expected,
+                currentGeneration: self.sendGeneration,
+                syncSuccess: syncSuccess
+            ) {
                 self.pendingOutboundSend = BalanceCalculator.PendingOutboundSend(timestampSecs: 0)
             }
             self.refreshBalances()

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -3096,14 +3096,14 @@ class AppState {
     /// Synchronizes wallets off the main actor and refreshes balances upon completion.
     private func syncWalletsInBackground() {
         let nodeService = self.nodeService
-        Task.detached(priority: .utility) { [weak self] in
-            let syncSuccess = (try? nodeService.syncWallets()) != nil
-            await MainActor.run {
-                if syncSuccess {
-                    self?.pendingOutboundSend = BalanceCalculator.PendingOutboundSend(timestampSecs: 0)
-                }
-                self?.refreshBalances()
+        Task { @MainActor in
+            let syncSuccess = await Task.detached(priority: .utility) {
+                (try? nodeService.syncWallets()) != nil
+            }.value
+            if syncSuccess {
+                self.pendingOutboundSend = BalanceCalculator.PendingOutboundSend(timestampSecs: 0)
             }
+            self.refreshBalances()
         }
     }
 

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -3063,6 +3063,9 @@ class AppState {
         // the wallet's raw balance already reflects the spend. Any positive balance delta
         // is a genuine incoming deposit, not a masked deduction. This fixes the relaunch+deposit
         // scenario where the old "succeeded-only" check left funds stuck until 6 confirmations.
+        // Invariant note: ldk-node creates Onchain payment rows strictly from wallet events
+        // (TxUnconfirmed/TxConfirmed) diffing the wallet's tx graph, ensuring raw balances
+        // already incorporate the spend when .pending is reached.
         let incorporatedPredicate: (String) -> Bool = { [weak self] tid in
             guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
             return payments.contains { p in

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -227,22 +227,56 @@ class AppState {
         let baseline = UInt64(bitPattern: Int64(ud?.integer(forKey: BalanceCacheKey.pendingBaseline) ?? 0))
         let timestamp = Int64(ud?.integer(forKey: BalanceCacheKey.pendingTimestamp) ?? 0)
         let txidsStr = ud?.string(forKey: BalanceCacheKey.pendingTxids) ?? ""
-        let txids = txidsStr.split(separator: ",").map(String.init).filter { !$0.isEmpty }
+
+        // If no pending amount was cached and it is not send-all, no send is pending.
+        guard amount > 0 || isSendAll else {
+            return BalanceCalculator.PendingOutboundSend()
+        }
+
+        // Parse per-txid entries. New format: "txid1:amount1,txid2:amount2".
+        // Legacy format: "txid1,txid2" (no colons). Backward compat: fall back to
+        // distributing the stored aggregate amount across legacy txids.
+        let parts = txidsStr.split(separator: ",").map(String.init).filter { !$0.isEmpty }
+        let hasEntryFormat = parts.contains { $0.contains(":") }
+
+        var entries: [BalanceCalculator.TxEntry] = []
+        if hasEntryFormat {
+            for part in parts {
+                let components = part.split(separator: ":", maxSplits: 1).map(String.init)
+                guard components.count == 2, let amt = UInt64(components[1]) else { continue }
+                entries.append(BalanceCalculator.TxEntry(txid: components[0], amountSats: amt))
+            }
+        } else {
+            // Legacy path: distribute stored aggregate across txids.
+            if !parts.isEmpty, amount > 0 {
+                let perTx = amount / UInt64(parts.count)
+                let remainder = amount % UInt64(parts.count)
+                entries = parts.enumerated().map { i, tid in
+                    BalanceCalculator.TxEntry(txid: tid, amountSats: perTx + (UInt64(i) < remainder ? 1 : 0))
+                }
+            } else if amount > 0 {
+                entries = [BalanceCalculator.TxEntry(txid: "", amountSats: amount)]
+            }
+        }
+
         return BalanceCalculator.PendingOutboundSend(
-            amountSats: amount,
             isSendAll: isSendAll,
             baselineOnchainSats: baseline,
             timestampSecs: timestamp,
-            txids: txids
+            entries: entries
         )
     }
 
     private func persistPendingOutboundSend(to ud: UserDefaults?) {
+        // Persist per-txid entries as "txid1:amount1,txid2:amount2".
+        let entriesStr = pendingOutboundSend.entries
+            .map { "\($0.txid):\($0.amountSats)" }
+            .joined(separator: ",")
         ud?.set(Int64(bitPattern: pendingOutboundSend.amountSats), forKey: BalanceCacheKey.pendingAmount)
         ud?.set(pendingOutboundSend.isSendAll, forKey: BalanceCacheKey.pendingIsSendAll)
         ud?.set(Int64(bitPattern: pendingOutboundSend.baselineOnchainSats), forKey: BalanceCacheKey.pendingBaseline)
         ud?.set(pendingOutboundSend.timestampSecs, forKey: BalanceCacheKey.pendingTimestamp)
-        ud?.set(pendingOutboundSend.txids.joined(separator: ","), forKey: BalanceCacheKey.pendingTxids)
+        ud?.set(entriesStr, forKey: BalanceCacheKey.pendingTxids)
     }
 
     private func clearPendingOutboundSendCache(from ud: UserDefaults?) {
@@ -3025,11 +3059,16 @@ class AppState {
         let lightning = balances.totalLightningBalanceSats
 
         // Resolve pending outbound deduction against raw wallet observation
-        let confirmedPredicate: (String) -> Bool = { [weak self] tid in
+        // Wallet-incorporation predicate: once LDK tracks the txid (pending or succeeded),
+        // the wallet's raw balance already reflects the spend. Any positive balance delta
+        // is a genuine incoming deposit, not a masked deduction. This fixes the relaunch+deposit
+        // scenario where the old "succeeded-only" check left funds stuck until 6 confirmations.
+        let incorporatedPredicate: (String) -> Bool = { [weak self] tid in
             guard let self, let payments = self.nodeService.node?.listPayments() else { return false }
             return payments.contains { p in
-                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid, case .succeeded = p.status {
-                    return true
+                if case let .onchain(paymentTxid, _) = p.kind, paymentTxid == tid {
+                    if case .succeeded = p.status { return true }
+                    if case .pending = p.status { return true }
                 }
                 return false
             }
@@ -3046,7 +3085,7 @@ class AppState {
         pendingOutboundSend = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: rawOnchain,
             pending: pendingOutboundSend,
-            isTxConfirmed: confirmedPredicate,
+            isTxIncorporated: incorporatedPredicate,
             isTxFailed: failedPredicate
         )
         let effective = BalanceCalculator.calculateEffectiveBalances(

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -98,4 +98,59 @@ enum BalanceCalculator {
         }
         return lightning + onchain
     }
+
+    struct PendingOutboundSend: Equatable, Sendable {
+        var amountSats: UInt64
+        var isSendAll: Bool
+        var baselineOnchainSats: UInt64
+
+        init(amountSats: UInt64 = 0, isSendAll: Bool = false, baselineOnchainSats: UInt64 = 0) {
+            self.amountSats = amountSats
+            self.isSendAll = isSendAll
+            self.baselineOnchainSats = baselineOnchainSats
+        }
+    }
+
+    /// Derives user-facing on-chain and spendable balances by subtracting any pending
+    /// outbound send that has not yet been incorporated into LDK/BDK's raw wallet view.
+    static func calculateEffectiveBalances(
+        rawOnchain: UInt64,
+        rawSpendable: UInt64,
+        pending: PendingOutboundSend
+    ) -> (onchain: UInt64, spendable: UInt64) {
+        if pending.isSendAll {
+            return (0, 0)
+        }
+        if pending.amountSats > 0 {
+            let onchain = rawOnchain >= pending.amountSats ? rawOnchain - pending.amountSats : 0
+            let spendable = rawSpendable >= pending.amountSats ? rawSpendable - pending.amountSats : 0
+            return (onchain, spendable)
+        }
+        return (rawOnchain, rawSpendable)
+    }
+
+    /// Resolves pending outbound send state against a fresh raw on-chain balance observation.
+    /// Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
+    /// to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
+    static func resolvePendingOutboundSend(
+        rawOnchain: UInt64,
+        pending: PendingOutboundSend
+    ) -> PendingOutboundSend {
+        if pending.isSendAll {
+            if rawOnchain == 0 || (pending.baselineOnchainSats > 0 && rawOnchain < pending.baselineOnchainSats) {
+                return PendingOutboundSend()
+            }
+            return pending
+        }
+        if pending.amountSats > 0 {
+            let expectedRemaining = pending.baselineOnchainSats >= pending.amountSats
+                ? pending.baselineOnchainSats - pending.amountSats
+                : 0
+            if rawOnchain <= expectedRemaining {
+                return PendingOutboundSend()
+            }
+            return pending
+        }
+        return pending
+    }
 }

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -29,7 +29,7 @@ struct ConfirmationProgress: Equatable {
 
     var label: String {
         if isComplete {
-            return "Confirmed"
+            return String(localized: "status_confirmed", defaultValue: "Confirmed")
         } else if raw <= 0 {
             return "0/\(required) confirmed"
         } else {
@@ -117,33 +117,45 @@ enum BalanceCalculator {
         var amountSats: UInt64
         var isSendAll: Bool
         var baselineOnchainSats: UInt64
+        var timestampSecs: Int64
 
-        init(amountSats: UInt64 = 0, isSendAll: Bool = false, baselineOnchainSats: UInt64 = 0) {
+        init(
+            amountSats: UInt64 = 0,
+            isSendAll: Bool = false,
+            baselineOnchainSats: UInt64 = 0,
+            timestampSecs: Int64 = Int64(Date().timeIntervalSince1970)
+        ) {
             self.amountSats = amountSats
             self.isSendAll = isSendAll
             self.baselineOnchainSats = baselineOnchainSats
+            self.timestampSecs = timestampSecs
         }
     }
+
+    static let defaultPendingExpirySecs: Int64 = 600
 
     /// Records an immediate outbound send broadcast and returns the updated pending state.
     static func recordBroadcast(
         currentPending: PendingOutboundSend,
         amountSats: UInt64,
         isSendAll: Bool,
-        currentOnchain: UInt64
+        currentOnchain: UInt64,
+        timestampSecs: Int64 = Int64(Date().timeIntervalSince1970)
     ) -> PendingOutboundSend {
+        let baseline = currentPending.baselineOnchainSats == 0 ? currentOnchain : currentPending.baselineOnchainSats
         if isSendAll {
             return PendingOutboundSend(
-                amountSats: currentOnchain,
+                amountSats: currentPending.amountSats + currentOnchain,
                 isSendAll: true,
-                baselineOnchainSats: currentOnchain
+                baselineOnchainSats: baseline,
+                timestampSecs: timestampSecs
             )
         } else {
             return PendingOutboundSend(
                 amountSats: currentPending.amountSats + amountSats,
                 isSendAll: false,
-                baselineOnchainSats: currentPending.baselineOnchainSats == 0 ? currentOnchain : currentPending
-                    .baselineOnchainSats
+                baselineOnchainSats: baseline,
+                timestampSecs: timestampSecs
             )
         }
     }
@@ -167,15 +179,23 @@ enum BalanceCalculator {
     }
 
     /// Resolves pending outbound send state against a fresh raw on-chain balance observation.
-    /// Once the raw balance proves the spend has been incorporated (e.g. raw balance has dropped
-    /// to 0/below baseline for send-all, or dropped by at least the send amount), pending state clears.
+    /// Once the raw balance proves the spend has been incorporated, or the pending TTL has expired,
+    /// pending state clears to avoid permanent balance suppression.
     static func resolvePendingOutboundSend(
         rawOnchain: UInt64,
-        pending: PendingOutboundSend
+        pending: PendingOutboundSend,
+        currentTimeSecs: Int64 = Int64(Date().timeIntervalSince1970),
+        expirySecs: Int64 = defaultPendingExpirySecs
     ) -> PendingOutboundSend {
+        guard pending.amountSats > 0 || pending.isSendAll else {
+            return pending
+        }
+        if pending.timestampSecs > 0, currentTimeSecs - pending.timestampSecs >= expirySecs {
+            return PendingOutboundSend(timestampSecs: 0)
+        }
         if pending.isSendAll {
-            if rawOnchain == 0 || (pending.baselineOnchainSats > 0 && rawOnchain < pending.baselineOnchainSats) {
-                return PendingOutboundSend()
+            if rawOnchain == 0 {
+                return PendingOutboundSend(timestampSecs: 0)
             }
             return pending
         }
@@ -184,7 +204,7 @@ enum BalanceCalculator {
                 ? pending.baselineOnchainSats - pending.amountSats
                 : 0
             if rawOnchain <= expectedRemaining {
-                return PendingOutboundSend()
+                return PendingOutboundSend(timestampSecs: 0)
             }
             return pending
         }

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -1,24 +1,55 @@
 import Foundation
 
 enum ConfirmationPolicy {
-    static let requiredConfirmations = 6
-    // Bitcoin mainnet = 6, Liquid = 2 — bump when adding network-specific policies
+    static let defaultRequiredConfirmations = 6
+    static let spliceRequiredConfirmations = 1
+
+    static var requiredConfirmations: Int { defaultRequiredConfirmations }
+
+    static func requiredConfirmations(for paymentType: String) -> Int {
+        switch paymentType {
+        case "splice_in", "splice_out":
+            return spliceRequiredConfirmations
+        default:
+            return defaultRequiredConfirmations
+        }
+    }
 }
 
 struct ConfirmationProgress: Equatable {
     let raw: Int
     let display: Int
+    let required: Int
 
-    var label: String { "\(display)/\(ConfirmationPolicy.requiredConfirmations) done" }
-    var isComplete: Bool { display == ConfirmationPolicy.requiredConfirmations }
+    init(raw: Int, display: Int, required: Int = ConfirmationPolicy.defaultRequiredConfirmations) {
+        self.raw = raw
+        self.display = display
+        self.required = required
+    }
+
+    var label: String {
+        if isComplete {
+            return "Confirmed"
+        } else if raw <= 0 {
+            return "0/\(required) confirmed"
+        } else {
+            return "\(display)/\(required) confirmed"
+        }
+    }
+
+    var isComplete: Bool { display >= required }
 }
 
 struct ConfirmationCalculator {
-    func progress(for txBlockHeight: UInt32, currentBlockHeight: UInt32) -> ConfirmationProgress {
+    func progress(
+        for txBlockHeight: UInt32,
+        currentBlockHeight: UInt32,
+        required: Int = ConfirmationPolicy.defaultRequiredConfirmations
+    ) -> ConfirmationProgress {
         let confs = Int(currentBlockHeight) - Int(txBlockHeight) + 1
         let raw = max(confs, 0)
-        let display = min(raw, ConfirmationPolicy.requiredConfirmations)
-        return ConfirmationProgress(raw: raw, display: display)
+        let display = min(raw, required)
+        return ConfirmationProgress(raw: raw, display: display, required: required)
     }
 }
 

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -40,7 +40,15 @@ struct ConfirmationProgress: Equatable {
     var isComplete: Bool { display >= required }
 }
 
-struct ConfirmationCalculator {
+protocol ConfirmationCalculating: Sendable {
+    func progress(
+        for txBlockHeight: UInt32,
+        currentBlockHeight: UInt32,
+        required: Int
+    ) -> ConfirmationProgress
+}
+
+struct ConfirmationCalculator: ConfirmationCalculating {
     func progress(
         for txBlockHeight: UInt32,
         currentBlockHeight: UInt32,
@@ -63,10 +71,16 @@ extension PaymentRecord {
     var isOnchainConfirmed: Bool {
         (txBlockHeight ?? 0) > 0
     }
+
+    var confirmationProgress: ConfirmationProgress {
+        let required = ConfirmationPolicy.requiredConfirmations(for: paymentType)
+        let raw = Int(confirmations)
+        let display = min(max(raw, 0), required)
+        return ConfirmationProgress(raw: raw, display: display, required: required)
+    }
 }
 
-/// Pure balance calculator enforcing Single Responsibility by isolating
-/// balance aggregation logic from UI state management.
+/// Pure balance calculator isolating balance aggregation logic from UI state management.
 enum BalanceCalculator {
     struct ChannelState: Equatable {
         var hasReadyChannel: Bool
@@ -108,6 +122,29 @@ enum BalanceCalculator {
             self.amountSats = amountSats
             self.isSendAll = isSendAll
             self.baselineOnchainSats = baselineOnchainSats
+        }
+    }
+
+    /// Records an immediate outbound send broadcast and returns the updated pending state.
+    static func recordBroadcast(
+        currentPending: PendingOutboundSend,
+        amountSats: UInt64,
+        isSendAll: Bool,
+        currentOnchain: UInt64
+    ) -> PendingOutboundSend {
+        if isSendAll {
+            return PendingOutboundSend(
+                amountSats: currentOnchain,
+                isSendAll: true,
+                baselineOnchainSats: currentOnchain
+            )
+        } else {
+            return PendingOutboundSend(
+                amountSats: currentPending.amountSats + amountSats,
+                isSendAll: false,
+                baselineOnchainSats: currentPending.baselineOnchainSats == 0 ? currentOnchain : currentPending
+                    .baselineOnchainSats
+            )
         }
     }
 

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -64,3 +64,38 @@ extension PaymentRecord {
         (txBlockHeight ?? 0) > 0
     }
 }
+
+/// Pure balance calculator enforcing Single Responsibility by isolating
+/// balance aggregation logic from UI state management.
+enum BalanceCalculator {
+    struct ChannelState: Equatable {
+        var hasReadyChannel: Bool
+        var hasAnyChannel: Bool = false
+        var isChannelClosing: Bool = false
+        var isOpeningChannel: Bool = false
+        var isSweeping: Bool = false
+    }
+
+    static func calculateTotalBalance(
+        lightning: UInt64,
+        onchain: UInt64,
+        pendingSweep: UInt64 = 0,
+        channelState: ChannelState
+    ) -> UInt64 {
+        if channelState.isChannelClosing {
+            return onchain
+        }
+        if channelState.isOpeningChannel {
+            return lightning > 0 ? lightning : onchain
+        }
+        if channelState.isSweeping {
+            return lightning
+        }
+        // If no ready channel and no channels exist, lightning balance contains stale claimables from
+        // closed channels — never count it, even when onchainBalanceSats reaches 0 (Issue #260).
+        if !channelState.hasReadyChannel && !channelState.hasAnyChannel {
+            return onchain + pendingSweep
+        }
+        return lightning + onchain
+    }
+}

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -113,27 +113,56 @@ enum BalanceCalculator {
         return lightning + onchain
     }
 
+    /// A single pending broadcast entry pairing a transaction id with its sent amount.
+    /// Enables per-transaction resolution so mixed succeeded/failed batches release
+    /// only the resolved portion instead of blocking the entire aggregate.
+    struct TxEntry: Equatable, Sendable {
+        let txid: String
+        let amountSats: UInt64
+    }
+
     struct PendingOutboundSend: Equatable, Sendable {
-        var amountSats: UInt64
         var isSendAll: Bool
         var baselineOnchainSats: UInt64
         var timestampSecs: Int64
-        var txids: [String]
+        var entries: [TxEntry]
 
-        var txid: String? { txids.first }
+        /// Aggregate pending amount across all unresolved entries.
+        var amountSats: UInt64 { entries.reduce(0) { $0 + $1.amountSats } }
+
+        /// All pending txids for predicate checks.
+        var txids: [String] { entries.map(\.txid) }
+
+        /// First broadcast txid, if any.
+        var txid: String? { entries.first?.txid }
 
         init(
             amountSats: UInt64 = 0,
             isSendAll: Bool = false,
             baselineOnchainSats: UInt64 = 0,
             timestampSecs: Int64 = Int64(Date().timeIntervalSince1970),
-            txids: [String] = []
+            txids: [String] = [],
+            entries: [TxEntry]? = nil
         ) {
-            self.amountSats = amountSats
             self.isSendAll = isSendAll
             self.baselineOnchainSats = baselineOnchainSats
             self.timestampSecs = timestampSecs
-            self.txids = txids
+            // If explicit entries are provided, use them; otherwise derive from legacy fields.
+            if let entries {
+                self.entries = entries
+            } else if !txids.isEmpty, amountSats > 0 {
+                // Backward compatibility: distribute aggregate evenly across txids.
+                let perTx = amountSats / UInt64(txids.count)
+                let remainder = amountSats % UInt64(txids.count)
+                self.entries = txids.enumerated().map { i, tid in
+                    TxEntry(txid: tid, amountSats: perTx + (UInt64(i) < remainder ? 1 : 0))
+                }
+            } else if amountSats > 0 {
+                // No txid yet (pre-broadcast state or legacy record without txid tracking).
+                self.entries = [TxEntry(txid: "", amountSats: amountSats)]
+            } else {
+                self.entries = []
+            }
         }
     }
 
@@ -149,27 +178,22 @@ enum BalanceCalculator {
         txid: String? = nil
     ) -> PendingOutboundSend {
         let baseline = currentPending.baselineOnchainSats == 0 ? currentOnchain : currentPending.baselineOnchainSats
-        var updatedTxids = currentPending.txids
-        if let txid, !txid.isEmpty, !updatedTxids.contains(txid) {
-            updatedTxids.append(txid)
-        }
-        if isSendAll {
-            return PendingOutboundSend(
-                amountSats: currentPending.amountSats + currentOnchain,
-                isSendAll: true,
-                baselineOnchainSats: baseline,
-                timestampSecs: timestampSecs,
-                txids: updatedTxids
-            )
+        var updatedEntries = currentPending.entries
+        let sendAmount = isSendAll ? currentOnchain : amountSats
+        if let txid, !txid.isEmpty {
+            if !updatedEntries.contains(where: { $0.txid == txid }) {
+                updatedEntries.append(TxEntry(txid: txid, amountSats: sendAmount))
+            }
         } else {
-            return PendingOutboundSend(
-                amountSats: currentPending.amountSats + amountSats,
-                isSendAll: false,
-                baselineOnchainSats: baseline,
-                timestampSecs: timestampSecs,
-                txids: updatedTxids
-            )
+            // No txid available yet; append an anonymous entry.
+            updatedEntries.append(TxEntry(txid: "", amountSats: sendAmount))
         }
+        return PendingOutboundSend(
+            isSendAll: isSendAll || currentPending.isSendAll,
+            baselineOnchainSats: baseline,
+            timestampSecs: timestampSecs,
+            entries: updatedEntries
+        )
     }
 
     /// Derives user-facing on-chain and spendable balances by subtracting any pending
@@ -184,9 +208,10 @@ enum BalanceCalculator {
         if pending.isSendAll {
             return (0, 0)
         }
-        if pending.amountSats > 0 {
+        let amount = pending.amountSats
+        if amount > 0 {
             let rawDrop = (rawOnchain < pending.baselineOnchainSats) ? (pending.baselineOnchainSats - rawOnchain) : 0
-            let pendingToDeduct = pending.amountSats > rawDrop ? (pending.amountSats - rawDrop) : 0
+            let pendingToDeduct = amount > rawDrop ? (amount - rawDrop) : 0
             let onchain = rawOnchain >= pendingToDeduct ? rawOnchain - pendingToDeduct : 0
             let spendable = rawSpendable >= pendingToDeduct ? rawSpendable - pendingToDeduct : 0
             return (onchain, spendable)
@@ -195,46 +220,78 @@ enum BalanceCalculator {
     }
 
     /// Resolves pending outbound send state against a fresh raw on-chain balance observation.
-    /// Once the raw balance proves the spend has been incorporated, or authoritative transaction
-    /// status confirms incorporation / failure, pending state clears.
+    /// Performs per-txid resolution: transactions whose authoritative status is known
+    /// (incorporated or failed) are removed individually, allowing partial clearing of
+    /// mixed-status batches instead of all-or-nothing.
     /// Fails closed during extended indexer/node outages to prevent re-exposing spent funds.
     static func resolvePendingOutboundSend(
         rawOnchain: UInt64,
         pending: PendingOutboundSend,
         currentTimeSecs _: Int64 = Int64(Date().timeIntervalSince1970),
         expirySecs _: Int64 = defaultPendingExpirySecs,
-        isTxConfirmed: ((String) -> Bool)? = nil,
-        isTxFailed: ((String) -> Bool)? = nil
+        isTxIncorporated: ((String) -> Bool)? = nil,
+        isTxFailed: ((String) -> Bool)? = nil,
+        isTxConfirmed: ((String) -> Bool)? = nil
     ) -> PendingOutboundSend {
         guard pending.amountSats > 0 || pending.isSendAll else {
             return pending
         }
 
-        // 1. Authoritative transaction failure check:
-        if let isTxFailed, !pending.txids.isEmpty, pending.txids.allSatisfy({ isTxFailed($0) }) {
-            return PendingOutboundSend(timestampSecs: 0)
+        let incorporated = isTxIncorporated ?? isTxConfirmed
+
+        // 1. Per-txid resolution: remove entries whose txid has a terminal or incorporated status.
+        var unresolvedEntries = pending.entries
+        if !unresolvedEntries.isEmpty {
+            unresolvedEntries = unresolvedEntries.filter { entry in
+                guard !entry.txid.isEmpty else { return true }
+                // Failed transactions: release the deduction (funds were never spent).
+                if let isTxFailed, isTxFailed(entry.txid) { return false }
+                // Incorporated transactions: wallet already reflects the spend.
+                if let incorporated, incorporated(entry.txid) { return false }
+                return true
+            }
+            // If all entries resolved, clear the entire record.
+            if unresolvedEntries.isEmpty {
+                return PendingOutboundSend(timestampSecs: 0)
+            }
+            // If some entries resolved, check if we can return a reduced pending record.
+            if unresolvedEntries.count < pending.entries.count {
+                let resolved = PendingOutboundSend(
+                    isSendAll: pending.isSendAll,
+                    baselineOnchainSats: pending.baselineOnchainSats,
+                    timestampSecs: pending.timestampSecs,
+                    entries: unresolvedEntries
+                )
+                // Re-check raw balance drop against the reduced aggregate.
+                return resolveByBalanceDrop(rawOnchain: rawOnchain, pending: resolved)
+            }
         }
 
-        // 2. Authoritative transaction confirmation check:
-        if let isTxConfirmed, !pending.txids.isEmpty, pending.txids.allSatisfy({ isTxConfirmed($0) }) {
-            return PendingOutboundSend(timestampSecs: 0)
-        }
+        // 2. No per-txid resolution occurred; check raw balance drop.
+        return resolveByBalanceDrop(rawOnchain: rawOnchain, pending: pending)
+    }
 
-        // 3. Raw balance drop check:
+    /// Checks whether the raw on-chain balance has dropped enough to account for the
+    /// remaining pending deduction. Pure helper for resolvePendingOutboundSend.
+    private static func resolveByBalanceDrop(
+        rawOnchain: UInt64,
+        pending: PendingOutboundSend
+    ) -> PendingOutboundSend {
         if pending.isSendAll {
             if rawOnchain == 0 {
                 return PendingOutboundSend(timestampSecs: 0)
             }
             return pending
         }
-        if pending.amountSats > 0 {
-            let expectedRemaining = pending.baselineOnchainSats >= pending.amountSats
-                ? pending.baselineOnchainSats - pending.amountSats
+        let amount = pending.amountSats
+        if amount > 0 {
+            let expectedRemaining = pending.baselineOnchainSats >= amount
+                ? pending.baselineOnchainSats - amount
                 : 0
             if rawOnchain <= expectedRemaining {
                 return PendingOutboundSend(timestampSecs: 0)
             }
-            // Fail closed beyond expiry: retain deduction until authoritative reconciliation
+            // Fail closed: retain deduction until authoritative reconciliation.
             return pending
         }
         return pending

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -118,17 +118,22 @@ enum BalanceCalculator {
         var isSendAll: Bool
         var baselineOnchainSats: UInt64
         var timestampSecs: Int64
+        var txids: [String]
+
+        var txid: String? { txids.first }
 
         init(
             amountSats: UInt64 = 0,
             isSendAll: Bool = false,
             baselineOnchainSats: UInt64 = 0,
-            timestampSecs: Int64 = Int64(Date().timeIntervalSince1970)
+            timestampSecs: Int64 = Int64(Date().timeIntervalSince1970),
+            txids: [String] = []
         ) {
             self.amountSats = amountSats
             self.isSendAll = isSendAll
             self.baselineOnchainSats = baselineOnchainSats
             self.timestampSecs = timestampSecs
+            self.txids = txids
         }
     }
 
@@ -140,22 +145,29 @@ enum BalanceCalculator {
         amountSats: UInt64,
         isSendAll: Bool,
         currentOnchain: UInt64,
-        timestampSecs: Int64 = Int64(Date().timeIntervalSince1970)
+        timestampSecs: Int64 = Int64(Date().timeIntervalSince1970),
+        txid: String? = nil
     ) -> PendingOutboundSend {
         let baseline = currentPending.baselineOnchainSats == 0 ? currentOnchain : currentPending.baselineOnchainSats
+        var updatedTxids = currentPending.txids
+        if let txid, !txid.isEmpty, !updatedTxids.contains(txid) {
+            updatedTxids.append(txid)
+        }
         if isSendAll {
             return PendingOutboundSend(
                 amountSats: currentPending.amountSats + currentOnchain,
                 isSendAll: true,
                 baselineOnchainSats: baseline,
-                timestampSecs: timestampSecs
+                timestampSecs: timestampSecs,
+                txids: updatedTxids
             )
         } else {
             return PendingOutboundSend(
                 amountSats: currentPending.amountSats + amountSats,
                 isSendAll: false,
                 baselineOnchainSats: baseline,
-                timestampSecs: timestampSecs
+                timestampSecs: timestampSecs,
+                txids: updatedTxids
             )
         }
     }
@@ -183,20 +195,32 @@ enum BalanceCalculator {
     }
 
     /// Resolves pending outbound send state against a fresh raw on-chain balance observation.
-    /// Once the raw balance proves the spend has been incorporated, or the pending TTL has expired,
-    /// pending state clears to avoid permanent balance suppression.
+    /// Once the raw balance proves the spend has been incorporated, or authoritative transaction
+    /// status confirms incorporation / failure, pending state clears.
+    /// Fails closed during extended indexer/node outages to prevent re-exposing spent funds.
     static func resolvePendingOutboundSend(
         rawOnchain: UInt64,
         pending: PendingOutboundSend,
-        currentTimeSecs: Int64 = Int64(Date().timeIntervalSince1970),
-        expirySecs: Int64 = defaultPendingExpirySecs
+        currentTimeSecs _: Int64 = Int64(Date().timeIntervalSince1970),
+        expirySecs _: Int64 = defaultPendingExpirySecs,
+        isTxConfirmed: ((String) -> Bool)? = nil,
+        isTxFailed: ((String) -> Bool)? = nil
     ) -> PendingOutboundSend {
         guard pending.amountSats > 0 || pending.isSendAll else {
             return pending
         }
-        if pending.timestampSecs > 0, currentTimeSecs - pending.timestampSecs >= expirySecs {
+
+        // 1. Authoritative transaction failure check:
+        if let isTxFailed, !pending.txids.isEmpty, pending.txids.allSatisfy({ isTxFailed($0) }) {
             return PendingOutboundSend(timestampSecs: 0)
         }
+
+        // 2. Authoritative transaction confirmation check:
+        if let isTxConfirmed, !pending.txids.isEmpty, pending.txids.allSatisfy({ isTxConfirmed($0) }) {
+            return PendingOutboundSend(timestampSecs: 0)
+        }
+
+        // 3. Raw balance drop check:
         if pending.isSendAll {
             if rawOnchain == 0 {
                 return PendingOutboundSend(timestampSecs: 0)
@@ -210,8 +234,19 @@ enum BalanceCalculator {
             if rawOnchain <= expectedRemaining {
                 return PendingOutboundSend(timestampSecs: 0)
             }
+            // Fail closed beyond expiry: retain deduction until authoritative reconciliation
             return pending
         }
         return pending
+    }
+
+    /// Pure helper to evaluate if a background wallet sync completion owns the active send generation
+    /// and succeeded, preventing older out-of-order syncs from clearing newer pending broadcasts.
+    static func shouldClearPendingOnSyncCompletion(
+        expectedGeneration: Int64,
+        currentGeneration: Int64,
+        syncSuccess: Bool
+    ) -> Bool {
+        return syncSuccess && expectedGeneration == currentGeneration
     }
 }

--- a/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
+++ b/ios/StableChannels/StableChannels/Domain/PaymentProgress.swift
@@ -162,6 +162,8 @@ enum BalanceCalculator {
 
     /// Derives user-facing on-chain and spendable balances by subtracting any pending
     /// outbound send that has not yet been incorporated into LDK/BDK's raw wallet view.
+    /// If raw balance has already dropped below baseline, only the unincorporated portion
+    /// of pending sends is subtracted to avoid double-deductions during partial syncs.
     static func calculateEffectiveBalances(
         rawOnchain: UInt64,
         rawSpendable: UInt64,
@@ -171,8 +173,10 @@ enum BalanceCalculator {
             return (0, 0)
         }
         if pending.amountSats > 0 {
-            let onchain = rawOnchain >= pending.amountSats ? rawOnchain - pending.amountSats : 0
-            let spendable = rawSpendable >= pending.amountSats ? rawSpendable - pending.amountSats : 0
+            let rawDrop = (rawOnchain < pending.baselineOnchainSats) ? (pending.baselineOnchainSats - rawOnchain) : 0
+            let pendingToDeduct = pending.amountSats > rawDrop ? (pending.amountSats - rawDrop) : 0
+            let onchain = rawOnchain >= pendingToDeduct ? rawOnchain - pendingToDeduct : 0
+            let spendable = rawSpendable >= pendingToDeduct ? rawSpendable - pendingToDeduct : 0
             return (onchain, spendable)
         }
         return (rawOnchain, rawSpendable)

--- a/ios/StableChannels/StableChannels/Features/History/HistoryView.swift
+++ b/ios/StableChannels/StableChannels/Features/History/HistoryView.swift
@@ -204,23 +204,17 @@ struct PaymentRowView: View {
 
     private var statusLabel: String {
         if payment.shouldShowConfirmationProgress {
-            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
-            let confs = Int(payment.confirmations)
-            if confs >= required {
-                return String(localized: "status_confirmed", defaultValue: "Confirmed")
-            }
-            return "\(confs)/\(required) confirmed"
+            return payment.confirmationProgress.label
         }
         return payment.status.capitalized
     }
 
     private var statusColor: Color {
         if payment.shouldShowConfirmationProgress {
-            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
-            let confs = Int(payment.confirmations)
-            if confs >= required {
+            let progress = payment.confirmationProgress
+            if progress.isComplete {
                 return .green
-            } else if confs > 0 {
+            } else if progress.raw > 0 {
                 return .blue
             } else {
                 return .orange

--- a/ios/StableChannels/StableChannels/Features/History/HistoryView.swift
+++ b/ios/StableChannels/StableChannels/Features/History/HistoryView.swift
@@ -204,19 +204,21 @@ struct PaymentRowView: View {
 
     private var statusLabel: String {
         if payment.shouldShowConfirmationProgress {
+            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
             let confs = Int(payment.confirmations)
-            if confs >= ConfirmationPolicy.requiredConfirmations {
+            if confs >= required {
                 return String(localized: "status_confirmed", defaultValue: "Confirmed")
             }
-            return "\(confs)/\(ConfirmationPolicy.requiredConfirmations) confirmed"
+            return "\(confs)/\(required) confirmed"
         }
         return payment.status.capitalized
     }
 
     private var statusColor: Color {
         if payment.shouldShowConfirmationProgress {
+            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
             let confs = Int(payment.confirmations)
-            if confs >= ConfirmationPolicy.requiredConfirmations {
+            if confs >= required {
                 return .green
             } else if confs > 0 {
                 return .blue

--- a/ios/StableChannels/StableChannels/Features/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Features/History/PaymentDetailView.swift
@@ -118,22 +118,23 @@ struct PaymentDetailView: View {
 
     private func statusLabel(for payment: PaymentRecord) -> String {
         if payment.shouldShowConfirmationProgress {
+            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
             let confs = Int(payment.confirmations)
-            if confs >= ConfirmationPolicy.requiredConfirmations {
+            if confs >= required {
                 return String(localized: "status_confirmed", defaultValue: "Confirmed")
             }
-            // Show confirmation count for all values 0..5 so the label
+            // Show confirmation count for all values below required so the label
             // never falls through to the stored status (which may be
             // "Completed" before the poller has run).
-            return "\(confs)/\(ConfirmationPolicy.requiredConfirmations) confirmed"
+            return "\(confs)/\(required) confirmed"
         }
         return payment.status.capitalized
     }
 
     @ViewBuilder
     private func confirmationProgressRow(for payment: PaymentRecord) -> some View {
-        let confs = min(Int(payment.confirmations), ConfirmationPolicy.requiredConfirmations)
-        let required = ConfirmationPolicy.requiredConfirmations
+        let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
+        let confs = min(Int(payment.confirmations), required)
         HStack {
             Text(String(localized: "label_confirmations", defaultValue: "Confirmations"))
                 .foregroundStyle(.secondary)

--- a/ios/StableChannels/StableChannels/Features/History/PaymentDetailView.swift
+++ b/ios/StableChannels/StableChannels/Features/History/PaymentDetailView.swift
@@ -118,28 +118,19 @@ struct PaymentDetailView: View {
 
     private func statusLabel(for payment: PaymentRecord) -> String {
         if payment.shouldShowConfirmationProgress {
-            let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
-            let confs = Int(payment.confirmations)
-            if confs >= required {
-                return String(localized: "status_confirmed", defaultValue: "Confirmed")
-            }
-            // Show confirmation count for all values below required so the label
-            // never falls through to the stored status (which may be
-            // "Completed" before the poller has run).
-            return "\(confs)/\(required) confirmed"
+            return payment.confirmationProgress.label
         }
         return payment.status.capitalized
     }
 
     @ViewBuilder
     private func confirmationProgressRow(for payment: PaymentRecord) -> some View {
-        let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
-        let confs = min(Int(payment.confirmations), required)
+        let progress = payment.confirmationProgress
         HStack {
             Text(String(localized: "label_confirmations", defaultValue: "Confirmations"))
                 .foregroundStyle(.secondary)
             Spacer()
-            if confs >= required {
+            if progress.isComplete {
                 Label(
                     String(localized: "confirmations_complete", defaultValue: "Confirmed"),
                     systemImage: "checkmark.circle.fill"
@@ -148,11 +139,11 @@ struct PaymentDetailView: View {
                 .font(.subheadline)
             } else {
                 HStack(spacing: 8) {
-                    Text("\(confs)/\(required)")
+                    Text("\(progress.display)/\(progress.required)")
                         .font(.subheadline)
-                    ProgressView(value: Double(confs), total: Double(required))
+                    ProgressView(value: Double(progress.display), total: Double(progress.required))
                         .frame(width: 60)
-                        .tint(confs > 0 ? .blue : .orange)
+                        .tint(progress.display > 0 ? .blue : .orange)
                 }
             }
         }

--- a/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
@@ -376,6 +376,7 @@ struct OnChainSendView: View {
                     txid: result,
                     address: address
                 )
+                appState.onchainSendBroadcasted(amountSats: onchainSats, isSendAll: true)
             } else {
                 let result = try appState.nodeService.sendOnchain(address: address, amountSats: sats)
                 txid = result
@@ -392,6 +393,7 @@ struct OnChainSendView: View {
                     txid: result,
                     address: address
                 )
+                appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false)
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/OnChainView.swift
@@ -376,7 +376,7 @@ struct OnChainSendView: View {
                     txid: result,
                     address: address
                 )
-                appState.onchainSendBroadcasted(amountSats: onchainSats, isSendAll: true)
+                appState.onchainSendBroadcasted(amountSats: onchainSats, isSendAll: true, txid: result)
             } else {
                 let result = try appState.nodeService.sendOnchain(address: address, amountSats: sats)
                 txid = result
@@ -393,7 +393,7 @@ struct OnChainSendView: View {
                     txid: result,
                     address: address
                 )
-                appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false)
+                appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false, txid: result)
             }
         } catch {
             errorMessage = error.localizedDescription

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -549,6 +549,7 @@ struct SendView: View {
                         txid: txid,
                         address: trimmed
                     )
+                    appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false)
                 }
                 sentAmountSats = sats
 

--- a/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
+++ b/ios/StableChannels/StableChannels/Features/Transfer/SendView.swift
@@ -549,7 +549,7 @@ struct SendView: View {
                         txid: txid,
                         address: trimmed
                     )
-                    appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false)
+                    appState.onchainSendBroadcasted(amountSats: sats, isSendAll: false, txid: txid)
                 }
                 sentAmountSats = sats
 

--- a/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationPollingService.swift
+++ b/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationPollingService.swift
@@ -43,12 +43,17 @@ final class ConfirmationPollingService {
             return
         }
 
+        var anyUpdated = false
         for payment in pending {
             guard !Task.isCancelled else { return }
-            await resolve(payment: payment, currentHeight: currentHeight)
+            if await resolve(payment: payment, currentHeight: currentHeight) {
+                anyUpdated = true
+            }
         }
 
-        onUpdate?()
+        if anyUpdated {
+            onUpdate?()
+        }
     }
 
     /// Revalidates both pending payments and recently completed payments (last ~12 blocks)
@@ -63,11 +68,15 @@ final class ConfirmationPollingService {
         let currentHeight = blockHeightService.currentHeight
         guard currentHeight > 0 else { return }
 
+        var anyUpdated = false
+
         // 1. Process pending payments
         if let pending = try? databaseService.paymentRepo.paymentsNeedingConfirmation() {
             for payment in pending {
                 guard !Task.isCancelled else { return }
-                await resolve(payment: payment, currentHeight: currentHeight)
+                if await resolve(payment: payment, currentHeight: currentHeight) {
+                    anyUpdated = true
+                }
             }
         }
 
@@ -87,6 +96,7 @@ final class ConfirmationPollingService {
                     // Esplora reports transaction is no longer confirmed — downgrade to pending
                     do {
                         try databaseService.paymentRepo.downgradePaymentToPending(paymentId: payment.id)
+                        anyUpdated = true
                         logger
                             .warning(
                                 "[Confirmation] Payment #\(payment.id) orphaned in reorg/gap — downgraded to pending."
@@ -100,12 +110,17 @@ final class ConfirmationPollingService {
                     }
                 case .confirmed(let progress, let blockHeight):
                     if blockHeight != payment.txBlockHeight || progress.display != payment.confirmations {
-                        try? databaseService.paymentRepo.updateConfirmations(
-                            paymentId: payment.id,
-                            paymentType: payment.paymentType,
-                            txBlockHeight: blockHeight,
-                            currentBlockHeight: currentHeight
-                        )
+                        do {
+                            try databaseService.paymentRepo.updateConfirmations(
+                                paymentId: payment.id,
+                                paymentType: payment.paymentType,
+                                txBlockHeight: blockHeight,
+                                currentBlockHeight: currentHeight
+                            )
+                            anyUpdated = true
+                        } catch {
+                            logger.error("Failed to update confirmations: \(error.localizedDescription)")
+                        }
                     }
                 case .error, .noTxid:
                     break
@@ -113,10 +128,13 @@ final class ConfirmationPollingService {
             }
         }
 
-        onUpdate?()
+        if anyUpdated {
+            onUpdate?()
+        }
     }
 
-    private func resolve(payment: PaymentRecord, currentHeight: UInt32) async {
+    @discardableResult
+    private func resolve(payment: PaymentRecord, currentHeight: UInt32) async -> Bool {
         let outcome = await confirmationService.resolve(
             payment: payment,
             currentBlockHeight: currentHeight
@@ -124,7 +142,8 @@ final class ConfirmationPollingService {
         switch outcome {
         case .confirmed(let progress, let blockHeight):
             // Skip redundant writes — only update if confirmations actually changed OR if block height changed (reorg)
-            guard progress.display != payment.confirmations || blockHeight != payment.txBlockHeight else { return }
+            guard progress.display != payment.confirmations || blockHeight != payment.txBlockHeight
+            else { return false }
             do {
                 try databaseService.paymentRepo.updateConfirmations(
                     paymentId: payment.id,
@@ -137,16 +156,19 @@ final class ConfirmationPollingService {
                     "confirmations": "\(progress.display)",
                     "block_height": "\(blockHeight)"
                 ])
+                return true
             } catch {
                 logger.error("Failed to update confirmations: \(error.localizedDescription)")
+                return false
             }
         case .error(let message):
             AuditService.log("CONFIRMATION_RESOLVE_FAILED", data: [
                 "payment_id": "\(payment.id)",
                 "error": message
             ])
+            return false
         case .pending, .noTxid:
-            break
+            return false
         }
     }
 }

--- a/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationPollingService.swift
+++ b/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationPollingService.swift
@@ -102,6 +102,7 @@ final class ConfirmationPollingService {
                     if blockHeight != payment.txBlockHeight || progress.display != payment.confirmations {
                         try? databaseService.paymentRepo.updateConfirmations(
                             paymentId: payment.id,
+                            paymentType: payment.paymentType,
                             txBlockHeight: blockHeight,
                             currentBlockHeight: currentHeight
                         )
@@ -127,6 +128,7 @@ final class ConfirmationPollingService {
             do {
                 try databaseService.paymentRepo.updateConfirmations(
                     paymentId: payment.id,
+                    paymentType: payment.paymentType,
                     txBlockHeight: blockHeight,
                     currentBlockHeight: currentHeight
                 )

--- a/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationService.swift
+++ b/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationService.swift
@@ -19,9 +19,14 @@ final class ConfirmationService {
         guard let txid = payment.txid, !txid.isEmpty else {
             return .noTxid
         }
+        let required = ConfirmationPolicy.requiredConfirmations(for: payment.paymentType)
         // Fast path: only trust cached tx_block_height when not forceRechecking
         if !forceRecheck, let existingHeight = payment.txBlockHeight, existingHeight > 0 {
-            let progress = calculator.progress(for: existingHeight, currentBlockHeight: currentBlockHeight)
+            let progress = calculator.progress(
+                for: existingHeight,
+                currentBlockHeight: currentBlockHeight,
+                required: required
+            )
             if progress.isComplete {
                 return .confirmed(progress: progress, blockHeight: existingHeight)
             }
@@ -30,7 +35,7 @@ final class ConfirmationService {
             guard let height = try await provider.blockHeight(for: txid) else {
                 return .pending
             }
-            let progress = calculator.progress(for: height, currentBlockHeight: currentBlockHeight)
+            let progress = calculator.progress(for: height, currentBlockHeight: currentBlockHeight, required: required)
             return .confirmed(progress: progress, blockHeight: height)
         } catch {
             return .error(error.localizedDescription)

--- a/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationService.swift
+++ b/ios/StableChannels/StableChannels/Services/Confirmation/ConfirmationService.swift
@@ -5,10 +5,14 @@ import SwiftUI
 @MainActor
 final class ConfirmationService {
     private let provider: TxConfirmationProvider
-    private let calculator = ConfirmationCalculator()
+    private let calculator: ConfirmationCalculating
 
-    init(provider: TxConfirmationProvider) {
+    init(
+        provider: TxConfirmationProvider,
+        calculator: ConfirmationCalculating = ConfirmationCalculator()
+    ) {
         self.provider = provider
+        self.calculator = calculator
     }
 
     func resolve(

--- a/ios/StableChannels/StableChannels/Services/NodeService.swift
+++ b/ios/StableChannels/StableChannels/Services/NodeService.swift
@@ -113,6 +113,7 @@ protocol NodeServiceProtocol {
     var savedMnemonic: String? { get }
     func start(network: Network, esploraURL: String, mnemonic: String, lspConfig: LSPConfig) async throws
     func stop()
+    func syncWallets() throws
 }
 
 @Observable
@@ -576,6 +577,11 @@ class NodeService: NodeServiceProtocol {
     func sendAllOnchain(address: String) throws -> Txid {
         guard let node else { throw NodeServiceError.notRunning }
         return try node.onchainPayment().sendAllToAddress(address: address, retainReserves: false, feeRate: nil)
+    }
+
+    func syncWallets() throws {
+        guard let node else { throw NodeServiceError.notRunning }
+        try node.syncWallets()
     }
 
     // MARK: - Balances

--- a/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
@@ -187,7 +187,8 @@ final class PaymentRepository {
         paymentId: Int64,
         paymentType: String? = nil,
         txBlockHeight: UInt32,
-        currentBlockHeight: UInt32
+        currentBlockHeight: UInt32,
+        calculator: ConfirmationCalculating = ConfirmationCalculator()
     ) throws {
         let type: String
         if let paymentType {
@@ -196,13 +197,16 @@ final class PaymentRepository {
             type = try getPayment(byId: paymentId)?.paymentType ?? "onchain"
         }
         let required = ConfirmationPolicy.requiredConfirmations(for: type)
-        let rawConfs = max(Int(currentBlockHeight) - Int(txBlockHeight) + 1, 0)
-        let confs = min(rawConfs, required)
-        let status = confs >= required ? "completed" : "pending"
+        let progress = calculator.progress(
+            for: txBlockHeight,
+            currentBlockHeight: currentBlockHeight,
+            required: required
+        )
+        let status = progress.isComplete ? "completed" : "pending"
         try rawSQL.execute(
             "UPDATE payments SET confirmations = ?, tx_block_height = ?, status = ? WHERE id = ?",
             params: [
-                .integer(Int64(confs)),
+                .integer(Int64(progress.display)),
                 .integer(Int64(txBlockHeight)),
                 .text(status),
                 .integer(paymentId)

--- a/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
@@ -146,22 +146,26 @@ final class PaymentRepository {
     }
 
     func paymentsNeedingConfirmation() throws -> [PaymentRecord] {
-        let required = ConfirmationPolicy.requiredConfirmations
+        let defaultRequired = ConfirmationPolicy.defaultRequiredConfirmations
+        let spliceRequired = ConfirmationPolicy.spliceRequiredConfirmations
         let sql = """
         SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price,
         counterparty, status, created_at, fee_msat, txid, address, confirmations, tx_block_height
         FROM payments
         WHERE txid IS NOT NULL
         AND txid != ''
-        AND payment_type IN ('onchain', 'splice_in', 'splice_out', 'channel_close')
         AND status != 'failed'
-        AND (confirmations IS NULL OR confirmations < ?)
+        AND (
+            (payment_type IN ('splice_in', 'splice_out') AND (confirmations IS NULL OR confirmations < ?))
+            OR
+            (payment_type IN ('onchain', 'channel_close') AND (confirmations IS NULL OR confirmations < ?))
+        )
         ORDER BY created_at DESC
         LIMIT 50
         """
         let rows = try rawSQL.query(
             sql,
-            params: [.integer(Int64(required))]
+            params: [.integer(Int64(spliceRequired)), .integer(Int64(defaultRequired))]
         )
         return rows.map { row in
             paymentRecord(from: row)
@@ -179,8 +183,19 @@ final class PaymentRepository {
         return paymentRecord(from: row)
     }
 
-    func updateConfirmations(paymentId: Int64, txBlockHeight: UInt32, currentBlockHeight: UInt32) throws {
-        let required = ConfirmationPolicy.requiredConfirmations
+    func updateConfirmations(
+        paymentId: Int64,
+        paymentType: String? = nil,
+        txBlockHeight: UInt32,
+        currentBlockHeight: UInt32
+    ) throws {
+        let type: String
+        if let paymentType {
+            type = paymentType
+        } else {
+            type = try getPayment(byId: paymentId)?.paymentType ?? "onchain"
+        }
+        let required = ConfirmationPolicy.requiredConfirmations(for: type)
         let rawConfs = max(Int(currentBlockHeight) - Int(txBlockHeight) + 1, 0)
         let confs = min(rawConfs, required)
         let status = confs >= required ? "completed" : "pending"

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -3,6 +3,28 @@ import XCTest
 
 @MainActor
 final class OnChainConfirmationPolicyTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        ud?.removeObject(forKey: "pending_outbound_onchain_sats")
+        ud?.removeObject(forKey: "pending_outbound_is_send_all")
+        ud?.removeObject(forKey: "pending_outbound_baseline_sats")
+        ud?.removeObject(forKey: "cached_onchain_sats")
+        ud?.removeObject(forKey: "cached_spendable_onchain_sats")
+        ud?.removeObject(forKey: "cached_lightning_sats")
+    }
+
+    override func tearDown() {
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        ud?.removeObject(forKey: "pending_outbound_onchain_sats")
+        ud?.removeObject(forKey: "pending_outbound_is_send_all")
+        ud?.removeObject(forKey: "pending_outbound_baseline_sats")
+        ud?.removeObject(forKey: "cached_onchain_sats")
+        ud?.removeObject(forKey: "cached_spendable_onchain_sats")
+        ud?.removeObject(forKey: "cached_lightning_sats")
+        super.tearDown()
+    }
+
     // MARK: - Confirmation Policy Tests
 
     func testConfirmationPolicyThresholds() {
@@ -215,5 +237,156 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
             channelState: state
         )
         XCTAssertEqual(total, 35_000)
+    }
+
+    // MARK: - Interleaving & Pending Outbound Send Tests
+
+    func testEffectiveBalancesDeductsPendingOutbound() {
+        // Normal send: raw onchain 100k, spendable 95k, pending send 30k
+        let pendingPartial = BalanceCalculator.PendingOutboundSend(
+            amountSats: 30_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000
+        )
+        let effPartial = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: pendingPartial
+        )
+        XCTAssertEqual(effPartial.onchain, 70_000)
+        XCTAssertEqual(effPartial.spendable, 65_000)
+
+        // Send All: zeroes both balances
+        let pendingAll = BalanceCalculator.PendingOutboundSend(
+            amountSats: 100_000,
+            isSendAll: true,
+            baselineOnchainSats: 100_000
+        )
+        let effAll = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: pendingAll
+        )
+        XCTAssertEqual(effAll.onchain, 0)
+        XCTAssertEqual(effAll.spendable, 0)
+
+        // Empty pending: passes through raw balances
+        let pendingNone = BalanceCalculator.PendingOutboundSend()
+        let effNone = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: pendingNone
+        )
+        XCTAssertEqual(effNone.onchain, 100_000)
+        XCTAssertEqual(effNone.spendable, 95_000)
+    }
+
+    func testResolvePendingOutboundSendIncorporation() {
+        let pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: 30_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000
+        )
+
+        // Before wallet sync incorporates the spend: raw balance is still 100k
+        let stillPending = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending
+        )
+        XCTAssertEqual(stillPending.amountSats, 30_000, "Pending send must not clear before balance drops")
+        XCTAssertFalse(stillPending.isSendAll)
+
+        // After wallet sync incorporates the spend: raw balance dropped to 70k or less (with fees)
+        let incorporated = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 69_850,
+            pending: pending
+        )
+        XCTAssertEqual(incorporated.amountSats, 0, "Pending send must clear once spend is incorporated")
+
+        // Send All incorporation
+        let pendingAll = BalanceCalculator.PendingOutboundSend(
+            amountSats: 100_000,
+            isSendAll: true,
+            baselineOnchainSats: 100_000
+        )
+        let allStillPending = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pendingAll
+        )
+        XCTAssertTrue(allStillPending.isSendAll)
+
+        let allIncorporated = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 0,
+            pending: pendingAll
+        )
+        XCTAssertFalse(allIncorporated.isSendAll)
+        XCTAssertEqual(allIncorporated.amountSats, 0)
+    }
+
+    func testOnchainSendBroadcastedUpdatesPendingOutboundState() {
+        let appState = AppState()
+        appState.onchainBalanceSats = 100_000
+        appState.spendableOnchainSats = 95_000
+
+        // Broadcast 30,000 sats send
+        appState.onchainSendBroadcasted(amountSats: 30_000, isSendAll: false)
+        XCTAssertEqual(appState.onchainBalanceSats, 70_000)
+        XCTAssertEqual(appState.spendableOnchainSats, 65_000)
+        XCTAssertEqual(appState.pendingOutboundSend.amountSats, 30_000)
+        XCTAssertEqual(appState.pendingOutboundSend.baselineOnchainSats, 100_000)
+        XCTAssertFalse(appState.pendingOutboundSend.isSendAll)
+    }
+
+    func testRefreshBalancesBeforeSyncCompletesPreservesOptimisticDeduction() {
+        // Simulates: broadcast send of 30,000 sats when raw balance is 100,000 sats.
+        // Intervening refresh receives old 100,000 balance from LDK before sync incorporates the spend.
+        // Invariant: effective balance MUST remain 70,000 and never resurrect the pre-send 100,000.
+        let rawPreSend: UInt64 = 100_000
+        let rawSpendablePreSend: UInt64 = 95_000
+        let sendAmount: UInt64 = 30_000
+
+        var pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: sendAmount,
+            isSendAll: false,
+            baselineOnchainSats: rawPreSend
+        )
+
+        // Intervening refresh: LDK still reports old 100k balance
+        let rawDuringSync = rawPreSend
+        let rawSpendableDuringSync = rawSpendablePreSend
+
+        pending = BalanceCalculator.resolvePendingOutboundSend(rawOnchain: rawDuringSync, pending: pending)
+        XCTAssertEqual(
+            pending.amountSats,
+            30_000,
+            "Pending send deduction must not be dropped while raw balance is old"
+        )
+
+        let effectiveDuringSync = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: rawDuringSync,
+            rawSpendable: rawSpendableDuringSync,
+            pending: pending
+        )
+        XCTAssertEqual(
+            effectiveDuringSync.onchain,
+            70_000,
+            "Balance must not resurrect to 100,000 during intervening refresh"
+        )
+        XCTAssertEqual(effectiveDuringSync.spendable, 65_000)
+
+        // Once sync completes and LDK reports the incorporated balance (e.g. 69,850 with fee):
+        let rawPostSync: UInt64 = 69_850
+        let rawSpendablePostSync: UInt64 = 64_850
+
+        pending = BalanceCalculator.resolvePendingOutboundSend(rawOnchain: rawPostSync, pending: pending)
+        XCTAssertEqual(pending.amountSats, 0, "Pending send must clear once raw balance reflects the spend")
+
+        let effectivePostSync = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: rawPostSync,
+            rawSpendable: rawSpendablePostSync,
+            pending: pending
+        )
+        XCTAssertEqual(effectivePostSync.onchain, 69_850)
+        XCTAssertEqual(effectivePostSync.spendable, 64_850)
     }
 }

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -1,0 +1,138 @@
+@testable import StableChannels
+import XCTest
+
+@MainActor
+final class OnChainConfirmationPolicyTests: XCTestCase {
+    // MARK: - Confirmation Policy Tests
+
+    func testConfirmationPolicyThresholds() {
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations(for: "splice_in"), 1)
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations(for: "splice_out"), 1)
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations(for: "onchain"), 6)
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations(for: "channel_close"), 6)
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations(for: "unknown"), 6)
+        XCTAssertEqual(ConfirmationPolicy.requiredConfirmations, 6)
+        XCTAssertEqual(ConfirmationPolicy.spliceRequiredConfirmations, 1)
+        XCTAssertEqual(ConfirmationPolicy.defaultRequiredConfirmations, 6)
+    }
+
+    // MARK: - Confirmation Calculator Tests
+
+    func testCalculatorForSplice() {
+        let calc = ConfirmationCalculator()
+        let required = ConfirmationPolicy.requiredConfirmations(for: "splice_in")
+        XCTAssertEqual(required, 1)
+
+        // 0 confirmations (tx block height is in future or unconfirmed)
+        let p0 = calc.progress(for: 101, currentBlockHeight: 100, required: required)
+        XCTAssertEqual(p0.raw, 0)
+        XCTAssertEqual(p0.display, 0)
+        XCTAssertFalse(p0.isComplete)
+        XCTAssertEqual(p0.label, "0/1 confirmed")
+
+        // 1 confirmation (same block)
+        let p1 = calc.progress(for: 100, currentBlockHeight: 100, required: required)
+        XCTAssertEqual(p1.raw, 1)
+        XCTAssertEqual(p1.display, 1)
+        XCTAssertTrue(p1.isComplete)
+        XCTAssertEqual(p1.label, "Confirmed")
+
+        // 3 confirmations
+        let p3 = calc.progress(for: 100, currentBlockHeight: 102, required: required)
+        XCTAssertEqual(p3.raw, 3)
+        XCTAssertEqual(p3.display, 1)
+        XCTAssertTrue(p3.isComplete)
+        XCTAssertEqual(p3.label, "Confirmed")
+    }
+
+    func testCalculatorForOnChain() {
+        let calc = ConfirmationCalculator()
+        let required = ConfirmationPolicy.requiredConfirmations(for: "onchain")
+        XCTAssertEqual(required, 6)
+
+        // 0 confirmations
+        let p0 = calc.progress(for: 501, currentBlockHeight: 500, required: required)
+        XCTAssertEqual(p0.display, 0)
+        XCTAssertFalse(p0.isComplete)
+        XCTAssertEqual(p0.label, "0/6 confirmed")
+
+        // 1 confirmation
+        let p1 = calc.progress(for: 500, currentBlockHeight: 500, required: required)
+        XCTAssertEqual(p1.display, 1)
+        XCTAssertFalse(p1.isComplete)
+        XCTAssertEqual(p1.label, "1/6 confirmed")
+
+        // 5 confirmations
+        let p5 = calc.progress(for: 500, currentBlockHeight: 504, required: required)
+        XCTAssertEqual(p5.display, 5)
+        XCTAssertFalse(p5.isComplete)
+        XCTAssertEqual(p5.label, "5/6 confirmed")
+
+        // 6 confirmations
+        let p6 = calc.progress(for: 500, currentBlockHeight: 505, required: required)
+        XCTAssertEqual(p6.display, 6)
+        XCTAssertTrue(p6.isComplete)
+        XCTAssertEqual(p6.label, "Confirmed")
+
+        // 10 confirmations
+        let p10 = calc.progress(for: 500, currentBlockHeight: 509, required: required)
+        XCTAssertEqual(p10.display, 6)
+        XCTAssertTrue(p10.isComplete)
+        XCTAssertEqual(p10.label, "Confirmed")
+    }
+
+    // MARK: - Ghost Balance Fix Tests (Issue #260)
+
+    func testTotalBalanceWithoutReadyChannelExcludesStaleLightningBalance() {
+        let appState = AppState()
+        appState.hasReadyChannel = false
+        appState.isOpeningChannel = false
+        appState.isChannelClosing = false
+
+        // Stale closing channel lightning balance exists from LDK
+        appState.lightningBalanceSats = 100_000
+        appState.onchainBalanceSats = 50_000
+        appState.pendingSweepBalanceSats = 10_000
+
+        // Total should only be onchain + pending sweep
+        XCTAssertEqual(appState.totalBalanceSats, 60_000)
+
+        // Issue #260 condition: User performs Send Max after channel close
+        // onchain drops to 0. Total must be 0, NEVER falling through to lightningBalanceSats (100_000)
+        appState.onchainBalanceSats = 0
+        appState.pendingSweepBalanceSats = 0
+        XCTAssertEqual(
+            appState.totalBalanceSats,
+            0,
+            "Stale lightning balance must not resurrect when onchain balance reaches 0"
+        )
+    }
+
+    func testTotalBalanceWithReadyChannelIncludesBothBalances() {
+        let appState = AppState()
+        appState.hasReadyChannel = true
+        appState.isOpeningChannel = false
+        appState.isChannelClosing = false
+
+        appState.lightningBalanceSats = 80_000
+        appState.onchainBalanceSats = 40_000
+
+        XCTAssertEqual(appState.totalBalanceSats, 120_000)
+    }
+
+    func testOnchainSendBroadcastedImmediateDeduction() {
+        let appState = AppState()
+        appState.onchainBalanceSats = 100_000
+        appState.spendableOnchainSats = 95_000
+
+        // Partial send of 30,000 sats
+        appState.onchainSendBroadcasted(amountSats: 30_000, isSendAll: false)
+        XCTAssertEqual(appState.onchainBalanceSats, 70_000)
+        XCTAssertEqual(appState.spendableOnchainSats, 65_000)
+
+        // Send All zeroes both
+        appState.onchainSendBroadcasted(amountSats: 70_000, isSendAll: true)
+        XCTAssertEqual(appState.onchainBalanceSats, 0)
+        XCTAssertEqual(appState.spendableOnchainSats, 0)
+    }
+}

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -476,7 +476,7 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertEqual(partial1.baselineOnchainSats, 100_000)
 
         // 2. Second partial send of 15,000 sats preserves original baseline
-        let partial2 = AppState.recordBroadcast(
+        let partial2 = BalanceCalculator.recordBroadcast(
             currentPending: partial1,
             amountSats: 15_000,
             isSendAll: false,
@@ -486,7 +486,16 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertFalse(partial2.isSendAll)
         XCTAssertEqual(partial2.baselineOnchainSats, 100_000)
 
-        // 3. Send All
+        // Effective balance against raw baseline is 65k (not 45k)
+        let effPartial2 = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: partial2
+        )
+        XCTAssertEqual(effPartial2.onchain, 65_000)
+        XCTAssertEqual(effPartial2.spendable, 60_000)
+
+        // 3. Send All directly from initial state
         let sendAll = BalanceCalculator.recordBroadcast(
             currentPending: initial,
             amountSats: 100_000,
@@ -496,6 +505,40 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertEqual(sendAll.amountSats, 100_000)
         XCTAssertTrue(sendAll.isSendAll)
         XCTAssertEqual(sendAll.baselineOnchainSats, 100_000)
+
+        // 4. Send All following an earlier partial send preserves the original baseline
+        let sendAllAfterPartial = BalanceCalculator.recordBroadcast(
+            currentPending: partial1,
+            amountSats: 80_000,
+            isSendAll: true,
+            currentOnchain: 80_000
+        )
+        XCTAssertEqual(sendAllAfterPartial.amountSats, 100_000)
+        XCTAssertTrue(sendAllAfterPartial.isSendAll)
+        XCTAssertEqual(sendAllAfterPartial.baselineOnchainSats, 100_000)
+
+        let effSendAll = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: sendAllAfterPartial
+        )
+        XCTAssertEqual(effSendAll.onchain, 0)
+        XCTAssertEqual(effSendAll.spendable, 0)
+
+        // Wallet refresh incorporating only partial send 1 (raw drops to 80k) does not prematurely clear send-all
+        let stillPendingSendAll = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 80_000,
+            pending: sendAllAfterPartial
+        )
+        XCTAssertTrue(stillPendingSendAll.isSendAll)
+
+        // Once send-all is incorporated (raw drops to 0), pending clears
+        let clearedSendAll = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 0,
+            pending: sendAllAfterPartial
+        )
+        XCTAssertFalse(clearedSendAll.isSendAll)
+        XCTAssertEqual(clearedSendAll.amountSats, 0)
     }
 
     func testConfirmationCalculatingProtocolPolymorphism() {
@@ -530,5 +573,103 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertNil(ud?.object(forKey: "pending_outbound_onchain_sats"))
         XCTAssertNil(ud?.object(forKey: "pending_outbound_is_send_all"))
         XCTAssertNil(ud?.object(forKey: "pending_outbound_baseline_sats"))
+    }
+
+    func testOverlappingConsecutiveSendsDoesNotDoubleDeduct() {
+        let appState = AppState()
+        appState.onchainBalanceSats = 100_000
+        appState.spendableOnchainSats = 95_000
+
+        // 1. First send of 30,000 sats
+        appState.onchainSendBroadcasted(amountSats: 30_000, isSendAll: false)
+        XCTAssertEqual(appState.onchainBalanceSats, 70_000)
+        XCTAssertEqual(appState.spendableOnchainSats, 65_000)
+        XCTAssertEqual(appState.pendingOutboundSend.amountSats, 30_000)
+
+        // 2. Second overlapping send of 20,000 sats before sync finishes
+        // Must display 50,000 sats (100k - 30k - 20k), NOT double-deducted 20,000 sats
+        appState.onchainSendBroadcasted(amountSats: 20_000, isSendAll: false)
+        XCTAssertEqual(
+            appState.onchainBalanceSats,
+            50_000,
+            "Consecutive overlapping send must not double-deduct earlier pending sends"
+        )
+        XCTAssertEqual(appState.spendableOnchainSats, 45_000)
+        XCTAssertEqual(appState.pendingOutboundSend.amountSats, 50_000)
+
+        // 3. Intervening refresh (LDK still reports raw 100k)
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: appState.pendingOutboundSend
+        )
+        XCTAssertEqual(effective.onchain, 50_000)
+        XCTAssertEqual(effective.spendable, 45_000)
+    }
+
+    func testPendingOutboundSendTtlExpiration() {
+        let baseTime: Int64 = 1_000_000
+        let pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: 30_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            timestampSecs: baseTime
+        )
+
+        // Within TTL (300 seconds elapsed) -> retains pending send
+        let unexpired = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            currentTimeSecs: baseTime + 300,
+            expirySecs: 600
+        )
+        XCTAssertEqual(unexpired.amountSats, 30_000)
+
+        // Beyond TTL (601 seconds elapsed) -> expires to prevent permanent balance suppression
+        let expired = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            currentTimeSecs: baseTime + 601,
+            expirySecs: 600
+        )
+        XCTAssertEqual(expired.amountSats, 0)
+        XCTAssertFalse(expired.isSendAll)
+    }
+
+    func testIncomingDepositDuringPendingSendClearsViaTtl() {
+        let baseTime: Int64 = 1_000_000
+        let pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: 30_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            timestampSecs: baseTime
+        )
+
+        // A large incoming deposit of 50k arrives, raising raw balance to 120k
+        let rawWithDeposit: UInt64 = 120_000
+
+        // Before TTL expires, balance alone does not clear because 120k > 70k
+        let beforeTtl = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: rawWithDeposit,
+            pending: pending,
+            currentTimeSecs: baseTime + 100,
+            expirySecs: 600
+        )
+        XCTAssertEqual(beforeTtl.amountSats, 30_000)
+
+        // After TTL expires, pending clears and user sees the updated deposit balance
+        let afterTtl = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: rawWithDeposit,
+            pending: pending,
+            currentTimeSecs: baseTime + 650,
+            expirySecs: 600
+        )
+        XCTAssertEqual(afterTtl.amountSats, 0)
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: rawWithDeposit,
+            rawSpendable: rawWithDeposit,
+            pending: afterTtl
+        )
+        XCTAssertEqual(effective.onchain, 120_000)
     }
 }

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -135,4 +135,85 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertEqual(appState.onchainBalanceSats, 0)
         XCTAssertEqual(appState.spendableOnchainSats, 0)
     }
+
+    func testTotalBalanceOpeningChannelIncludesLightningOrOnchain() {
+        let appState = AppState()
+        appState.hasReadyChannel = false
+        appState.isOpeningChannel = true
+        appState.isChannelClosing = false
+
+        appState.lightningBalanceSats = 50_000
+        appState.onchainBalanceSats = 0
+        XCTAssertEqual(appState.totalBalanceSats, 50_000)
+
+        appState.lightningBalanceSats = 0
+        appState.onchainBalanceSats = 60_000
+        XCTAssertEqual(appState.totalBalanceSats, 60_000)
+    }
+
+    // MARK: - Pure BalanceCalculator Tests (SOLID SRP & DIP)
+
+    func testPureBalanceCalculationStaticEntryPoints() {
+        // Ready channel
+        let ready = AppState.calculateTotalBalance(
+            lightning: 100_000,
+            onchain: 50_000,
+            hasReadyChannel: true
+        )
+        XCTAssertEqual(ready, 150_000)
+
+        // Channel closing
+        let closing = AppState.calculateTotalBalance(
+            lightning: 100_000,
+            onchain: 50_000,
+            hasReadyChannel: false,
+            isChannelClosing: true
+        )
+        XCTAssertEqual(closing, 50_000)
+
+        // Sweeping
+        let sweeping = AppState.calculateTotalBalance(
+            lightning: 100_000,
+            onchain: 50_000,
+            hasReadyChannel: true,
+            isSweeping: true
+        )
+        XCTAssertEqual(sweeping, 100_000)
+
+        // Ghost balance: no ready channel & no channels exist
+        let ghost = AppState.calculateTotalBalance(
+            lightning: 100_000,
+            onchain: 0,
+            hasReadyChannel: false,
+            hasAnyChannel: false,
+            pendingSweep: 0
+        )
+        XCTAssertEqual(ghost, 0)
+
+        // Pending channel (channel exists, but not ready yet)
+        let pending = AppState.calculateTotalBalance(
+            lightning: 80_000,
+            onchain: 20_000,
+            hasReadyChannel: false,
+            hasAnyChannel: true
+        )
+        XCTAssertEqual(pending, 100_000)
+    }
+
+    func testBalanceCalculatorDirectly() {
+        let state = BalanceCalculator.ChannelState(
+            hasReadyChannel: false,
+            hasAnyChannel: false,
+            isChannelClosing: false,
+            isOpeningChannel: false,
+            isSweeping: false
+        )
+        let total = BalanceCalculator.calculateTotalBalance(
+            lightning: 90_000,
+            onchain: 30_000,
+            pendingSweep: 5_000,
+            channelState: state
+        )
+        XCTAssertEqual(total, 35_000)
+    }
 }

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -173,7 +173,7 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         XCTAssertEqual(appState.totalBalanceSats, 60_000)
     }
 
-    // MARK: - Pure BalanceCalculator Tests (SOLID SRP & DIP)
+    // MARK: - Pure BalanceCalculator Tests
 
     func testPureBalanceCalculationStaticEntryPoints() {
         // Ready channel
@@ -388,5 +388,147 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         )
         XCTAssertEqual(effectivePostSync.onchain, 69_850)
         XCTAssertEqual(effectivePostSync.spendable, 64_850)
+    }
+
+    // MARK: - Progress, Broadcast, and Invariant Tests
+
+    func testPaymentRecordConfirmationProgress() {
+        let splicePayment = PaymentRecord(
+            id: 1,
+            paymentId: "p1",
+            paymentType: "splice_in",
+            direction: "sent",
+            amountMsat: 50_000_000,
+            amountUSD: 50.0,
+            btcPrice: 100_000,
+            counterparty: nil,
+            status: "pending",
+            createdAt: 1_700_000_000,
+            feeMsat: 1000,
+            txid: "dummy_txid",
+            address: "bc1qtest",
+            confirmations: 0,
+            txBlockHeight: 100
+        )
+        XCTAssertTrue(splicePayment.shouldShowConfirmationProgress)
+        XCTAssertEqual(splicePayment.confirmationProgress.required, 1)
+        XCTAssertEqual(splicePayment.confirmationProgress.display, 0)
+        XCTAssertFalse(splicePayment.confirmationProgress.isComplete)
+        XCTAssertEqual(splicePayment.confirmationProgress.label, "0/1 confirmed")
+
+        let confirmedSplice = PaymentRecord(
+            id: 2,
+            paymentId: "p2",
+            paymentType: "splice_out",
+            direction: "sent",
+            amountMsat: 50_000_000,
+            amountUSD: 50.0,
+            btcPrice: 100_000,
+            counterparty: nil,
+            status: "completed",
+            createdAt: 1_700_000_000,
+            feeMsat: 1000,
+            txid: "dummy_txid",
+            address: "bc1qtest",
+            confirmations: 1,
+            txBlockHeight: 100
+        )
+        XCTAssertEqual(confirmedSplice.confirmationProgress.required, 1)
+        XCTAssertEqual(confirmedSplice.confirmationProgress.display, 1)
+        XCTAssertTrue(confirmedSplice.confirmationProgress.isComplete)
+        XCTAssertEqual(confirmedSplice.confirmationProgress.label, "Confirmed")
+
+        let onchainPayment = PaymentRecord(
+            id: 3,
+            paymentId: "p3",
+            paymentType: "onchain",
+            direction: "sent",
+            amountMsat: 50_000_000,
+            amountUSD: 50.0,
+            btcPrice: 100_000,
+            counterparty: nil,
+            status: "pending",
+            createdAt: 1_700_000_000,
+            feeMsat: 1000,
+            txid: "dummy_txid",
+            address: "bc1qtest",
+            confirmations: 3,
+            txBlockHeight: 100
+        )
+        XCTAssertEqual(onchainPayment.confirmationProgress.required, 6)
+        XCTAssertEqual(onchainPayment.confirmationProgress.display, 3)
+        XCTAssertFalse(onchainPayment.confirmationProgress.isComplete)
+        XCTAssertEqual(onchainPayment.confirmationProgress.label, "3/6 confirmed")
+    }
+
+    func testRecordBroadcastPureLogic() {
+        let initial = BalanceCalculator.PendingOutboundSend()
+
+        // 1. Partial send of 20,000 sats from 100,000 baseline
+        let partial1 = BalanceCalculator.recordBroadcast(
+            currentPending: initial,
+            amountSats: 20_000,
+            isSendAll: false,
+            currentOnchain: 100_000
+        )
+        XCTAssertEqual(partial1.amountSats, 20_000)
+        XCTAssertFalse(partial1.isSendAll)
+        XCTAssertEqual(partial1.baselineOnchainSats, 100_000)
+
+        // 2. Second partial send of 15,000 sats preserves original baseline
+        let partial2 = AppState.recordBroadcast(
+            currentPending: partial1,
+            amountSats: 15_000,
+            isSendAll: false,
+            currentOnchain: 80_000
+        )
+        XCTAssertEqual(partial2.amountSats, 35_000)
+        XCTAssertFalse(partial2.isSendAll)
+        XCTAssertEqual(partial2.baselineOnchainSats, 100_000)
+
+        // 3. Send All
+        let sendAll = BalanceCalculator.recordBroadcast(
+            currentPending: initial,
+            amountSats: 100_000,
+            isSendAll: true,
+            currentOnchain: 100_000
+        )
+        XCTAssertEqual(sendAll.amountSats, 100_000)
+        XCTAssertTrue(sendAll.isSendAll)
+        XCTAssertEqual(sendAll.baselineOnchainSats, 100_000)
+    }
+
+    func testConfirmationCalculatingProtocolPolymorphism() {
+        struct MockCalculator: ConfirmationCalculating {
+            func progress(for _: UInt32, currentBlockHeight _: UInt32, required: Int) -> ConfirmationProgress {
+                ConfirmationProgress(raw: 99, display: required, required: required)
+            }
+        }
+
+        let mock: ConfirmationCalculating = MockCalculator()
+        let result = mock.progress(for: 100, currentBlockHeight: 105, required: 6)
+        XCTAssertTrue(result.isComplete)
+        XCTAssertEqual(result.display, 6)
+        XCTAssertEqual(result.label, "Confirmed")
+    }
+
+    func testResetOnLogoutClearsPendingOutboundSend() {
+        let appState = AppState()
+        appState.onchainBalanceSats = 50_000
+        appState.spendableOnchainSats = 50_000
+        appState.onchainSendBroadcasted(amountSats: 20_000, isSendAll: false)
+
+        XCTAssertEqual(appState.pendingOutboundSend.amountSats, 20_000)
+
+        appState.resetInMemoryWalletState()
+
+        XCTAssertEqual(appState.pendingOutboundSend.amountSats, 0)
+        XCTAssertFalse(appState.pendingOutboundSend.isSendAll)
+        XCTAssertEqual(appState.pendingOutboundSend.baselineOnchainSats, 0)
+
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+        XCTAssertNil(ud?.object(forKey: "pending_outbound_onchain_sats"))
+        XCTAssertNil(ud?.object(forKey: "pending_outbound_is_send_all"))
+        XCTAssertNil(ud?.object(forKey: "pending_outbound_baseline_sats"))
     }
 }

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -613,7 +613,8 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
             amountSats: 30_000,
             isSendAll: false,
             baselineOnchainSats: 100_000,
-            timestampSecs: baseTime
+            timestampSecs: baseTime,
+            txids: ["tx1"]
         )
 
         // Within TTL (300 seconds elapsed) -> retains pending send
@@ -625,52 +626,114 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         )
         XCTAssertEqual(unexpired.amountSats, 30_000)
 
-        // Beyond TTL (601 seconds elapsed) -> expires to prevent permanent balance suppression
-        let expired = BalanceCalculator.resolvePendingOutboundSend(
+        // Beyond TTL (601 seconds elapsed) -> fails closed and retains deduction during indexer/node outage
+        let pastTtl = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: 100_000,
             pending: pending,
             currentTimeSecs: baseTime + 601,
             expirySecs: 600
         )
-        XCTAssertEqual(expired.amountSats, 0)
-        XCTAssertFalse(expired.isSendAll)
+        XCTAssertEqual(pastTtl.amountSats, 30_000)
     }
 
-    func testIncomingDepositDuringPendingSendClearsViaTtl() {
+    func testIncomingDepositWithAuthoritativeTxConfirmationClearsPending() {
         let baseTime: Int64 = 1_000_000
         let pending = BalanceCalculator.PendingOutboundSend(
             amountSats: 30_000,
             isSendAll: false,
             baselineOnchainSats: 100_000,
-            timestampSecs: baseTime
+            timestampSecs: baseTime,
+            txids: ["tx1"]
         )
 
         // A large incoming deposit of 50k arrives, raising raw balance to 120k
         let rawWithDeposit: UInt64 = 120_000
 
-        // Before TTL expires, balance alone does not clear because 120k > 70k
-        let beforeTtl = BalanceCalculator.resolvePendingOutboundSend(
+        // Prior to confirmation, balance predicate alone does not clear because 120k > 70k (fails closed)
+        let unconfirmed = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: rawWithDeposit,
             pending: pending,
             currentTimeSecs: baseTime + 100,
-            expirySecs: 600
+            expirySecs: 600,
+            isTxConfirmed: { _ in false }
         )
-        XCTAssertEqual(beforeTtl.amountSats, 30_000)
+        XCTAssertEqual(unconfirmed.amountSats, 30_000)
 
-        // After TTL expires, pending clears and user sees the updated deposit balance
-        let afterTtl = BalanceCalculator.resolvePendingOutboundSend(
+        // Even past TTL, if unconfirmed it fails closed
+        let pastTtlUnconfirmed = BalanceCalculator.resolvePendingOutboundSend(
             rawOnchain: rawWithDeposit,
             pending: pending,
             currentTimeSecs: baseTime + 650,
-            expirySecs: 600
+            expirySecs: 600,
+            isTxConfirmed: { _ in false }
         )
-        XCTAssertEqual(afterTtl.amountSats, 0)
+        XCTAssertEqual(pastTtlUnconfirmed.amountSats, 30_000)
+
+        // Once authoritative confirmation verifies tx1 is incorporated, pending clears
+        let confirmed = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: rawWithDeposit,
+            pending: pending,
+            currentTimeSecs: baseTime + 100,
+            expirySecs: 600,
+            isTxConfirmed: { $0 == "tx1" }
+        )
+        XCTAssertEqual(confirmed.amountSats, 0)
         let effective = BalanceCalculator.calculateEffectiveBalances(
             rawOnchain: rawWithDeposit,
             rawSpendable: rawWithDeposit,
-            pending: afterTtl
+            pending: confirmed
         )
         XCTAssertEqual(effective.onchain, 120_000)
+    }
+
+    func testOutOfOrderSyncCompletionCannotClearNewerBroadcastGeneration() {
+        // Generation 1 (older broadcast) finishes after Generation 2 was broadcast
+        let shouldClearOlder = BalanceCalculator.shouldClearPendingOnSyncCompletion(
+            expectedGeneration: 1,
+            currentGeneration: 2,
+            syncSuccess: true
+        )
+        XCTAssertFalse(shouldClearOlder)
+
+        // Generation 2 (current broadcast) finishes and clears
+        let shouldClearCurrent = BalanceCalculator.shouldClearPendingOnSyncCompletion(
+            expectedGeneration: 2,
+            currentGeneration: 2,
+            syncSuccess: true
+        )
+        XCTAssertTrue(shouldClearCurrent)
+    }
+
+    func testAllSyncAttemptsFailPreservesPendingDeduction() {
+        let shouldClearFailedSync = BalanceCalculator.shouldClearPendingOnSyncCompletion(
+            expectedGeneration: 1,
+            currentGeneration: 1,
+            syncSuccess: false
+        )
+        XCTAssertFalse(shouldClearFailedSync)
+    }
+
+    func testAuthoritativeTxFailureClearsPendingAndRestoresSpendable() {
+        let pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: 30_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            txids: ["tx_failed"]
+        )
+
+        let resolved = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            isTxFailed: { $0 == "tx_failed" }
+        )
+        XCTAssertEqual(resolved.amountSats, 0)
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: resolved
+        )
+        XCTAssertEqual(effective.onchain, 100_000)
+        XCTAssertEqual(effective.spendable, 95_000)
     }
 
     func testPartialIncorporationOfMultipleSendsDoesNotDoubleDeduct() {

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -672,4 +672,51 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         )
         XCTAssertEqual(effective.onchain, 120_000)
     }
+
+    func testPartialIncorporationOfMultipleSendsDoesNotDoubleDeduct() {
+        // Baseline 100k, spendable 95k. User performs two sends: 30k, then 20k (total pending = 50k).
+        let pending = BalanceCalculator.PendingOutboundSend(
+            amountSats: 50_000,
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            timestampSecs: 1_000_000
+        )
+
+        // Stage 1: No sends incorporated into raw yet (rawOnchain = 100k)
+        let stage1 = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: pending
+        )
+        XCTAssertEqual(stage1.onchain, 50_000)
+        XCTAssertEqual(stage1.spendable, 45_000)
+
+        // Stage 2: Intermediate state - send 1 (30k) has landed in raw balance (rawOnchain = 70k),
+        // but send 2 (20k) is still unincorporated.
+        // Effective balance must remain 50k, NOT drop to 20k from double-deduction.
+        let stage2 = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 70_000,
+            rawSpendable: 65_000,
+            pending: pending
+        )
+        XCTAssertEqual(stage2.onchain, 50_000)
+        XCTAssertEqual(stage2.spendable, 45_000)
+
+        // Stage 3: Both sends incorporated into raw balance (rawOnchain = 50k)
+        let stage3 = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 50_000,
+            rawSpendable: 45_000,
+            pending: pending
+        )
+        XCTAssertEqual(stage3.onchain, 50_000)
+        XCTAssertEqual(stage3.spendable, 45_000)
+
+        let resolved = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 50_000,
+            pending: pending,
+            currentTimeSecs: 1_000_100,
+            expirySecs: 600
+        )
+        XCTAssertEqual(resolved.amountSats, 0)
+    }
 }

--- a/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnChainConfirmationPolicyTests.swift
@@ -9,6 +9,8 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         ud?.removeObject(forKey: "pending_outbound_onchain_sats")
         ud?.removeObject(forKey: "pending_outbound_is_send_all")
         ud?.removeObject(forKey: "pending_outbound_baseline_sats")
+        ud?.removeObject(forKey: "pending_outbound_timestamp")
+        ud?.removeObject(forKey: "pending_outbound_txids")
         ud?.removeObject(forKey: "cached_onchain_sats")
         ud?.removeObject(forKey: "cached_spendable_onchain_sats")
         ud?.removeObject(forKey: "cached_lightning_sats")
@@ -19,6 +21,8 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
         ud?.removeObject(forKey: "pending_outbound_onchain_sats")
         ud?.removeObject(forKey: "pending_outbound_is_send_all")
         ud?.removeObject(forKey: "pending_outbound_baseline_sats")
+        ud?.removeObject(forKey: "pending_outbound_timestamp")
+        ud?.removeObject(forKey: "pending_outbound_txids")
         ud?.removeObject(forKey: "cached_onchain_sats")
         ud?.removeObject(forKey: "cached_spendable_onchain_sats")
         ud?.removeObject(forKey: "cached_lightning_sats")
@@ -781,5 +785,166 @@ final class OnChainConfirmationPolicyTests: XCTestCase {
             expirySecs: 600
         )
         XCTAssertEqual(resolved.amountSats, 0)
+    }
+
+    // MARK: - Review Fix Tests (Issue #267)
+
+    func testMixedSucceededFailedBatchPartialRelease() {
+        // Two sends aggregated: tx_fail (30k) and tx_success (20k). Total = 50k.
+        let pending = BalanceCalculator.PendingOutboundSend(
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            timestampSecs: 1_000_000,
+            entries: [
+                BalanceCalculator.TxEntry(txid: "tx_fail", amountSats: 30_000),
+                BalanceCalculator.TxEntry(txid: "tx_success", amountSats: 20_000)
+            ]
+        )
+        XCTAssertEqual(pending.amountSats, 50_000)
+        XCTAssertEqual(pending.txids, ["tx_fail", "tx_success"])
+
+        // Case 1: tx_fail fails; tx_success is not yet incorporated.
+        // The failed 30k must be released, retaining only 20k for tx_success.
+        let partialFail = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            isTxIncorporated: { _ in false },
+            isTxFailed: { $0 == "tx_fail" }
+        )
+        XCTAssertEqual(partialFail.amountSats, 20_000)
+        XCTAssertEqual(partialFail.entries.count, 1)
+        XCTAssertEqual(partialFail.entries.first?.txid, "tx_success")
+
+        let effPartialFail = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 100_000,
+            rawSpendable: 95_000,
+            pending: partialFail
+        )
+        XCTAssertEqual(effPartialFail.onchain, 80_000)
+        XCTAssertEqual(effPartialFail.spendable, 75_000)
+
+        // Case 2: tx_success is incorporated; tx_fail is still pending.
+        // The incorporated 20k is removed, retaining only 30k for tx_fail.
+        let partialSuccess = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            isTxIncorporated: { $0 == "tx_success" },
+            isTxFailed: { _ in false }
+        )
+        XCTAssertEqual(partialSuccess.amountSats, 30_000)
+        XCTAssertEqual(partialSuccess.entries.count, 1)
+        XCTAssertEqual(partialSuccess.entries.first?.txid, "tx_fail")
+
+        // Case 3: Both resolve (one failed, one incorporated). Entire record clears.
+        let bothResolved = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 100_000,
+            pending: pending,
+            isTxIncorporated: { $0 == "tx_success" },
+            isTxFailed: { $0 == "tx_fail" }
+        )
+        XCTAssertEqual(bothResolved.amountSats, 0)
+        XCTAssertTrue(bothResolved.entries.isEmpty)
+    }
+
+    func testRelaunchWithConcurrentDepositClearsOnIncorporation() {
+        // gpt-6-astra P1 scenario:
+        // App was killed before sync, restored on relaunch from cache.
+        // During relaunch, an incoming deposit raised raw onchain to 120_000 (baseline was 100_000).
+        // Since rawOnchain > baseline, rawDrop is 0.
+        // The broadcast tx ("tx_mempool") is tracked in LDK with .pending status (not .succeeded).
+        let pending = BalanceCalculator.PendingOutboundSend(
+            isSendAll: false,
+            baselineOnchainSats: 100_000,
+            timestampSecs: 1_000_000,
+            entries: [
+                BalanceCalculator.TxEntry(txid: "tx_mempool", amountSats: 50_000)
+            ]
+        )
+
+        // Under new policy, isTxIncorporated returns true for .pending status.
+        let resolved = BalanceCalculator.resolvePendingOutboundSend(
+            rawOnchain: 120_000,
+            pending: pending,
+            isTxIncorporated: { $0 == "tx_mempool" },
+            isTxFailed: { _ in false }
+        )
+        XCTAssertEqual(resolved.amountSats, 0)
+
+        // Effective balance immediately displays full deposit without stuck deduction.
+        let effective = BalanceCalculator.calculateEffectiveBalances(
+            rawOnchain: 120_000,
+            rawSpendable: 115_000,
+            pending: resolved
+        )
+        XCTAssertEqual(effective.onchain, 120_000)
+        XCTAssertEqual(effective.spendable, 115_000)
+    }
+
+    func testPerTxidEntryRecordBroadcastAccumulation() {
+        var pending = BalanceCalculator.PendingOutboundSend()
+
+        // First broadcast: 30,000 sats with txid "tx_alpha"
+        pending = BalanceCalculator.recordBroadcast(
+            currentPending: pending,
+            amountSats: 30_000,
+            isSendAll: false,
+            currentOnchain: 100_000,
+            txid: "tx_alpha"
+        )
+        XCTAssertEqual(pending.entries.count, 1)
+        XCTAssertEqual(pending.entries[0], BalanceCalculator.TxEntry(txid: "tx_alpha", amountSats: 30_000))
+        XCTAssertEqual(pending.amountSats, 30_000)
+        XCTAssertEqual(pending.txids, ["tx_alpha"])
+
+        // Second broadcast: 20,000 sats with txid "tx_beta"
+        pending = BalanceCalculator.recordBroadcast(
+            currentPending: pending,
+            amountSats: 20_000,
+            isSendAll: false,
+            currentOnchain: 70_000,
+            txid: "tx_beta"
+        )
+        XCTAssertEqual(pending.entries.count, 2)
+        XCTAssertEqual(pending.entries[0], BalanceCalculator.TxEntry(txid: "tx_alpha", amountSats: 30_000))
+        XCTAssertEqual(pending.entries[1], BalanceCalculator.TxEntry(txid: "tx_beta", amountSats: 20_000))
+        XCTAssertEqual(pending.amountSats, 50_000)
+        XCTAssertEqual(pending.txids, ["tx_alpha", "tx_beta"])
+    }
+
+    func testBackwardCompatibilityCachedPendingDeserialization() {
+        let ud = UserDefaults(suiteName: Constants.appGroupIdentifier)
+
+        // 1. Test legacy format (flat txids without amount colons)
+        ud?.set(Int64(50_000), forKey: "pending_outbound_onchain_sats")
+        ud?.set(false, forKey: "pending_outbound_is_send_all")
+        ud?.set(Int64(100_000), forKey: "pending_outbound_baseline_sats")
+        ud?.set(Int64(1_000_000), forKey: "pending_outbound_timestamp")
+        ud?.set("legacy_tx1,legacy_tx2", forKey: "pending_outbound_txids")
+
+        let legacyLoaded = AppState.loadCachedPendingOutboundSend(from: ud)
+        XCTAssertEqual(legacyLoaded.amountSats, 50_000)
+        XCTAssertEqual(legacyLoaded.entries.count, 2)
+        XCTAssertEqual(legacyLoaded.entries[0].txid, "legacy_tx1")
+        XCTAssertEqual(legacyLoaded.entries[0].amountSats, 25_000)
+        XCTAssertEqual(legacyLoaded.entries[1].txid, "legacy_tx2")
+        XCTAssertEqual(legacyLoaded.entries[1].amountSats, 25_000)
+
+        // 2. Test new format (txid:amount pairs)
+        ud?.set(Int64(50_000), forKey: "pending_outbound_onchain_sats")
+        ud?.set("new_tx1:30000,new_tx2:20000", forKey: "pending_outbound_txids")
+        let newLoaded = AppState.loadCachedPendingOutboundSend(from: ud)
+        XCTAssertEqual(newLoaded.amountSats, 50_000)
+        XCTAssertEqual(newLoaded.entries.count, 2)
+        XCTAssertEqual(newLoaded.entries[0].txid, "new_tx1")
+        XCTAssertEqual(newLoaded.entries[0].amountSats, 30_000)
+        XCTAssertEqual(newLoaded.entries[1].txid, "new_tx2")
+        XCTAssertEqual(newLoaded.entries[1].amountSats, 20_000)
+
+        // Clean up test values
+        ud?.removeObject(forKey: "pending_outbound_onchain_sats")
+        ud?.removeObject(forKey: "pending_outbound_is_send_all")
+        ud?.removeObject(forKey: "pending_outbound_baseline_sats")
+        ud?.removeObject(forKey: "pending_outbound_timestamp")
+        ud?.removeObject(forKey: "pending_outbound_txids")
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -245,6 +245,24 @@ pub fn payment_status_display(
     }
 }
 
+/// Determines if a pending outbound on-chain send deduction should be cleared.
+/// Clears when wallet sync succeeds (proving spend is incorporated) or when the payment
+/// reaches a terminal failed status (proving broadcast failed and inputs remain spendable).
+/// During network outages or incomplete sync, returns false (fails closed) to prevent
+/// re-exposing already-spent funds.
+pub fn should_clear_pending_outbound(
+    sync_succeeded: bool,
+    payment_status: Option<PaymentStatus>,
+) -> bool {
+    if sync_succeeded {
+        return true;
+    }
+    match payment_status {
+        Some(PaymentStatus::Failed) => true,
+        _ => false,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LocalTradeAllocationError {
     StabilizationLimit(u64),
@@ -1913,7 +1931,9 @@ impl UserApp {
                                     self.update_balances();
                                     let node_clone = Arc::clone(&self.node);
                                     let pending_clone = Arc::clone(&self.pending_outbound_onchain_sats);
+                                    let txid_clone = txid_str.clone();
                                     std::thread::spawn(move || {
+                                        // 1. Immediate sync retries
                                         for attempt in 0..3 {
                                             if node_clone.sync_wallets().is_ok() {
                                                 let cur = pending_clone
@@ -1928,12 +1948,36 @@ impl UserApp {
                                                 500 * (attempt + 1),
                                             ));
                                         }
-                                        let cur = pending_clone
-                                            .load(std::sync::atomic::Ordering::Relaxed);
-                                        pending_clone.fetch_sub(
-                                            deducted_sats.min(cur),
-                                            std::sync::atomic::Ordering::Relaxed,
-                                        );
+
+                                        // 2. Immediate sync attempts exhausted. Retain pending deduction!
+                                        // A network, indexer, or node-sync failure does not undo the broadcast.
+                                        // Fail closed and poll until wallet sync succeeds or the payment fails.
+                                        loop {
+                                            std::thread::sleep(std::time::Duration::from_secs(5));
+                                            let terminal_failed = node_clone.list_payments().iter().any(|p| {
+                                                if let PaymentKind::Onchain { ref txid, .. } = p.kind {
+                                                    txid.to_string() == txid_clone && p.status == PaymentStatus::Failed
+                                                } else {
+                                                    false
+                                                }
+                                            });
+                                            let sync_ok = node_clone.sync_wallets().is_ok();
+                                            let payment_status = if terminal_failed {
+                                                Some(PaymentStatus::Failed)
+                                            } else {
+                                                None
+                                            };
+
+                                            if should_clear_pending_outbound(sync_ok, payment_status) {
+                                                let cur = pending_clone
+                                                    .load(std::sync::atomic::Ordering::Relaxed);
+                                                pending_clone.fetch_sub(
+                                                    deducted_sats.min(cur),
+                                                    std::sync::atomic::Ordering::Relaxed,
+                                                );
+                                                return;
+                                            }
+                                        }
                                     });
                                     return true;
                                 }
@@ -12872,6 +12916,39 @@ mod tests {
         });
         h2.join().unwrap();
         assert_eq!(multi_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_should_clear_pending_outbound() {
+        use ldk_node::payment::PaymentStatus;
+
+        // Sync success always clears pending deduction
+        assert!(super::should_clear_pending_outbound(true, None));
+        assert!(super::should_clear_pending_outbound(
+            true,
+            Some(PaymentStatus::Pending)
+        ));
+        assert!(super::should_clear_pending_outbound(
+            true,
+            Some(PaymentStatus::Succeeded)
+        ));
+
+        // Sync failure with terminal payment failure clears deduction (inputs safely spendable)
+        assert!(super::should_clear_pending_outbound(
+            false,
+            Some(PaymentStatus::Failed)
+        ));
+
+        // Sync failure during outage / pending payment FAILS CLOSED (retains deduction)
+        assert!(!super::should_clear_pending_outbound(false, None));
+        assert!(!super::should_clear_pending_outbound(
+            false,
+            Some(PaymentStatus::Pending)
+        ));
+        assert!(!super::should_clear_pending_outbound(
+            false,
+            Some(PaymentStatus::Succeeded)
+        ));
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -12749,6 +12749,36 @@ mod tests {
         assert_eq!(super::closure_reason_to_json(&none)["kind"], "UNKNOWN");
     }
 
+    #[test]
+    fn test_required_confirmations_for_payment() {
+        assert_eq!(super::required_confirmations_for_payment("splice_in", "inbound"), 1);
+        assert_eq!(super::required_confirmations_for_payment("splice_out", "outbound"), 1);
+        assert_eq!(super::required_confirmations_for_payment("onchain", "inbound"), 6);
+        assert_eq!(super::required_confirmations_for_payment("onchain", "outbound"), 6);
+        assert_eq!(super::required_confirmations_for_payment("lightning", "inbound"), 0);
+        assert_eq!(super::required_confirmations_for_payment("lightning", "outbound"), 0);
+        assert_eq!(super::required_confirmations_for_payment("unknown", "outbound"), 0);
+    }
+
+    #[test]
+    fn test_pending_outbound_onchain_deduction() {
+        let live_onchain_sats: u64 = 50_000;
+        let send_amount_sats: u64 = 20_000;
+
+        // Immediately after broadcast:
+        let pending_outbound = send_amount_sats;
+        let displayed_onchain = live_onchain_sats.saturating_sub(pending_outbound);
+        assert_eq!(displayed_onchain, 30_000);
+
+        // Send max / full balance broadcast:
+        let send_max_pending = 50_000;
+        let displayed_send_max = live_onchain_sats.saturating_sub(send_max_pending);
+        assert_eq!(displayed_send_max, 0);
+
+        // Over-deduction edge case safely saturates at 0:
+        let over_deduction = 60_000;
+        assert_eq!(live_onchain_sats.saturating_sub(over_deduction), 0);
+    }
 }
 
 /// Convert an LDK `ClosureReason` into a structured JSON object for the audit log so a channel

--- a/src/user.rs
+++ b/src/user.rs
@@ -196,6 +196,20 @@ struct IncomingSync {
     request_hash: Option<String>,
 }
 
+/// Dynamic confirmation threshold policy for splices and on-chain transactions:
+/// - splices (splice_in, splice_out): 1 confirmation (channel established/trusted)
+/// - onchain (inbound / outbound): 6 confirmations
+/// - lightning: 0 confirmations
+pub fn required_confirmations_for_payment(payment_type: &str, direction: &str) -> u32 {
+    let _ = direction;
+    match payment_type {
+        "splice_in" | "splice_out" => 1,
+        "onchain" => 6,
+        "lightning" => 0,
+        _ => 0,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LocalTradeAllocationError {
     StabilizationLimit(u64),
@@ -8616,12 +8630,21 @@ impl UserApp {
                                         ),
                                     );
 
-                                    let (status_label, status_color) = match payment.status.as_str()
-                                    {
-                                        "completed" => ("Confirmed", theme::SUCCESS),
-                                        "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
-                                        "failed" => ("Failed", theme::DANGER_HOVER),
-                                        _ => (&*payment.status, Color32::DARK_GRAY),
+                                    let (status_label, status_color) = match payment.status.as_str() {
+                                        "completed" => ("Confirmed".to_string(), theme::SUCCESS),
+                                        "pending" => {
+                                            let threshold = required_confirmations_for_payment(
+                                                &payment.payment_type,
+                                                &payment.direction,
+                                            );
+                                            if threshold > 0 {
+                                                (format!("{}/{}", payment.confirmations, threshold), Color32::from_rgb(234, 179, 8))
+                                            } else {
+                                                ("Pending".to_string(), Color32::from_rgb(234, 179, 8))
+                                            }
+                                        }
+                                        "failed" => ("Failed".to_string(), theme::DANGER_HOVER),
+                                        _ => (payment.status.clone(), Color32::DARK_GRAY),
                                     };
                                     let (badge_rect, _) = ui.allocate_exact_size(
                                         egui::vec2(58.0, 18.0),
@@ -8636,7 +8659,7 @@ impl UserApp {
                                     ui.painter().text(
                                         badge_rect.center(),
                                         egui::Align2::CENTER_CENTER,
-                                        status_label,
+                                        &status_label,
                                         egui::FontId::proportional(10.0),
                                         status_color,
                                     );
@@ -8914,10 +8937,20 @@ impl UserApp {
                 }
 
                 let (status_label, status_color) = match payment.status.as_str() {
-                    "completed" => ("Confirmed", theme::SUCCESS),
-                    "pending" => ("Pending", Color32::from_rgb(234, 179, 8)),
-                    "failed" => ("Failed", theme::DANGER_HOVER),
-                    _ => (&*payment.status, Color32::DARK_GRAY),
+                    "completed" => ("Confirmed".to_string(), theme::SUCCESS),
+                    "pending" => {
+                        let threshold = required_confirmations_for_payment(
+                            &payment.payment_type,
+                            &payment.direction,
+                        );
+                        if threshold > 0 {
+                            (format!("{}/{}", payment.confirmations, threshold), Color32::from_rgb(234, 179, 8))
+                        } else {
+                            ("Pending".to_string(), Color32::from_rgb(234, 179, 8))
+                        }
+                    }
+                    "failed" => ("Failed".to_string(), theme::DANGER_HOVER),
+                    _ => (payment.status.clone(), Color32::DARK_GRAY),
                 };
                 ui.horizontal(|ui| {
                     ui.add_sized(
@@ -8926,13 +8959,23 @@ impl UserApp {
                     );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.label(
-                            RichText::new(status_label)
+                            RichText::new(&status_label)
                                 .size(12.0)
                                 .color(status_color)
                                 .strong(),
                         );
                     });
                 });
+                let threshold = required_confirmations_for_payment(
+                    &payment.payment_type,
+                    &payment.direction,
+                );
+                if threshold > 0 {
+                    let conf_str = format!("{}/{}", payment.confirmations, threshold);
+                    row(ui, "Confirmations", &conf_str);
+                } else if payment.confirmations > 0 {
+                    row(ui, "Confirmations", &payment.confirmations.to_string());
+                }
                 ui.add_space(2.0);
 
                 row(ui, "Date", &Self::format_timestamp(payment.created_at));

--- a/src/user.rs
+++ b/src/user.rs
@@ -198,16 +198,27 @@ struct IncomingSync {
 
 /// Dynamic confirmation threshold policy for splices and on-chain transactions:
 /// - splices (splice_in, splice_out): 1 confirmation (channel established/trusted)
-/// - onchain (inbound / outbound): 6 confirmations
+/// - onchain (inbound / outbound) / channel_close: 6 confirmations
 /// - lightning: 0 confirmations
-pub fn required_confirmations_for_payment(payment_type: &str, direction: &str) -> u32 {
-    let _ = direction;
-    match payment_type {
-        "splice_in" | "splice_out" => 1,
-        "onchain" => 6,
-        "lightning" => 0,
-        _ => 0,
+pub struct ConfirmationPolicy;
+
+impl ConfirmationPolicy {
+    pub const DEFAULT_ONCHAIN_REQUIRED: u32 = 6;
+    pub const SPLICE_REQUIRED: u32 = 1;
+    pub const LIGHTNING_REQUIRED: u32 = 0;
+
+    pub fn required(payment_type: &str, _direction: &str) -> u32 {
+        match payment_type {
+            "splice_in" | "splice_out" => Self::SPLICE_REQUIRED,
+            "onchain" | "channel_close" => Self::DEFAULT_ONCHAIN_REQUIRED,
+            "lightning" => Self::LIGHTNING_REQUIRED,
+            _ => 0,
+        }
     }
+}
+
+pub fn required_confirmations_for_payment(payment_type: &str, direction: &str) -> u32 {
+    ConfirmationPolicy::required(payment_type, direction)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1805,10 +1816,17 @@ impl UserApp {
                             }
                         } else {
                             // No channel — fallback to regular onchain send
-                            let amount_sats = match self.send_amount.trim().parse::<f64>() {
-                                Ok(btc) if btc > 0.0 => (btc * 100_000_000.0) as u64,
+                            let balances = self.node.list_balances();
+                            let (amount_sats, deducted_sats) = match self.send_amount.trim().parse::<f64>() {
+                                Ok(btc) if btc > 0.0 => {
+                                    let sats = (btc * 100_000_000.0) as u64;
+                                    (sats, sats)
+                                }
                                 _ if self.send_all => {
-                                    self.node.list_balances().spendable_onchain_balance_sats
+                                    (
+                                        balances.spendable_onchain_balance_sats,
+                                        balances.total_onchain_balance_sats,
+                                    )
                                 }
                                 _ => {
                                     self.send_error = "Enter a valid amount in BTC".to_string();
@@ -1866,25 +1884,15 @@ impl UserApp {
                                     self.send_input.clear();
                                     self.send_amount.clear();
                                     self.send_error.clear();
+                                    self.pending_outbound_onchain_sats
+                                        .store(deducted_sats, std::sync::atomic::Ordering::Relaxed);
+                                    self.update_balances();
                                     let node_clone = Arc::clone(&self.node);
                                     let pending_clone = Arc::clone(&self.pending_outbound_onchain_sats);
                                     std::thread::spawn(move || {
                                         let _ = node_clone.sync_wallets();
                                         pending_clone.store(0, std::sync::atomic::Ordering::Relaxed);
                                     });
-                                    self.update_balances();
-                                    let deducted_sats = if self.send_all {
-                                        self.node.list_balances().spendable_onchain_balance_sats
-                                    } else {
-                                        amount_sats
-                                    };
-                                    self.pending_outbound_onchain_sats
-                                        .store(deducted_sats, std::sync::atomic::Ordering::Relaxed);
-                                    let deducted_btc = deducted_sats as f64 / 100_000_000.0;
-                                    self.onchain_balance_btc = (self.onchain_balance_btc - deducted_btc).max(0.0);
-                                    self.onchain_balance_usd = self.onchain_balance_btc * self.btc_price;
-                                    self.total_balance_btc = (self.total_balance_btc - deducted_btc).max(0.0);
-                                    self.total_balance_usd = self.total_balance_btc * self.btc_price;
                                     return true;
                                 }
                                 Err(e) => {
@@ -12755,6 +12763,8 @@ mod tests {
         assert_eq!(super::required_confirmations_for_payment("splice_out", "outbound"), 1);
         assert_eq!(super::required_confirmations_for_payment("onchain", "inbound"), 6);
         assert_eq!(super::required_confirmations_for_payment("onchain", "outbound"), 6);
+        assert_eq!(super::required_confirmations_for_payment("channel_close", "inbound"), 6);
+        assert_eq!(super::required_confirmations_for_payment("channel_close", "outbound"), 6);
         assert_eq!(super::required_confirmations_for_payment("lightning", "inbound"), 0);
         assert_eq!(super::required_confirmations_for_payment("lightning", "outbound"), 0);
         assert_eq!(super::required_confirmations_for_payment("unknown", "outbound"), 0);
@@ -12771,13 +12781,29 @@ mod tests {
         assert_eq!(displayed_onchain, 30_000);
 
         // Send max / full balance broadcast:
-        let send_max_pending = 50_000;
+        // Even if spendable is lower than total due to anchor reserve (e.g. 48k vs 50k),
+        // send_all sets deducted_sats to total_onchain_balance_sats (50k) so display hits 0:
+        let send_max_pending = live_onchain_sats;
         let displayed_send_max = live_onchain_sats.saturating_sub(send_max_pending);
         assert_eq!(displayed_send_max, 0);
 
         // Over-deduction edge case safely saturates at 0:
         let over_deduction = 60_000;
         assert_eq!(live_onchain_sats.saturating_sub(over_deduction), 0);
+
+        // Test store-before-spawn thread lifecycle:
+        let atomic_pending = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        // Main thread stores deduction BEFORE spawning sync thread:
+        atomic_pending.store(send_amount_sats, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 20_000);
+
+        // Background thread clears to 0 after sync:
+        let atomic_clone = std::sync::Arc::clone(&atomic_pending);
+        let handle = std::thread::spawn(move || {
+            atomic_clone.store(0, std::sync::atomic::Ordering::Relaxed);
+        });
+        handle.join().unwrap();
+        assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1952,7 +1952,8 @@ impl UserApp {
                                         // 2. Immediate sync attempts exhausted. Retain pending deduction!
                                         // A network, indexer, or node-sync failure does not undo the broadcast.
                                         // Fail closed and poll until wallet sync succeeds or the payment fails.
-                                        loop {
+                                        // Bounded to 60 iterations (~5 minutes) to prevent unbounded thread leaks.
+                                        for _ in 0..60 {
                                             std::thread::sleep(std::time::Duration::from_secs(5));
                                             let terminal_failed = node_clone.list_payments().iter().any(|p| {
                                                 if let PaymentKind::Onchain { ref txid, .. } = p.kind {

--- a/src/user.rs
+++ b/src/user.rs
@@ -379,6 +379,7 @@ pub struct UserApp {
     auto_splice_in_progress: Arc<std::sync::atomic::AtomicBool>,
     /// On-chain sats at the time the auto-splice was initiated; used to detect confirmation.
     auto_splice_onchain_at_start: Arc<std::sync::atomic::AtomicU64>,
+    pub pending_outbound_onchain_sats: Arc<std::sync::atomic::AtomicU64>,
     pub show_onchain_receive: bool,
     pub show_onchain_send: bool,
     pub show_advanced: bool,
@@ -747,6 +748,7 @@ impl UserApp {
             pending_splice: Arc::new(std::sync::Mutex::new(None)),
             auto_splice_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             auto_splice_onchain_at_start: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            pending_outbound_onchain_sats: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             show_onchain_receive: false,
             show_onchain_send: false,
             lightning_balance_btc: 0.0,
@@ -1042,23 +1044,31 @@ impl UserApp {
                     // every deposit, not just the latest.
                     let mut new_deposits: Vec<(String, u64, PaymentStatus)> = Vec::new();
                     for p in node_arc.list_payments() {
-                        if p.direction != PaymentDirection::Inbound {
-                            continue;
-                        }
                         let PaymentKind::Onchain { ref txid, .. } = p.kind else {
                             continue;
                         };
                         let txid = txid.to_string();
-                        if p.status == PaymentStatus::Succeeded {
-                            if let Err(e) = db.complete_payment_by_txid(&txid) {
+                        if p.direction == PaymentDirection::Inbound {
+                            if p.status == PaymentStatus::Succeeded {
+                                if let Err(e) = db.complete_payment_by_txid(&txid) {
+                                    audit_event(
+                                        "ONCHAIN_DEPOSIT_COMPLETION_FAILED",
+                                        json!({ "txid": txid, "error": e.to_string() }),
+                                    );
+                                }
+                            }
+                            if p.latest_update_timestamp >= thread_started_unix {
+                                new_deposits.push((txid, p.amount_msat.unwrap_or(0), p.status));
+                            }
+                        } else if p.direction == PaymentDirection::Outbound
+                            && p.status == PaymentStatus::Succeeded
+                        {
+                            if let Err(e) = db.update_payment_confirmations(&txid, 6, "completed") {
                                 audit_event(
-                                    "ONCHAIN_DEPOSIT_COMPLETION_FAILED",
+                                    "ONCHAIN_OUTBOUND_CONFIRMATION_FAILED",
                                     json!({ "txid": txid, "error": e.to_string() }),
                                 );
                             }
-                        }
-                        if p.latest_update_timestamp >= thread_started_unix {
-                            new_deposits.push((txid, p.amount_msat.unwrap_or(0), p.status));
                         }
                     }
 
@@ -1847,7 +1857,7 @@ impl UserApp {
                                         amount_usd,
                                         btc_price_opt,
                                         None,
-                                        "completed",
+                                        "pending",
                                         Some(&txid_str),
                                         None,
                                     );
@@ -1857,10 +1867,24 @@ impl UserApp {
                                     self.send_amount.clear();
                                     self.send_error.clear();
                                     let node_clone = Arc::clone(&self.node);
+                                    let pending_clone = Arc::clone(&self.pending_outbound_onchain_sats);
                                     std::thread::spawn(move || {
                                         let _ = node_clone.sync_wallets();
+                                        pending_clone.store(0, std::sync::atomic::Ordering::Relaxed);
                                     });
                                     self.update_balances();
+                                    let deducted_sats = if self.send_all {
+                                        self.node.list_balances().spendable_onchain_balance_sats
+                                    } else {
+                                        amount_sats
+                                    };
+                                    self.pending_outbound_onchain_sats
+                                        .store(deducted_sats, std::sync::atomic::Ordering::Relaxed);
+                                    let deducted_btc = deducted_sats as f64 / 100_000_000.0;
+                                    self.onchain_balance_btc = (self.onchain_balance_btc - deducted_btc).max(0.0);
+                                    self.onchain_balance_usd = self.onchain_balance_btc * self.btc_price;
+                                    self.total_balance_btc = (self.total_balance_btc - deducted_btc).max(0.0);
+                                    self.total_balance_usd = self.total_balance_btc * self.btc_price;
                                     return true;
                                 }
                                 Err(e) => {
@@ -1919,10 +1943,17 @@ impl UserApp {
             balances.total_onchain_balance_sats,
         );
 
+        let pending_outbound = self
+            .pending_outbound_onchain_sats
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let total_onchain_sats = balances
+            .total_onchain_balance_sats
+            .saturating_sub(pending_outbound);
+
         // Detect incoming payment: total sats went up → trigger balance flash
         let total_sats_now = balances
             .total_lightning_balance_sats
-            .saturating_add(balances.total_onchain_balance_sats)
+            .saturating_add(total_onchain_sats)
             .saturating_sub(splice_overlap_sats);
         if self.last_known_total_sats > 0 && total_sats_now > self.last_known_total_sats {
             self.payment_flash_at = Some(std::time::Instant::now());
@@ -1930,7 +1961,7 @@ impl UserApp {
         self.last_known_total_sats = total_sats_now;
 
         self.lightning_balance_btc = balances.total_lightning_balance_sats as f64 / 100_000_000.0;
-        self.onchain_balance_btc = balances.total_onchain_balance_sats as f64 / 100_000_000.0;
+        self.onchain_balance_btc = total_onchain_sats as f64 / 100_000_000.0;
 
         self.lightning_balance_usd = self.lightning_balance_btc * self.btc_price;
         self.onchain_balance_usd = self.onchain_balance_btc * self.btc_price;
@@ -6186,8 +6217,15 @@ impl UserApp {
             // LDK reports stale entries long after sweep confirms and funds are spent.
 
             // Total onchain balance (includes confirmed + AwaitingThresholdConfirmations)
-            let total_onchain_sats = balances.total_onchain_balance_sats;
-            let spendable_onchain_sats = balances.spendable_onchain_balance_sats;
+            let pending_outbound = self
+                .pending_outbound_onchain_sats
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let total_onchain_sats = balances
+                .total_onchain_balance_sats
+                .saturating_sub(pending_outbound);
+            let spendable_onchain_sats = balances
+                .spendable_onchain_balance_sats
+                .saturating_sub(pending_outbound);
 
             // Get balance info
             let (btc_price, last_update, expected_usd, backing_sats) = {
@@ -12710,6 +12748,7 @@ mod tests {
         let none: Option<ClosureReason> = None;
         assert_eq!(super::closure_reason_to_json(&none)["kind"], "UNKNOWN");
     }
+
 }
 
 /// Convert an LDK `ClosureReason` into a structured JSON object for the audit log so a channel

--- a/src/user.rs
+++ b/src/user.rs
@@ -1952,9 +1952,20 @@ impl UserApp {
                                         // 2. Immediate sync attempts exhausted. Retain pending deduction!
                                         // A network, indexer, or node-sync failure does not undo the broadcast.
                                         // Fail closed and poll until wallet sync succeeds or the payment fails.
-                                        // Bounded to 60 iterations (~5 minutes) to prevent unbounded thread leaks.
-                                        for _ in 0..60 {
-                                            std::thread::sleep(std::time::Duration::from_secs(5));
+                                        // Initial burst: poll every 5s for the first 60 attempts (~5 mins).
+                                        // If outage persists beyond 5 minutes, adaptively back off to polling every 60s
+                                        // so we don't spin heavily (opus-5), while never abandoning reconciliation
+                                        // which would leave desktop balance permanently understated (gpt-6-astra P1).
+                                        let mut attempt: u32 = 0;
+                                        loop {
+                                            let delay = if attempt < 60 {
+                                                std::time::Duration::from_secs(5)
+                                            } else {
+                                                std::time::Duration::from_secs(60)
+                                            };
+                                            std::thread::sleep(delay);
+                                            attempt = attempt.saturating_add(1);
+
                                             let terminal_failed = node_clone.list_payments().iter().any(|p| {
                                                 if let PaymentKind::Onchain { ref txid, .. } = p.kind {
                                                     txid.to_string() == txid_clone && p.status == PaymentStatus::Failed
@@ -12917,6 +12928,32 @@ mod tests {
         });
         h2.join().unwrap();
         assert_eq!(multi_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_pending_outbound_prolonged_outage_recovery() {
+        // Simulates recovery after extended outage (past 60 iterations):
+        // Deduction remains active during outage, but is cleared when sync eventually recovers.
+        let atomic_pending = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        atomic_pending.fetch_add(30_000, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 30_000);
+
+        let atomic_clone = std::sync::Arc::clone(&atomic_pending);
+        let handle = std::thread::spawn(move || {
+            let mut sync_attempts = 0;
+            loop {
+                sync_attempts += 1;
+                // Simulate 65 failed sync attempts during outage, then success on attempt 66
+                let sync_ok = sync_attempts > 65;
+                if super::should_clear_pending_outbound(sync_ok, None) {
+                    let cur = atomic_clone.load(std::sync::atomic::Ordering::Relaxed);
+                    atomic_clone.fetch_sub(30_000_u64.min(cur), std::sync::atomic::Ordering::Relaxed);
+                    return;
+                }
+            }
+        });
+        handle.join().unwrap();
+        assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/src/user.rs
+++ b/src/user.rs
@@ -221,6 +221,30 @@ pub fn required_confirmations_for_payment(payment_type: &str, direction: &str) -
     ConfirmationPolicy::required(payment_type, direction)
 }
 
+pub fn payment_status_display(
+    status: &str,
+    payment_type: &str,
+    direction: &str,
+    confirmations: u32,
+) -> (String, Color32) {
+    match status {
+        "completed" => ("Confirmed".to_string(), theme::SUCCESS),
+        "pending" => {
+            let threshold = required_confirmations_for_payment(payment_type, direction);
+            if threshold > 0 {
+                (
+                    format!("{}/{}", confirmations, threshold),
+                    Color32::from_rgb(234, 179, 8),
+                )
+            } else {
+                ("Pending".to_string(), Color32::from_rgb(234, 179, 8))
+            }
+        }
+        "failed" => ("Failed".to_string(), theme::DANGER_HOVER),
+        _ => (status.to_string(), Color32::DARK_GRAY),
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LocalTradeAllocationError {
     StabilizationLimit(u64),
@@ -1885,13 +1909,31 @@ impl UserApp {
                                     self.send_amount.clear();
                                     self.send_error.clear();
                                     self.pending_outbound_onchain_sats
-                                        .store(deducted_sats, std::sync::atomic::Ordering::Relaxed);
+                                        .fetch_add(deducted_sats, std::sync::atomic::Ordering::Relaxed);
                                     self.update_balances();
                                     let node_clone = Arc::clone(&self.node);
                                     let pending_clone = Arc::clone(&self.pending_outbound_onchain_sats);
                                     std::thread::spawn(move || {
-                                        let _ = node_clone.sync_wallets();
-                                        pending_clone.store(0, std::sync::atomic::Ordering::Relaxed);
+                                        for attempt in 0..3 {
+                                            if node_clone.sync_wallets().is_ok() {
+                                                let cur = pending_clone
+                                                    .load(std::sync::atomic::Ordering::Relaxed);
+                                                pending_clone.fetch_sub(
+                                                    deducted_sats.min(cur),
+                                                    std::sync::atomic::Ordering::Relaxed,
+                                                );
+                                                return;
+                                            }
+                                            std::thread::sleep(std::time::Duration::from_millis(
+                                                500 * (attempt + 1),
+                                            ));
+                                        }
+                                        let cur = pending_clone
+                                            .load(std::sync::atomic::Ordering::Relaxed);
+                                        pending_clone.fetch_sub(
+                                            deducted_sats.min(cur),
+                                            std::sync::atomic::Ordering::Relaxed,
+                                        );
                                     });
                                     return true;
                                 }
@@ -8676,22 +8718,12 @@ impl UserApp {
                                         ),
                                     );
 
-                                    let (status_label, status_color) = match payment.status.as_str() {
-                                        "completed" => ("Confirmed".to_string(), theme::SUCCESS),
-                                        "pending" => {
-                                            let threshold = required_confirmations_for_payment(
-                                                &payment.payment_type,
-                                                &payment.direction,
-                                            );
-                                            if threshold > 0 {
-                                                (format!("{}/{}", payment.confirmations, threshold), Color32::from_rgb(234, 179, 8))
-                                            } else {
-                                                ("Pending".to_string(), Color32::from_rgb(234, 179, 8))
-                                            }
-                                        }
-                                        "failed" => ("Failed".to_string(), theme::DANGER_HOVER),
-                                        _ => (payment.status.clone(), Color32::DARK_GRAY),
-                                    };
+                                    let (status_label, status_color) = payment_status_display(
+                                        &payment.status,
+                                        &payment.payment_type,
+                                        &payment.direction,
+                                        payment.confirmations,
+                                    );
                                     let (badge_rect, _) = ui.allocate_exact_size(
                                         egui::vec2(58.0, 18.0),
                                         Sense::hover(),
@@ -8982,22 +9014,12 @@ impl UserApp {
                     row(ui, "BTC Price", &Self::format_price(price));
                 }
 
-                let (status_label, status_color) = match payment.status.as_str() {
-                    "completed" => ("Confirmed".to_string(), theme::SUCCESS),
-                    "pending" => {
-                        let threshold = required_confirmations_for_payment(
-                            &payment.payment_type,
-                            &payment.direction,
-                        );
-                        if threshold > 0 {
-                            (format!("{}/{}", payment.confirmations, threshold), Color32::from_rgb(234, 179, 8))
-                        } else {
-                            ("Pending".to_string(), Color32::from_rgb(234, 179, 8))
-                        }
-                    }
-                    "failed" => ("Failed".to_string(), theme::DANGER_HOVER),
-                    _ => (payment.status.clone(), Color32::DARK_GRAY),
-                };
+                let (status_label, status_color) = payment_status_display(
+                    &payment.status,
+                    &payment.payment_type,
+                    &payment.direction,
+                    payment.confirmations,
+                );
                 ui.horizontal(|ui| {
                     ui.add_sized(
                         [90.0, 18.0],
@@ -12771,6 +12793,26 @@ mod tests {
     }
 
     #[test]
+    fn test_payment_status_display() {
+        let (label, color) = super::payment_status_display("completed", "onchain", "inbound", 6);
+        assert_eq!(label, "Confirmed");
+        assert_eq!(color, super::theme::SUCCESS);
+
+        let (label, _) = super::payment_status_display("pending", "splice_in", "inbound", 0);
+        assert_eq!(label, "0/1");
+
+        let (label, _) = super::payment_status_display("pending", "onchain", "inbound", 3);
+        assert_eq!(label, "3/6");
+
+        let (label, _) = super::payment_status_display("pending", "lightning", "inbound", 0);
+        assert_eq!(label, "Pending");
+
+        let (label, color) = super::payment_status_display("failed", "onchain", "outbound", 0);
+        assert_eq!(label, "Failed");
+        assert_eq!(color, super::theme::DANGER_HOVER);
+    }
+
+    #[test]
     fn test_pending_outbound_onchain_deduction() {
         let live_onchain_sats: u64 = 50_000;
         let send_amount_sats: u64 = 20_000;
@@ -12794,16 +12836,42 @@ mod tests {
         // Test store-before-spawn thread lifecycle:
         let atomic_pending = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
         // Main thread stores deduction BEFORE spawning sync thread:
-        atomic_pending.store(send_amount_sats, std::sync::atomic::Ordering::Relaxed);
+        atomic_pending.fetch_add(send_amount_sats, std::sync::atomic::Ordering::Relaxed);
         assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 20_000);
 
-        // Background thread clears to 0 after sync:
+        // Background thread clears after sync:
         let atomic_clone = std::sync::Arc::clone(&atomic_pending);
         let handle = std::thread::spawn(move || {
-            atomic_clone.store(0, std::sync::atomic::Ordering::Relaxed);
+            let cur = atomic_clone.load(std::sync::atomic::Ordering::Relaxed);
+            atomic_clone.fetch_sub(
+                send_amount_sats.min(cur),
+                std::sync::atomic::Ordering::Relaxed,
+            );
         });
         handle.join().unwrap();
         assert_eq!(atomic_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+        // Consecutive sends accumulate incrementally and clear independently:
+        let multi_pending = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        multi_pending.fetch_add(20_000, std::sync::atomic::Ordering::Relaxed);
+        multi_pending.fetch_add(10_000, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(multi_pending.load(std::sync::atomic::Ordering::Relaxed), 30_000);
+
+        let m_clone1 = std::sync::Arc::clone(&multi_pending);
+        let h1 = std::thread::spawn(move || {
+            let cur = m_clone1.load(std::sync::atomic::Ordering::Relaxed);
+            m_clone1.fetch_sub(20_000_u64.min(cur), std::sync::atomic::Ordering::Relaxed);
+        });
+        h1.join().unwrap();
+        assert_eq!(multi_pending.load(std::sync::atomic::Ordering::Relaxed), 10_000);
+
+        let m_clone2 = std::sync::Arc::clone(&multi_pending);
+        let h2 = std::thread::spawn(move || {
+            let cur = m_clone2.load(std::sync::atomic::Ordering::Relaxed);
+            m_clone2.fetch_sub(10_000_u64.min(cur), std::sync::atomic::Ordering::Relaxed);
+        });
+        h2.join().unwrap();
+        assert_eq!(multi_pending.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two issues across iOS, Android, and Desktop:
- **#260**: After closing a channel, doing a "Send Max" on-chain send resurrected the closed channel's balance. The derivation logic checked `!hasReady && lightning > 0 && onchain > 0 -> onchain`, so when on-chain dropped to 0, it fell through to `lightning + onchain`. Because LDK keeps reporting channel balance until it's forgotten, the phantom balance reappeared.
- **#262**: On-chain sends lagged until the node's next background poll (10–30s) before updating the balance. Also, splices were hardcoded to require 6 confirmations instead of 1.

---

## Changes

### 1. Balance Derivation & Channel Closure (#260)
- **iOS (`AppState.swift`) & Android (`AppState.kt`)**: Replaced the fall-through branch with `!hasReady -> onchain + pendingSweepBalance`. When on-chain hits 0 after Send Max, total balance correctly stays at 0.
- Folded closure sweep states (`PendingBroadcast`, `BroadcastAwaitingConfirmation`) into pending sweeps.
- **Desktop (`src/user.rs`)**: Subtracted `pending_outbound_onchain_sats` in `update_balances()` and `render_balance_card()` using `saturating_sub`.

### 2. Immediate Send Deduction (#262)
- **iOS & Android**: Added `onchainSendBroadcasted()`. When an on-chain send broadcasts, it immediately decrements in-memory balances, writes them to disk cache (`UserDefaults` / `SharedPreferences`) to survive cold starts, and triggers a background `syncWallets()`.
- **Desktop**: Tracked via an atomic `pending_outbound_onchain_sats`. Deducted right after broadcast, then cleared once background `node.sync_wallets()` returns.

### 3. Dynamic Confirmation Policy (#262)
- Added threshold policy based on payment type:
  - Splices (`splice_in`, `splice_out`): **1 confirmation** (channel counterparty and state are already established).
  - Direct on-chain: **6 confirmations**.
  - Lightning: **0 confirmations**.
- Updated payment repositories, resolvers, and history/detail views to display dynamic progress (e.g. `0/1` or `x/6`).
- In block polling, only trigger wallet sync and balance refreshes when a payment's confirmation state actually changes (`anyUpdated`).

---

## Testing

- **iOS**: Added `OnChainConfirmationPolicyTests.swift` covering policy thresholds, progress fractions, and Send Max 0-balance derivation. `xcodebuild build-for-testing` passes cleanly.
- **Android**: Added `OnChainSendBalanceTest.kt` verifying Send Max balance retention, closure sweeps, and threshold lookups.
- **Desktop**: Added unit tests in `src/user.rs` for policy thresholds and pending send deductions (`cargo test` passes; `cargo clippy` has 0 warnings on modified code).

---

## Related
- Closes #260
- Closes #262
