### PR TITLE
sign and verify stability settlements on all clients

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1538,7 +1538,10 @@ class AppState(private val context: Context) : ViewModel() {
         }
 
         val price = priceService.currentPrice.value
-        val isStabilityPayment = customRecords.any { it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() && it.value.contentEquals(byteArrayOf(1)) }
+        val signedRecord = customRecords.firstOrNull {
+            it.typeNum == Constants.SIGNED_STABILITY_TLV_TYPE.toULong()
+        }
+        var isStabilityPayment = false
         val hasStableControlMessage = customRecords.any {
             it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() &&
                 !it.value.contentEquals(byteArrayOf(1))
@@ -1552,11 +1555,12 @@ class AppState(private val context: Context) : ViewModel() {
             ))
             return
         }
-        val paymentType = if (isStabilityPayment) "stability" else "lightning"
         var sc0 = _stableChannel.value
         // Always use paymentHash as fallback so dedup check runs even when paymentId is null.
         val effectiveId = paymentId ?: paymentHash
-        if (isStabilityPayment && sc0.userChannelId.isEmpty()) {
+        if (signedRecord != null &&
+            (sc0.userChannelId.isEmpty() || sc0.channelId.isEmpty())
+        ) {
             // Inline discovery from the node's channel list (mirrors StabilityService.updateBalances)
             // before giving up on the backing update.
             nodeService.refreshChannels()
@@ -1573,6 +1577,47 @@ class AppState(private val context: Context) : ViewModel() {
                 ))
             }
         }
