### PR TITLE
Android: auto-clear 'Move confirmed' status banner after splice completes

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -2234,6 +2234,17 @@ class AppState(private val context: Context) : ViewModel() {
             monitoredSpliceTxid = null
             spliceConfirmationJob = null
             _statusMessage.value = "Move confirmed"
+            // Unlike "Move pending confirmation" (which the user can dismiss by tapping, or
+            // which naturally gets replaced by a later status), "Move confirmed" is terminal —
+            // nothing else ever overwrites or clears it, so without this it would sit in the
+            // status capsule forever. Auto-clear it a few seconds later, but only if some other
+            // event hasn't already replaced it with a newer message in the meantime.
+            viewModelScope.launch {
+                delay(4_000)
+                if (_statusMessage.value == "Move confirmed") {
+                    _statusMessage.value = ""
+                }
+            }
         } else {
             AuditService.log("SPLICE_CONFIRM_STALE_GENERATION", mapOf("txid" to txid))
         }


### PR DESCRIPTION
## Problem

When a splice-in/out completes, the status capsule shows "Move pending confirmation" until the tx gets 1 on-chain confirmation, at which point it switches to "Move confirmed". That final message never gets cleared — it stays in the status capsule indefinitely until the user manually taps it or an unrelated event happens to overwrite it.

## Fix

Auto-clear the status message ~4 seconds after it's set to "Move confirmed", guarded so it only clears if nothing else has replaced it with a newer message in the meantime.

## Testing

- Verified on-device: performed a splice-in, confirmed via the on-device audit log (`CHANNEL_READY` → `SPLICE_CONFIRMED` with `completed_row: true`) that the splice completed correctly, and confirmed the status banner now disappears ~4s after switching to "Move confirmed" instead of staying forever.
- Full unit suite passes (238 tests, 0 failures).