### PR TITLE
feat(ios,desktop): typed trade-failure results — parity with Android …

### DIFF
--- a/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
+++ b/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
@@ -33,13 +33,33 @@ enum StabilizationPolicy {
     }
 }
 
-enum TradeValidationError: LocalizedError {
-    case invalidAmount, unavailable, unsafeAllocation, stabilizationLimit(UInt64)
+/// Why a trade could not be prepared or executed on this device. Distinct from a signed
+/// TRADE_REJECTED_V1 reason code: these are decided locally, before anything is signed or
+/// sent, so no fee has been spent and there is nothing to reconcile with the LSP.
+///
+/// Every local refusal must map to one of these. Collapsing them into a bare `nil` is what
+/// let a failed local check surface as one generic order-failure message (issue #272).
+/// The taxonomy and copy mirror Android's `TradeFailure`.
+enum TradeValidationError: LocalizedError, Equatable {
+    case invalidAmount
+    case invalidPrice
+    case exceedsStableBalance
+    case channelNotReady
+    case feeUnavailable
+    case feeExceedsBalance
+    case allocationUnavailable
+    case stabilizationLimit(UInt64)
+
+    /// Fixed local copy. Says what happened and, where the user can act, what to do about it.
     var errorDescription: String? {
         switch self {
-        case .invalidAmount: return "Enter a positive amount within your balance and use a fresh BTC/USD quote"
-        case .unavailable: return "The live channel balance is unavailable. Retry when the channel is ready."
-        case .unsafeAllocation: return "This trade cannot preserve the current channel allocation safely. Settle the stability adjustment and retry."
+        case .invalidAmount: return "Enter a valid amount and try again."
+        case .invalidPrice: return "A fresh BTC/USD consensus is required before trading."
+        case .exceedsStableBalance: return "That is more than your stabilized balance. Reduce the amount."
+        case .channelNotReady: return "This channel is not ready to trade yet."
+        case .feeUnavailable: return "The trade fee could not be calculated. Refresh the price and try again."
+        case .feeExceedsBalance: return "Your balance cannot cover this trade and its fee. Reduce the amount."
+        case .allocationUnavailable: return "That is more than this channel can convert right now. Reduce the amount."
         case .stabilizationLimit(let cents): return StabilizationPolicy.limitExceededMessage(cents)
         }
     }
@@ -189,6 +209,7 @@ enum TradeProtocol {
         return max(UInt64(feeSats.rounded(.towardZero)) * 1000, 1)
     }
 
+    /// Nullable form, kept for callers that only care whether a trade could be built.
     static func prepare(
         channelId: String,
         userChannelId: String,
@@ -205,17 +226,55 @@ enum TradeProtocol {
         now: UInt64 = UInt64(Date().timeIntervalSince1970),
         tradeId: String = randomIdentifier()
     ) -> PreparedMobileTrade? {
+        try? prepareOrFailure(
+            channelId: channelId,
+            userChannelId: userChannelId,
+            currentExpectedUSD: currentExpectedUSD,
+            currentBackingSats: currentBackingSats,
+            receiverSats: receiverSats,
+            spendableSats: spendableSats,
+            action: action,
+            amountUSD: amountUSD,
+            amountBTC: amountBTC,
+            feeUSD: feeUSD,
+            newExpectedUSD: newExpectedUSD,
+            quotePrice: quotePrice,
+            now: now,
+            tradeId: tradeId
+        ).get()
+    }
+
+    /// Builds a trade, or reports which local check refused it.
+    static func prepareOrFailure(
+        channelId: String,
+        userChannelId: String,
+        currentExpectedUSD: Double,
+        currentBackingSats: UInt64,
+        receiverSats: UInt64,
+        spendableSats: UInt64,
+        action: String,
+        amountUSD: Double,
+        amountBTC: Double,
+        feeUSD: Double,
+        newExpectedUSD: Double,
+        quotePrice: Double,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970),
+        tradeId: String = randomIdentifier()
+    ) -> Result<PreparedMobileTrade, TradeValidationError> {
         let normalizedExpected = normalizeExpectedUSD(newExpectedUSD)
         guard isCanonicalIdentifier(channelId), !userChannelId.isEmpty,
-              isCanonicalIdentifier(tradeId), amountUSD.isFinite, amountUSD > 0,
-              amountBTC.isFinite, amountBTC >= 0, feeUSD.isFinite, feeUSD >= 0,
-              let feeMsat = expectedTradeFeeMsat(
-                  oldExpectedUSD: currentExpectedUSD,
-                  newExpectedUSD: normalizedExpected,
-                  quotePrice: quotePrice
-              ) else { return nil }
+              isCanonicalIdentifier(tradeId) else { return .failure(.channelNotReady) }
+        guard amountUSD.isFinite, amountUSD > 0,
+              amountBTC.isFinite, amountBTC >= 0, feeUSD.isFinite, feeUSD >= 0 else {
+            return .failure(.invalidAmount)
+        }
+        guard let feeMsat = expectedTradeFeeMsat(
+            oldExpectedUSD: currentExpectedUSD,
+            newExpectedUSD: normalizedExpected,
+            quotePrice: quotePrice
+        ) else { return .failure(.feeUnavailable) }
         let feeSats = feeMsat / 1000
-        guard feeSats <= receiverSats else { return nil }
+        guard feeSats <= receiverSats else { return .failure(.feeExceedsBalance) }
         let postFeeReceiver = receiverSats - feeSats
         guard let backing = tradeBackingAfterDelta(
             receiverSats: postFeeReceiver,
@@ -223,17 +282,19 @@ enum TradeProtocol {
             currentExpectedUSD: currentExpectedUSD,
             newExpectedUSD: normalizedExpected,
             price: quotePrice
-        ) else { return nil }
+        ) else { return .failure(.allocationUnavailable) }
 
         // Preparation is the last pure guard before persistence/payment, not a settlement rule.
         if action == "sell" || normalizedExpected > currentExpectedUSD {
             let snapshot = StabilizationSnapshot(receiverSats: receiverSats, spendableSats: spendableSats,
                                                  backingSats: currentBackingSats, expectedUSD: currentExpectedUSD,
                                                  price: quotePrice)
-            guard feeSats <= spendableSats,
-                  let limit = StabilizationPolicy.clientLimit(spendableSats - feeSats), backing <= limit,
+            guard feeSats <= spendableSats else { return .failure(.feeExceedsBalance) }
+            guard let limit = StabilizationPolicy.clientLimit(spendableSats - feeSats), backing <= limit,
                   amountUSD * 100 < Double(Int64.max),
-                  snapshot.accepts(UInt64((amountUSD * 100 + 1e-7).rounded(.down))) else { return nil }
+                  snapshot.accepts(UInt64((amountUSD * 100 + 1e-7).rounded(.down))) else {
+                return .failure(.stabilizationLimit(snapshot.maxOrderCents()))
+            }
         }
 
         let object: [String: Any] = [
@@ -245,13 +306,17 @@ enum TradeProtocol {
             "quote_price": quotePrice,
             "ts": now
         ]
+        // Unreachable once the identifiers and amounts above are validated; keep the amount
+        // reason rather than inventing an internal one the user could never act on.
         guard JSONSerialization.isValidJSONObject(object),
               let payloadData = try? JSONSerialization.data(
                   withJSONObject: object,
                   options: [.sortedKeys, .withoutEscapingSlashes]
               ),
-              let payload = String(data: payloadData, encoding: .utf8) else { return nil }
-        return PreparedMobileTrade(
+              let payload = String(data: payloadData, encoding: .utf8) else {
+            return .failure(.invalidAmount)
+        }
+        return .success(PreparedMobileTrade(
             channelId: channelId,
             userChannelId: userChannelId,
             tradeId: tradeId,
@@ -268,7 +333,7 @@ enum TradeProtocol {
             quotePrice: quotePrice,
             createdAt: now,
             expiresAt: now + resultTimeoutSecs
-        )
+        ))
     }
 
     static func tradeBackingAfterDelta(

--- a/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/BuyView.swift
@@ -284,20 +284,24 @@ struct BuyView: View {
             isExecuting = false
             return
         }
+        // A generic "order failed" belongs only to an actually absent service. A refusal from
+        // the service throws its own TradeValidationError reason and is rendered as-is below,
+        // never re-labeled (issue #272).
+        guard let service = appState.tradeService else {
+            errorMessage = String(
+                localized: "error_trade_service_unavailable",
+                defaultValue: "Trade service unavailable"
+            )
+            isExecuting = false
+            return
+        }
         do {
-            guard let result = try appState.tradeService?.executeBuy(
+            let result = try service.executeBuy(
                 sc: sc,
                 amountUSD: amountUSD,
                 feeUSD: feeUSD,
                 price: price
-            ) else {
-                errorMessage = String(
-                    localized: "error_trade_failed",
-                    defaultValue: "Order failed — check amount and try again"
-                )
-                isExecuting = false
-                return
-            }
+            )
 
             // View cache only; the prepared correlation was persisted before the fee send.
             appState.pendingTradePayments[result.paymentId] = PendingTradePayment(

--- a/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
+++ b/ios/StableChannels/StableChannels/Features/Trade/SellView.swift
@@ -284,20 +284,24 @@ struct SellView: View {
             isExecuting = false
             return
         }
+        // A generic "order failed" belongs only to an actually absent service. A refusal from
+        // the service throws its own TradeValidationError reason and is rendered as-is below,
+        // never re-labeled (issue #272).
+        guard let service = appState.tradeService else {
+            errorMessage = String(
+                localized: "error_trade_service_unavailable",
+                defaultValue: "Trade service unavailable"
+            )
+            isExecuting = false
+            return
+        }
         do {
-            guard let result = try appState.tradeService?.executeSell(
+            let result = try service.executeSell(
                 sc: sc,
                 amountUSD: amountUSD,
                 feeUSD: feeUSD,
                 price: price
-            ) else {
-                errorMessage = String(
-                    localized: "error_trade_failed",
-                    defaultValue: "Order failed — check amount and try again"
-                )
-                isExecuting = false
-                return
-            }
+            )
 
             // View cache only; the prepared correlation was persisted before the fee send.
             appState.pendingTradePayments[result.paymentId] = PendingTradePayment(

--- a/ios/StableChannels/StableChannels/Services/TradeService.swift
+++ b/ios/StableChannels/StableChannels/Services/TradeService.swift
@@ -36,9 +36,12 @@ final class TradeService {
         amountUSD: Double,
         feeUSD: Double,
         price: Double
-    ) throws -> TradeExecutionResult? {
-        guard amountUSD.isFinite, amountUSD > 0, amountUSD <= sc.expectedUSD.amount, price.isFinite,
-              price > 0 else { throw TradeValidationError.invalidAmount }
+    ) throws -> TradeExecutionResult {
+        guard price.isFinite, price > 0 else { throw TradeValidationError.invalidPrice }
+        guard amountUSD.isFinite, amountUSD > 0 else { throw TradeValidationError.invalidAmount }
+        guard amountUSD <= sc.expectedUSD.amount else {
+            throw TradeValidationError.exceedsStableBalance
+        }
         let netAmount = amountUSD - feeUSD
         return try preparePersistAndSend(
             sc: sc,
@@ -56,9 +59,9 @@ final class TradeService {
         amountUSD: Double,
         feeUSD: Double,
         price: Double
-    ) throws -> TradeExecutionResult? {
-        guard amountUSD.isFinite, amountUSD > 0, price.isFinite,
-              price > 0 else { throw TradeValidationError.invalidAmount }
+    ) throws -> TradeExecutionResult {
+        guard price.isFinite, price > 0 else { throw TradeValidationError.invalidPrice }
+        guard amountUSD.isFinite, amountUSD > 0 else { throw TradeValidationError.invalidAmount }
         let netAmount = amountUSD - feeUSD
         return try preparePersistAndSend(
             sc: sc,
@@ -79,15 +82,19 @@ final class TradeService {
         feeUSD: Double,
         newExpectedUSD: Double,
         price: Double
-    ) throws -> TradeExecutionResult? {
-        guard let snapshot = liveSnapshot(sc: sc, price: price) else { throw TradeValidationError.unavailable }
+    ) throws -> TradeExecutionResult {
+        guard let snapshot = liveSnapshot(sc: sc, price: price) else {
+            throw TradeValidationError.channelNotReady
+        }
         if newExpectedUSD > sc.expectedUSD.amount {
             guard amountUSD * 100 < Double(Int64.max),
                   snapshot.accepts(UInt64((amountUSD * 100 + 1e-7).rounded(.down))) else {
                 throw TradeValidationError.stabilizationLimit(snapshot.maxOrderCents())
             }
         }
-        guard let prepared = TradeProtocol.prepare(
+        // A refused preparation is terminal for this attempt and nothing has been sent yet,
+        // so the reason reaches the caller unchanged instead of collapsing into one string.
+        let prepared = try TradeProtocol.prepareOrFailure(
             channelId: sc.channelId,
             userChannelId: sc.userChannelId,
             currentExpectedUSD: sc.expectedUSD.amount,
@@ -100,7 +107,7 @@ final class TradeService {
             feeUSD: feeUSD,
             newExpectedUSD: newExpectedUSD,
             quotePrice: price
-        ) else { throw TradeValidationError.unsafeAllocation }
+        ).get()
 
         // Persist the exact signed payload and local allocation before the fee can leave.
         let tradeDbId = try databaseService.channelRepo.recordPreparedTrade(prepared)

--- a/src/user.rs
+++ b/src/user.rs
@@ -196,11 +196,17 @@ struct IncomingSync {
     request_hash: Option<String>,
 }
 
+/// Why a trade could not be prepared or sent by this wallet. Distinct from a signed
+/// TRADE_REJECTED_V1 reason code: these are decided locally, before anything is signed or
+/// sent, so no fee has been spent and there is nothing to reconcile with the LSP. Every
+/// local refusal must carry its own variant so it surfaces with its own message instead of
+/// collapsing into a generic failure (issue #272); the taxonomy mirrors the mobile apps'.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LocalTradeAllocationError {
     StabilizationLimit(u64),
     InvalidValues,
     LiveBalanceUnavailable,
+    FeeUnavailable,
     FeeExceedsBalance,
     TargetExceedsCapacity,
     SettlementRequired,
@@ -2187,7 +2193,7 @@ impl UserApp {
                             new_expected_usd,
                             trade_price,
                         )
-                        .ok_or(LocalTradeAllocationError::InvalidValues)?;
+                        .ok_or(LocalTradeAllocationError::FeeUnavailable)?;
                         // Trade-entry only. Settlements and accepted syncs are uncapped.
                         if (trade_action == "sell" || new_expected_usd > sc.expected_usd.0)
                             && !snapshot.accepts(floor_usd_cents(amount_usd))
@@ -2247,18 +2253,22 @@ impl UserApp {
                         "Settle the current stability adjustment, then retry this trade."
                             .to_string()
                     }
+                    LocalTradeAllocationError::FeeUnavailable => {
+                        "The trade fee could not be calculated. Refresh the price and try again."
+                            .to_string()
+                    }
                     LocalTradeAllocationError::FeeExceedsBalance => {
-                        "The trade fee exceeds the live channel balance.".to_string()
+                        "Your balance cannot cover this trade and its fee. Reduce the amount."
+                            .to_string()
                     }
                     LocalTradeAllocationError::TargetExceedsCapacity => {
                         "The trade target exceeds the wallet's local channel capacity.".to_string()
                     }
                     LocalTradeAllocationError::InvalidValues => {
-                        "A trusted local price is required before trading.".to_string()
+                        "A fresh BTC/USD consensus is required before trading.".to_string()
                     }
                     LocalTradeAllocationError::LiveBalanceUnavailable => {
-                        "The live channel balance is unavailable. Retry when the channel is ready."
-                            .to_string()
+                        "This channel is not ready to trade yet.".to_string()
                     }
                     LocalTradeAllocationError::UnsafeAllocation => {
                         "This trade cannot preserve the current stability allocation safely."
@@ -10814,6 +10824,14 @@ impl UserApp {
             return;
         }
 
+        // A zero or malformed amount previously slipped past the exceeds-balance check below
+        // (0 > expected is false) and went on to prepare a no-op trade. Refuse it by name,
+        // like the mobile apps do (issue #272).
+        if !amount_usd.is_finite() || amount_usd <= 0.0 {
+            self.trade_error = "Enter a valid amount and try again.".to_string();
+            return;
+        }
+
         // Buying BTC means reducing the stabilized USD amount
         // Subtract full amount (fee comes out of the trade)
         let remaining_usd = (current_expected_usd - amount_usd).max(0.0);
@@ -10824,7 +10842,8 @@ impl UserApp {
         };
 
         if floor_usd_cents(amount_usd) > floor_usd_cents(current_expected_usd) {
-            self.trade_error = "Amount exceeds available USD".to_string();
+            self.trade_error =
+                "That is more than your stabilized balance. Reduce the amount.".to_string();
             return;
         }
 
@@ -10880,7 +10899,7 @@ impl UserApp {
 
         let max_cents = self.maximum_sell_cents(btc_price);
         if !amount_usd.is_finite() || amount_usd <= 0.0 {
-            self.trade_error = "Enter a positive amount".to_string();
+            self.trade_error = "Enter a valid amount and try again.".to_string();
             return;
         }
         if floor_usd_cents(amount_usd) > max_cents {


### PR DESCRIPTION
…mislabel fix

Local trade refusals on iOS and desktop collapsed distinct failure causes into one generic message, the same defect Android fixed on fix/android-trade-mislabel (issue #272). Give each refusal a name and its own copy, mirroring Android's TradeFailure taxonomy and wording.

iOS:
- TradeValidationError grows to the full taxonomy: invalidAmount, invalidPrice, exceedsStableBalance, channelNotReady, feeUnavailable, feeExceedsBalance, allocationUnavailable, plus the existing stabilizationLimit(cents) which keeps reusing StabilizationPolicy.limitExceededMessage.
- TradeProtocol.prepareOrFailure returns Result<PreparedMobileTrade, TradeValidationError>; prepare() keeps its nullable signature and delegates, so existing test call sites are untouched. The type stays in the shared app+NSE file — no duplication.
- executeBuy/executeSell/preparePersistAndSend return a non-optional result and throw the typed reason; the unreasoned-nil paths are gone.
- Sell/BuyView resolve the service first, so a generic outage-style message is reserved for an actually absent service; every refusal is rendered with its own errorDescription instead of "Order failed — check amount and try again".

Desktop:
- execute_buy refuses a zero/non-finite amount by name; previously 0 > expected was false, so a zero-USD buy slipped past the balance check and went on to prepare a no-op trade.
- LocalTradeAllocationError gains FeeUnavailable for a fee derivation failure, which was mislabeled as InvalidValues ("a trusted local price is required").
- Refusal copy aligned with the Android/iOS wording (invalid amount, exceeds stable balance, fee unpayable, channel not ready); the 99% cap keeps its existing stabilization_limit_message copy.


Claude-Session: https://claude.ai/code/session_01BwhgoR3792HQaH6TKJfwKX