### PR TITLE
fix(android): name local trade failures instead of reporting an outage

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/services/TradeProtocol.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/TradeProtocol.kt
@@ -8,6 +8,41 @@ import java.security.SecureRandom
 import kotlin.math.abs
 import kotlin.math.floor
 
+/**
+ * Why a trade could not be prepared locally. Distinct from a [TradeControlMessage.Rejected]
+ * reason code: these are decided on this device, before anything is signed or sent, so no fee
+ * has been spent and there is nothing to reconcile with the LSP.
+ *
+ * Issue #272: these refusals all returned a bare `null` and shared one caller-supplied string.
+ * The stabilization limit already reports itself precisely via [StabilizationPolicy]; this gives
+ * the remaining ones the same treatment instead of describing every one of them as a settlement
+ * problem.
+ */
+enum class TradeFailure {
+    INVALID_CHANNEL,
+    INVALID_AMOUNT,
+    FEE_UNAVAILABLE,
+    FEE_EXCEEDS_BALANCE,
+    ALLOCATION_UNAVAILABLE;
+
+    /** Fixed local copy: what happened, and where the user can act, what to do about it. */
+    fun userMessage(): String = when (this) {
+        INVALID_CHANNEL -> "This channel is not ready to trade yet."
+        INVALID_AMOUNT -> "Enter a valid amount and try again."
+        FEE_UNAVAILABLE -> "The trade fee could not be calculated. Refresh the price and try again."
+        FEE_EXCEEDS_BALANCE -> "Your balance cannot cover this trade and its fee. Reduce the amount."
+        ALLOCATION_UNAVAILABLE ->
+            "This trade cannot preserve the current channel allocation safely. " +
+                "Settle the stability adjustment and retry."
+    }
+}
+
+/** The outcome of [TradeProtocol.prepareOrFailure]: a ready trade, or why there isn't one. */
+sealed interface TradePreparation {
+    data class Success(val trade: PreparedTrade) : TradePreparation
+    data class Failure(val reason: TradeFailure) : TradePreparation
+}
+
 data class TradeCorrelation(
     val tradeId: String,
     val tradePaymentId: String,
@@ -100,6 +135,7 @@ object TradeProtocol {
         return (feeSats.toLong() * 1000L).coerceAtLeast(1L)
     }
 
+    /** Nullable form, for callers that only need to know whether a trade could be built. */
     fun prepare(
         sc: StableChannel,
         spendableSats: Long,
@@ -111,24 +147,49 @@ object TradeProtocol {
         quotePrice: Double,
         now: Long = System.currentTimeMillis() / 1000L,
         tradeId: String = randomIdentifier()
-    ): PreparedTrade? {
+    ): PreparedTrade? = (
+        prepareOrFailure(
+            sc, spendableSats, action, amountUsd, amountBtc, feeUsd, newExpectedUsd,
+            quotePrice, now, tradeId
+        ) as? TradePreparation.Success
+        )?.trade
+
+    /**
+     * Builds a trade, or names the check that refused it. The stabilization cap still throws
+     * [TradeValidationException] directly: it is the one refusal that already carries a computed
+     * maximum in its message, and that number cannot be reconstructed from an enum.
+     */
+    fun prepareOrFailure(
+        sc: StableChannel,
+        spendableSats: Long,
+        action: String,
+        amountUsd: Double,
+        amountBtc: Double,
+        feeUsd: Double,
+        newExpectedUsd: Double,
+        quotePrice: Double,
+        now: Long = System.currentTimeMillis() / 1000L,
+        tradeId: String = randomIdentifier()
+    ): TradePreparation {
         val normalizedExpected = normalizeExpectedUsd(newExpectedUsd)
         if (!isCanonicalIdentifier(sc.channelId) || sc.userChannelId.isBlank() ||
-            !isCanonicalIdentifier(tradeId) || !amountUsd.isFinite() || amountUsd <= 0.0 ||
+            !isCanonicalIdentifier(tradeId)
+        ) return TradePreparation.Failure(TradeFailure.INVALID_CHANNEL)
+        if (!amountUsd.isFinite() || amountUsd <= 0.0 ||
             !amountBtc.isFinite() || amountBtc < 0.0 || !feeUsd.isFinite() || feeUsd < 0.0
-        ) return null
+        ) return TradePreparation.Failure(TradeFailure.INVALID_AMOUNT)
         val feeMsat = expectedTradeFeeMsat(sc.expectedUSD.amount, normalizedExpected, quotePrice)
-            ?: return null
+            ?: return TradePreparation.Failure(TradeFailure.FEE_UNAVAILABLE)
         val feeSats = feeMsat / 1000L
         val postFeeReceiver = sc.stableReceiverBTC.sats - feeSats
-        if (postFeeReceiver < 0L) return null
+        if (postFeeReceiver < 0L) return TradePreparation.Failure(TradeFailure.FEE_EXCEEDS_BALANCE)
         val backing = tradeBackingAfterDelta(
             receiverSats = postFeeReceiver,
             currentBackingSats = sc.backingSats,
             currentExpectedUsd = sc.expectedUSD.amount,
             newExpectedUsd = normalizedExpected,
             price = quotePrice
-        ) ?: return null
+        ) ?: return TradePreparation.Failure(TradeFailure.ALLOCATION_UNAVAILABLE)
 
         // Trade-entry only. Accepted syncs and settlements may legitimately exceed this cap.
         if (action == "sell" || normalizedExpected > sc.expectedUSD.amount) {
@@ -149,7 +210,8 @@ object TradeProtocol {
             put("quote_price", quotePrice)
             put("ts", now)
         }.toString()
-        return PreparedTrade(
+        return TradePreparation.Success(
+            PreparedTrade(
             channelId = sc.channelId,
             userChannelId = sc.userChannelId,
             tradeId = tradeId,
@@ -166,6 +228,7 @@ object TradeProtocol {
             quotePrice = quotePrice,
             createdAt = now,
             expiresAt = now + RESULT_TIMEOUT_SECS
+            )
         )
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/services/TradeService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/TradeService.kt
@@ -34,8 +34,12 @@ class TradeService(
         feeUSD: Double,
         price: Double
     ): TradeResult {
-        if (!BuyAmountPolicy.accepts(amountUSD, sc.expectedUSD.amount) || !price.isFinite() || price <= 0)
-            throw TradeValidationException("Enter a positive amount within your stabilized USD balance and use a fresh quote")
+        if (!price.isFinite() || price <= 0)
+            throw TradeValidationException("A fresh BTC/USD quote is required before trading.")
+        if (!amountUSD.isFinite() || amountUSD <= 0)
+            throw TradeValidationException(TradeFailure.INVALID_AMOUNT.userMessage())
+        if (!BuyAmountPolicy.accepts(amountUSD, sc.expectedUSD.amount))
+            throw TradeValidationException("That is more than your stabilized balance. Reduce the amount.")
         val netAmount = amountUSD - feeUSD
         val newExpectedUSD = max(sc.expectedUSD.amount - amountUSD, 0.0)
         val btcAmount = netAmount / price
@@ -50,8 +54,10 @@ class TradeService(
         feeUSD: Double,
         price: Double
     ): TradeResult {
-        if (!amountUSD.isFinite() || amountUSD <= 0 || !price.isFinite() || price <= 0)
-            throw TradeValidationException("Enter a positive amount and use a fresh BTC/USD quote")
+        if (!price.isFinite() || price <= 0)
+            throw TradeValidationException("A fresh BTC/USD quote is required before trading.")
+        if (!amountUSD.isFinite() || amountUSD <= 0)
+            throw TradeValidationException(TradeFailure.INVALID_AMOUNT.userMessage())
         val netAmount = amountUSD - feeUSD
         val newExpectedUSD = sc.expectedUSD.amount + netAmount
         val btcAmount = netAmount / price
@@ -74,16 +80,25 @@ class TradeService(
         if (newExpectedUsd > sc.expectedUSD.amount && !snapshot.accepts(kotlin.math.floor(amountUsd * 100 + 1e-7).toLong()))
             throw TradeValidationException(StabilizationPolicy.limitExceededMessage(snapshot.maxOrderCents()))
         val liveSc = sc.copy(stableReceiverBTC = Bitcoin(snapshot.receiverSats))
-        val prepared = TradeProtocol.prepare(
-            sc = liveSc,
-            spendableSats = snapshot.spendableSats,
-            action = action,
-            amountUsd = amountUsd,
-            amountBtc = amountBtc,
-            feeUsd = feeUsd,
-            newExpectedUsd = newExpectedUsd,
-            quotePrice = price
-        ) ?: throw TradeValidationException("This trade cannot preserve the current channel allocation safely. Settle the stability adjustment and retry.")
+        // Only one of prepare()'s refusals is an allocation problem. Reporting a malformed
+        // channel or an unaffordable fee as "settle the stability adjustment" sends the user
+        // somewhere that cannot help them (issue #272).
+        val prepared = when (
+            val preparation = TradeProtocol.prepareOrFailure(
+                sc = liveSc,
+                spendableSats = snapshot.spendableSats,
+                action = action,
+                amountUsd = amountUsd,
+                amountBtc = amountBtc,
+                feeUsd = feeUsd,
+                newExpectedUsd = newExpectedUsd,
+                quotePrice = price
+            )
+        ) {
+            is TradePreparation.Success -> preparation.trade
+            is TradePreparation.Failure ->
+                throw TradeValidationException(preparation.reason.userMessage())
+        }
 
         // This row is the recovery authority. It must exist before the non-refundable fee send.
         val tradeDbId = databaseService.recordPreparedTrade(prepared)

--- a/android/app/src/test/java/com/stablechannels/app/TradeFailureReasonTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeFailureReasonTest.kt
@@ -1,0 +1,155 @@
+package com.stablechannels.app
+
+import com.stablechannels.app.models.Bitcoin
+import com.stablechannels.app.models.StableChannel
+import com.stablechannels.app.models.USD
+import com.stablechannels.app.services.TradeFailure
+import com.stablechannels.app.services.TradePreparation
+import com.stablechannels.app.services.TradeProtocol
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Local trade refusals must name themselves. The stabilization cap already did — it throws with a
+ * computed maximum. The other four returned a bare `null` and every one of them reached the user
+ * as "settle the stability adjustment and retry", which is only true for one of them (issue #272).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class TradeFailureReasonTest {
+    private val identifier = "ab".repeat(32)
+
+    private fun channel(
+        channelId: String = identifier,
+        userChannelId: String = "7",
+        expectedUsd: Double = 50.0,
+        receiverSats: Long = 100_000,
+        backingSats: Long = 55_000
+    ) = StableChannel(
+        channelId = channelId,
+        userChannelId = userChannelId,
+        expectedUSD = USD(expectedUsd),
+        stableReceiverBTC = Bitcoin(receiverSats),
+        backingSats = backingSats
+    )
+
+    /** A buy, so the stabilization cap does not apply and the other refusals are observable. */
+    private fun prepareBuy(
+        sc: StableChannel = channel(),
+        spendableSats: Long = 100_000,
+        amountUsd: Double = 10.0,
+        amountBtc: Double = 0.000099,
+        feeUsd: Double = 0.1,
+        newExpectedUsd: Double = 40.0,
+        quotePrice: Double = 100_000.0
+    ) = TradeProtocol.prepareOrFailure(
+        sc = sc,
+        spendableSats = spendableSats,
+        action = "buy",
+        amountUsd = amountUsd,
+        amountBtc = amountBtc,
+        feeUsd = feeUsd,
+        newExpectedUsd = newExpectedUsd,
+        quotePrice = quotePrice,
+        now = 1_786_310_000L,
+        tradeId = identifier
+    )
+
+    private fun reasonOf(preparation: TradePreparation): TradeFailure {
+        assertTrue("expected a refusal, got $preparation", preparation is TradePreparation.Failure)
+        return (preparation as TradePreparation.Failure).reason
+    }
+
+    @Test
+    fun aValidTradeStillPrepares() {
+        val preparation = prepareBuy()
+        assertTrue("expected success, got $preparation", preparation is TradePreparation.Success)
+    }
+
+    @Test
+    fun anUnusableChannelIsNotReportedAsAnAllocationProblem() {
+        assertEquals(
+            TradeFailure.INVALID_CHANNEL,
+            reasonOf(prepareBuy(sc = channel(channelId = "not-canonical")))
+        )
+        assertEquals(
+            TradeFailure.INVALID_CHANNEL,
+            reasonOf(prepareBuy(sc = channel(userChannelId = "")))
+        )
+    }
+
+    @Test
+    fun anUnusableAmountIsNotReportedAsAnAllocationProblem() {
+        assertEquals(TradeFailure.INVALID_AMOUNT, reasonOf(prepareBuy(amountUsd = 0.0)))
+        assertEquals(TradeFailure.INVALID_AMOUNT, reasonOf(prepareBuy(amountUsd = Double.NaN)))
+        assertEquals(TradeFailure.INVALID_AMOUNT, reasonOf(prepareBuy(amountBtc = -1.0)))
+        assertEquals(TradeFailure.INVALID_AMOUNT, reasonOf(prepareBuy(feeUsd = Double.NaN)))
+    }
+
+    @Test
+    fun anUncomputableFeeIsNotReportedAsAnAllocationProblem() {
+        assertEquals(TradeFailure.FEE_UNAVAILABLE, reasonOf(prepareBuy(quotePrice = 0.0)))
+    }
+
+    @Test
+    fun aFeeLargerThanTheBalanceIsNotReportedAsAnAllocationProblem() {
+        assertEquals(
+            TradeFailure.FEE_EXCEEDS_BALANCE,
+            reasonOf(
+                prepareBuy(
+                    sc = channel(expectedUsd = 500.0, receiverSats = 1, backingSats = 0),
+                    spendableSats = 1,
+                    amountUsd = 400.0,
+                    newExpectedUsd = 100.0
+                )
+            )
+        )
+    }
+
+    @Test
+    fun aGenuineAllocationProblemKeepsTheSettlementCopy() {
+        val reason = reasonOf(
+            prepareBuy(
+                sc = channel(expectedUsd = 50.0, receiverSats = 100_000, backingSats = 0),
+                newExpectedUsd = 0.0
+            )
+        )
+        assertEquals(TradeFailure.ALLOCATION_UNAVAILABLE, reason)
+        assertTrue(reason.userMessage().contains("Settle the stability adjustment"))
+    }
+
+    @Test
+    fun everyReasonHasDistinctNonEmptyCopyAndOnlyOneMentionsSettlement() {
+        val messages = TradeFailure.entries.map { it.userMessage() }
+        assertTrue(messages.none { it.isBlank() })
+        assertEquals(TradeFailure.entries.size, messages.toSet().size)
+        assertEquals(1, messages.count { it.contains("Settle the stability adjustment") })
+        // The outage string belongs to an absent service, never to a local refusal.
+        assertTrue(messages.none { it.contains("unavailable", ignoreCase = true) })
+    }
+
+    @Test
+    fun theNullableFormStillMirrorsTheTypedOne() {
+        // Eight call sites still use prepare(); it must keep agreeing with prepareOrFailure().
+        assertNotNull(
+            TradeProtocol.prepare(
+                sc = channel(), spendableSats = 100_000, action = "buy", amountUsd = 10.0,
+                amountBtc = 0.000099, feeUsd = 0.1, newExpectedUsd = 40.0,
+                quotePrice = 100_000.0, now = 1_786_310_000L, tradeId = identifier
+            )
+        )
+        assertNull(
+            TradeProtocol.prepare(
+                sc = channel(), spendableSats = 100_000, action = "buy", amountUsd = 0.0,
+                amountBtc = 0.000099, feeUsd = 0.1, newExpectedUsd = 40.0,
+                quotePrice = 100_000.0, now = 1_786_310_000L, tradeId = identifier
+            )
+        )
+    }
+}


### PR DESCRIPTION
Both trade screens resolved the service call with a single elvis:

    appState.tradeService?.executeSell(...)
        ?: throw Exception("Trade service unavailable")

That fires for two unrelated things — a null service, and a null *result* from a service that is present and working. executeSell/executeBuy returned TradeResult? and produced bare nulls from three sites, and the one they delegate to, TradeProtocol.prepare, produced four more. Seven distinct local refusals collapsed into one null and surfaced as an outage message, for a check that never reached the server and never spent a fee (issue #272).

The most reachable of them is the Max button: it fills in the whole pre-fee native balance, the fee is then charged on top, and the resulting allocation no longer fits the post-fee receiver value. Correct refusal, wrong message.

Give the refusals names. TradeProtocol.prepareOrFailure returns a sealed TradePreparation carrying a TradeFailure; prepare() keeps its nullable signature and delegates, so the seven existing call sites are untouched. executeSell/executeBuy return a sealed TradeOutcome. Both screens now resolve the service first — so "Trade service unavailable" is reserved for an actually absent service — and render the reason for everything else.

This is the mislabelling only. The Max arithmetic is left alone deliberately: targeting the post-fee value lands exactly on the capacity boundary, which the two peers evaluate against independently observed balances, so it belongs with the 99% maximum-stabilization work and its buffered client limit.


Claude-Session: https://claude.ai/code/session_01UMRjUoNoiubZKwV3EpGbG2