+        // A valid signed STABILITY_PAYMENT_V1 record is the only stability classifier —
+        // the legacy [0x01] marker is gone (#270); without one this is ordinary Lightning.
+        var settlementId: String? = null
+        if (signedRecord != null) {
+            if (sc0.channelId.isEmpty() || sc0.userChannelId.isEmpty()) {
+                // Discovery above could not recover local state. This is a retryable local
+                // condition, not a bad envelope: demoting it to a Lightning receipt would dedupe
+                // the payment id and make the backing credit unrecoverable. Nack instead.
+                AuditService.log("STABILITY_PAYMENT_STATE_UNAVAILABLE", mapOf(
+                    "payment_id" to (paymentId ?: ""),
+                    "payment_hash" to paymentHash,
+                    "amount_msat" to amountMsat
+                ))
+                throw Exception(
+                    "Channel state unavailable for signed settlement — not acknowledging, will retry"
+                )
+            }
+            when (val validation = StabilityPaymentProtocol.validateInbound(
+                signedRecord.value,
+                sc0.counterparty,
+                sc0.channelId,
+                amountMsat
+            ) { msg, sig, pk -> nodeService.verifySignature(msg, sig, pk) }) {
+                is SignedSettlementValidation.Valid -> {
+                    isStabilityPayment = true
+                    settlementId = validation.payment.settlementId
+                }
+                is SignedSettlementValidation.Invalid -> {
+                    // An invalid signed record must not credit backing — record the keysend as
+                    // an ordinary Lightning receipt instead (mirrors desktop user.rs).
+                    AuditService.log("STABILITY_PAYMENT_INVALID", mapOf(
+                        "payment_id" to (paymentId ?: ""),
+                        "payment_hash" to paymentHash,
+                        "amount_msat" to amountMsat,
+                        "reason" to validation.reason
+                    ))
+                    isStabilityPayment = false
+                }
+            }
+        }
+        val paymentType = if (isStabilityPayment) "stability" else "lightning"
         val userChannelId = if (isStabilityPayment) sc0.userChannelId.ifEmpty { null } else null
         if (isStabilityPayment && userChannelId == null) {
             throw Exception("Stability payment received but userChannelId is empty — cannot update backing, not acknowledging")
@@ -1587,7 +1632,8 @@ class AppState(private val context: Context) : ViewModel() {
                 amountUSD = (amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * price,
                 btcPrice = price, counterparty = sc0.counterparty,
                 userChannelId = userChannelId,
-                backingDeltaSats = backingDelta
+                backingDeltaSats = backingDelta,
+                settlementId = settlementId
             ) ?: throw Exception("DB service unavailable")
         }
         val persistence = try {
@@ -1599,6 +1645,12 @@ class AppState(private val context: Context) : ViewModel() {
             AuditService.log("CHANNEL_ROW_RECREATED", mapOf("user_channel_id" to (userChannelId ?: "")))
             saveChannelToDB()
             record()
+        }
+        if (settlementId != null && !persistence.isNewPayment) {
+            AuditService.log("STABILITY_PAYMENT_REPLAY_IGNORED", mapOf(
+                "settlement_id" to settlementId,
+                "payment_hash" to paymentHash
+            ))
         }
         refreshBalances()
         updateStableBalances()
@@ -2541,7 +2593,9 @@ class AppState(private val context: Context) : ViewModel() {
             val now = System.currentTimeMillis() / 1000
             if (now - sc.lastStabilityPayment < Constants.STABILITY_PAYMENT_COOLDOWN_SECS.toLong()) return
 
-            val amountMsat = USD(abs(result.dollarsFromPar)).toMsats(price)
+            // Stable allocations are sat-denominated — floor to whole sats so the signed
+            // amount matches the keysend exactly (mirrors src/stable.rs).
+            val amountMsat = (USD(abs(result.dollarsFromPar)).toMsats(price) / 1000L) * 1000L
             if (amountMsat == 0L) return
 
             // Chain-freshness gate (see #243): never pay on a stale chain tip, and check
@@ -2570,14 +2624,25 @@ class AppState(private val context: Context) : ViewModel() {
             }
 
             val paymentId = try {
-                // Tag with the STABLE_CHANNEL_TLV [0x01] marker so the LSP classifies
-                // this as a settlement (operator GUI) and runs reconcile_incoming_stability
-                // immediately, matching every other sender. See issue #161.
-                nodeService.sendStabilityPayment(
-                    amountMsat,
-                    sc.counterparty,
-                    listOf(CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), byteArrayOf(1)))
+                // Attach only the signed STABILITY_PAYMENT_V1 envelope — the legacy
+                // STABLE_CHANNEL_TLV [0x01] marker is gone (#270). If the envelope can't
+                // be built, release the claim and skip the payment entirely.
+                val signedEnvelope = StabilityPaymentProtocol.buildSignedEnvelope(
+                    channelId = sc.channelId,
+                    amountMsat = amountMsat,
+                    expectedUsd = sc.expectedUSD.amount,
+                    sign = { payload -> nodeService.signMessage(payload) }
                 )
+                if (signedEnvelope == null) {
+                    try { databaseService?.clearPendingSend() } catch (_: Exception) {}
+                    AuditService.log("STABILITY_SKIP", mapOf("reason" to "envelope_build_failed"))
+                    return
+                }
+                val records = listOf(CustomTlvRecord(
+                    Constants.SIGNED_STABILITY_TLV_TYPE.toULong(),
+                    signedEnvelope.toByteArray(Charsets.UTF_8)
+                ))
+                nodeService.sendStabilityPayment(amountMsat, sc.counterparty, records)
             } catch (e: NodeService.StaleLightningSyncException) {
                 // The wrapper's send-boundary gate fired (sync went stale after the precheck
                 // above). Send never happened — release the claim and retry next tick.

--- a/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/push/StabilityProcessingService.kt
@@ -8,8 +8,11 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.stablechannels.app.R
 import com.stablechannels.app.StableChannelsApp
+import com.stablechannels.app.services.AuditService
 import com.stablechannels.app.services.LdkNodeOwner
 import com.stablechannels.app.services.DatabaseService
+import com.stablechannels.app.services.SignedSettlementValidation
+import com.stablechannels.app.services.StabilityPaymentProtocol
 import com.stablechannels.app.services.TradeControlApplyStatus
 import com.stablechannels.app.services.TradeControlMessage
 import com.stablechannels.app.services.TradeProtocol
@@ -64,11 +67,55 @@ class StabilityProcessingService : Service() {
         .callTimeout(Constants.PRICE_FETCH_TIMEOUT_SECS, TimeUnit.SECONDS)
         .build()
 
-    private fun isStabilityMarker(records: List<CustomTlvRecord>): Boolean =
-        records.any {
-            it.typeNum == Constants.STABLE_CHANNEL_TLV_TYPE.toULong() &&
-                it.value.contentEquals(byteArrayOf(1))
+    private data class InboundClassification(
+        val isStability: Boolean,
+        val settlementId: String?,
+        /// Local channel state was unreadable, which says nothing about the peer's envelope.
+        val stateUnavailable: Boolean = false
+    )
+
+    /** A payment is a stability settlement only with a valid signed STABILITY_PAYMENT_V1
+     *  record on TLV 13377333 — the legacy [0x01] marker is gone (#270), so anything
+     *  without a signed record is ordinary Lightning. An invalid signed record must not
+     *  credit backing either, so it also falls through as Lightning (mirrors desktop user.rs).
+     *  Unreadable local channel state is NOT an invalid envelope: it is reported separately so
+     *  the caller can leave the event unacked instead of demoting a real settlement. */
+    private fun classifyInboundPayment(
+        node: Node,
+        records: List<CustomTlvRecord>,
+        amountMsat: Long
+    ): InboundClassification {
+        val signedRecord = records.firstOrNull {
+            it.typeNum == Constants.SIGNED_STABILITY_TLV_TYPE.toULong()
+        } ?: return InboundClassification(false, null)
+        val channelId = loadChannelStateFromDB()?.channelId.orEmpty()
+        if (channelId.isEmpty()) {
+            // Retryable local condition: recording now would dedupe the payment id and make
+            // the backing credit unrecoverable once the channel row is readable again.
+            Log.w(TAG, "Channel state unavailable for signed stability record — deferring")
+            AuditService.log("STABILITY_PAYMENT_STATE_UNAVAILABLE", mapOf(
+                "amount_msat" to amountMsat
+            ))
+            return InboundClassification(false, null, stateUnavailable = true)
         }
+        return when (val validation = StabilityPaymentProtocol.validateInbound(
+            signedRecord.value,
+            LspPreferencesManager.getLspPubkey(this),
+            channelId,
+            amountMsat
+        ) { msg, sig, pk -> node.verifySignature(msg.map { it.toUByte() }, sig, pk) }) {
+            is SignedSettlementValidation.Valid ->
+                InboundClassification(true, validation.payment.settlementId)
+            is SignedSettlementValidation.Invalid -> {
+                Log.w(TAG, "Invalid signed stability record (${validation.reason}) — recording as lightning")
+                AuditService.log("STABILITY_PAYMENT_INVALID", mapOf(
+                    "amount_msat" to amountMsat,
+                    "reason" to validation.reason
+                ))
+                InboundClassification(false, null)
+            }
+        }
+    }
 
     private fun hasStableControlMessage(records: List<CustomTlvRecord>): Boolean =
         records.any {
@@ -167,6 +214,9 @@ class StabilityProcessingService : Service() {
         Log.d(TAG, "Processing stability: direction=$direction")
 
         val dataDir = Constants.userDataDir(this)
+        // AuditService is a process-wide singleton with no path until set, so audit calls from
+        // this service would silently no-op without it.
+        AuditService.setLogPath(File(dataDir, "audit_log.txt").absolutePath)
         val keySeedFile = File(dataDir, "keys_seed")
         val seedPhraseFile = File(dataDir, "seed_phrase")
         if (!keySeedFile.exists() && !seedPhraseFile.exists()) {
@@ -289,7 +339,13 @@ class StabilityProcessingService : Service() {
                             Log.d(TAG, "Ignored sub-sat incoming event")
                             continue
                         }
-                        val isStabilityPayment = isStabilityMarker(event.customRecords)
+                        val inbound = classifyInboundPayment(node, event.customRecords, event.amountMsat.toLong())
+                        if (inbound.stateUnavailable) {
+                            throw BackingUpdateFailed(
+                                "Channel state unavailable for signed settlement — not acknowledging, foreground will heal"
+                            )
+                        }
+                        val isStabilityPayment = inbound.isStability
                         val paymentId = event.paymentId ?: event.paymentHash
                         if (price <= 0) price = fetchMedianPrice()
                         if (isStabilityPayment) {
@@ -297,7 +353,8 @@ class StabilityProcessingService : Service() {
                             val result = recordPaymentAtomicInDB(
                                 dbPath, paymentId, "stability", "received",
                                 event.amountMsat.toLong(), price, amountSats,
-                                userChannelId = activeUserChannelId()
+                                userChannelId = activeUserChannelId(),
+                                settlementId = inbound.settlementId
                             )
                             when (result) {
                                 InsertResult.INSERTED, InsertResult.DUPLICATE -> {
@@ -357,10 +414,12 @@ class StabilityProcessingService : Service() {
         amountMsat: Long,
         btcPrice: Double,
         backingDeltaSats: Long?,
-        userChannelId: String? = null
+        userChannelId: String? = null,
+        settlementId: String? = null
     ): InsertResult {
         return try {
             val db = SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READWRITE)
+            ensureSettlementTable(db)
             // BEGIN IMMEDIATE acquires the write lock before the dedup SELECT.
             db.execSQL("BEGIN IMMEDIATE")
             try {
@@ -374,11 +433,31 @@ class StabilityProcessingService : Service() {
                         return InsertResult.DUPLICATE
                     }
                 }
+                if (settlementId != null) {
+                    // Replay guard: an already-applied settlement id never credits backing again.
+                    val cursor = db.rawQuery(
+                        "SELECT settlement_id FROM stability_settlements WHERE settlement_id = ?",
+                        arrayOf(settlementId)
+                    )
+                    val seen = cursor.use { it.moveToFirst() }
+                    if (seen) {
+                        Log.d(TAG, "recordPaymentAtomicInDB: settlement $settlementId already applied, skipping")
+                        db.execSQL("ROLLBACK")
+                        db.close()
+                        return InsertResult.DUPLICATE
+                    }
+                }
                 val amountUsd = if (btcPrice > 0) (amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * btcPrice else 0.0
                 db.execSQL(
                     "INSERT INTO payments (payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, status) VALUES (?, ?, ?, ?, ?, ?, 'completed')",
                     arrayOf<Any?>(paymentId, paymentType, direction, amountMsat, amountUsd, btcPrice)
                 )
+                if (settlementId != null) {
+                    db.execSQL(
+                        "INSERT INTO stability_settlements (settlement_id) VALUES (?)",
+                        arrayOf(settlementId)
+                    )
+                }
                 if (backingDeltaSats != null) {
                     // Target the backing UPDATE by the explicit user_channel_id — never by recency —
                     // so a push-triggered payment can't credit/debit the wrong channel row.
@@ -465,13 +544,20 @@ class StabilityProcessingService : Service() {
                         val pid = event.paymentId ?: event.paymentHash
                         // Classify by TLV like handleLspToUser — a stability payment must credit
                         // backing, not be misfiled as a plain lightning receive.
-                        val isStabilityPayment = isStabilityMarker(event.customRecords)
+                        val inbound = classifyInboundPayment(node, event.customRecords, event.amountMsat.toLong())
+                        if (inbound.stateUnavailable) {
+                            throw BackingUpdateFailed(
+                                "Channel state unavailable for signed settlement — not acknowledging, foreground will heal"
+                            )
+                        }
+                        val isStabilityPayment = inbound.isStability
                         val result = if (isStabilityPayment) {
                             val amountSats = event.amountMsat.toLong() / 1000
                             recordPaymentAtomicInDB(
                                 dbPath, pid, "stability", "received",
                                 event.amountMsat.toLong(), price, amountSats,
-                                userChannelId = activeUserChannelId()
+                                userChannelId = activeUserChannelId(),
+                                settlementId = inbound.settlementId
                             )
                         } else {
                             recordPaymentAtomicInDB(dbPath, pid, "lightning", "received", event.amountMsat.toLong(), price, null)
@@ -575,7 +661,9 @@ class StabilityProcessingService : Service() {
             return
         }
 
-        val amountMsat = Math.floor(dollarsFromPar / price * Constants.SATS_IN_BTC * 1000).toLong()
+        // Stable allocations are sat-denominated — floor to whole sats so the signed amount
+        // matches the keysend exactly (mirrors src/stable.rs).
+        val amountMsat = Math.floor(dollarsFromPar / price * Constants.SATS_IN_BTC * 1000).toLong() / 1000L * 1000L
         if (amountMsat <= 0) return
 
         Log.d(TAG, "Sending stability payment: $amountMsat msat ($$dollarsFromPar)")
@@ -629,12 +717,29 @@ class StabilityProcessingService : Service() {
 
         val paymentIdString: String
         try {
-            val tlv = CustomTlvRecord(Constants.STABLE_CHANNEL_TLV_TYPE.toULong(), byteArrayOf(1))
+            // Attach only the signed STABILITY_PAYMENT_V1 envelope bound to this exact
+            // amount and channel — the legacy [0x01] marker is gone (#270). If the
+            // envelope can't be built, release the claim and skip the payment entirely.
+            val signedEnvelope = StabilityPaymentProtocol.buildSignedEnvelope(
+                channelId = channelState.channelId,
+                amountMsat = amountMsat,
+                expectedUsd = channelState.expectedUsd,
+                sign = { payload -> node.signMessage(payload.map { it.toUByte() }) }
+            )
+            if (signedEnvelope == null) {
+                try { clearPendingSendInDB(dbPath) } catch (_: Exception) {}
+                Log.w(TAG, "Could not build signed stability envelope — skipping payment")
+                return
+            }
+            val records = listOf(CustomTlvRecord(
+                Constants.SIGNED_STABILITY_TLV_TYPE.toULong(),
+                signedEnvelope.toByteArray(Charsets.UTF_8)
+            ))
             val paymentId = node.spontaneousPayment().sendWithCustomTlvs(
                 amountMsat.toULong(),
                 LspPreferencesManager.getLspPubkey(this),
                 null,
-                listOf(tlv)
+                records
             )
             paymentIdString = paymentId.toString()
         } catch (e: Exception) {
@@ -790,6 +895,17 @@ class StabilityProcessingService : Service() {
         """)
     }
 
+    /** Applied inbound STABILITY_PAYMENT_V1 settlement ids (replay guard). Same schema as
+     *  DatabaseService.createStabilitySettlementsTable — IF NOT EXISTS for either process. */
+    private fun ensureSettlementTable(db: SQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS stability_settlements (
+                settlement_id TEXT PRIMARY KEY,
+                created_at INTEGER DEFAULT (strftime('%s','now'))
+            )
+        """)
+    }
+
     /** Atomic check-and-set: returns false when a marker already exists (claim denied).
      *  BEGIN IMMEDIATE holds the write lock across the SELECT + INSERT. */
     private fun claimPendingSendInDB(dbPath: String, amountMsat: Long, price: Double): Boolean {
@@ -870,7 +986,8 @@ class StabilityProcessingService : Service() {
         val nativeSats: Long,
         val backingSats: Long,
         val latestPrice: Double,
-        val userChannelId: String
+        val userChannelId: String,
+        val channelId: String
     )
 
     private fun loadChannelStateFromDB(): ChannelState? {
@@ -882,7 +999,7 @@ class StabilityProcessingService : Service() {
             val cursor = db.rawQuery(
                 // Pick the single active channel deterministically. The user_channel_id it returns is
                 // the stable key every backing UPDATE targets by — the write never re-selects by recency.
-                "SELECT expected_usd, receiver_sats, latest_price, stable_sats, user_channel_id FROM channels WHERE user_channel_id IS NOT NULL AND user_channel_id != '' ORDER BY updated_at DESC, channel_id DESC LIMIT 1",
+                "SELECT expected_usd, receiver_sats, latest_price, stable_sats, user_channel_id, channel_id FROM channels WHERE user_channel_id IS NOT NULL AND user_channel_id != '' ORDER BY updated_at DESC, channel_id DESC LIMIT 1",
                 null
             )
             val result = cursor.use {
@@ -893,7 +1010,8 @@ class StabilityProcessingService : Service() {
                         nativeSats = 0,  // not in DB schema, computed at runtime
                         backingSats = it.getLong(3),
                         latestPrice = it.getDouble(2),
-                        userChannelId = it.getString(4)
+                        userChannelId = it.getString(4),
+                        channelId = it.getString(5)
                     )
                 } else null
             }

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -148,6 +148,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         """)
 
         createPendingStabilitySendTable(db)
+        createStabilitySettlementsTable(db)
 
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_price_history_ts ON price_history(timestamp)")
         db.execSQL("CREATE INDEX IF NOT EXISTS idx_payments_created ON payments(created_at)")
@@ -189,6 +190,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         // IF NOT EXISTS so either process (main app or background service) can create it,
         // including on databases created before this table existed.
         createPendingStabilitySendTable(db)
+        createStabilitySettlementsTable(db)
         createTradeIndexes(db)
     }
 
@@ -200,6 +202,17 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 amount_msat INTEGER NOT NULL,
                 price REAL NOT NULL,
                 created_at INTEGER NOT NULL
+            )
+        """)
+    }
+
+    /** Applied inbound STABILITY_PAYMENT_V1 settlement ids — replay guard so a signed
+     *  settlement can never credit backing twice, even under a re-sent keysend. */
+    private fun createStabilitySettlementsTable(db: SQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS stability_settlements (
+                settlement_id TEXT PRIMARY KEY,
+                created_at INTEGER DEFAULT (strftime('%s','now'))
             )
         """)
     }
@@ -920,7 +933,8 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         btcPrice: Double? = null,
         counterparty: String? = null,
         userChannelId: String? = null,
-        backingDeltaSats: Long? = null
+        backingDeltaSats: Long? = null,
+        settlementId: String? = null
     ): PaymentPersistenceResult {
         val db = writableDatabase
         // BEGIN IMMEDIATE acquires the write lock before the dedup SELECT, preventing
@@ -944,6 +958,26 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                     return PaymentPersistenceResult(false, backing)
                 }
             }
+            // Replay guard: an already-applied settlement id never credits backing again.
+            if (settlementId != null) {
+                val cursor = db.rawQuery(
+                    "SELECT settlement_id FROM stability_settlements WHERE settlement_id = ?",
+                    arrayOf(settlementId)
+                )
+                val seen = cursor.use { it.moveToFirst() }
+                if (seen) {
+                    val backing = if (backingDeltaSats != null) {
+                        val ucid = userChannelId
+                            ?: throw IllegalStateException("userChannelId required for backing update")
+                        readBackingSats(db, ucid)
+                            ?: throw MissingChannelRowException(ucid)
+                    } else {
+                        null
+                    }
+                    db.execSQL("ROLLBACK")
+                    return PaymentPersistenceResult(false, backing)
+                }
+            }
             val cv = ContentValues().apply {
                 put("payment_id", paymentId)
                 put("payment_type", paymentType)
@@ -955,6 +989,12 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 put("status", "completed")
             }
             db.insertOrThrow("payments", null, cv)
+            if (settlementId != null) {
+                db.execSQL(
+                    "INSERT INTO stability_settlements (settlement_id) VALUES (?)",
+                    arrayOf(settlementId)
+                )
+            }
             var resultingBacking: Long? = null
             if (backingDeltaSats != null) {
                 val ucid = userChannelId

--- a/android/app/src/main/java/com/stablechannels/app/services/StabilityPaymentProtocol.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/StabilityPaymentProtocol.kt
@@ -1,0 +1,176 @@
+package com.stablechannels.app.services
+
+import com.stablechannels.app.util.Constants
+import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
+import java.security.SecureRandom
+
+data class StabilityPayment(
+    val settlementId: String,
+    val channelId: String,
+    val amountMsat: Long,
+    val direction: String,
+    val expectedUsd: Double,
+    val createdAt: Long,
+    val expiresAt: Long
+)
+
+sealed interface SignedSettlementValidation {
+    data class Valid(val payment: StabilityPayment) : SignedSettlementValidation
+    data class Invalid(val reason: String) : SignedSettlementValidation
+}
+
+/** STABILITY_PAYMENT_V1 payload/envelope codec shared by both send paths and both receive
+ *  paths. Mirrors stable.rs build/parse_stability_payment_payload exactly so the wire format
+ *  stays interchangeable with the Rust peers. */
+object StabilityPaymentProtocol {
+    const val DIRECTION_USER_TO_LSP = "user_to_lsp"
+    const val DIRECTION_LSP_TO_USER = "lsp_to_user"
+
+    fun newSettlementId(): String = ByteArray(32)
+        .also { SecureRandom().nextBytes(it) }
+        .joinToString("") { "%02x".format(it) }
+
+    fun buildPayload(
+        settlementId: String,
+        channelId: String,
+        amountMsat: Long,
+        direction: String,
+        expectedUsd: Double,
+        createdAt: Long,
+        expiresAt: Long
+    ): String? {
+        if (!TradeProtocol.isCanonicalIdentifier(settlementId) ||
+            !TradeProtocol.isCanonicalIdentifier(channelId) ||
+            amountMsat <= 0L || amountMsat % 1000L != 0L ||
+            (direction != DIRECTION_USER_TO_LSP && direction != DIRECTION_LSP_TO_USER) ||
+            !expectedUsd.isFinite() || expectedUsd < 0.0 ||
+            createdAt < 0L || expiresAt < createdAt ||
+            expiresAt - createdAt > Constants.STABILITY_PAYMENT_TTL_SECS
+        ) return null
+        return JSONObject().apply {
+            put("type", Constants.STABILITY_PAYMENT_MESSAGE_TYPE)
+            put("settlement_id", settlementId)
+            put("channel_id", channelId)
+            put("amount_msat", amountMsat)
+            put("direction", direction)
+            put("expected_usd", expectedUsd)
+            put("created_at", createdAt)
+            put("expires_at", expiresAt)
+        }.toString()
+    }
+
+    /** Signed envelope for an outgoing user_to_lsp settlement, or null when the inputs cannot
+     *  produce a payload the LSP would accept. The caller must send the same whole-sat amount. */
+    fun buildSignedEnvelope(
+        channelId: String,
+        amountMsat: Long,
+        expectedUsd: Double,
+        sign: (ByteArray) -> String,
+        now: Long = System.currentTimeMillis() / 1000L,
+        settlementId: String = newSettlementId()
+    ): String? {
+        val payload = buildPayload(
+            settlementId, channelId, amountMsat, DIRECTION_USER_TO_LSP,
+            expectedUsd, now, now + Constants.STABILITY_PAYMENT_TTL_SECS
+        ) ?: return null
+        val signature = sign(payload.toByteArray(Charsets.UTF_8))
+        return JSONObject().apply {
+            put("payload", payload)
+            put("signature", signature)
+        }.toString()
+    }
+
+    fun parsePayload(payloadStr: String): StabilityPayment? {
+        return try {
+            val payload = JSONObject(payloadStr)
+            if (payload.optString("type") != Constants.STABILITY_PAYMENT_MESSAGE_TYPE) return null
+            val settlementId = payload.optString("settlement_id")
+            val channelId = payload.optString("channel_id")
+            val amountMsat = jsonInteger(payload, "amount_msat")
+            val direction = payload.optString("direction")
+            val expectedUsd = (payload.opt("expected_usd") as? Number)?.toDouble()
+            val createdAt = jsonInteger(payload, "created_at")
+            val expiresAt = jsonInteger(payload, "expires_at")
+            if (!TradeProtocol.isCanonicalIdentifier(settlementId) ||
+                !TradeProtocol.isCanonicalIdentifier(channelId) ||
+                amountMsat == null || amountMsat <= 0L || amountMsat % 1000L != 0L ||
+                (direction != DIRECTION_USER_TO_LSP && direction != DIRECTION_LSP_TO_USER) ||
+                expectedUsd == null || !expectedUsd.isFinite() || expectedUsd < 0.0 ||
+                createdAt == null || createdAt < 0L ||
+                expiresAt == null || expiresAt < createdAt ||
+                expiresAt - createdAt > Constants.STABILITY_PAYMENT_TTL_SECS
+            ) return null
+            StabilityPayment(
+                settlementId, channelId, amountMsat, direction,
+                expectedUsd, createdAt, expiresAt
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun isFresh(payment: StabilityPayment, now: Long): Boolean =
+        payment.createdAt <= now + Constants.STABILITY_PAYMENT_CLOCK_SKEW_SECS &&
+            now <= payment.expiresAt + Constants.STABILITY_PAYMENT_CLOCK_SKEW_SECS
+
+    /** Validate an inbound SIGNED_STABILITY_TLV record against the received keysend.
+     *  Check order mirrors user.rs handle_signed_stability_payment_received. */
+    fun validateInbound(
+        data: ByteArray,
+        expectedCounterparty: String,
+        ownChannelId: String,
+        amountMsat: Long,
+        now: Long = System.currentTimeMillis() / 1000L,
+        verifySignature: (ByteArray, String, String) -> Boolean
+    ): SignedSettlementValidation {
+        if (data.size > Constants.MAX_SIGNED_STABILITY_TLV_VALUE_BYTES) {
+            return SignedSettlementValidation.Invalid("oversize")
+        }
+        val raw = try {
+            Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(data)).toString()
+        } catch (_: Exception) {
+            return SignedSettlementValidation.Invalid("utf8")
+        }
+        val envelope = try { JSONObject(raw) } catch (_: Exception) {
+            return SignedSettlementValidation.Invalid("envelope")
+        }
+        val payloadStr = envelope.opt("payload") as? String
+            ?: return SignedSettlementValidation.Invalid("envelope")
+        val signature = envelope.opt("signature") as? String
+            ?: return SignedSettlementValidation.Invalid("envelope")
+        val payment = parsePayload(payloadStr)
+            ?: return SignedSettlementValidation.Invalid("fields")
+        if (payment.direction != DIRECTION_LSP_TO_USER) {
+            return SignedSettlementValidation.Invalid("direction")
+        }
+        if (payment.amountMsat != amountMsat) {
+            return SignedSettlementValidation.Invalid("amount")
+        }
+        if (!isFresh(payment, now)) {
+            return SignedSettlementValidation.Invalid("expired")
+        }
+        if (payment.channelId != ownChannelId) {
+            return SignedSettlementValidation.Invalid("channel")
+        }
+        if (!verifySignature(payloadStr.toByteArray(Charsets.UTF_8), signature, expectedCounterparty)) {
+            return SignedSettlementValidation.Invalid("signature")
+        }
+        return SignedSettlementValidation.Valid(payment)
+    }
+
+    private fun jsonInteger(payload: JSONObject, key: String): Long? {
+        val value = payload.opt(key)
+        return when (value) {
+            is Byte -> value.toLong()
+            is Short -> value.toLong()
+            is Int -> value.toLong()
+            is Long -> value
+            else -> null
+        }
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -9,6 +9,12 @@ object Constants {
     const val CLIENT_SAFETY_MARGIN_SATS = 50L
     const val SATS_IN_BTC: Long = 100_000_000L
     const val STABLE_CHANNEL_TLV_TYPE: Long = 13_377_331L
+    const val SIGNED_STABILITY_TLV_TYPE: Long = 13_377_333L
+    /** Maximum signed stability metadata accepted before parsing (src/constants.rs). */
+    const val MAX_SIGNED_STABILITY_TLV_VALUE_BYTES: Int = 8 * 1024
+    const val STABILITY_PAYMENT_MESSAGE_TYPE = "STABILITY_PAYMENT_V1"
+    const val STABILITY_PAYMENT_TTL_SECS: Long = 1_209_600L
+    const val STABILITY_PAYMENT_CLOCK_SKEW_SECS: Long = 60L
     const val TRADE_MESSAGE_TYPE = "TRADE_V1"
     const val SYNC_MESSAGE_TYPE = "SYNC_V1"
     const val TRADE_REJECTED_MESSAGE_TYPE = "TRADE_REJECTED_V1"

--- a/android/app/src/test/java/com/stablechannels/app/StabilityPaymentProtocolTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/StabilityPaymentProtocolTest.kt
@@ -1,0 +1,210 @@
+package com.stablechannels.app
+
+import com.stablechannels.app.services.SignedSettlementValidation
+import com.stablechannels.app.services.StabilityPaymentProtocol
+import com.stablechannels.app.util.Constants
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class StabilityPaymentProtocolTest {
+    private val identifier = "ab".repeat(32)
+    private val now = 1_786_310_000L
+
+    private fun envelopeFor(
+        payload: String,
+        signature: String = "valid"
+    ): ByteArray = JSONObject().apply {
+        put("payload", payload)
+        put("signature", signature)
+    }.toString().toByteArray()
+
+    private fun validate(
+        data: ByteArray,
+        amountMsat: Long = 25_000L,
+        channelId: String = identifier,
+        at: Long = now
+    ) = StabilityPaymentProtocol.validateInbound(data, "lsp", channelId, amountMsat, at) { bytes, sig, pk ->
+        pk == "lsp" && sig == "valid" && bytes.contentEquals(
+            JSONObject(String(data, Charsets.UTF_8)).getString("payload").toByteArray(Charsets.UTF_8)
+        )
+    }
+
+    private fun inboundPayload(
+        amountMsat: Long = 25_000L,
+        direction: String = StabilityPaymentProtocol.DIRECTION_LSP_TO_USER,
+        settlementId: String = identifier,
+        channelId: String = identifier,
+        createdAt: Long = now,
+        expiresAt: Long = now + Constants.STABILITY_PAYMENT_TTL_SECS
+    ): String = JSONObject().apply {
+        put("type", "STABILITY_PAYMENT_V1")
+        put("settlement_id", settlementId)
+        put("channel_id", channelId)
+        put("amount_msat", amountMsat)
+        put("direction", direction)
+        put("expected_usd", 50.0)
+        put("created_at", createdAt)
+        put("expires_at", expiresAt)
+    }.toString()
+
+    @Test
+    fun signedSettlementRoundTrips() {
+        val envelope = StabilityPaymentProtocol.buildSignedEnvelope(
+            channelId = identifier,
+            amountMsat = 25_000L,
+            expectedUsd = 50.0,
+            sign = { "valid" },
+            now = now,
+            settlementId = identifier
+        )
+        assertNotNull(envelope)
+        val parsed = JSONObject(envelope!!)
+        val payload = JSONObject(parsed.getString("payload"))
+        assertEquals("STABILITY_PAYMENT_V1", payload.getString("type"))
+        assertEquals(identifier, payload.getString("settlement_id"))
+        assertEquals(identifier, payload.getString("channel_id"))
+        assertEquals(25_000L, payload.getLong("amount_msat"))
+        assertEquals("user_to_lsp", payload.getString("direction"))
+        assertEquals(50.0, payload.getDouble("expected_usd"), 0.0)
+        assertEquals(now, payload.getLong("created_at"))
+        assertEquals(now + Constants.STABILITY_PAYMENT_TTL_SECS, payload.getLong("expires_at"))
+
+        // The same payload signed by the LSP in the opposite direction validates inbound.
+        val inbound = JSONObject(payload.toString()).apply {
+            put("direction", "lsp_to_user")
+        }.toString()
+        val result = validate(envelopeFor(inbound))
+        assertTrue(result is SignedSettlementValidation.Valid)
+        assertEquals(identifier, (result as SignedSettlementValidation.Valid).payment.settlementId)
+    }
+
+    @Test
+    fun randomSettlementIdsAreCanonicalAndUnique() {
+        val ids = (1..8).map { StabilityPaymentProtocol.newSettlementId() }
+        assertTrue(ids.all { it.length == 64 && it.all { c -> c in '0'..'9' || c in 'a'..'f' } })
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun legacyMarkerBytesAreNotASettlement() {
+        // The removed [0x01] stability marker TLV value must never validate — a
+        // marker-only payment is now an ordinary Lightning receipt (#270 follow-up).
+        assertInvalid("envelope", byteArrayOf(1))
+    }
+
+    @Test
+    fun signedRecordAloneClassifiesAsStability() {
+        // No legacy marker attached: a valid signed record on TLV 13377333 alone
+        // classifies the payment as a stability settlement.
+        assertValid(envelopeFor(inboundPayload()))
+    }
+
+    @Test
+    fun buildRejectsNonWholeSatAmounts() {
+        assertNull(StabilityPaymentProtocol.buildPayload(
+            identifier, identifier, 1_500L, "user_to_lsp", 50.0, now, now + 100
+        ))
+        assertNull(StabilityPaymentProtocol.buildPayload(
+            identifier, identifier, 0L, "user_to_lsp", 50.0, now, now + 100
+        ))
+        assertNull(StabilityPaymentProtocol.buildSignedEnvelope(
+            identifier, 25_001L, 50.0, { "valid" }, now, identifier
+        ))
+    }
+
+    @Test
+    fun invalidWireShapesAreRejected() {
+        // Envelope shape
+        assertInvalid("envelope", "not json".toByteArray())
+        assertInvalid("envelope", envelopeFor("{}", signature = "").let {
+            JSONObject(String(it, Charsets.UTF_8)).apply { remove("signature") }.toString().toByteArray()
+        })
+        // Field validation
+        assertInvalid("fields", envelopeFor("{\"type\":\"WRONG\"}"))
+        assertInvalid("fields", envelopeFor(inboundPayload(settlementId = "AB".repeat(32))))
+        assertInvalid("fields", envelopeFor(inboundPayload(channelId = "ab".repeat(31))))
+        assertInvalid("fields", envelopeFor(
+            JSONObject(inboundPayload()).apply { put("amount_msat", 25_001L) }.toString()
+        ))
+        assertInvalid("fields", envelopeFor(
+            JSONObject(inboundPayload()).apply { put("expected_usd", -1.0) }.toString()
+        ))
+        // TTL exceeded
+        assertInvalid("fields", envelopeFor(inboundPayload(
+            createdAt = now, expiresAt = now + Constants.STABILITY_PAYMENT_TTL_SECS + 1
+        )))
+    }
+
+    @Test
+    fun bindingChecksRejectWrongDirectionAmountAndChannel() {
+        assertInvalid("direction", envelopeFor(inboundPayload(direction = "user_to_lsp")))
+        assertInvalid("amount", envelopeFor(inboundPayload(amountMsat = 26_000L)))
+        assertInvalid("channel", envelopeFor(inboundPayload()), channelId = "cd".repeat(32))
+    }
+
+    @Test
+    fun freshnessWindowHonorsClockSkew() {
+        // Expired beyond the 60s skew
+        assertInvalid("expired", envelopeFor(inboundPayload(
+            createdAt = now - 2_000L, expiresAt = now - 120L
+        )))
+        // Not yet valid beyond the 60s skew
+        assertInvalid("expired", envelopeFor(inboundPayload(
+            createdAt = now + 120L, expiresAt = now + Constants.STABILITY_PAYMENT_TTL_SECS
+        )))
+        // Within skew on both edges
+        assertValid(envelopeFor(inboundPayload(
+            createdAt = now - 2_000L, expiresAt = now - 30L
+        )))
+        assertValid(envelopeFor(inboundPayload(
+            createdAt = now + 30L, expiresAt = now + Constants.STABILITY_PAYMENT_TTL_SECS
+        )))
+    }
+
+    @Test
+    fun signatureAndOversizeAreRejected() {
+        val payload = inboundPayload()
+        val badSig = JSONObject().apply {
+            put("payload", payload)
+            put("signature", "forged")
+        }.toString().toByteArray()
+        assertInvalid("signature", badSig)
+        assertInvalid("oversize", ByteArray(Constants.MAX_SIGNED_STABILITY_TLV_VALUE_BYTES + 1))
+        assertInvalid("utf8", byteArrayOf(0xC3.toByte(), 0x28))
+    }
+
+    @Test
+    fun unreadableChannelStateMustNotLookLikeAnInvalidEnvelope() {
+        // Regression: an empty local channelId used to reach validateInbound and come back as
+        // Invalid("channel"), indistinguishable from a forged envelope. Callers demoted that to a
+        // deduped Lightning receipt, so the backing credit could never be recovered. Receivers now
+        // check for unreadable local state BEFORE validating; this pins the reason strings apart so
+        // a future refactor cannot silently merge the two cases again.
+        val envelope = envelopeFor(inboundPayload())
+        assertInvalid("channel", envelope, channelId = "")
+        assertValid(envelope)
+    }
+
+    private fun assertValid(data: ByteArray) {
+        assertTrue(validate(data) is SignedSettlementValidation.Valid)
+    }
+
+    private fun assertInvalid(
+        reason: String,
+        data: ByteArray,
+        channelId: String = identifier
+    ) {
+        val result = validate(data, channelId = channelId)
+        assertTrue(result is SignedSettlementValidation.Invalid)
+        assertEquals(reason, (result as SignedSettlementValidation.Invalid).reason)
+    }
+}

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -447,6 +447,56 @@ class TradeDatabaseServiceTest {
         service.close()
     }
 
+    @Test
+    fun demotingASettlementToLightningMakesTheBackingCreditUnrecoverable() {
+        // Regression for the receive-side classification bug: when local channel state was
+        // unreadable, receivers recorded the settlement as an ordinary Lightning receipt. This
+        // pins WHY that is unsafe — the payment_id is now taken, so the later retry that does
+        // have channel state dedups and the backing credit is lost for good. Receivers must
+        // leave the event unacked instead of demoting it.
+        val identifier = "ab".repeat(32)
+        val settlementId = "cd".repeat(32)
+        val paymentId = "ef".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUSD = 50.0,
+            backingSats = 55_000,
+            note = null,
+            receiverSats = 100_000,
+            latestPrice = 100_000.0
+        )
+
+        // The demotion: same payment id, recorded as lightning with no backing delta.
+        val demoted = service.recordPaymentAndMaybeUpdateBacking(
+            paymentId = paymentId,
+            paymentType = "lightning",
+            direction = "received",
+            amountMsat = 25_000
+        )
+        assertTrue(demoted.isNewPayment)
+        assertEquals(55_000L, service.loadChannel("7")?.backingSats)
+
+        // The retry, now with channel state available, cannot repair it: the payment id dedups.
+        val retry = service.recordPaymentAndMaybeUpdateBacking(
+            paymentId = paymentId,
+            paymentType = "stability",
+            direction = "received",
+            amountMsat = 25_000,
+            userChannelId = "7",
+            backingDeltaSats = 25,
+            settlementId = settlementId
+        )
+        assertFalse(retry.isNewPayment)
+        assertEquals(55_000L, service.loadChannel("7")?.backingSats)
+        assertEquals(
+            "lightning",
+            service.getRecentPayments().first { it.paymentId == paymentId }.paymentType
+        )
+        service.close()
+    }
+
     private fun deleteDatabaseFiles() {
         listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
             .forEach { file -> if (file.exists()) assertTrue(file.delete()) }

--- a/ios/StableChannels/NotificationService/Services/Constants.swift
+++ b/ios/StableChannels/NotificationService/Services/Constants.swift
@@ -5,6 +5,7 @@ enum Constants {
     static let lspPubkey = "0388948c5c7775a5eda3ee4a96434a270f20f5beeed7e9c99f242f21b87d658850"
     static let lspAddress = "stablechannels.com:9735"
     static let stableChannelTLVType: UInt64 = 13_377_331
+    static let signedStabilityTLVType: UInt64 = 13_377_333
     static let syncMessageType = "SYNC_V1"
     static let satsInBTC: Double = 100_000_000.0
     static let stabilityThresholdPercent: Double = 0.1

--- a/ios/StableChannels/NotificationService/Services/IncomingPaymentHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/IncomingPaymentHandler.swift
@@ -60,7 +60,39 @@ final class IncomingPaymentHandler: PaymentHandler {
                     break
                 }
 
-                if StableControlParser.isStabilityPayment(customRecords) {
+                // Only a valid signed settlement record makes this a stability payment
+                // (issue #270): invalid or replayed records are acked and ignored, and
+                // payments without one are ordinary Lightning receipts.
+                var settlementId: String?
+                let isStability: Bool
+                switch StableControlParser.signedSettlementStatus(
+                    node: node,
+                    db: db,
+                    customRecords: customRecords,
+                    amountMsat: amountMsat
+                ) {
+                case .valid(let id):
+                    isStability = true
+                    settlementId = id
+                case .invalid(let reason):
+                    // The sats arrived regardless, so record a Lightning receipt, not backing.
+                    NSLog("[NSE] invalid signed stability settlement, recording as lightning: \(reason)")
+                    isStability = false
+                case .duplicate(let id):
+                    NSLog("[NSE] ignoring replayed signed stability settlement: \(id)")
+                    try? node.eventHandled()
+                    continue eventLoop
+                case .stateUnavailable:
+                    // Do not ack: the sats arrived but local channel state is unreadable, so
+                    // recording now would dedupe the payment id and lose the backing credit.
+                    NSLog("[NSE] channel state unavailable for signed settlement, deferring to foreground")
+                    persistenceFailed = true
+                    break eventLoop
+                case .none:
+                    isStability = false
+                }
+
+                if isStability {
                     let result = db.recordPayment(
                         paymentId: payId,
                         paymentType: "stability",
@@ -69,7 +101,8 @@ final class IncomingPaymentHandler: PaymentHandler {
                         amountUSD: self.calculateUSD(amountMsat / 1000, price: price),
                         btcPrice: price,
                         backingDeltaSats: Int64(amountMsat / 1000),
-                        userChannelId: db.activeUserChannelId()
+                        userChannelId: db.activeUserChannelId(),
+                        settlementId: settlementId
                     )
                     switch result {
                     case .inserted, .duplicate:
@@ -88,7 +121,8 @@ final class IncomingPaymentHandler: PaymentHandler {
                         amountUSD: self.calculateUSD(amountMsat / 1000, price: price),
                         btcPrice: price,
                         backingDeltaSats: nil,
-                        userChannelId: nil
+                        userChannelId: nil,
+                        settlementId: nil
                     )
                     switch result {
                     case .inserted, .duplicate:

--- a/ios/StableChannels/NotificationService/Services/LSPToUserHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/LSPToUserHandler.swift
@@ -60,7 +60,36 @@ final class LSPToUserHandler: PaymentHandler {
                     break
                 }
 
-                let isStability = StableControlParser.isStabilityPayment(customRecords)
+                // Only a valid signed settlement record makes this a stability payment
+                // (issue #270): invalid or replayed records are acked and ignored, and
+                // payments without one are ordinary Lightning receipts.
+                var settlementId: String?
+                let isStability: Bool
+                switch StableControlParser.signedSettlementStatus(
+                    node: node,
+                    db: db,
+                    customRecords: customRecords,
+                    amountMsat: amountMsat
+                ) {
+                case .valid(let id):
+                    isStability = true
+                    settlementId = id
+                case .invalid(let reason):
+                    // The sats arrived regardless, so record a Lightning receipt, not backing.
+                    NSLog("[NSE] invalid signed stability settlement, recording as lightning: \(reason)")
+                    isStability = false
+                case .duplicate(let id):
+                    NSLog("[NSE] ignoring replayed signed stability settlement: \(id)")
+                    try? node.eventHandled()
+                    continue eventLoop
+                case .stateUnavailable:
+                    // Do not ack: the sats arrived but local channel state is unreadable, so
+                    // recording now would dedupe the payment id and lose the backing credit.
+                    NSLog("[NSE] channel state unavailable for signed settlement, deferring to foreground")
+                    break eventLoop
+                case .none:
+                    isStability = false
+                }
                 if isStability {
                     let amountSats = amountMsat / 1000
                     switch db.recordPayment(
@@ -71,7 +100,8 @@ final class LSPToUserHandler: PaymentHandler {
                         amountUSD: self.calculateUSD(amountSats, price: price),
                         btcPrice: price,
                         backingDeltaSats: Int64(amountSats),
-                        userChannelId: db.activeUserChannelId()
+                        userChannelId: db.activeUserChannelId(),
+                        settlementId: settlementId
                     ) {
                     case .inserted, .duplicate:
                         try? node.eventHandled()
@@ -91,7 +121,8 @@ final class LSPToUserHandler: PaymentHandler {
                         amountUSD: self.calculateUSD(amountMsat / 1000, price: price),
                         btcPrice: price,
                         backingDeltaSats: nil,
-                        userChannelId: nil
+                        userChannelId: nil,
+                        settlementId: nil
                     )
                     switch result {
                     case .inserted, .duplicate:

--- a/ios/StableChannels/NotificationService/Services/Protocols/PaymentDatabase.swift
+++ b/ios/StableChannels/NotificationService/Services/Protocols/PaymentDatabase.swift
@@ -11,7 +11,8 @@ protocol PaymentDatabase {
         amountUSD: Double,
         btcPrice: Double,
         backingDeltaSats: Int64?,
-        userChannelId: String?
+        userChannelId: String?,
+        settlementId: String?
     ) -> PaymentInsertResult
 
     func paymentExists(paymentId: String) -> Bool
@@ -26,6 +27,7 @@ protocol PaymentDatabase {
     func loadPendingSend() -> PendingOutgoingStabilityPayment?
     func clearPendingSend()
     func reconcilePendingOutgoingPayment(node: LDKNode.Node) -> Bool
+    func isSettlementSeen(settlementId: String) -> Bool
 }
 
 enum StableControlDatabaseResult {
@@ -59,4 +61,5 @@ struct ChannelState {
     let receiverSats: UInt64
     let latestPrice: Double
     let userChannelId: String
+    let channelId: String
 }

--- a/ios/StableChannels/NotificationService/Services/SQLitePaymentDatabase.swift
+++ b/ios/StableChannels/NotificationService/Services/SQLitePaymentDatabase.swift
@@ -16,6 +16,12 @@ final class SQLitePaymentDatabase: PaymentDatabase {
     created_at INTEGER NOT NULL
     )
     """
+    private static let seenSettlementsTableSQL = """
+    CREATE TABLE IF NOT EXISTS seen_stability_settlements (
+    settlement_id TEXT PRIMARY KEY,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+    )
+    """
 
     init(dbPath: String) {
         self.dbPath = dbPath
@@ -60,10 +66,15 @@ final class SQLitePaymentDatabase: PaymentDatabase {
         amountUSD: Double,
         btcPrice: Double,
         backingDeltaSats: Int64?,
-        userChannelId: String?
+        userChannelId: String?,
+        settlementId: String?
     ) -> PaymentInsertResult {
         guard let db = openDB() else { return .failed }
         defer { sqlite3_close(db) }
+
+        if settlementId != nil {
+            _ = sqlite3_exec(db, Self.seenSettlementsTableSQL, nil, nil, nil)
+        }
 
         guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return .failed }
 
@@ -84,6 +95,29 @@ final class SQLitePaymentDatabase: PaymentDatabase {
                     return .duplicate
                 }
                 sqlite3_finalize(checkStmt)
+            }
+        }
+
+        // Replay guard inside the transaction that credits backing, so a crash can never leave
+        // backing credited with the settlement id still replayable.
+        if let sid = settlementId {
+            var seenStmt: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                db,
+                "SELECT 1 FROM seen_stability_settlements WHERE settlement_id = ?",
+                -1,
+                &seenStmt,
+                nil
+            ) == SQLITE_OK else {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+                return .failed
+            }
+            bindText(seenStmt, 1, sid)
+            let alreadySeen = sqlite3_step(seenStmt) == SQLITE_ROW
+            sqlite3_finalize(seenStmt)
+            if alreadySeen {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+                return .duplicate
             }
         }
 
@@ -128,6 +162,23 @@ final class SQLitePaymentDatabase: PaymentDatabase {
         guard sqlite3_step(stmt) == SQLITE_DONE else {
             sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
             return .failed
+        }
+
+        // Burn the settlement id in the same transaction that credits backing.
+        if let sid = settlementId {
+            var seenInsert: OpaquePointer?
+            let seenSQL = "INSERT INTO seen_stability_settlements (settlement_id) VALUES (?)"
+            guard sqlite3_prepare_v2(db, seenSQL, -1, &seenInsert, nil) == SQLITE_OK else {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+                return .failed
+            }
+            bindText(seenInsert, 1, sid)
+            let burned = sqlite3_step(seenInsert) == SQLITE_DONE
+            sqlite3_finalize(seenInsert)
+            guard burned else {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+                return .failed
+            }
         }
 
         // Update backing if needed
@@ -197,7 +248,7 @@ final class SQLitePaymentDatabase: PaymentDatabase {
 
         var stmt: OpaquePointer?
         let sql = """
-        SELECT expected_usd, stable_sats, receiver_sats, latest_price, native_sats, user_channel_id
+        SELECT expected_usd, stable_sats, receiver_sats, latest_price, native_sats, user_channel_id, channel_id
         FROM channels
         WHERE user_channel_id IS NOT NULL AND user_channel_id != ''
         ORDER BY updated_at DESC, channel_id DESC
@@ -214,7 +265,8 @@ final class SQLitePaymentDatabase: PaymentDatabase {
             nativeSats: UInt64(sqlite3_column_int64(stmt, 4)),
             receiverSats: UInt64(sqlite3_column_int64(stmt, 2)),
             latestPrice: sqlite3_column_double(stmt, 3),
-            userChannelId: sqlite3_column_text(stmt, 5).map { String(cString: $0) } ?? ""
+            userChannelId: sqlite3_column_text(stmt, 5).map { String(cString: $0) } ?? "",
+            channelId: sqlite3_column_text(stmt, 6).map { String(cString: $0) } ?? ""
         )
     }
 
@@ -698,7 +750,8 @@ final class SQLitePaymentDatabase: PaymentDatabase {
             amountUSD: amountUSD,
             btcPrice: pending.btcPrice,
             backingDeltaSats: -Int64(pending.amountMsat / 1000),
-            userChannelId: activeUserChannelId()
+            userChannelId: activeUserChannelId(),
+            settlementId: nil
         )
 
         switch result {
@@ -729,5 +782,26 @@ final class SQLitePaymentDatabase: PaymentDatabase {
             SQLITE_TRANSIENT
         )
         return sqlite3_step(stmt) == SQLITE_DONE
+    }
+
+    // MARK: - Seen Settlement IDs (STABILITY_PAYMENT_V1 replay protection)
+
+    func isSettlementSeen(settlementId: String) -> Bool {
+        guard let db = openDB(write: false) else { return false }
+        defer { sqlite3_close(db) }
+
+        var stmt: OpaquePointer?
+        let sql = "SELECT 1 FROM seen_stability_settlements WHERE settlement_id = ?"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(
+            stmt,
+            1,
+            (settlementId as NSString).utf8String,
+            -1,
+            SQLITE_TRANSIENT
+        )
+        return sqlite3_step(stmt) == SQLITE_ROW
     }
 }

--- a/ios/StableChannels/NotificationService/Services/StableControlParser.swift
+++ b/ios/StableChannels/NotificationService/Services/StableControlParser.swift
@@ -7,6 +7,15 @@ enum StableControlResult {
     case deferToForeground
 }
 
+enum SignedSettlementStatus: Equatable {
+    case none
+    case valid(settlementId: String)
+    case duplicate(settlementId: String)
+    case invalid(reason: String)
+    /// Local channel state is unreadable, which says nothing about the peer's envelope.
+    case stateUnavailable
+}
+
 enum StableControlParser {
     static func handleStableControl(
         node: LDKNode.Node,
@@ -16,6 +25,8 @@ enum StableControlParser {
         amountMsat: UInt64
     ) -> StableControlResult {
         for record in customRecords where record.typeNum == Constants.stableChannelTLVType {
+            // Senders still attach the legacy [1] marker beside the signed record; it is not
+            // control traffic, so skipping it keeps the settlement path reachable.
             if record.value == Data([1]) {
                 continue
             }
@@ -47,7 +58,45 @@ enum StableControlParser {
         return .none
     }
 
-    static func isStabilityPayment(_ customRecords: [CustomTlvRecord]) -> Bool {
-        customRecords.contains { $0.typeNum == Constants.stableChannelTLVType && $0.value == Data([1]) }
+    /// A payment is a stability settlement only when it carries a signed
+    /// STABILITY_PAYMENT_V1 record: a fully valid, fresh, amount- and channel-bound
+    /// settlement is accepted (once per settlement_id); anything invalid or replayed
+    /// must not be treated as a settlement. `.invalid` still arrived as sats, so callers record a
+    /// Lightning receipt; `.duplicate` is dropped so backing is never credited twice.
+    /// `.stateUnavailable` must be left unacked so LDK redelivers once local state is readable.
+    /// `.none` means no signed record was attached.
+    static func signedSettlementStatus(
+        node: LDKNode.Node,
+        db: PaymentDatabase,
+        customRecords: [CustomTlvRecord],
+        amountMsat: UInt64
+    ) -> SignedSettlementStatus {
+        guard let record = customRecords.first(where: { $0.typeNum == Constants.signedStabilityTLVType }) else {
+            return .none
+        }
+        // Missing local channel state is a retryable local condition, not a bad envelope.
+        // Demoting it to a Lightning receipt would dedupe the payment id and make the
+        // backing credit unrecoverable once the channel row comes back.
+        guard let channelId = db.readChannelState()?.channelId, !channelId.isEmpty else {
+            return .stateUnavailable
+        }
+        switch TradeProtocol.parseSignedStabilitySettlement(
+            data: record.value,
+            expectedDirection: TradeProtocol.stabilityDirectionLspToUser,
+            expectedChannelId: channelId,
+            actualAmountMsat: amountMsat,
+            expectedCounterparty: Constants.lspPubkey,
+            verifySignature: { msg, signature, publicKey in
+                node.verifySignature(msg: msg, sig: signature, pkey: publicKey)
+            }
+        ) {
+        case .valid(let settlement):
+            if db.isSettlementSeen(settlementId: settlement.settlementId) {
+                return .duplicate(settlementId: settlement.settlementId)
+            }
+            return .valid(settlementId: settlement.settlementId)
+        case .invalid(let reason):
+            return .invalid(reason: reason)
+        }
     }
 }

--- a/ios/StableChannels/NotificationService/Services/StableControlParser.swift
+++ b/ios/StableChannels/NotificationService/Services/StableControlParser.swift
@@ -77,15 +77,23 @@ enum StableControlParser {
         // Missing local channel state is a retryable local condition, not a bad envelope.
         // Demoting it to a Lightning receipt would dedupe the payment id and make the
         // backing credit unrecoverable once the channel row comes back.
-        guard let channelId = db.readChannelState()?.channelId, !channelId.isEmpty else {
+        guard let state = db.readChannelState(),
+              let counterparty = TradeProtocol.settlementCounterparty(
+                  channelId: state.channelId,
+                  userChannelId: state.userChannelId,
+                  channels: node.listChannels().map {
+                      (channelId: $0.channelId, userChannelId: $0.userChannelId,
+                       counterparty: $0.counterpartyNodeId)
+                  }
+              ) else {
             return .stateUnavailable
         }
         switch TradeProtocol.parseSignedStabilitySettlement(
             data: record.value,
             expectedDirection: TradeProtocol.stabilityDirectionLspToUser,
-            expectedChannelId: channelId,
+            expectedChannelId: state.channelId,
             actualAmountMsat: amountMsat,
-            expectedCounterparty: Constants.lspPubkey,
+            expectedCounterparty: counterparty,
             verifySignature: { msg, signature, publicKey in
                 node.verifySignature(msg: msg, sig: signature, pkey: publicKey)
             }

--- a/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
+++ b/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
@@ -522,3 +522,133 @@ enum TradeProtocol {
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
 }
+
+// MARK: - Signed stability settlements (STABILITY_PAYMENT_V1, issue #270)
+
+struct StabilitySettlement: Equatable {
+    let settlementId: String
+    let channelId: String
+    let amountMsat: UInt64
+    let direction: String
+    let expectedUSD: Double
+    let createdAt: UInt64
+    let expiresAt: UInt64
+}
+
+enum StabilitySettlementValidation: Equatable {
+    case valid(StabilitySettlement)
+    case invalid(String)
+}
+
+extension TradeProtocol {
+    static let stabilitySettlementMessageType = "STABILITY_PAYMENT_V1"
+    static let stabilityDirectionUserToLsp = "user_to_lsp"
+    static let stabilityDirectionLspToUser = "lsp_to_user"
+    static let stabilitySettlementTTLSecs: UInt64 = 1_209_600
+    static let stabilitySettlementClockSkewSecs: UInt64 = 60
+    static let stabilitySettlementMaxEnvelopeBytes = 8 * 1024
+
+    /// Build the signed STABILITY_PAYMENT_V1 envelope TLV value for an outgoing settlement.
+    /// Returns nil on invalid inputs or signing failure; callers must skip the payment
+    /// entirely — there is no legacy [1] marker fallback.
+    static func buildSignedStabilitySettlement(
+        channelId: String,
+        amountMsat: UInt64,
+        direction: String,
+        expectedUSD: Double,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970),
+        settlementId: String = randomIdentifier(),
+        sign: ([UInt8]) throws -> String
+    ) -> Data? {
+        guard isCanonicalIdentifier(settlementId), isCanonicalIdentifier(channelId),
+              amountMsat > 0, amountMsat % 1000 == 0,
+              direction == stabilityDirectionUserToLsp || direction == stabilityDirectionLspToUser,
+              expectedUSD.isFinite, expectedUSD >= 0 else { return nil }
+        let object: [String: Any] = [
+            "type": stabilitySettlementMessageType,
+            "settlement_id": settlementId,
+            "channel_id": channelId,
+            "amount_msat": amountMsat,
+            "direction": direction,
+            "expected_usd": expectedUSD,
+            "created_at": now,
+            "expires_at": now + stabilitySettlementTTLSecs
+        ]
+        guard JSONSerialization.isValidJSONObject(object),
+              let payloadData = try? JSONSerialization.data(
+                  withJSONObject: object,
+                  options: [.sortedKeys, .withoutEscapingSlashes]
+              ),
+              let payload = String(data: payloadData, encoding: .utf8),
+              let signature = try? sign(Array(payload.utf8)) else { return nil }
+        let envelope: [String: Any] = [
+            "payload": payload,
+            "signature": signature
+        ]
+        guard let envelopeData = try? JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        ), envelopeData.count <= stabilitySettlementMaxEnvelopeBytes else { return nil }
+        return envelopeData
+    }
+
+    /// Parse and fully validate an inbound signed settlement TLV value: envelope size and
+    /// shape, payload fields, freshness window, direction, channel, amount binding, and
+    /// counterparty signature. The invalid reason strings are stable for log assertions.
+    static func parseSignedStabilitySettlement(
+        data: Data,
+        expectedDirection: String,
+        expectedChannelId: String,
+        actualAmountMsat: UInt64,
+        expectedCounterparty: String,
+        now: UInt64 = UInt64(Date().timeIntervalSince1970),
+        verifySignature: ([UInt8], String, String) -> Bool
+    ) -> StabilitySettlementValidation {
+        guard data.count <= stabilitySettlementMaxEnvelopeBytes else {
+            return .invalid("envelope_too_large")
+        }
+        guard let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let payload = envelope["payload"] as? String,
+              let signature = envelope["signature"] as? String,
+              let payloadData = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let type = object["type"] as? String,
+              type == stabilitySettlementMessageType else {
+            return .invalid("malformed_envelope")
+        }
+        guard let settlementId = object["settlement_id"] as? String,
+              let channelId = object["channel_id"] as? String,
+              let direction = object["direction"] as? String,
+              let amountSigned = jsonInteger(object["amount_msat"]),
+              let expectedValue = jsonDouble(object["expected_usd"]),
+              let createdSigned = jsonInteger(object["created_at"]),
+              let expiresSigned = jsonInteger(object["expires_at"]),
+              isCanonicalIdentifier(settlementId), isCanonicalIdentifier(channelId),
+              amountSigned > 0, amountSigned % 1000 == 0,
+              expectedValue.isFinite, expectedValue >= 0,
+              createdSigned >= 0, expiresSigned >= createdSigned,
+              expiresSigned - createdSigned <= Int64(stabilitySettlementTTLSecs) else {
+            return .invalid("invalid_fields")
+        }
+        let settlement = StabilitySettlement(
+            settlementId: settlementId,
+            channelId: channelId,
+            amountMsat: UInt64(amountSigned),
+            direction: direction,
+            expectedUSD: expectedValue,
+            createdAt: UInt64(createdSigned),
+            expiresAt: UInt64(expiresSigned)
+        )
+        guard settlement.createdAt <= now + stabilitySettlementClockSkewSecs,
+              now <= settlement.expiresAt + stabilitySettlementClockSkewSecs else {
+            return .invalid("stale")
+        }
+        guard settlement.direction == expectedDirection else { return .invalid("wrong_direction") }
+        guard settlement.channelId == expectedChannelId else { return .invalid("channel_mismatch") }
+        guard settlement.amountMsat == actualAmountMsat else { return .invalid("amount_mismatch") }
+        guard verifySignature(Array(payload.utf8), signature, expectedCounterparty) else {
+            return .invalid("bad_signature")
+        }
+        return .valid(settlement)
+    }
+}

--- a/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
+++ b/ios/StableChannels/NotificationService/Services/TradeProtocol.swift
@@ -541,6 +541,22 @@ enum StabilitySettlementValidation: Equatable {
 }
 
 extension TradeProtocol {
+    /// Resolve authentication from the channel being accounted for, never from the default
+    /// LSP or a different channel. Readiness is irrelevant for an already received payment.
+    static func settlementCounterparty(
+        channelId: String,
+        userChannelId: String,
+        channels: [(channelId: String, userChannelId: String, counterparty: String)]
+    ) -> String? {
+        guard !channelId.isEmpty, !userChannelId.isEmpty else { return nil }
+        let matching = channels.filter {
+            $0.channelId == channelId && $0.userChannelId == userChannelId
+        }
+        guard matching.count == 1, let peer = matching.first?.counterparty,
+              !peer.isEmpty else { return nil }
+        return peer
+    }
+
     static let stabilitySettlementMessageType = "STABILITY_PAYMENT_V1"
     static let stabilityDirectionUserToLsp = "user_to_lsp"
     static let stabilityDirectionLspToUser = "lsp_to_user"

--- a/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
+++ b/ios/StableChannels/NotificationService/Services/UserToLSPHandler.swift
@@ -109,11 +109,16 @@ final class UserToLSPHandler: PaymentHandler {
             return
         }
 
-        // Calculate amount
+        // Calculate amount. The signed settlement requires whole sats: floor to a
+        // sat boundary so the signed amount_msat equals the keysend amount exactly.
         let dollarsAbs = abs(dollarsFromPar)
         let btcAmount = dollarsAbs / price
-        let amountMsat = UInt64(btcAmount * Constants.satsInBTC * 1000)
+        let amountMsat = UInt64(btcAmount * Constants.satsInBTC * 1000) / 1000 * 1000
         let amountSats = amountMsat / 1000
+        guard amountSats > 0 else {
+            completion(mutator.buildStablePosition(base: baseContent, body: "Position is stable"), nil)
+            return
+        }
 
         // Chain-freshness gate at the send boundary (see #243): never keysend on a stale
         // chain tip — an outbound HTLC built on an old best block understates its expiry,
@@ -192,12 +197,33 @@ final class UserToLSPHandler: PaymentHandler {
 
         // Send keysend
         do {
-            let tlvRecord = CustomTlvRecord(typeNum: Constants.stableChannelTLVType, value: Data([1]))
+            // Signed-only (issue #270): attach only the signed STABILITY_PAYMENT_V1
+            // envelope on 13377333 — the legacy [1] marker is gone. If the envelope
+            // cannot be built, skip the payment entirely; the next run retries.
+            guard let envelope = TradeProtocol.buildSignedStabilitySettlement(
+                channelId: channelState.channelId,
+                amountMsat: amountMsat,
+                direction: TradeProtocol.stabilityDirectionUserToLsp,
+                expectedUSD: channelState.expectedUSD,
+                sign: { message in try node.signMessage(msg: message) }
+            ) else {
+                db.clearPendingSend()
+                NSLog("[NSE] skipping stability payment: signed settlement envelope build failed")
+                completion(
+                    mutator.buildPending(
+                        base: baseContent,
+                        title: "Payment Pending",
+                        body: "Open app to process stability payment"
+                    ),
+                    true
+                )
+                return
+            }
             let paymentId = try node.spontaneousPayment().sendWithCustomTlvs(
                 amountMsat: amountMsat,
                 nodeId: Constants.lspPubkey,
                 routeParameters: nil,
-                customTlvs: [tlvRecord]
+                customTlvs: [CustomTlvRecord(typeNum: Constants.signedStabilityTLVType, value: envelope)]
             )
 
             // Only an accepted send counts as sent_* — cooldown, no-action, denied-claim,
@@ -233,7 +259,8 @@ final class UserToLSPHandler: PaymentHandler {
                 amountUSD: dollarsAbs,
                 btcPrice: price,
                 backingDeltaSats: -Int64(amountSats),
-                userChannelId: channelState.userChannelId
+                userChannelId: channelState.userChannelId,
+                settlementId: nil
             )
 
             switch result {

--- a/ios/StableChannels/README.md
+++ b/ios/StableChannels/README.md
@@ -196,7 +196,8 @@ The NSE target depends only on LDK Node (no KeychainAccess or CodeScanner needed
 | `stabilityCheckIntervalSecs` | 60 | Main app stability check frequency |
 | `stabilityThresholdPercent` | 0.1% | Minimum deviation to trigger payment |
 | `stabilityPaymentCooldownSecs` | 120 | Minimum time between stability payments |
-| `stableChannelTLVType` | 13377331 | Custom TLV type for stability markers |
+| `stableChannelTLVType` | 13377331 | Custom TLV type for stable-channel trade/control messages |
+| `signedStabilityTLVType` | 13377333 | Custom TLV type for signed stability settlement records |
 
 ## Testing Push Notifications
 

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		49D4DB092FD02F4E0074ACD2 /* CloseTxidResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */; };
 		49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */; };
 		5C279A022FEA00020074ACD2 /* SpliceRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C279A012FEA00010074ACD2 /* SpliceRepositoryTests.swift */; };
+		5C279A042FEA00040074ACD2 /* StabilitySettlementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C279A032FEA00030074ACD2 /* StabilitySettlementTests.swift */; };
 		49D9C2E22FB6E52E00133509 /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E12FB6E52E00133509 /* BiometricService.swift */; };
 		49D9C2E42FB6F45600133509 /* AppAccessSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */; };
 		49DAFB3A2FDB5FEB003BE0EB /* FeeRateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DAFB392FDB5FEB003BE0EB /* FeeRateService.swift */; };
@@ -265,6 +266,7 @@
 		49D4DB072FD02F4E0074ACD2 /* CloseTxidResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTxidResolverTests.swift; sourceTree = "<group>"; };
 		49D4DB082FD02F4E0074ACD2 /* DatabaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseServiceTests.swift; sourceTree = "<group>"; };
 		5C279A012FEA00010074ACD2 /* SpliceRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpliceRepositoryTests.swift; sourceTree = "<group>"; };
+		5C279A032FEA00030074ACD2 /* StabilitySettlementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StabilitySettlementTests.swift; sourceTree = "<group>"; };
 		49D9C2E12FB6E52E00133509 /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		49D9C2E32FB6F45600133509 /* AppAccessSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccessSettingsView.swift; sourceTree = "<group>"; };
 		49DAFB392FDB5FEB003BE0EB /* FeeRateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeRateService.swift; sourceTree = "<group>"; };
@@ -742,6 +744,7 @@
 				D1A60F120000000000000004 /* SPVHeaderChainServiceTests.swift */,
 				5C279A012FEA00010074ACD2 /* SpliceRepositoryTests.swift */,
 				8ABF9700FAF2E4B9C85D8CB7 /* StabilityServiceTests.swift */,
+				5C279A032FEA00030074ACD2 /* StabilitySettlementTests.swift */,
 				499DBE752FD2DADF003E89F9 /* StaggeredTaskLauncherTests.swift */,
 			);
 			path = StableChannelsTests;
@@ -884,6 +887,7 @@
 				49DAFB3C2FDB6587003BE0EB /* FeeRateServiceTests.swift in Sources */,
 				49D4DB0A2FD02F4E0074ACD2 /* DatabaseServiceTests.swift in Sources */,
 				5C279A022FEA00020074ACD2 /* SpliceRepositoryTests.swift in Sources */,
+				5C279A042FEA00040074ACD2 /* StabilitySettlementTests.swift in Sources */,
 				499B40AC2F9D46C70004CB73 /* PendingPushPaymentTests.swift in Sources */,
 				70CCF0022F9D46C70004CB73 /* OnChainConfirmationPolicyTests.swift in Sources */,
 				1B87226F9DC3AC6D3362D0CB /* StabilityServiceTests.swift in Sources */,

--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -9,6 +9,16 @@ private enum SyncMessageHandlingResult {
     case retry
 }
 
+private enum IncomingSettlementResult {
+    case valid(settlementId: String)
+    /// Validation failed but the sats arrived: record a Lightning receipt, not backing.
+    case invalid
+    /// Already applied — dropping it is what keeps backing from being credited twice.
+    case replayed
+    /// Local channel state is unreadable, which says nothing about the peer's envelope.
+    case stateUnavailable
+}
+
 @MainActor
 @Observable
 class AppState {
@@ -1579,6 +1589,8 @@ class AppState {
             break
         }
 
+        // Senders still attach the legacy [1] marker beside the signed record, so counting it as
+        // control traffic here would drop real settlements before they are ever validated.
         let hasStableControlTLV = customRecords.contains {
             $0.typeNum == Constants.stableChannelTLVType && $0.value != Data([1])
         }
@@ -1595,6 +1607,32 @@ class AppState {
             return
         }
 
+        // Only a valid signed STABILITY_PAYMENT_V1 record (issue #270) makes this a
+        // stability settlement; invalid or replayed records ignore the payment
+        // entirely. Payments without one are ordinary Lightning receipts.
+        var isStabilityPayment = false
+        var incomingSettlementId: String?
+        if customRecords.contains(where: { $0.typeNum == Constants.signedStabilityTLVType }) {
+            switch validateIncomingStabilitySettlement(
+                customRecords: customRecords,
+                amountMsat: amountMsat,
+                paymentHash: paymentHashStr
+            ) {
+            case .valid(let settlementId):
+                isStabilityPayment = true
+                incomingSettlementId = settlementId
+            case .invalid:
+                isStabilityPayment = false
+            case .replayed:
+                return
+            case .stateUnavailable:
+                // Veto the ack: the sats arrived but local channel state is unreadable, so
+                // recording now would dedupe the payment id and lose the backing credit.
+                ackToken?.shouldAck = false
+                return
+            }
+        }
+
         // Normal payment received
         AuditService.log("PAYMENT_RECEIVED", data: [
             "amount_msat": "\(amountMsat)",
@@ -1604,8 +1642,6 @@ class AppState {
 
         let price = stableChannel.latestPrice
         let amountUSD: Double? = price > 0 ? (Double(amountMsat) / 1000.0 / 100_000_000.0) * price : nil
-        let isStabilityPayment = customRecords
-            .contains { $0.typeNum == Constants.stableChannelTLVType && $0.value == Data([1]) }
         let paymentType = isStabilityPayment ? "stability" : "lightning"
         let backingDelta: Int64? = isStabilityPayment ? Int64(amountMsat / 1000) : nil
 
@@ -1625,7 +1661,8 @@ class AppState {
                 btcPrice: price > 0 ? price : nil,
                 status: "completed",
                 userChannelId: isStabilityPayment ? self.stableChannel.userChannelId : nil,
-                backingDeltaSats: backingDelta
+                backingDeltaSats: backingDelta,
+                settlementId: incomingSettlementId
             )
         }
         let persistence: PaymentPersistenceResult
@@ -1650,6 +1687,7 @@ class AppState {
             return
         }
 
+        // The settlement id was burned in the same transaction that credited backing.
         refreshBalances()
         updateStableBalances()
         if isStabilityPayment {
@@ -1680,6 +1718,59 @@ class AppState {
         paymentFlash = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
             self?.paymentFlash = false
+        }
+    }
+
+    /// Validate a signed STABILITY_PAYMENT_V1 record bound to this payment: signature by
+    /// the channel counterparty, lsp_to_user direction, amount and channel binding, and
+    /// freshness. A replayed settlement_id is refused so a settlement never applies twice.
+    /// Anything that fails validation downgrades to an ordinary Lightning receipt.
+    private func validateIncomingStabilitySettlement(
+        customRecords: [CustomTlvRecord],
+        amountMsat: UInt64,
+        paymentHash: String
+    ) -> IncomingSettlementResult {
+        guard let record = customRecords.first(where: { $0.typeNum == Constants.signedStabilityTLVType }) else {
+            return .invalid
+        }
+        // Missing local channel state is a retryable local condition, not a bad envelope.
+        // Demoting it would dedupe the payment id and lose the backing credit for good.
+        guard !stableChannel.channelId.isEmpty else {
+            AuditService.log("STABILITY_PAYMENT_STATE_UNAVAILABLE", data: [
+                "payment_hash": paymentHash,
+                "amount_msat": "\(amountMsat)"
+            ])
+            return .stateUnavailable
+        }
+        switch TradeProtocol.parseSignedStabilitySettlement(
+            data: record.value,
+            expectedDirection: TradeProtocol.stabilityDirectionLspToUser,
+            expectedChannelId: stableChannel.channelId,
+            actualAmountMsat: amountMsat,
+            expectedCounterparty: stableChannel.counterparty,
+            verifySignature: { [weak self] msg, sig, pubkey in
+                self?.nodeService.verifySignature(message: msg, signature: sig, pubkey: pubkey) ?? false
+            }
+        ) {
+        case .valid(let settlement):
+            let seen = databaseService?.paymentRepo.isSettlementSeen(
+                settlementId: settlement.settlementId
+            ) ?? false
+            guard !seen else {
+                AuditService.log("STABILITY_SETTLEMENT_REPLAY_IGNORED", data: [
+                    "settlement_id": settlement.settlementId,
+                    "payment_hash": paymentHash
+                ])
+                return .replayed
+            }
+            return .valid(settlementId: settlement.settlementId)
+        case .invalid(let reason):
+            AuditService.log("STABILITY_PAYMENT_INVALID", data: [
+                "payment_hash": paymentHash,
+                "amount_msat": "\(amountMsat)",
+                "reason": reason
+            ])
+            return .invalid
         }
     }
 
@@ -2506,7 +2597,9 @@ class AppState {
         let now = Int64(Date().timeIntervalSince1970)
         guard now - stableChannel.lastStabilityPayment >= Int64(Constants.stabilityPaymentCooldownSecs) else { return }
 
-        let amountMsat = USD(amount: abs(result.dollarsFromPar)).toMsats(price: price)
+        // The signed settlement requires whole sats: floor to a sat boundary so the
+        // signed amount_msat equals the keysend amount exactly.
+        let amountMsat = USD(amount: abs(result.dollarsFromPar)).toMsats(price: price) / 1000 * 1000
         guard amountMsat > 0 else { return }
 
         guard let databaseService else { return }
@@ -2535,13 +2628,28 @@ class AppState {
         // Send stability payment
         let paymentId: PaymentId
         do {
-            // Tag with the STABLE_CHANNEL_TLV [0x01] marker so the LSP classifies
-            // this as a settlement (operator GUI) and runs reconcile_incoming_stability
-            // immediately, matching every other sender. See issue #161.
+            // Signed-only (issue #270): attach only the signed STABILITY_PAYMENT_V1
+            // envelope on 13377333 — the legacy [1] marker is gone. If the envelope
+            // cannot be built, skip the payment entirely; the next tick retries.
+            guard let envelope = TradeProtocol.buildSignedStabilitySettlement(
+                channelId: stableChannel.channelId,
+                amountMsat: amountMsat,
+                direction: TradeProtocol.stabilityDirectionUserToLsp,
+                expectedUSD: stableChannel.expectedUSD.amount,
+                sign: { message in try nodeService.signMessage(message) }
+            ) else {
+                databaseService.stabilityRepo.clearPendingSend()
+                AuditService.log("STABILITY_PAYMENT_SKIPPED", data: [
+                    "reason": "settlement_envelope_failed",
+                    "channel_id": stableChannel.channelId,
+                    "amount_msat": "\(amountMsat)"
+                ])
+                return
+            }
             paymentId = try nodeService.sendStabilityPayment(
                 amountMsat: amountMsat,
                 to: stableChannel.counterparty,
-                tlvs: [CustomTlvRecord(typeNum: Constants.stableChannelTLVType, value: Data([1]))]
+                tlvs: [CustomTlvRecord(typeNum: Constants.signedStabilityTLVType, value: envelope)]
             )
         } catch NodeServiceError.staleLightningSync {
             // The wrapper's send-boundary gate fired (sync went stale after the precheck

--- a/ios/StableChannels/StableChannels/Services/DatabaseService.swift
+++ b/ios/StableChannels/StableChannels/Services/DatabaseService.swift
@@ -182,6 +182,12 @@ final class DatabaseService {
             )
             """,
             """
+            CREATE TABLE IF NOT EXISTS seen_stability_settlements (
+                settlement_id TEXT PRIMARY KEY,
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+            )
+            """,
+            """
             CREATE TABLE IF NOT EXISTS onchain_receive_txids (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 address TEXT NOT NULL,

--- a/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/PaymentRepository.swift
@@ -235,6 +235,20 @@ final class PaymentRepository {
         )
     }
 
+    // MARK: - Seen Settlement IDs (STABILITY_PAYMENT_V1 replay protection)
+
+    func isSettlementSeen(settlementId: String) -> Bool {
+        do {
+            let rows = try rawSQL.query(
+                "SELECT 1 FROM seen_stability_settlements WHERE settlement_id = ? LIMIT 1",
+                params: [.text(settlementId)]
+            )
+            return !rows.isEmpty
+        } catch {
+            return false
+        }
+    }
+
     func recordPaymentAndMaybeUpdateBacking(
         paymentId: String?,
         paymentType: String,
@@ -244,7 +258,8 @@ final class PaymentRepository {
         btcPrice: Double?,
         status: String,
         userChannelId: String?,
-        backingDeltaSats: Int64?
+        backingDeltaSats: Int64?,
+        settlementId: String? = nil
     ) throws -> PaymentPersistenceResult {
         try rawSQL.inTransaction(mode: "IMMEDIATE") {
             if let pid = paymentId, !pid.isEmpty {
@@ -253,6 +268,21 @@ final class PaymentRepository {
                     params: [.text(pid)]
                 )
                 if !existing.isEmpty {
+                    let backing = try authoritativeBacking(
+                        userChannelId: userChannelId,
+                        required: backingDeltaSats != nil
+                    )
+                    return PaymentPersistenceResult(isNewPayment: false, backingSats: backing)
+                }
+            }
+            // Replay guard inside the transaction that credits backing, so a crash can never leave
+            // backing credited with the settlement id still replayable.
+            if let sid = settlementId {
+                let seen = try rawSQL.query(
+                    "SELECT 1 FROM seen_stability_settlements WHERE settlement_id = ? LIMIT 1",
+                    params: [.text(sid)]
+                )
+                if !seen.isEmpty {
                     let backing = try authoritativeBacking(
                         userChannelId: userChannelId,
                         required: backingDeltaSats != nil
@@ -271,6 +301,12 @@ final class PaymentRepository {
                     .text(status)
                 ]
             )
+            if let sid = settlementId {
+                try rawSQL.execute(
+                    "INSERT INTO seen_stability_settlements (settlement_id) VALUES (?)",
+                    params: [.text(sid)]
+                )
+            }
             var resultingBacking: UInt64?
             if let delta = backingDeltaSats {
                 guard let ucid = userChannelId, !ucid.isEmpty else {

--- a/ios/StableChannels/StableChannels/Utilities/Constants.swift
+++ b/ios/StableChannels/StableChannels/Utilities/Constants.swift
@@ -5,6 +5,7 @@ enum Constants {
 
     static let satsInBTC: UInt64 = 100_000_000
     static let stableChannelTLVType: UInt64 = 13_377_331
+    static let signedStabilityTLVType: UInt64 = 13_377_333
     static let tradeMessageType = "TRADE_V1"
     static let syncMessageType = "SYNC_V1"
 

--- a/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
+++ b/ios/StableChannels/StableChannelsTests/DatabaseServiceTests.swift
@@ -157,6 +157,106 @@ final class DatabaseServiceTests: XCTestCase {
         XCTAssertEqual(replay.backingSats, 0)
     }
 
+    func testSettlementIdIsBurnedInTheSameTransactionAsBacking() throws {
+        try service.channelRepo.saveChannel(
+            channelId: "channel-1",
+            userChannelId: "user-channel-1",
+            expectedUSD: 100,
+            backingSats: 1_000,
+            note: nil
+        )
+
+        let settlementId = String(repeating: "a1", count: 32)
+        XCTAssertFalse(service.paymentRepo.isSettlementSeen(settlementId: settlementId))
+
+        let applied = try service.paymentRepo.recordPaymentAndMaybeUpdateBacking(
+            paymentId: "payment-1",
+            paymentType: "stability",
+            direction: "received",
+            amountMsat: 100_000,
+            amountUSD: 1,
+            btcPrice: 100_000,
+            status: "completed",
+            userChannelId: "user-channel-1",
+            backingDeltaSats: 100,
+            settlementId: settlementId
+        )
+        XCTAssertTrue(applied.isNewPayment)
+        XCTAssertEqual(applied.backingSats, 1_100)
+        // The commit that credited backing also burned the id — no separate write needed.
+        XCTAssertTrue(service.paymentRepo.isSettlementSeen(settlementId: settlementId))
+
+        // A replay under a fresh payment_id is refused by the settlement guard, not the dedup.
+        let replay = try service.paymentRepo.recordPaymentAndMaybeUpdateBacking(
+            paymentId: "payment-2",
+            paymentType: "stability",
+            direction: "received",
+            amountMsat: 100_000,
+            amountUSD: 1,
+            btcPrice: 100_000,
+            status: "completed",
+            userChannelId: "user-channel-1",
+            backingDeltaSats: 100,
+            settlementId: settlementId
+        )
+        XCTAssertFalse(replay.isNewPayment)
+        XCTAssertEqual(replay.backingSats, 1_100)
+
+        let stored = try XCTUnwrap(service.channelRepo.loadChannel(userChannelId: "user-channel-1"))
+        XCTAssertEqual(stored.backingSats, 1_100)
+        XCTAssertNil(service.paymentRepo.payment(paymentId: "payment-2"))
+    }
+
+    func testDemotingASettlementToLightningMakesTheBackingCreditUnrecoverable() throws {
+        // Regression for the receive-side classification bug: when local channel state was
+        // unreadable, receivers recorded the settlement as an ordinary Lightning receipt. This
+        // pins WHY that is unsafe — the payment_id is now taken, so the later retry that does
+        // have channel state dedups and the backing credit is lost for good. Receivers must
+        // leave the event unacked instead of demoting it.
+        try service.channelRepo.saveChannel(
+            channelId: "channel-1",
+            userChannelId: "user-channel-1",
+            expectedUSD: 100,
+            backingSats: 1_000,
+            note: nil
+        )
+        let settlementId = String(repeating: "b2", count: 32)
+
+        // The demotion: same payment id, recorded as lightning with no backing delta.
+        let demoted = try service.paymentRepo.recordPaymentAndMaybeUpdateBacking(
+            paymentId: "payment-1",
+            paymentType: "lightning",
+            direction: "received",
+            amountMsat: 25_000,
+            amountUSD: nil,
+            btcPrice: nil,
+            status: "completed",
+            userChannelId: nil,
+            backingDeltaSats: nil
+        )
+        XCTAssertTrue(demoted.isNewPayment)
+
+        // The retry, now with channel state available, cannot repair it: the payment id dedups.
+        let retry = try service.paymentRepo.recordPaymentAndMaybeUpdateBacking(
+            paymentId: "payment-1",
+            paymentType: "stability",
+            direction: "received",
+            amountMsat: 25_000,
+            amountUSD: nil,
+            btcPrice: nil,
+            status: "completed",
+            userChannelId: "user-channel-1",
+            backingDeltaSats: 25,
+            settlementId: settlementId
+        )
+        XCTAssertFalse(retry.isNewPayment)
+
+        let stored = try XCTUnwrap(service.channelRepo.loadChannel(userChannelId: "user-channel-1"))
+        XCTAssertEqual(stored.backingSats, 1_000)
+        XCTAssertFalse(service.paymentRepo.isSettlementSeen(settlementId: settlementId))
+        XCTAssertEqual(service.paymentRepo.payment(paymentId: "payment-1")?.paymentType, "lightning")
+    }
+
     func testBackingUpdateWithMissingChannelRowThrowsDedicatedError() throws {
         XCTAssertThrowsError(
             try service.paymentRepo.recordPaymentAndMaybeUpdateBacking(

--- a/ios/StableChannels/StableChannelsTests/StabilitySettlementTests.swift
+++ b/ios/StableChannels/StableChannelsTests/StabilitySettlementTests.swift
@@ -87,6 +87,50 @@ final class StabilitySettlementTests: XCTestCase {
         XCTAssertEqual(settlement.expiresAt, now + ttl)
     }
 
+    func testBackgroundSettlementUsesMatchingCustomCounterparty() throws {
+        let customPeer = "custom-lsp"
+        let peer = try XCTUnwrap(TradeProtocol.settlementCounterparty(
+            channelId: channelId,
+            userChannelId: "our-channel",
+            channels: [
+                ("another-channel", "another-user-channel", "default-lsp"),
+                (channelId, "our-channel", customPeer)
+            ]
+        ))
+        let result = TradeProtocol.parseSignedStabilitySettlement(
+            data: makeEnvelope(),
+            expectedDirection: TradeProtocol.stabilityDirectionLspToUser,
+            expectedChannelId: channelId,
+            actualAmountMsat: 25_000,
+            expectedCounterparty: peer,
+            now: now,
+            verifySignature: { _, signature, key in signature == "sig" && key == customPeer }
+        )
+        guard case .valid = result else {
+            return XCTFail("A custom-LSP settlement must reach backing accounting")
+        }
+    }
+
+    func testUnresolvedSettlementIdentityHasNoDefaultPeerFallback() {
+        let channels = [(channelId: channelId, userChannelId: "our-channel", counterparty: "custom-lsp")]
+        for ids in [("", "our-channel"), (channelId, ""),
+                    ("stale-channel", "our-channel"), (channelId, "wrong-user-channel")] {
+            XCTAssertNil(TradeProtocol.settlementCounterparty(
+                channelId: ids.0, userChannelId: ids.1, channels: channels
+            ))
+        }
+        XCTAssertNil(TradeProtocol.settlementCounterparty(
+            channelId: channelId, userChannelId: "our-channel", channels: []
+        ))
+        XCTAssertNil(TradeProtocol.settlementCounterparty(
+            channelId: channelId, userChannelId: "our-channel", channels: channels + channels
+        ))
+        XCTAssertNil(TradeProtocol.settlementCounterparty(
+            channelId: channelId, userChannelId: "our-channel",
+            channels: [(channelId, "our-channel", "")]
+        ))
+    }
+
     func testBuildRejectsNonWholeSatAmounts() {
         XCTAssertNil(TradeProtocol.buildSignedStabilitySettlement(
             channelId: channelId, amountMsat: 1_500,

--- a/ios/StableChannels/StableChannelsTests/StabilitySettlementTests.swift
+++ b/ios/StableChannels/StableChannelsTests/StabilitySettlementTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import XCTest
+@testable import StableChannels
+
+final class StabilitySettlementTests: XCTestCase {
+    private let channelId = String(repeating: "ab", count: 32)
+    private let settlementId = String(repeating: "cd", count: 32)
+    private let now: UInt64 = 1_700_000_000
+    private let ttl = TradeProtocol.stabilitySettlementTTLSecs
+
+    private func sign(_: [UInt8]) throws -> String { "sig" }
+
+    private func makeEnvelope(
+        settlementId: String? = nil,
+        channelId: String? = nil,
+        amountMsat: Int64 = 25_000,
+        direction: String = "lsp_to_user",
+        expectedUSD: Double = 10.5,
+        createdAt: Int64 = 1_700_000_000,
+        expiresAt: Int64? = nil,
+        signature: String = "sig"
+    ) -> Data {
+        let payload: [String: Any] = [
+            "type": "STABILITY_PAYMENT_V1",
+            "settlement_id": settlementId ?? self.settlementId,
+            "channel_id": channelId ?? self.channelId,
+            "amount_msat": amountMsat,
+            "direction": direction,
+            "expected_usd": expectedUSD,
+            "created_at": createdAt,
+            "expires_at": expiresAt ?? createdAt + 1_209_600
+        ]
+        let payloadData = try! JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        let envelope: [String: Any] = [
+            "payload": String(data: payloadData, encoding: .utf8)!,
+            "signature": signature
+        ]
+        return try! JSONSerialization.data(
+            withJSONObject: envelope,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+
+    private func parse(
+        _ data: Data,
+        expectedDirection: String = "lsp_to_user",
+        expectedChannelId: String? = nil,
+        actualAmountMsat: UInt64 = 25_000,
+        now: UInt64? = nil,
+        verifySignature: @escaping ([UInt8], String, String) -> Bool = { _, sig, _ in sig == "sig" }
+    ) -> StabilitySettlementValidation {
+        TradeProtocol.parseSignedStabilitySettlement(
+            data: data,
+            expectedDirection: expectedDirection,
+            expectedChannelId: expectedChannelId ?? channelId,
+            actualAmountMsat: actualAmountMsat,
+            expectedCounterparty: "counterparty",
+            now: now ?? self.now,
+            verifySignature: verifySignature
+        )
+    }
+
+    func testRoundTripHappyPath() throws {
+        let envelope = try XCTUnwrap(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: channelId,
+            amountMsat: 25_000,
+            direction: TradeProtocol.stabilityDirectionLspToUser,
+            expectedUSD: 10.5,
+            now: now,
+            settlementId: settlementId,
+            sign: sign
+        ))
+        XCTAssertLessThanOrEqual(envelope.count, TradeProtocol.stabilitySettlementMaxEnvelopeBytes)
+
+        guard case .valid(let settlement) = parse(envelope) else {
+            return XCTFail("expected valid settlement")
+        }
+        XCTAssertEqual(settlement.settlementId, settlementId)
+        XCTAssertEqual(settlement.channelId, channelId)
+        XCTAssertEqual(settlement.amountMsat, 25_000)
+        XCTAssertEqual(settlement.direction, "lsp_to_user")
+        XCTAssertEqual(settlement.expectedUSD, 10.5)
+        XCTAssertEqual(settlement.createdAt, now)
+        XCTAssertEqual(settlement.expiresAt, now + ttl)
+    }
+
+    func testBuildRejectsNonWholeSatAmounts() {
+        XCTAssertNil(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: channelId, amountMsat: 1_500,
+            direction: TradeProtocol.stabilityDirectionUserToLsp,
+            expectedUSD: 10.5, now: now, settlementId: settlementId, sign: sign
+        ))
+        XCTAssertNil(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: channelId, amountMsat: 0,
+            direction: TradeProtocol.stabilityDirectionUserToLsp,
+            expectedUSD: 10.5, now: now, settlementId: settlementId, sign: sign
+        ))
+    }
+
+    func testBuildRejectsNonCanonicalIds() {
+        XCTAssertNil(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: "not-hex", amountMsat: 25_000,
+            direction: TradeProtocol.stabilityDirectionUserToLsp,
+            expectedUSD: 10.5, now: now, settlementId: settlementId, sign: sign
+        ))
+        XCTAssertNil(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: channelId, amountMsat: 25_000,
+            direction: TradeProtocol.stabilityDirectionUserToLsp,
+            expectedUSD: 10.5, now: now,
+            settlementId: String(repeating: "AB", count: 32), sign: sign
+        ))
+    }
+
+    func testParseRejectsAmountNotMultipleOf1000() {
+        XCTAssertEqual(parse(makeEnvelope(amountMsat: 1_500)), .invalid("invalid_fields"))
+        XCTAssertEqual(parse(makeEnvelope(amountMsat: 0)), .invalid("invalid_fields"))
+    }
+
+    func testParseRejectsNonCanonicalIds() {
+        XCTAssertEqual(parse(makeEnvelope(settlementId: "zz" + String(settlementId.dropFirst(2)))),
+                       .invalid("invalid_fields"))
+        XCTAssertEqual(parse(makeEnvelope(channelId: String(channelId.dropFirst(2)))),
+                       .invalid("invalid_fields"))
+    }
+
+    func testParseRejectsTTLExceeded() {
+        let data = makeEnvelope(createdAt: 1_700_000_000, expiresAt: 1_700_000_000 + 1_209_601)
+        XCTAssertEqual(parse(data), .invalid("invalid_fields"))
+    }
+
+    func testParseRejectsExpiredSettlement() {
+        XCTAssertEqual(parse(makeEnvelope(), now: now + ttl + 61), .invalid("stale"))
+        // Boundary: exactly expires_at + skew is still fresh.
+        guard case .valid = parse(makeEnvelope(), now: now + ttl + 60) else {
+            return XCTFail("expected valid at freshness boundary")
+        }
+    }
+
+    func testParseRejectsFutureCreatedAt() {
+        XCTAssertEqual(parse(makeEnvelope(), now: now - 61), .invalid("stale"))
+    }
+
+    func testParseRejectsWrongDirection() {
+        XCTAssertEqual(parse(makeEnvelope(direction: "user_to_lsp")), .invalid("wrong_direction"))
+    }
+
+    func testParseRejectsChannelMismatch() {
+        let other = String(repeating: "ef", count: 32)
+        XCTAssertEqual(parse(makeEnvelope(), expectedChannelId: other), .invalid("channel_mismatch"))
+    }
+
+    func testParseRejectsAmountMismatch() {
+        XCTAssertEqual(parse(makeEnvelope(), actualAmountMsat: 26_000), .invalid("amount_mismatch"))
+    }
+
+    func testParseRejectsBadSignature() {
+        XCTAssertEqual(
+            parse(makeEnvelope(), verifySignature: { _, _, _ in false }),
+            .invalid("bad_signature")
+        )
+    }
+
+    func testParseRejectsOversizedEnvelope() {
+        XCTAssertEqual(parse(Data(count: 8_193)), .invalid("envelope_too_large"))
+    }
+
+    func testParseRejectsMalformedEnvelope() throws {
+        XCTAssertEqual(parse(Data("[]".utf8)), .invalid("malformed_envelope"))
+        XCTAssertEqual(parse(Data("{\"payload\":{}}".utf8)), .invalid("malformed_envelope"))
+        let wrongType = makeEnvelope(direction: "lsp_to_user")
+        var tampered = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: wrongType) as? [String: Any]
+        )
+        tampered["payload"] = "{\"type\":\"SYNC_V1\"}"
+        let tamperedData = try JSONSerialization.data(withJSONObject: tampered)
+        XCTAssertEqual(parse(tamperedData), .invalid("malformed_envelope"))
+    }
+
+    func testLegacyMarkerValueNeverValidatesAsSettlement() {
+        // The legacy one-byte [1] stability marker is removed (issue #270 follow-up):
+        // a marker-only TLV value must never be accepted as a settlement.
+        XCTAssertEqual(parse(Data([1])), .invalid("malformed_envelope"))
+    }
+
+    func testSignedEnvelopeAloneValidatesWithoutMarker() throws {
+        // Signed-only send: the envelope on 13377333 with no legacy marker attached
+        // must be sufficient to classify the payment as a stability settlement.
+        let envelope = try XCTUnwrap(TradeProtocol.buildSignedStabilitySettlement(
+            channelId: channelId,
+            amountMsat: 25_000,
+            direction: TradeProtocol.stabilityDirectionLspToUser,
+            expectedUSD: 10.5,
+            now: now,
+            settlementId: settlementId,
+            sign: sign
+        ))
+        guard case .valid(let settlement) = parse(envelope) else {
+            return XCTFail("expected signed-only envelope to validate")
+        }
+        XCTAssertEqual(settlement.settlementId, settlementId)
+    }
+}

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -1062,10 +1062,7 @@ pub fn check_stability(
             return None;
         }
     };
-    let marker = ldk_node::CustomTlvRecord {
-        type_num: crate::constants::STABLE_CHANNEL_TLV_TYPE,
-        value: vec![1u8],
-    };
+    // Signed record only: the unauthenticated [1] marker is no longer sent by any client.
     let signed_record = ldk_node::CustomTlvRecord {
         type_num: crate::constants::SIGNED_STABILITY_TLV_TYPE,
         value: signed_envelope.into_bytes(),
@@ -1074,7 +1071,7 @@ pub fn check_stability(
         amt,
         sc.counterparty,
         None,
-        vec![marker, signed_record],
+        vec![signed_record],
     ) {
         Ok(payment_id) => {
             sc.payment_made = true;


### PR DESCRIPTION
Closes the client side of #270.

The one-byte `[1]` stability marker on TLV 13377331 is unauthenticated: any peer could keysend 1 sat with it and have the receiver treat a settlement as made (#231). This replaces it on every client with a signed `STABILITY_PAYMENT_V1` envelope on TLV 13377333.

## Sending

Android (app + background service), iOS (app + NSE) and the desktop wallet now attach only the signed record. The payload binds `settlement_id`, `channel_id`, the exact `amount_msat`, `direction`, `expected_usd`, and a 14-day created/expires window, signed with the node key. If the envelope can't be built the payment is skipped and the pending-send claim released, never sent unsigned.

## Receiving

A payment counts as a stability settlement only via a valid signed record: canonical fields, expected direction, amount equal to the actual keysend amount, channel binding, freshness with 60s skew, and a counterparty signature.

Invalid records are audited and recorded as ordinary Lightning receipts, so the sats are never lost, but backing is not credited. Replays are dropped. The `settlement_id` is burned in the same `BEGIN IMMEDIATE` transaction that credits backing, so a crash between the two can't leave backing credited with the id still replayable.