### PR TITLE
Android: fix missing biometric gate on OnChainScreen; make Payment Confirmation toggle also govern on-chain sends (iOS parity)

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/services/AppAccessPreferences.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/AppAccessPreferences.kt
@@ -7,12 +7,11 @@ import android.content.Context
  *
  * Two independent toggles:
  * - App Unlock: requires biometric auth on launch and resume after 5s in background
- * - Payment Confirmation: requires biometric auth before Lightning sends
+ * - Payment Confirmation: requires biometric auth before sends (on-chain or Lightning)
  *
- * Auth gate rules:
- * - On-chain sends ALWAYS require auth (regardless of toggle state)
+ * Auth gate rules (matches iOS parity: a single toggle governs both send types):
  * - Seed phrase viewing ALWAYS requires auth (regardless of toggle state)
- * - Lightning sends require auth only when Payment Confirmation is enabled
+ * - On-chain and Lightning sends both require auth only when Payment Confirmation is enabled
  * - Disabling either toggle requires auth; enabling does not
  */
 data class AppAccessPreferences(
@@ -75,16 +74,14 @@ object AppAccessPreferencesManager {
     /**
      * Determines whether biometric authentication should be required for a send operation.
      *
-     * Rules:
-     * - On-chain sends ALWAYS require auth (regardless of Payment Confirmation toggle)
-     * - Lightning sends require auth only when Payment Confirmation is enabled
+     * Matches iOS parity: a single Payment Confirmation toggle governs both send types,
+     * with no hardcoded exception for on-chain.
      *
      * @param context Android context for reading preferences
      * @param isOnChain true if this is an on-chain send (splice-out or direct), false for Lightning
      * @return true if auth should be required before proceeding with the send
      */
     fun shouldRequireAuth(context: Context, isOnChain: Boolean): Boolean {
-        if (isOnChain) return true
         return isPaymentConfirmationEnabled(context)
     }
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/settings/AppAccessView.kt
@@ -117,7 +117,7 @@ fun AppAccessView() {
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "Require authentication before Lightning sends",
+                        text = "Require authentication before sends (Lightning and on-chain)",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/OnChainScreen.kt
@@ -20,7 +20,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.platform.LocalContext
+import androidx.fragment.app.FragmentActivity
 import com.stablechannels.app.AppState
+import com.stablechannels.app.services.AppAccessPreferencesManager
+import com.stablechannels.app.services.BiometricService
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.QRCodeUtils
 import com.stablechannels.app.util.satsFormatted
@@ -41,6 +45,8 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
     var error by remember { mutableStateOf<String?>(null) }
     var feeRateSatVb by remember { mutableStateOf<Long?>(null) }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val activity = context.findActivity()
     val btcPrice by appState.priceService.currentPrice.collectAsState()
     // Amount derivation and send enablement track the trusted accounting price, so an untrusted
     // oracle state is visible (blank sats, disabled button) before tapping — iOS parity.
@@ -292,59 +298,80 @@ fun OnChainSendScreen(appState: AppState, onDismiss: () -> Unit) {
                 onClick = {
                     isSending = true
                     error = null
-                    scope.launch(Dispatchers.IO) {
-                        try {
-                            val addr = QRCodeUtils.normalizeAddress(QRCodeUtils.stripUriPrefix(address))
-                            val price = btcPrice
-                            if (sendAll) {
-                                val txid = appState.nodeService.sendAllOnchain(addr)
-                                val sendSats = onchainSats
-                                appState.onchainSendBroadcasted(sendSats, isSendAll = true, txid = txid)
-                                appState.databaseService?.recordPayment(
-                                    paymentId = txid, paymentType = "onchain", direction = "sent",
-                                    amountMsat = sendSats * 1000,
-                                    amountUSD = if (price > 0) (sendSats.toDouble() / Constants.SATS_IN_BTC) * price else null,
-                                    btcPrice = if (price > 0) price else null,
-                                    txid = txid, address = addr
-                                )
-                                result = "All funds sent successfully."
-                                successTxid = txid
-                            } else {
-                                val usd = amountUSDStr.toDoubleOrNull() ?: throw Exception("Enter amount")
-                                // Money movement converts USD at the trusted accounting price,
-                                // never the raw display price (iOS parity). The same captured
-                                // price is recorded so history reflects the rate actually used.
-                                val accountingPrice = appState.priceService.currentAccountingPrice()
-                                val sats = accountingSatsFromUSD(usd, accountingPrice)
-                                    ?: throw Exception("A trusted BTC/USD price is required")
-                                if (hasChannel) {
-                                    if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
-                                    val sc = appState.stableChannel.value
-                                    appState.beginSpliceOut(sats, addr, accountingPrice)
-                                    try {
-                                        appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
-                                    } catch (e: Exception) {
-                                        appState.cancelPendingSpliceStart()
-                                        throw e
-                                    }
-                                    result = "Splice-out initiated for ${sats.satsFormatted()} sats."
-                                    successTxid = null
-                                } else {
-                                    val txid = appState.nodeService.sendOnchain(addr, sats)
-                                    appState.onchainSendBroadcasted(sats, isSendAll = false, txid = txid)
+                    scope.launch {
+                        // Auth gate: gated by the Payment Confirmation toggle, same as
+                        // SendScreen's on-chain path (matches iOS: one toggle governs
+                        // both on-chain and Lightning sends). This screen previously had
+                        // no gate at all, letting withdrawals and splice-outs bypass
+                        // biometric confirmation entirely regardless of the toggle.
+                        val requiresAuth = AppAccessPreferencesManager.shouldRequireAuth(context, isOnChain = true)
+                        if (requiresAuth) {
+                            if (activity == null) {
+                                error = "Authentication required to send"
+                                isSending = false
+                                return@launch
+                            }
+                            val authResult = BiometricService.authenticate(activity, "Confirm onchain withdrawal")
+                            if (authResult != BiometricService.AuthResult.SUCCESS) {
+                                error = "Authentication required to send"
+                                isSending = false
+                                return@launch
+                            }
+                        }
+                        withContext(Dispatchers.IO) {
+                            try {
+                                val addr = QRCodeUtils.normalizeAddress(QRCodeUtils.stripUriPrefix(address))
+                                val price = btcPrice
+                                if (sendAll) {
+                                    val txid = appState.nodeService.sendAllOnchain(addr)
+                                    val sendSats = onchainSats
+                                    appState.onchainSendBroadcasted(sendSats, isSendAll = true, txid = txid)
                                     appState.databaseService?.recordPayment(
                                         paymentId = txid, paymentType = "onchain", direction = "sent",
-                                        amountMsat = sats * 1000,
-                                        amountUSD = (sats.toDouble() / Constants.SATS_IN_BTC) * accountingPrice,
-                                        btcPrice = accountingPrice,
+                                        amountMsat = sendSats * 1000,
+                                        amountUSD = if (price > 0) (sendSats.toDouble() / Constants.SATS_IN_BTC) * price else null,
+                                        btcPrice = if (price > 0) price else null,
                                         txid = txid, address = addr
                                     )
-                                    result = "Sent successfully."
+                                    result = "All funds sent successfully."
                                     successTxid = txid
+                                } else {
+                                    val usd = amountUSDStr.toDoubleOrNull() ?: throw Exception("Enter amount")
+                                    // Money movement converts USD at the trusted accounting price,
+                                    // never the raw display price (iOS parity). The same captured
+                                    // price is recorded so history reflects the rate actually used.
+                                    val accountingPrice = appState.priceService.currentAccountingPrice()
+                                    val sats = accountingSatsFromUSD(usd, accountingPrice)
+                                        ?: throw Exception("A trusted BTC/USD price is required")
+                                    if (hasChannel) {
+                                        if (appState.isSpliceInFlight) throw Exception("A splice is already in progress — try again shortly")
+                                        val sc = appState.stableChannel.value
+                                        appState.beginSpliceOut(sats, addr, accountingPrice)
+                                        try {
+                                            appState.nodeService.spliceOut(sc.userChannelId, sc.counterparty, addr, sats)
+                                        } catch (e: Exception) {
+                                            appState.cancelPendingSpliceStart()
+                                            throw e
+                                        }
+                                        result = "Splice-out initiated for ${sats.satsFormatted()} sats."
+                                        successTxid = null
+                                    } else {
+                                        val txid = appState.nodeService.sendOnchain(addr, sats)
+                                        appState.onchainSendBroadcasted(sats, isSendAll = false, txid = txid)
+                                        appState.databaseService?.recordPayment(
+                                            paymentId = txid, paymentType = "onchain", direction = "sent",
+                                            amountMsat = sats * 1000,
+                                            amountUSD = (sats.toDouble() / Constants.SATS_IN_BTC) * accountingPrice,
+                                            btcPrice = accountingPrice,
+                                            txid = txid, address = addr
+                                        )
+                                        result = "Sent successfully."
+                                        successTxid = txid
+                                    }
                                 }
+                            } catch (e: Exception) {
+                                error = e.message ?: "Send failed"
                             }
-                        } catch (e: Exception) {
-                            error = e.message ?: "Send failed"
                         }
                         isSending = false
                     }

--- a/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/transfer/SendScreen.kt
@@ -822,8 +822,10 @@ private fun InputTypeIndicator(inputType: InputType) {
 /**
  * Walks up the Context wrapper chain to find the hosting FragmentActivity.
  * Works even inside ModalBottomSheet where LocalContext is a ContextThemeWrapper.
+ * Internal (not private) so other send screens, e.g. OnChainScreen, can reuse it for
+ * their own biometric auth gate instead of duplicating this walk.
  */
-private fun android.content.Context.findActivity(): FragmentActivity? {
+internal fun android.content.Context.findActivity(): FragmentActivity? {
     var ctx = this
     while (ctx is ContextWrapper) {
         if (ctx is FragmentActivity) return ctx

--- a/android/app/src/test/java/com/stablechannels/app/AppAccessPreferencesTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/AppAccessPreferencesTest.kt
@@ -25,11 +25,15 @@ class AppAccessPreferencesTest {
     // ---------------------------------------------------------------------------
 
     @Test
-    fun `on-chain sends always require auth regardless of context`() {
-        // shouldRequireAuth with isOnChain=true should always return true
-        // We test the static logic here (context-free version)
-        assertTrue(shouldRequireAuthPure(isOnChain = true, paymentConfirmationEnabled = false))
+    fun `on-chain sends require auth when payment confirmation enabled`() {
+        // Matches iOS: a single Payment Confirmation toggle governs both send types,
+        // with no hardcoded exception for on-chain.
         assertTrue(shouldRequireAuthPure(isOnChain = true, paymentConfirmationEnabled = true))
+    }
+
+    @Test
+    fun `on-chain sends do not require auth when payment confirmation disabled`() {
+        assertFalse(shouldRequireAuthPure(isOnChain = true, paymentConfirmationEnabled = false))
     }
 
     @Test
@@ -107,7 +111,6 @@ class AppAccessPreferencesTest {
      * without requiring an Android Context, for unit test verification.
      */
     private fun shouldRequireAuthPure(isOnChain: Boolean, paymentConfirmationEnabled: Boolean): Boolean {
-        if (isOnChain) return true
         return paymentConfirmationEnabled
     }
 }


### PR DESCRIPTION
## Problem

OnChainScreen (dedicated withdraw / splice-out screen) had no biometric auth gate at all, unlike SendScreen's on-chain path. Depending on which screen was used, on-chain sends were sometimes auth-gated and sometimes not.

## Fix

- Added the same auth-gate pattern already used in SendScreen to OnChainScreen's Send button.
- Made SendScreen.findActivity() internal so OnChainScreen can reuse it instead of duplicating the walk.
- Changed Payment Confirmation to a single toggle governing both on-chain and Lightning sends, matching iOS (OnChainView.swift and SendView.swift both read the same transactionAuthEnabled key, no on-chain exception).

## Important behavior change — please read

Before this PR, on-chain sends via SendScreen **always** required biometric auth, regardless of the Payment Confirmation toggle (the toggle's label only mentioned Lightning sends). After this PR, on-chain sends via both SendScreen and OnChainScreen only require auth when Payment Confirmation is ON — same as Lightning sends, matching iOS.

This means: any existing user who has Payment Confirmation turned OFF will no longer be prompted for on-chain sends from SendScreen either (previously they always were). This is intentional — it fixes an Android/iOS inconsistency and makes the toggle behavior match its (now updated) label — but it is a real reduction in the default protection for on-chain sends when the toggle is off, not just an addition of a missing gate on OnChainScreen. No migration is included to auto-enable the toggle for existing users; flagging this explicitly for maintainer awareness before merge.

## Testing

- Full unit suite passes cleanly (227 tests, 0 failures) once local untracked WIP test files are excluded.
- Updated AppAccessPreferencesTest to cover the new toggle-driven behavior for both send types.
- Built debug APK, installed on device, verified: biometric prompt appears for on-chain sends when Payment Confirmation is ON, and is skipped when OFF, for both SendScreen and OnChainScreen.