### PR TITLE
fix(ios): persist onchain receive address so deposit resolution works after restart

### DIFF
--- a/ios/StableChannels/StableChannels/App/AppState.swift
+++ b/ios/StableChannels/StableChannels/App/AppState.swift
@@ -2194,8 +2194,12 @@ class AppState {
            let row = db.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId) {
             if let wsPayment = db.paymentRepo.payment(txid: txid) {
                 if wsPayment.amountMsat == UInt64(row.amountMsat) {
-                    // WebSocket beat us to it, this fallback placeholder is a duplicate.
-                    db.paymentRepo.deletePayment(paymentId: row.paymentId)
+                    // Equal amounts do not prove identity. If another writer recorded this
+                    // txid after resolution, retain the placeholder rather than erase a deposit.
+                    AuditService.log("ONCHAIN_RECEIVE_RES_AMBIGUOUS", data: [
+                        "resolution_id": "\(resolutionId)",
+                        "txid": txid
+                    ])
                 } else {
                     // Mismatched amount! This placeholder belongs to a different deposit.
                     // Leave it intact to prevent erasing it from history.

--- a/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
+++ b/ios/StableChannels/StableChannels/Services/OnchainTxidResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Polls Esplora for the first txid hitting a receive address. On hit,
+/// Polls Esplora for an unrecorded incoming transaction matching a deposit. On hit,
 /// updates the DB row (`resolutionId`) and fires `onResolved`. Thin
 /// policy wrapper over `ResilientEsploraClient`: paths + parser only.
 struct OnchainTxidResolver {
@@ -30,19 +30,42 @@ struct OnchainTxidResolver {
         )
     }
 
-    /// Poll for any tx hitting `address`. On first hit, update the DB
+    /// Poll for an unrecorded tx paying the pending amount to `address`. On hit, update the DB
     /// row at `resolutionId` and fire `onResolved`. Returns silently
     /// on exhaustion, budget overrun, or cancellation.
     func resolve(resolutionId: Int64, address: String, databaseService: DatabaseService) async {
+        // A persisted address can have years of history. Never attach an already-accounted
+        // transaction to a new deposit, and fail closed if history cannot be read.
+        guard let context = await MainActor.run(body: { () -> (Set<String>, Int64)? in
+            guard let excluded = try? databaseService.onchainRepo.recordedReceiveTxids(),
+                  let payment = databaseService.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId),
+                  payment.amountMsat > 0, payment.amountMsat % 1000 == 0 else { return nil }
+            return (excluded, payment.amountMsat / 1000)
+        }) else { return }
         let onResolved = self.onResolved
         let workId = "res-\(resolutionId)"
         let parser: ResilientEsploraClient.ResultParser<String> = { data in
             guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
             else { return nil }
-            if let first = arr.first,
-               let txid = first["txid"] as? String,
-               ResilientEsploraClient.isValidTxid(txid) {
-                return txid
+            for transaction in arr {
+                if let txid = transaction["txid"] as? String,
+                   ResilientEsploraClient.isValidTxid(txid), !context.0.contains(txid),
+                   let outputs = transaction["vout"] as? [[String: Any]] {
+                    let received = outputs.filter { $0["scriptpubkey_address"] as? String == address }
+                        .compactMap { $0["value"] as? Int64 }
+                    // Bind to an incoming output, not merely an address-history entry (which
+                    // also includes spends). Non-matching aggregate deposits remain pending.
+                    guard !received.isEmpty,
+                          received.allSatisfy({ $0 > 0 && $0 <= context.1 }) else { continue }
+                    var total: Int64 = 0
+                    for value in received {
+                        let sum = total.addingReportingOverflow(value)
+                        if sum.overflow { return nil }
+                        total = sum.partialValue
+                    }
+                    guard total == context.1 else { continue }
+                    return txid
+                }
             }
             return nil
         }

--- a/ios/StableChannels/StableChannels/Services/Repositories/OnchainReceiveRepository.swift
+++ b/ios/StableChannels/StableChannels/Services/Repositories/OnchainReceiveRepository.swift
@@ -59,13 +59,27 @@ final class OnchainReceiveRepository {
                 UPDATE onchain_receive_txids
                 SET txid = ?, status = 'resolved', resolved_at = strftime('%s', 'now')
                 WHERE id = ? AND status = 'pending'
+                  AND NOT EXISTS (SELECT 1 FROM payments WHERE txid = ?)
+                  AND NOT EXISTS (SELECT 1 FROM onchain_receive_txids WHERE txid = ?)
                 """,
-                params: [.text(txid), .integer(id)]
+                params: [.text(txid), .integer(id), .text(txid), .text(txid)]
             )
             return rawSQL.changes > 0
         } catch {
             return false
         }
+    }
+
+    /// Throw on read failure: an unavailable history must never look like an empty history.
+    func recordedReceiveTxids() throws -> Set<String> {
+        let rows = try rawSQL.query(
+            """
+            SELECT txid FROM payments WHERE txid IS NOT NULL
+            UNION SELECT txid FROM onchain_receive_txids WHERE txid IS NOT NULL
+            """,
+            params: []
+        )
+        return Set(rows.map { $0.string(0) })
     }
 
     func fetchPendingOnchainReceiveRows() -> [PendingOnchainPayment] {

--- a/ios/StableChannels/StableChannels/Services/TransactionLinkService.swift
+++ b/ios/StableChannels/StableChannels/Services/TransactionLinkService.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 
 /// Service responsible for managing transaction link states (receive address,
@@ -7,7 +8,10 @@ import Observation
 final class TransactionLinkService {
     private let txidLinks = TxidLinkStore()
 
-    var onchainReceiveAddress: String?
+    var onchainReceiveAddress: String? {
+        get { txidLinks.onchainReceiveAddress }
+        set { txidLinks.setReceiveAddress(newValue) }
+    }
 
     var lastCloseTxid: String? { txidLinks.lastCloseTxid }
     var lastReceiveTxid: String? { txidLinks.lastReceiveTxid }

--- a/ios/StableChannels/StableChannels/Services/TxidLinkStore.swift
+++ b/ios/StableChannels/StableChannels/Services/TxidLinkStore.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-/// Persists the most recent close and onchain-receive txids across app
-/// launches, with a 7-day expiry so a txid from a long-finished session
-/// does not linger on the UI forever.
+/// Persists the most recent close and onchain-receive txids and receive
+/// address across app launches, with a 7-day expiry for txids so a txid
+/// from a long-finished session does not linger on the UI forever.
 ///
-/// One value type holds both slots and the shared UserDefaults read/write
-/// logic. Callers observe via the `lastCloseTxid` / `lastReceiveTxid`
-/// computed properties and call `setClose(_:)` / `setReceive(_:)` to
-/// update. All access is MainActor-isolated because the values drive UI.
+/// The receive address is persisted without expiry so the deposit resolver
+/// can match incoming onchain funds after app restart. It is cleared when
+/// the user generates a new address.
 @MainActor
 @Observable
 final class TxidLinkStore {
     private(set) var lastCloseTxid: String?
     private(set) var lastReceiveTxid: String?
+    private(set) var onchainReceiveAddress: String?
 
     private let defaults: UserDefaults?
     private static let expirySeconds: TimeInterval = 7 * 86400
@@ -22,6 +22,7 @@ final class TxidLinkStore {
         static let closeAt = "last_close_txid_at"
         static let receive = "last_receive_txid"
         static let receiveAt = "last_receive_txid_at"
+        static let receiveAddr = "last_receive_address"
     }
 
     init(defaults: UserDefaults? = UserDefaults(suiteName: Constants.appGroupIdentifier)) {
@@ -29,6 +30,7 @@ final class TxidLinkStore {
         let now = Date().timeIntervalSince1970
         self.lastCloseTxid = Self.restore(key: Key.close, atKey: Key.closeAt, now: now, defaults: defaults)
         self.lastReceiveTxid = Self.restore(key: Key.receive, atKey: Key.receiveAt, now: now, defaults: defaults)
+        self.onchainReceiveAddress = defaults?.string(forKey: Key.receiveAddr)
     }
 
     func setClose(_ txid: String?) {
@@ -39,6 +41,19 @@ final class TxidLinkStore {
     func setReceive(_ txid: String?) {
         lastReceiveTxid = txid
         Self.persist(txid: txid, valueKey: Key.receive, atKey: Key.receiveAt, defaults: defaults)
+    }
+
+    func setReceiveAddress(_ address: String?) {
+        onchainReceiveAddress = address
+        if let address {
+            defaults?.set(address, forKey: Key.receiveAddr)
+        } else {
+            defaults?.removeObject(forKey: Key.receiveAddr)
+        }
+    }
+
+    func clearReceiveAddress() {
+        setReceiveAddress(nil)
     }
 
     private static func restore(key: String, atKey: String, now: TimeInterval, defaults: UserDefaults?) -> String? {

--- a/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
+++ b/ios/StableChannels/StableChannelsTests/OnchainTxidResolverTests.swift
@@ -19,6 +19,10 @@ final class OnchainTxidResolverTests: XCTestCase {
         service = try? DatabaseService(dataDir: dataDir)
         resolutionId = service?.onchainRepo.insertOnchainReceiveResolution(address: testAddress)
         XCTAssertNotNil(resolutionId, "Failed to insert seed row for test")
+        XCTAssertTrue(service.onchainRepo.recordOnchainPaymentWithResolution(
+            paymentId: "pending-deposit", amountMsat: 100_000, amountUSD: nil,
+            btcPrice: nil, resolutionId: resolutionId
+        ))
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
@@ -41,7 +45,14 @@ final class OnchainTxidResolverTests: XCTestCase {
     }
 
     private func jsonArrayResponse(body: [[String: Any]], status: Int = 200) -> (HTTPURLResponse, Data) {
-        let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        let transactions = body.map { transaction in
+            var transaction = transaction
+            if transaction["vout"] == nil {
+                transaction["vout"] = [["scriptpubkey_address": testAddress, "value": 100]]
+            }
+            return transaction
+        }
+        let data = (try? JSONSerialization.data(withJSONObject: transactions)) ?? Data()
         let resp = HTTPURLResponse(
             url: URL(string: "https://mock.local")!,
             statusCode: status,
@@ -83,6 +94,80 @@ final class OnchainTxidResolverTests: XCTestCase {
     }
 
     // MARK: - resolve()
+
+    @MainActor
+    func testRestoredAddressSkipsOldEqualDepositAndResolvesNewMempoolDeposit() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "deposit-test-\(UUID().uuidString)"))
+        let store = TxidLinkStore(defaults: defaults)
+        store.setReceiveAddress(testAddress)
+        let restored = TxidLinkStore(defaults: defaults)
+        XCTAssertEqual(restored.onchainReceiveAddress, testAddress)
+        defer { store.clearReceiveAddress() }
+        let oldTxid = String(repeating: "b", count: 64)
+        try service.paymentRepo.recordPayment(
+            paymentId: "old-deposit", paymentType: "onchain", direction: "received",
+            amountMsat: 100_000, amountUSD: nil, btcPrice: nil, counterparty: nil,
+            status: "completed", txid: oldTxid
+        )
+        MockURLProtocol.requestHandler = { req in
+            self.jsonArrayResponse(body: [["txid": req.url!.path.hasSuffix("/txs/chain") ? oldTxid : self.validTxid]])
+        }
+        await makeResolver().resolve(
+            resolutionId: resolutionId, address: try XCTUnwrap(restored.onchainReceiveAddress), databaseService: service
+        )
+        let captured = await box.value
+        XCTAssertEqual(captured?.txid, validTxid)
+        XCTAssertNotNil(service.paymentRepo.payment(txid: oldTxid))
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId))
+        XCTAssertTrue(MockURLProtocol.seenURLs.contains { $0.path.hasSuffix("/txs/mempool") })
+        restored.setReceiveAddress(nil)
+        XCTAssertNil(TxidLinkStore(defaults: defaults).onchainReceiveAddress)
+    }
+
+    func testOnlyHistoricalTransactionLeavesDepositPending() async throws {
+        try service.paymentRepo.recordPayment(
+            paymentId: "old-deposit", paymentType: "onchain", direction: "received",
+            amountMsat: 100_000, amountUSD: nil, btcPrice: nil, counterparty: nil,
+            status: "completed", txid: validTxid
+        )
+        MockURLProtocol.requestHandler = { _ in self.jsonArrayResponse(body: [["txid": self.validTxid]]) }
+        await makeResolver().resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        let captured = await box.value
+        XCTAssertNil(captured)
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceives().first { $0.id == resolutionId })
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId))
+        XCTAssertFalse(service.onchainRepo.updateOnchainReceiveResolution(id: resolutionId, txid: validTxid))
+    }
+
+    func testWrongIncomingAmountLeavesDepositPending() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonArrayResponse(body: [["txid": self.validTxid,
+                                           "vout": [["scriptpubkey_address": self.testAddress, "value": 99]]]])
+        }
+        await makeResolver().resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        let captured = await box.value
+        XCTAssertNil(captured)
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceives().first { $0.id == resolutionId })
+    }
+
+    func testResolutionCannotReuseAnotherResolutionTransaction() throws {
+        let other = try XCTUnwrap(service.onchainRepo.insertOnchainReceiveResolution(address: testAddress))
+        XCTAssertTrue(service.onchainRepo.updateOnchainReceiveResolution(id: other, txid: validTxid))
+        XCTAssertFalse(service.onchainRepo.updateOnchainReceiveResolution(id: resolutionId, txid: validTxid))
+        XCTAssertTrue(try service.onchainRepo.recordedReceiveTxids().contains(validTxid))
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceiveRow(resolutionId: resolutionId))
+    }
+
+    func testAddressHistorySpendDoesNotResolveIncomingDeposit() async {
+        MockURLProtocol.requestHandler = { _ in
+            self.jsonArrayResponse(body: [["txid": self.validTxid,
+                                           "vout": [["scriptpubkey_address": "another-address", "value": 100]]]])
+        }
+        await makeResolver().resolve(resolutionId: resolutionId, address: testAddress, databaseService: service)
+        let captured = await box.value
+        XCTAssertNil(captured)
+        XCTAssertNotNil(service.onchainRepo.fetchPendingOnchainReceives().first { $0.id == resolutionId })
+    }
 
     func testResolve_findsTxidOnChainEndpoint() async {
         MockURLProtocol.requestHandler = { req in


### PR DESCRIPTION
## Summary

Fixes onchain deposit detection failing after app restart by persisting the receive address across launches.

## Bug

`TransactionLinkService.onchainReceiveAddress` was in-memory only. On every restart it reset to `nil`, causing deposit detection to always take the `UnknownAddressDepositRecorder` path (no txid, no Esplora resolver, no explorer link).

## Fix

- `TxidLinkStore` now persists `onchainReceiveAddress` in UserDefaults (no expiry — cleared only when user generates a new address)
- `TransactionLinkService.onchainReceiveAddress` routes through `TxidLinkStore` getter/setter
- After restart, address is available, WebSocket tracks it, deposit detection uses `KnownAddressDepositRecorder` which launches the Esplora resolver

## Related
- Closes #289 
