### PR TITLE
Android: fix stability backing/USD desync on ordinary sends (#296)

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -591,6 +591,14 @@ class AppState(private val context: Context) : ViewModel() {
     val spendableOnchainSats: StateFlow<Long> = _spendableOnchainSats
 
     private val pendingLock = Any()
+
+    /** Serializes "commit a stable-books mutation, then publish the row to _stableChannel"
+     *  across every path that changes expected_usd/stable_sats in-process: the stability
+     *  timer, the pending-send replay, incoming settlements and ordinary-send reconciles.
+     *  Without it, path A can commit+publish between path B's commit and B's publish, and B's
+     *  publish (built from B's own transaction result or an earlier snapshot) then overwrites
+     *  A's newer books in memory — which is what the stability check reads (#299 review). */
+    private val booksLock = Any()
     private var sendGeneration: Long = 0L
 
     @Volatile
@@ -1636,15 +1644,25 @@ class AppState(private val context: Context) : ViewModel() {
                 settlementId = settlementId
             ) ?: throw Exception("DB service unavailable")
         }
-        val persistence = try {
-            record()
-        } catch (e: MissingChannelRowException) {
-            // The channels row vanished (e.g. DB recreated) — rebuild it from in-memory state
-            // via the full save, then retry once. If it still fails, rethrow to nack.
-            Log.w("AppState", "Channel row missing during payment persist — recreating and retrying: ${e.message}")
-            AuditService.log("CHANNEL_ROW_RECREATED", mapOf("user_channel_id" to (userChannelId ?: "")))
-            saveChannelToDB()
-            record()
+        val persistence = synchronized(booksLock) {
+            val p = try {
+                record()
+            } catch (e: MissingChannelRowException) {
+                // The channels row vanished (e.g. DB recreated) — rebuild it from in-memory state
+                // via the full save, then retry once. If it still fails, rethrow to nack.
+                Log.w("AppState", "Channel row missing during payment persist — recreating and retrying: ${e.message}")
+                AuditService.log("CHANNEL_ROW_RECREATED", mapOf("user_channel_id" to (userChannelId ?: "")))
+                saveChannelToDB()
+                record()
+            }
+            if (isStabilityPayment) {
+                p.backingSats ?: throw Exception("DB did not return backing after stability payment")
+                // Publish the credited backing from the row, under booksLock, for the same reason
+                // as the outgoing paths: an absolute taken from this transaction can overwrite a
+                // newer value another path committed and published in the meantime.
+                publishBooksFromDB()
+            }
+            p
         }
         if (settlementId != null && !persistence.isNewPayment) {
             AuditService.log("STABILITY_PAYMENT_REPLAY_IGNORED", mapOf(
@@ -1654,11 +1672,6 @@ class AppState(private val context: Context) : ViewModel() {
         }
         refreshBalances()
         updateStableBalances()
-        if (isStabilityPayment) {
-            val backing = persistence.backingSats
-                ?: throw Exception("DB did not return backing after stability payment")
-            _stableChannel.value = _stableChannel.value.copy(backingSats = backing)
-        }
         val sc = StabilityService.reconcileIncoming(_stableChannel.value)
         _stableChannel.value = sc
         saveChannelToDB(preserveBacking = isStabilityPayment)
@@ -1965,53 +1978,58 @@ class AppState(private val context: Context) : ViewModel() {
         // stableReceiverBTC is refreshed from live channel state just above, not from the
         // racy in-memory backingSats copy — safe to use directly as the reconcile input.
         val receiverSats = _stableChannel.value.stableReceiverBTC.sats
-        val reconcileResult = if (userChannelId.isEmpty()) null else try {
-            databaseService?.reconcileOutgoingBacking(
-                channelId = channelId,
-                userChannelId = userChannelId,
-                note = note,
-                receiverSats = receiverSats,
-                latestPrice = latestPrice,
-                price = price
-            )
-        } catch (e: MissingChannelRowException) {
-            // Structural: there is no row to reconcile against and a retry can't create one.
-            // Treat as nothing-to-reconcile, but leave a trace in the audit log.
-            AuditService.log("OUTGOING_RECONCILE_SKIPPED", mapOf(
-                "payment_id" to (paymentId ?: ""),
-                "reason" to "missing_channel_row",
-                "user_channel_id" to userChannelId
-            ))
-            null
-        } catch (e: Exception) {
-            // Anything else (SQLite I/O error, disk full, lock timeout) is transient. The
-            // transaction rolled back, so the deduction has NOT been recorded — rethrow so the
-            // event loop leaves this PaymentSuccessful un-acked and LDK redelivers it with
-            // backoff. reconcileOutgoingBacking() is idempotent on retry because it measures
-            // overflow against live channel state. Swallowing the error here acked the payment
-            // with the books still wrong (#299 review, P2).
-            AuditService.log("OUTGOING_RECONCILE_FAILED", mapOf(
-                "payment_id" to (paymentId ?: ""),
-                "error" to (e.message ?: e.javaClass.simpleName),
-                "will_retry" to true
-            ))
-            throw e
-        }
-        if (reconcileResult != null) {
-            // Refresh in-memory state from the DB's current, authoritative row instead of
-            // trusting reconcileResult's values directly: reconcileOutgoingBacking()'s
-            // transaction may have already committed some time ago by the time this line runs,
-            // and the stability timer (a concurrent coroutine) could have committed and
-            // published its own newer backing update in between. loadChannelFromDB() re-reads
-            // fresh, so this can never clobber a concurrent writer's already-applied change —
-            // the same pattern onForegroundResume() already relies on for this exact reason.
-            loadChannelFromDB()
-            _stableChannel.update { it.copy(lastStabilityPayment = System.currentTimeMillis() / 1000) }
-            // reconcileOutgoingBacking() wrote directly to the DB, bypassing saveChannelToDB()
-            // — so the SharedPreferences launch cache (used to seed Stable USD before the DB is
-            // open on next launch) needs its own explicit refresh here too, or it keeps showing
-            // the pre-send, too-high figure until loadChannelFromDB() runs during DB init.
-            cacheBalanceForLaunch()
+        // The transaction that mutates the books and the in-memory publish of its result run
+        // under booksLock, and the publish re-reads the row rather than trusting the
+        // transaction's return value. Every other path that mutates expected_usd/stable_sats
+        // takes the same lock, so none of them can commit-and-publish between this commit and
+        // this publish — the interleaving that let an older absolute backing overwrite a newer
+        // one in memory and trigger a phantom stability payment (#299 review).
+        val reconcileResult = synchronized(booksLock) {
+            val result = if (userChannelId.isEmpty()) null else try {
+                databaseService?.reconcileOutgoingBacking(
+                    channelId = channelId,
+                    userChannelId = userChannelId,
+                    note = note,
+                    receiverSats = receiverSats,
+                    latestPrice = latestPrice,
+                    price = price
+                )
+            } catch (e: MissingChannelRowException) {
+                // Structural: there is no row to reconcile against and a retry can't create one.
+                // Treat as nothing-to-reconcile, but leave a trace in the audit log.
+                AuditService.log("OUTGOING_RECONCILE_SKIPPED", mapOf(
+                    "payment_id" to (paymentId ?: ""),
+                    "reason" to "missing_channel_row",
+                    "user_channel_id" to userChannelId
+                ))
+                null
+            } catch (e: Exception) {
+                // Anything else (SQLite I/O error, disk full, lock timeout) is transient. The
+                // transaction rolled back, so the deduction has NOT been recorded — rethrow so
+                // the event loop leaves this PaymentSuccessful un-acked and LDK redelivers it
+                // with backoff. reconcileOutgoingBacking() is idempotent on retry because it
+                // measures overflow against live channel state. Swallowing the error here acked
+                // the payment with the books still wrong (#299 review, P2).
+                AuditService.log("OUTGOING_RECONCILE_FAILED", mapOf(
+                    "payment_id" to (paymentId ?: ""),
+                    "error" to (e.message ?: e.javaClass.simpleName),
+                    "will_retry" to true
+                ))
+                throw e
+            }
+            if (result != null) {
+                // receiverSats above is live post-send channel state, so native is safe to
+                // recompute against it here.
+                publishBooksFromDB(
+                    lastStabilityPayment = System.currentTimeMillis() / 1000,
+                    recomputeNative = true
+                )
+                // reconcileOutgoingBacking() bypasses saveChannelToDB(), the usual writer of the
+                // SharedPreferences launch cache — refresh it so the next cold start doesn't
+                // briefly show the pre-send Stable USD.
+                cacheBalanceForLaunch()
+            }
+            result
         }
         var displayVal: String? = null
         if (paymentId != null) {
@@ -2769,28 +2787,30 @@ class AppState(private val context: Context) : ViewModel() {
             }
 
             try {
-                val persistence = databaseService?.recordPaymentAndMaybeUpdateBacking(
-                    paymentId = paymentIdString,
-                    paymentType = "stability",
-                    direction = "sent",
-                    amountMsat = amountMsat,
-                    amountUSD = (amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * price,
-                    btcPrice = price,
-                    counterparty = sc.counterparty,
-                    userChannelId = sc.userChannelId,
-                    backingDeltaSats = -(amountMsat / 1000)
-                ) ?: throw IllegalStateException("DB service unavailable")
-                val backing = persistence.backingSats
-                    ?: throw IllegalStateException("DB did not return backing after outgoing stability payment")
-                // Patch only the fields this tick owns, against the *current* in-memory value —
-                // not the `sc` snapshot captured at the top of the tick. A concurrent ordinary
-                // send (handlePaymentSuccessful) may have reconciled expectedUSD/backing since
-                // then; republishing `sc` clobbered that in memory, and the old
-                // saveChannelToDB(preserveBacking = true) here then wrote the stale expected_usd
-                // back to the DB, undoing the send's committed reconcile (#299 review, P1).
-                // The debit itself is already durable via recordPaymentAndMaybeUpdateBacking(),
-                // and lastStabilityPayment is not a DB column, so no save is needed here.
-                _stableChannel.update { it.copy(lastStabilityPayment = now, backingSats = backing) }
+                synchronized(booksLock) {
+                    val persistence = databaseService?.recordPaymentAndMaybeUpdateBacking(
+                        paymentId = paymentIdString,
+                        paymentType = "stability",
+                        direction = "sent",
+                        amountMsat = amountMsat,
+                        amountUSD = (amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * price,
+                        btcPrice = price,
+                        counterparty = sc.counterparty,
+                        userChannelId = sc.userChannelId,
+                        backingDeltaSats = -(amountMsat / 1000)
+                    ) ?: throw IllegalStateException("DB service unavailable")
+                    persistence.backingSats
+                        ?: throw IllegalStateException("DB did not return backing after outgoing stability payment")
+                    // Publish from the row — not from persistence.backingSats and not from the
+                    // tick-top `sc` snapshot. An ordinary send can reconcile (commit + publish)
+                    // at any point; republishing `sc` clobbered its expectedUSD, and publishing
+                    // the transaction-returned absolute backing clobbered its newer backing,
+                    // leaving in-memory books off-par and the next tick paying for nothing
+                    // (#299 review). Under booksLock the read-and-publish can't interleave with
+                    // another path's commit-and-publish. The debit is already durable and
+                    // lastStabilityPayment isn't a column, so no save is needed here.
+                    publishBooksFromDB(lastStabilityPayment = now)
+                }
                 databaseService?.clearPendingSend()
                 AuditService.log("STABILITY_PAYMENT_SENT", mapOf("amount_msat" to amountMsat))
             } catch (e: Exception) {
@@ -2876,21 +2896,25 @@ class AppState(private val context: Context) : ViewModel() {
         }
 
         return try {
-            val persistence = db.recordPaymentAndMaybeUpdateBacking(
-                paymentId = pendingPaymentId,
-                paymentType = "stability",
-                direction = "sent",
-                amountMsat = pending.amountMsat,
-                amountUSD = (pending.amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * pending.price,
-                btcPrice = pending.price,
-                counterparty = sc.counterparty,
-                userChannelId = sc.userChannelId,
-                backingDeltaSats = -(pending.amountMsat / 1000)
-            )
-            val backing = persistence.backingSats
-                ?: throw IllegalStateException("DB did not return backing during outgoing reconciliation")
-            _stableChannel.value = sc.copy(backingSats = backing)
-            saveChannelToDB(preserveBacking = true)
+            synchronized(booksLock) {
+                val persistence = db.recordPaymentAndMaybeUpdateBacking(
+                    paymentId = pendingPaymentId,
+                    paymentType = "stability",
+                    direction = "sent",
+                    amountMsat = pending.amountMsat,
+                    amountUSD = (pending.amountMsat.toDouble() / 1000 / Constants.SATS_IN_BTC) * pending.price,
+                    btcPrice = pending.price,
+                    counterparty = sc.counterparty,
+                    userChannelId = sc.userChannelId,
+                    backingDeltaSats = -(pending.amountMsat / 1000)
+                )
+                persistence.backingSats
+                    ?: throw IllegalStateException("DB did not return backing during outgoing reconciliation")
+                // Same rule as runStabilityCheck(): publish from the row under booksLock. The
+                // old snapshot republish + preserveBacking save here wrote a stale expected_usd
+                // over a concurrent ordinary-send reconcile (#299 review).
+                publishBooksFromDB()
+            }
             db.clearPendingSend()
             true
         } catch (e: Exception) {
@@ -3547,6 +3571,24 @@ class AppState(private val context: Context) : ViewModel() {
      *  cached are picked up before any save can clobber them. Cheap and safe to call repeatedly. */
     fun onForegroundResume() {
         loadChannelFromDB()
+    }
+
+    /** Republish expectedUSD/backingSats from the channel row — the single source of truth for
+     *  the stable books — never from an earlier in-memory snapshot or a transaction's return
+     *  value. Must be called inside synchronized(booksLock), immediately after the transaction
+     *  that changed the row, so no other path can commit-and-publish in between.
+     *  [recomputeNative] is only safe when the in-memory receiver balance is already live. */
+    private fun publishBooksFromDB(lastStabilityPayment: Long? = null, recomputeNative: Boolean = false) {
+        val ucid = _stableChannel.value.userChannelId
+        if (ucid.isEmpty()) return
+        val record = databaseService?.loadChannel(ucid) ?: return
+        _stableChannel.update {
+            it.copy(
+                expectedUSD = USD(record.expectedUSD),
+                backingSats = record.backingSats,
+                lastStabilityPayment = lastStabilityPayment ?: it.lastStabilityPayment
+            ).also { c -> if (recomputeNative) StabilityService.recomputeNative(c) }
+        }
     }
 
     private fun loadChannelFromDB() {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1990,6 +1990,11 @@ class AppState(private val context: Context) : ViewModel() {
             _stableChannel.value = _stableChannel.value.copy(
                 lastStabilityPayment = System.currentTimeMillis() / 1000
             )
+            // reconcileOutgoingBacking() wrote directly to the DB, bypassing saveChannelToDB()
+            // — so the SharedPreferences launch cache (used to seed Stable USD before the DB is
+            // open on next launch) needs its own explicit refresh here too, or it keeps showing
+            // the pre-send, too-high figure until loadChannelFromDB() runs during DB init.
+            cacheBalanceForLaunch()
         }
         var displayVal: String? = null
         if (paymentId != null) {
@@ -3498,7 +3503,15 @@ class AppState(private val context: Context) : ViewModel() {
                 latestPrice = sc.latestPrice
             )
         }
-        // Cache in SharedPreferences so UI has correct state on next launch
+        cacheBalanceForLaunch()
+    }
+
+    /** Cache in SharedPreferences so the UI has correct state on next launch, before the
+     *  database is open. Must be called any time _stableChannel's expectedUSD changes and is
+     *  considered durable — including paths that update the DB directly (e.g.
+     *  reconcileOutgoingBacking()) without going through saveChannelToDB(). */
+    private fun cacheBalanceForLaunch() {
+        val sc = _stableChannel.value
         context.getSharedPreferences("balance_cache", Context.MODE_PRIVATE).edit()
             .putString("cached_channel_id", sc.channelId)
             .putString("cached_user_channel_id", sc.userChannelId)

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -593,11 +593,16 @@ class AppState(private val context: Context) : ViewModel() {
     private val pendingLock = Any()
 
     /** Serializes "commit a stable-books mutation, then publish the row to _stableChannel"
-     *  across every path that changes expected_usd/stable_sats in-process: the stability
-     *  timer, the pending-send replay, incoming settlements and ordinary-send reconciles.
+     *  across the four payment paths that change expected_usd/stable_sats: runStabilityCheck()
+     *  (decision re-validation and post-send debit), reconcilePendingOutgoingStabilityPayment(),
+     *  handlePaymentReceived() and handlePaymentSuccessful()'s ordinary-send reconcile.
      *  Without it, path A can commit+publish between path B's commit and B's publish, and B's
      *  publish (built from B's own transaction result or an earlier snapshot) then overwrites
-     *  A's newer books in memory — which is what the stability check reads (#299 review). */
+     *  A's newer books in memory — which is what the stability check reads (#299 review).
+     *
+     *  NOT yet covered (pre-existing, tracked as a follow-up to #299): the trade-sync apply
+     *  paths under processSignedSyncMessage() and completeConfirmedSplice()'s full save. Both
+     *  write these columns from in-memory state without taking this lock. */
     private val booksLock = Any()
     private var sendGeneration: Long = 0L
 
@@ -1662,6 +1667,14 @@ class AppState(private val context: Context) : ViewModel() {
                 // newer value another path committed and published in the meantime.
                 publishBooksFromDB()
             }
+            // The balance refresh, native recompute and save below are a read-modify-write of
+            // the books too — the save writes expected_usd from memory — so they stay inside
+            // the lock. Released early, an ordinary-send reconcile could commit and publish in
+            // between and this save would write the pre-reconcile target back (#299 review).
+            refreshBalances()
+            updateStableBalances()
+            _stableChannel.update { StabilityService.reconcileIncoming(it) }
+            saveChannelToDB(preserveBacking = isStabilityPayment)
             p
         }
         if (settlementId != null && !persistence.isNewPayment) {
@@ -1670,11 +1683,6 @@ class AppState(private val context: Context) : ViewModel() {
                 "payment_hash" to paymentHash
             ))
         }
-        refreshBalances()
-        updateStableBalances()
-        val sc = StabilityService.reconcileIncoming(_stableChannel.value)
-        _stableChannel.value = sc
-        saveChannelToDB(preserveBacking = isStabilityPayment)
         if (persistence.isNewPayment) {
             val usdVal = (amountMsat.toDouble() / 1000.0 / Constants.SATS_IN_BTC) * price
             _statusMessage.value = "Payment received: ${usdVal.usdFormatted()}"
@@ -2731,14 +2739,40 @@ class AppState(private val context: Context) : ViewModel() {
                 return
             }
 
+            // Re-validate under booksLock now that the send is claimed. The decision above was
+            // made on the tick-top `sc`; an ordinary-send reconcile or an incoming settlement
+            // may have committed and published since, leaving the books already on par. Re-read
+            // the row and re-decide at the same price; if the answer or the amount changed,
+            // release the claim and let the next tick decide afresh. This narrows the
+            // stale-decision window to the sign+send below — it cannot be closed without
+            // holding the lock across a network call, which would block the LDK event handler
+            // (#299 review).
+            val revalidated = synchronized(booksLock) {
+                publishBooksFromDB()
+                _stableChannel.value
+            }
+            val recheck = StabilityService.checkStabilityAction(revalidated, price)
+            val recheckedAmountMsat = if (recheck.action == StabilityService.StabilityAction.PAY) {
+                (USD(abs(recheck.dollarsFromPar)).toMsats(price) / 1000L) * 1000L
+            } else 0L
+            if (recheckedAmountMsat != amountMsat) {
+                try { databaseService?.clearPendingSend() } catch (_: Exception) {}
+                AuditService.log("STABILITY_SKIP", mapOf(
+                    "reason" to "books_changed_after_decision",
+                    "claimed_amount_msat" to amountMsat,
+                    "rechecked_amount_msat" to recheckedAmountMsat
+                ))
+                return
+            }
+
             val paymentId = try {
                 // Attach only the signed STABILITY_PAYMENT_V1 envelope — the legacy
                 // STABLE_CHANNEL_TLV [0x01] marker is gone (#270). If the envelope can't
                 // be built, release the claim and skip the payment entirely.
                 val signedEnvelope = StabilityPaymentProtocol.buildSignedEnvelope(
-                    channelId = sc.channelId,
+                    channelId = revalidated.channelId,
                     amountMsat = amountMsat,
-                    expectedUsd = sc.expectedUSD.amount,
+                    expectedUsd = revalidated.expectedUSD.amount,
                     sign = { payload -> nodeService.signMessage(payload) }
                 )
                 if (signedEnvelope == null) {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1965,7 +1965,7 @@ class AppState(private val context: Context) : ViewModel() {
         // stableReceiverBTC is refreshed from live channel state just above, not from the
         // racy in-memory backingSats copy — safe to use directly as the reconcile input.
         val receiverSats = _stableChannel.value.stableReceiverBTC.sats
-        val reconcileResult = try {
+        val reconcileResult = if (userChannelId.isEmpty()) null else try {
             databaseService?.reconcileOutgoingBacking(
                 channelId = channelId,
                 userChannelId = userChannelId,
@@ -1974,9 +1974,28 @@ class AppState(private val context: Context) : ViewModel() {
                 latestPrice = latestPrice,
                 price = price
             )
-        } catch (e: Exception) {
-            Log.w("AppState", "Failed to reconcile outgoing send: ${e.message}")
+        } catch (e: MissingChannelRowException) {
+            // Structural: there is no row to reconcile against and a retry can't create one.
+            // Treat as nothing-to-reconcile, but leave a trace in the audit log.
+            AuditService.log("OUTGOING_RECONCILE_SKIPPED", mapOf(
+                "payment_id" to (paymentId ?: ""),
+                "reason" to "missing_channel_row",
+                "user_channel_id" to userChannelId
+            ))
             null
+        } catch (e: Exception) {
+            // Anything else (SQLite I/O error, disk full, lock timeout) is transient. The
+            // transaction rolled back, so the deduction has NOT been recorded — rethrow so the
+            // event loop leaves this PaymentSuccessful un-acked and LDK redelivers it with
+            // backoff. reconcileOutgoingBacking() is idempotent on retry because it measures
+            // overflow against live channel state. Swallowing the error here acked the payment
+            // with the books still wrong (#299 review, P2).
+            AuditService.log("OUTGOING_RECONCILE_FAILED", mapOf(
+                "payment_id" to (paymentId ?: ""),
+                "error" to (e.message ?: e.javaClass.simpleName),
+                "will_retry" to true
+            ))
+            throw e
         }
         if (reconcileResult != null) {
             // Refresh in-memory state from the DB's current, authoritative row instead of
@@ -1987,9 +2006,7 @@ class AppState(private val context: Context) : ViewModel() {
             // fresh, so this can never clobber a concurrent writer's already-applied change —
             // the same pattern onForegroundResume() already relies on for this exact reason.
             loadChannelFromDB()
-            _stableChannel.value = _stableChannel.value.copy(
-                lastStabilityPayment = System.currentTimeMillis() / 1000
-            )
+            _stableChannel.update { it.copy(lastStabilityPayment = System.currentTimeMillis() / 1000) }
             // reconcileOutgoingBacking() wrote directly to the DB, bypassing saveChannelToDB()
             // — so the SharedPreferences launch cache (used to seed Stable USD before the DB is
             // open on next launch) needs its own explicit refresh here too, or it keeps showing
@@ -2765,15 +2782,21 @@ class AppState(private val context: Context) : ViewModel() {
                 ) ?: throw IllegalStateException("DB service unavailable")
                 val backing = persistence.backingSats
                     ?: throw IllegalStateException("DB did not return backing after outgoing stability payment")
-                val updated = sc.copy(lastStabilityPayment = now, backingSats = backing)
-                _stableChannel.value = updated
-                saveChannelToDB(preserveBacking = true)
+                // Patch only the fields this tick owns, against the *current* in-memory value —
+                // not the `sc` snapshot captured at the top of the tick. A concurrent ordinary
+                // send (handlePaymentSuccessful) may have reconciled expectedUSD/backing since
+                // then; republishing `sc` clobbered that in memory, and the old
+                // saveChannelToDB(preserveBacking = true) here then wrote the stale expected_usd
+                // back to the DB, undoing the send's committed reconcile (#299 review, P1).
+                // The debit itself is already durable via recordPaymentAndMaybeUpdateBacking(),
+                // and lastStabilityPayment is not a DB column, so no save is needed here.
+                _stableChannel.update { it.copy(lastStabilityPayment = now, backingSats = backing) }
                 databaseService?.clearPendingSend()
                 AuditService.log("STABILITY_PAYMENT_SENT", mapOf("amount_msat" to amountMsat))
             } catch (e: Exception) {
                 // The send already succeeded. Keep the durable marker and block all later sends
                 // until the payment row and backing delta can be committed together.
-                _stableChannel.value = sc.copy(lastStabilityPayment = now)
+                _stableChannel.update { it.copy(lastStabilityPayment = now) }
                 FCMService.flagPendingPayment(context)
                 AuditService.log(
                     "STABILITY_PAYMENT_PERSISTENCE_FAILED",

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1979,11 +1979,17 @@ class AppState(private val context: Context) : ViewModel() {
             null
         }
         if (reconcileResult != null) {
+            // Refresh in-memory state from the DB's current, authoritative row instead of
+            // trusting reconcileResult's values directly: reconcileOutgoingBacking()'s
+            // transaction may have already committed some time ago by the time this line runs,
+            // and the stability timer (a concurrent coroutine) could have committed and
+            // published its own newer backing update in between. loadChannelFromDB() re-reads
+            // fresh, so this can never clobber a concurrent writer's already-applied change —
+            // the same pattern onForegroundResume() already relies on for this exact reason.
+            loadChannelFromDB()
             _stableChannel.value = _stableChannel.value.copy(
-                expectedUSD = USD(reconcileResult.newExpectedUSD),
-                backingSats = reconcileResult.newBackingSats,
                 lastStabilityPayment = System.currentTimeMillis() / 1000
-            ).also { StabilityService.recomputeNative(it) }
+            )
         }
         var displayVal: String? = null
         if (paymentId != null) {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1940,33 +1940,51 @@ class AppState(private val context: Context) : ViewModel() {
         if (handleStabilityPaymentSuccessful(paymentId, feePaidMsat)) return
 
         // Ordinary (non-trade, non-stability) outgoing payment. Mirrors iOS's
-        // handlePaymentSuccessful: reconcileOutgoing() reduces expectedUSD and backingSats
-        // together when this send dipped into the stable backing — otherwise the on-screen
-        // Stable USD never reflects the send and the balances stop adding up to the total.
-        // The original bug (#296) was persisting only the expectedUSD half of that result via
+        // handlePaymentSuccessful: reconcile expectedUSD and backingSats together when this
+        // send dipped into the stable backing — otherwise the on-screen Stable USD never
+        // reflects the send and the balances stop adding up to the total. The original bug
+        // (#296) was persisting only the expectedUSD half of that result via
         // saveChannelToDB(preserveBacking = true), permanently desyncing the two fields.
         //
-        // Persisting is NOT a plain full save, though: the stability timer (runStabilityCheck(),
-        // a separate in-process coroutine) can commit its own backing debit straight to the DB
-        // between when _stableChannel.value was last refreshed here and when this save runs. An
-        // absolute overwrite of backingSats computed from that possibly-stale in-memory value
-        // would silently clobber the timer's already-committed debit. So only the *delta*
-        // reconcileOutgoing() computed is persisted, applied against the DB's current value
-        // inside a transaction (saveChannelWithBackingDelta) — the same delta-against-fresh-state
-        // pattern recordPaymentAndMaybeUpdateBacking() uses for stability payments. When nothing
-        // was deducted, backing is untouched and the existing preserveBacking save is used.
+        // The reconcile math itself has to run inside the DB transaction that persists it, not
+        // be precomputed against an in-memory snapshot: the stability timer (runStabilityCheck(),
+        // a separate in-process coroutine) can commit its own backing debit straight to this row
+        // via recordPaymentAndMaybeUpdateBacking() at any time. reconcileOutgoing()'s result is a
+        // function of the backing value it's given, so computing it against a snapshot taken
+        // before that debit — then applying the result as a delta on top of the DB's
+        // already-debited row — double-counts the difference. reconcileOutgoingBacking() instead
+        // re-reads expected_usd/stable_sats fresh and does the whole computation inside one
+        // BEGIN IMMEDIATE transaction, composing correctly with whatever the timer already wrote.
         refreshBalances()
         updateStableBalances()
         val price = priceService.currentPrice.value
-        val preReconcileBacking = _stableChannel.value.backingSats
-        val oldExpected = _stableChannel.value.expectedUSD.amount
-        val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
-        val reconciled = result.first
-        val usdDeducted = result.second
-        if (usdDeducted != null) {
-            reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
+        val channelId = _stableChannel.value.channelId
+        val userChannelId = _stableChannel.value.userChannelId
+        val note = _stableChannel.value.note
+        val latestPrice = _stableChannel.value.latestPrice
+        // stableReceiverBTC is refreshed from live channel state just above, not from the
+        // racy in-memory backingSats copy — safe to use directly as the reconcile input.
+        val receiverSats = _stableChannel.value.stableReceiverBTC.sats
+        val reconcileResult = try {
+            databaseService?.reconcileOutgoingBacking(
+                channelId = channelId,
+                userChannelId = userChannelId,
+                note = note,
+                receiverSats = receiverSats,
+                latestPrice = latestPrice,
+                price = price
+            )
+        } catch (e: Exception) {
+            Log.w("AppState", "Failed to reconcile outgoing send: ${e.message}")
+            null
         }
-        _stableChannel.value = reconciled
+        if (reconcileResult != null) {
+            _stableChannel.value = _stableChannel.value.copy(
+                expectedUSD = USD(reconcileResult.newExpectedUSD),
+                backingSats = reconcileResult.newBackingSats,
+                lastStabilityPayment = System.currentTimeMillis() / 1000
+            ).also { StabilityService.recomputeNative(it) }
+        }
         var displayVal: String? = null
         if (paymentId != null) {
             databaseService?.updatePaymentStatus(paymentId, "completed", feePaidMsat ?: 0)
@@ -1985,39 +2003,19 @@ class AppState(private val context: Context) : ViewModel() {
                 Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
             }
         }
-        if (usdDeducted != null) {
-            // Apply only the delta reconcileOutgoing() computed, against the DB's current
-            // backing, inside a transaction — never an absolute overwrite (see comment above).
-            val deltaSats = reconciled.backingSats - preReconcileBacking
-            try {
-                val persistedBacking = databaseService?.saveChannelWithBackingDelta(
-                    channelId = reconciled.channelId,
-                    userChannelId = reconciled.userChannelId,
-                    expectedUSD = reconciled.expectedUSD.amount,
-                    note = reconciled.note,
-                    receiverSats = reconciled.stableReceiverBTC.sats,
-                    latestPrice = reconciled.latestPrice,
-                    backingDeltaSats = deltaSats
-                )
-                if (persistedBacking != null && persistedBacking != reconciled.backingSats) {
-                    // A concurrent stability debit landed in between — resync in-memory state
-                    // with what was actually persisted instead of what we computed.
-                    _stableChannel.value = _stableChannel.value.copy(backingSats = persistedBacking)
-                }
-            } catch (e: Exception) {
-                Log.w("AppState", "Failed to persist outgoing reconcile delta: ${e.message}")
-            }
+        if (reconcileResult != null) {
             AuditService.log("OUTGOING_STABLE_DEDUCTED", mapOf(
                 "payment_id" to (paymentId ?: ""),
-                "usd_deducted" to usdDeducted,
-                "old_expected_usd" to oldExpected,
-                "new_expected_usd" to reconciled.expectedUSD.amount,
+                "usd_deducted" to reconcileResult.usdDeducted,
+                "old_expected_usd" to reconcileResult.oldExpectedUSD,
+                "new_expected_usd" to reconcileResult.newExpectedUSD,
                 "btc_price" to price
             ))
         } else {
-            // Nothing to reconcile — only expectedUSD-independent metadata (status, note,
-            // price) may have changed. preserveBacking keeps this call from ever touching
-            // stable_sats, so it's always safe regardless of any concurrent stability write.
+            // Nothing to reconcile (or the reconcile attempt failed) — only
+            // expectedUSD-independent metadata (status, note, price) may have changed.
+            // preserveBacking keeps this call from ever touching stable_sats, so it's always
+            // safe regardless of any concurrent stability write.
             saveChannelToDB(preserveBacking = true)
         }
         val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1939,12 +1939,24 @@ class AppState(private val context: Context) : ViewModel() {
 
         if (handleStabilityPaymentSuccessful(paymentId, feePaidMsat)) return
 
+        // Ordinary (non-trade, non-stability) outgoing payment. Mirrors iOS's
+        // handlePaymentSuccessful exactly: reconcileOutgoing() reduces expectedUSD and
+        // backingSats together when this send dipped into the stable backing, and that
+        // reduction is persisted with a full saveChannelToDB() (not preserveBacking) —
+        // otherwise the on-screen Stable USD never reflects the send and the balances stop
+        // adding up to the total. The original bug (#296) wasn't calling reconcileOutgoing()
+        // here — it was calling saveChannelToDB(preserveBacking = true) afterward, which only
+        // ever writes expectedUSD and silently dropped the matching backingSats reduction,
+        // permanently desyncing the two. Fixing the persistence, not removing the reconcile,
+        // is what keeps this consistent with iOS.
         refreshBalances()
         updateStableBalances()
         val price = priceService.currentPrice.value
+        val oldExpected = _stableChannel.value.expectedUSD.amount
         val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
         val reconciled = result.first
-        if (result.second != null) {
+        val usdDeducted = result.second
+        if (usdDeducted != null) {
             reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
         }
         _stableChannel.value = reconciled
@@ -1966,7 +1978,20 @@ class AppState(private val context: Context) : ViewModel() {
                 Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
             }
         }
-        saveChannelToDB(preserveBacking = true)
+        // Full save (no preserveBacking) so both expectedUSD and backingSats are persisted
+        // together, matching iOS. This is the one call site where reconcileOutgoing()'s
+        // output is safe to persist in full: it's the foreground, user-initiated send path,
+        // not a background/replay path racing StabilityProcessingService's locked writes.
+        saveChannelToDB()
+        if (usdDeducted != null) {
+            AuditService.log("OUTGOING_STABLE_DEDUCTED", mapOf(
+                "payment_id" to (paymentId ?: ""),
+                "usd_deducted" to usdDeducted,
+                "old_expected_usd" to oldExpected,
+                "new_expected_usd" to reconciled.expectedUSD.amount,
+                "btc_price" to price
+            ))
+        }
         val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""
         val successMsg = if (displayVal != null) "Payment sent: $displayVal$feeSuffix" else "Payment sent$feeSuffix"
         _statusMessage.value = successMsg

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1940,18 +1940,25 @@ class AppState(private val context: Context) : ViewModel() {
         if (handleStabilityPaymentSuccessful(paymentId, feePaidMsat)) return
 
         // Ordinary (non-trade, non-stability) outgoing payment. Mirrors iOS's
-        // handlePaymentSuccessful exactly: reconcileOutgoing() reduces expectedUSD and
-        // backingSats together when this send dipped into the stable backing, and that
-        // reduction is persisted with a full saveChannelToDB() (not preserveBacking) —
-        // otherwise the on-screen Stable USD never reflects the send and the balances stop
-        // adding up to the total. The original bug (#296) wasn't calling reconcileOutgoing()
-        // here — it was calling saveChannelToDB(preserveBacking = true) afterward, which only
-        // ever writes expectedUSD and silently dropped the matching backingSats reduction,
-        // permanently desyncing the two. Fixing the persistence, not removing the reconcile,
-        // is what keeps this consistent with iOS.
+        // handlePaymentSuccessful: reconcileOutgoing() reduces expectedUSD and backingSats
+        // together when this send dipped into the stable backing — otherwise the on-screen
+        // Stable USD never reflects the send and the balances stop adding up to the total.
+        // The original bug (#296) was persisting only the expectedUSD half of that result via
+        // saveChannelToDB(preserveBacking = true), permanently desyncing the two fields.
+        //
+        // Persisting is NOT a plain full save, though: the stability timer (runStabilityCheck(),
+        // a separate in-process coroutine) can commit its own backing debit straight to the DB
+        // between when _stableChannel.value was last refreshed here and when this save runs. An
+        // absolute overwrite of backingSats computed from that possibly-stale in-memory value
+        // would silently clobber the timer's already-committed debit. So only the *delta*
+        // reconcileOutgoing() computed is persisted, applied against the DB's current value
+        // inside a transaction (saveChannelWithBackingDelta) — the same delta-against-fresh-state
+        // pattern recordPaymentAndMaybeUpdateBacking() uses for stability payments. When nothing
+        // was deducted, backing is untouched and the existing preserveBacking save is used.
         refreshBalances()
         updateStableBalances()
         val price = priceService.currentPrice.value
+        val preReconcileBacking = _stableChannel.value.backingSats
         val oldExpected = _stableChannel.value.expectedUSD.amount
         val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
         val reconciled = result.first
@@ -1978,12 +1985,28 @@ class AppState(private val context: Context) : ViewModel() {
                 Log.w("AppState", "Failed to retrieve amount for status message: ${e.message}")
             }
         }
-        // Full save (no preserveBacking) so both expectedUSD and backingSats are persisted
-        // together, matching iOS. This is the one call site where reconcileOutgoing()'s
-        // output is safe to persist in full: it's the foreground, user-initiated send path,
-        // not a background/replay path racing StabilityProcessingService's locked writes.
-        saveChannelToDB()
         if (usdDeducted != null) {
+            // Apply only the delta reconcileOutgoing() computed, against the DB's current
+            // backing, inside a transaction — never an absolute overwrite (see comment above).
+            val deltaSats = reconciled.backingSats - preReconcileBacking
+            try {
+                val persistedBacking = databaseService?.saveChannelWithBackingDelta(
+                    channelId = reconciled.channelId,
+                    userChannelId = reconciled.userChannelId,
+                    expectedUSD = reconciled.expectedUSD.amount,
+                    note = reconciled.note,
+                    receiverSats = reconciled.stableReceiverBTC.sats,
+                    latestPrice = reconciled.latestPrice,
+                    backingDeltaSats = deltaSats
+                )
+                if (persistedBacking != null && persistedBacking != reconciled.backingSats) {
+                    // A concurrent stability debit landed in between — resync in-memory state
+                    // with what was actually persisted instead of what we computed.
+                    _stableChannel.value = _stableChannel.value.copy(backingSats = persistedBacking)
+                }
+            } catch (e: Exception) {
+                Log.w("AppState", "Failed to persist outgoing reconcile delta: ${e.message}")
+            }
             AuditService.log("OUTGOING_STABLE_DEDUCTED", mapOf(
                 "payment_id" to (paymentId ?: ""),
                 "usd_deducted" to usdDeducted,
@@ -1991,6 +2014,11 @@ class AppState(private val context: Context) : ViewModel() {
                 "new_expected_usd" to reconciled.expectedUSD.amount,
                 "btc_price" to price
             ))
+        } else {
+            // Nothing to reconcile — only expectedUSD-independent metadata (status, note,
+            // price) may have changed. preserveBacking keeps this call from ever touching
+            // stable_sats, so it's always safe regardless of any concurrent stability write.
+            saveChannelToDB(preserveBacking = true)
         }
         val feeSuffix = feePaidMsat?.let { " (fee: ${(it / 1000).satsFormatted()} sats)" } ?: ""
         val successMsg = if (displayVal != null) "Payment sent: $displayVal$feeSuffix" else "Payment sent$feeSuffix"

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -247,6 +247,59 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
     }
 
     /**
+     * Persist an ordinary-send reconcile (expectedUSD reduced, backing reduced to match) as a
+     * signed delta against the *current DB row*, not as an absolute overwrite of in-memory state.
+     *
+     * Written the same way recordPaymentAndMaybeUpdateBacking() updates backing for stability
+     * payments: BEGIN IMMEDIATE, re-read stable_sats fresh, apply the delta, clamp at 0. This is
+     * required because the stability timer (runStabilityCheck(), a separate in-process coroutine)
+     * can commit its own backing debit directly to this table between when this call's caller last
+     * refreshed in-memory state and when it actually runs. An absolute write of a possibly-stale
+     * in-memory backingSats would silently undo that debit; a delta survives it.
+     *
+     * Returns the resulting backing sats so the caller can resync its in-memory copy with what was
+     * actually persisted (which may differ slightly from what it computed, if a concurrent debit
+     * landed in between).
+     */
+    fun saveChannelWithBackingDelta(
+        channelId: String,
+        userChannelId: String,
+        expectedUSD: Double,
+        note: String?,
+        receiverSats: Long,
+        latestPrice: Double,
+        backingDeltaSats: Long
+    ): Long {
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val current = readBackingSats(db, userChannelId)
+                ?: throw MissingChannelRowException(userChannelId)
+            val newBacking = maxOf(0L, current + backingDeltaSats)
+            val cv = ContentValues().apply {
+                put("channel_id", channelId)
+                put("expected_usd", expectedUSD)
+                put("stable_sats", newBacking)
+                put("note", note)
+                put("receiver_sats", receiverSats)
+                put("latest_price", latestPrice)
+                put("updated_at", System.currentTimeMillis() / 1000)
+            }
+            val rows = db.update("channels", cv, "user_channel_id = ?", arrayOf(userChannelId))
+            if (rows != 1) {
+                throw IllegalStateException(
+                    "channel UPDATE affected $rows rows for user_channel_id=$userChannelId"
+                )
+            }
+            db.execSQL("COMMIT")
+            return newBacking
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
+    /**
      * Persist channel metadata without touching stable_sats.
      *
      * Incoming stability payments update stable_sats transactionally. Keeping that column out of

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -10,6 +10,7 @@ import com.stablechannels.app.models.*
 import com.stablechannels.app.util.Constants
 import com.stablechannels.app.util.HistoricalPrices
 import java.io.File
+import kotlin.math.roundToLong
 
 data class PaymentPersistenceResult(
     val isNewPayment: Boolean,
@@ -246,39 +247,68 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    /** Result of [reconcileOutgoingBacking]: the USD/backing values it actually wrote. */
+    data class OutgoingReconcileResult(
+        val usdDeducted: Double,
+        val oldExpectedUSD: Double,
+        val newExpectedUSD: Double,
+        val newBackingSats: Long
+    )
+
     /**
-     * Persist an ordinary-send reconcile (expectedUSD reduced, backing reduced to match) as a
-     * signed delta against the *current DB row*, not as an absolute overwrite of in-memory state.
+     * Atomically reconciles an ordinary outgoing send against the row's *current, freshly-read*
+     * expected_usd/stable_sats — mirroring StabilityService.reconcileOutgoing()'s math exactly,
+     * but performed entirely inside one BEGIN IMMEDIATE transaction instead of being computed
+     * ahead of time against an in-memory snapshot.
      *
-     * Written the same way recordPaymentAndMaybeUpdateBacking() updates backing for stability
-     * payments: BEGIN IMMEDIATE, re-read stable_sats fresh, apply the delta, clamp at 0. This is
-     * required because the stability timer (runStabilityCheck(), a separate in-process coroutine)
-     * can commit its own backing debit directly to this table between when this call's caller last
-     * refreshed in-memory state and when it actually runs. An absolute write of a possibly-stale
-     * in-memory backingSats would silently undo that debit; a delta survives it.
+     * This has to read-and-compute in one transaction, not read-precompute-then-apply-a-delta:
+     * reconcileOutgoing()'s result (both the USD deducted and the resulting backing) is a
+     * function of the backing value it's given. If that input is a snapshot taken before the
+     * stability timer's own concurrent debit (runStabilityCheck(), a separate in-process
+     * coroutine that commits its debit straight to this table via
+     * recordPaymentAndMaybeUpdateBacking()), the computed reduction implicitly assumes the old,
+     * pre-debit backing — so applying it as a delta on top of the DB's already-debited row
+     * double-counts the difference. Recomputing fresh, inside the same transaction that writes
+     * the result, uses only one read of backing and composes correctly with whatever the timer
+     * already committed.
      *
-     * Returns the resulting backing sats so the caller can resync its in-memory copy with what was
-     * actually persisted (which may differ slightly from what it computed, if a concurrent debit
-     * landed in between).
+     * [receiverSats] must be the live, already-fresh post-send receiver balance (from
+     * refreshBalances()/updateStableBalances()) — that value reflects real channel state
+     * directly and isn't subject to the same race as the in-memory backingSats copy.
+     *
+     * Returns null if there was nothing to reconcile at the DB's current state (no overflow).
      */
-    fun saveChannelWithBackingDelta(
+    fun reconcileOutgoingBacking(
         channelId: String,
         userChannelId: String,
-        expectedUSD: Double,
         note: String?,
         receiverSats: Long,
         latestPrice: Double,
-        backingDeltaSats: Long
-    ): Long {
+        price: Double
+    ): OutgoingReconcileResult? {
+        if (price <= 0.0) return null
         val db = writableDatabase
         db.execSQL("BEGIN IMMEDIATE")
         try {
-            val current = readBackingSats(db, userChannelId)
-                ?: throw MissingChannelRowException(userChannelId)
-            val newBacking = maxOf(0L, current + backingDeltaSats)
+            val cursor = db.rawQuery(
+                "SELECT expected_usd, stable_sats FROM channels WHERE user_channel_id = ?",
+                arrayOf(userChannelId)
+            )
+            val (currentExpected, currentBacking) = cursor.use {
+                if (!it.moveToFirst()) throw MissingChannelRowException(userChannelId)
+                it.getDouble(0) to it.getLong(1)
+            }
+            if (currentExpected < 0.01 || currentBacking == 0L || currentBacking <= receiverSats) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            val overflowSats = currentBacking - receiverSats
+            val usdToDeduct = (overflowSats.toDouble() / Constants.SATS_IN_BTC) * price
+            val newExpected = maxOf(currentExpected - usdToDeduct, 0.0)
+            val newBacking = ((newExpected / price) * Constants.SATS_IN_BTC).roundToLong()
             val cv = ContentValues().apply {
                 put("channel_id", channelId)
-                put("expected_usd", expectedUSD)
+                put("expected_usd", newExpected)
                 put("stable_sats", newBacking)
                 put("note", note)
                 put("receiver_sats", receiverSats)
@@ -292,7 +322,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
                 )
             }
             db.execSQL("COMMIT")
-            return newBacking
+            return OutgoingReconcileResult(usdToDeduct, currentExpected, newExpected, newBacking)
         } catch (e: Exception) {
             try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
             throw e

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -497,6 +497,63 @@ class TradeDatabaseServiceTest {
         service.close()
     }
 
+    @Test
+    fun outgoingReconcileComposesCorrectlyWithAConcurrentStabilityDebit() {
+        // Regression for a review finding on PR #299 (gpt-6-astra / opus-5): computing the
+        // outgoing reconcile against a snapshot of in-memory state and then persisting it as a
+        // delta double-counts whatever the stability timer (a separate in-process coroutine)
+        // already committed straight to this row via recordPaymentAndMaybeUpdateBacking().
+        // reconcileOutgoingBacking() must instead read expected_usd/stable_sats fresh and do the
+        // whole computation inside its own transaction, so it composes correctly no matter what
+        // ran immediately before it.
+        val identifier = "ab".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "7",
+            expectedUSD = 90.0,
+            backingSats = 100_000,
+            note = null,
+            receiverSats = 100_000,
+            latestPrice = 100_000.0
+        )
+
+        // Simulate the stability timer's own concurrent debit landing first: it commits
+        // directly to the DB (and, in real code, only updates in-memory state afterward).
+        service.recordPaymentAndMaybeUpdateBacking(
+            paymentId = "11".repeat(32),
+            paymentType = "stability",
+            direction = "sent",
+            amountMsat = 10_000_000,
+            userChannelId = "7",
+            backingDeltaSats = -10_000
+        )
+        assertEquals(90_000L, service.loadChannel("7")?.backingSats)
+
+        // The ordinary send's own overflow, measured against the live (post-send) receiver
+        // balance and whatever backing is actually in the DB right now (90,000 sats, $90 —
+        // already corrected by the timer above), not a stale pre-timer snapshot (100,000 sats).
+        val result = service.reconcileOutgoingBacking(
+            channelId = identifier,
+            userChannelId = "7",
+            note = null,
+            receiverSats = 80_000,
+            latestPrice = 100_000.0,
+            price = 100_000.0
+        )
+
+        assertNotNull(result)
+        assertEquals(90.0, result!!.oldExpectedUSD, 0.0001)
+        assertEquals(10.0, result.usdDeducted, 0.0001)
+        assertEquals(80.0, result.newExpectedUSD, 0.0001)
+        assertEquals(80_000L, result.newBackingSats)
+
+        val persisted = service.loadChannel("7")
+        assertEquals(80.0, persisted?.expectedUSD ?: -1.0, 0.0001)
+        assertEquals(80_000L, persisted?.backingSats)
+        service.close()
+    }
+
     private fun deleteDatabaseFiles() {
         listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
             .forEach { file -> if (file.exists()) assertTrue(file.delete()) }


### PR DESCRIPTION
## Summary
Fixes #296. `handlePaymentSuccessful()` called `StabilityService.reconcileOutgoing()` for plain outgoing Lightning payments, then persisted the result with `saveChannelToDB(preserveBacking = true)` — which only ever writes `expectedUSD`. The matching `backingSats` reduction `reconcileOutgoing()` computed was silently dropped, leaving the DB with a reduced target paired with a stale `backingSats`. This desync caused an oversized stability payment ($8.53 vs. the usual <$1) and 100% subsequent trade rejection (`invalid_fee`), reproduced end-to-end from device audit logs/DB/`ldk_node.log` in the issue.

**Fix**: `reconcileOutgoingBacking()` (in `DatabaseService`) re-reads `expected_usd`/`stable_sats` fresh and performs the entire reconcile computation — same math as iOS's `reconcileOutgoing()` — inside one `BEGIN IMMEDIATE` transaction, then writes both fields together. Also adds an `OUTGOING_STABLE_DEDUCTED` audit log entry on deduction, mirroring iOS's `AuditService.log(...)` call, for observability/parity.

### Review history on this PR
Three iterations were needed to get the persistence side fully correct — noted here for anyone following along, and so reviewers don't have to re-derive it:
1. Stopped calling `reconcileOutgoing()` entirely for ordinary sends (per an earlier review comment on the issue, to avoid racing the stability timer). Reverted: broke the UX — Stable USD stopped updating and Native BTC clamped at 0 after an overflow send.
2. Restored `reconcileOutgoing()` + an **unconditional full save**. Automated review (gpt-6-astra) found this could clobber a backing debit the stability timer (`runStabilityCheck()`, a separate in-process coroutine) commits directly to the DB via `recordPaymentAndMaybeUpdateBacking()`, since `saveChannel()` writes `stable_sats` as an absolute overwrite with no version/delta check.
3. Switched to persisting the reconcile as a **delta** against the DB's current value. Both reviews (opus-5 and gpt-6-astra) then independently found this still double-counted: `reconcileOutgoing()`'s result is a function of the backing value it's given, so a delta computed from a snapshot taken *before* the timer's concurrent debit — then applied on top of the DB's already-debited row — double-counts the difference. astra reproduced this deterministically with a Robolectric test.
4. **Current**: moved the entire reconcile computation (read → compute → write) inside one transaction in `reconcileOutgoingBacking()`, so there is only ever one read of the current backing/target, and it composes correctly with whatever a concurrent writer already committed. Added a regression test (`outgoingReconcileComposesCorrectlyWithAConcurrentStabilityDebit`) reproducing the exact interleaving both reviews described.

## ✅ Verified
- **On-device** (physical Android device), against the repro steps from #296, at each iteration including this one: triggered a real overflow Lightning send, confirmed `OUTGOING_STABLE_DEDUCTED` fired in `audit_log.txt` with correct old/new `expectedUSD`, and confirmed the DB's `expected_usd`/`stable_sats` are consistent post-send (no desync). Stable USD and Native BTC both update correctly and add up to the total, matching iOS (a sub-cent rounding residue is expected on both platforms, per iOS's own unit tests).
- **Regression test** added for the concurrent-debit interleaving both reviews flagged (`TradeDatabaseServiceTest.outgoingReconcileComposesCorrectlyWithAConcurrentStabilityDebit`), asserting the reconciled target/backing match what a fresh-read-inside-the-transaction should produce, not what a stale snapshot would.
- Compile clean + existing unit test suite passing (229/230 — the 1 failure is a pre-existing, unrelated environment issue in an untracked test file, not caused by this change).

## Fixed after opus-5's whole-branch review (commit ef8490e)
Two more issues found on later commits, both fixed:
- **1a00e36 / f35e5bd**: opus-5 and gpt-6-astra found the delta-based persistence (66df53e) still double-counted a concurrent stability-timer debit, and that the post-reconcile in-memory update could clobber a concurrent timer publish. Fixed by moving the whole reconcile computation into one DB transaction (`reconcileOutgoingBacking()`) and refreshing in-memory state via `loadChannelFromDB()` afterward instead of trusting the transaction's return value directly.
- **ef8490e**: opus-5's review of the resulting branch found the SharedPreferences launch cache (`cached_expected_usd`, used to seed Stable USD before the DB opens on next launch) stopped updating after ordinary sends, since `reconcileOutgoingBacking()` writes the DB directly and bypasses `saveChannelToDB()` — the cache's only prior writer. Extracted `cacheBalanceForLaunch()` and call it on the reconcile-success path too.

## Out of scope for this PR (per the issue/review thread)
- LSP-side divergence-tolerance check (settlement was applied despite a logged 16% divergence warning).
- Recovery/resync path for wallets already corrupted by this bug.
- Sibling desktop discrepancy in its own `reconcile_outgoing`.

## Follow-up: LSP-side change also needed

@Billa05 — flagging this for you since it likely lives on the LSP/server side, outside this PR's scope.

Per @toneloc's review comment on #296: the LSP saw the same corrupted payment and logged the divergence, but applied the settlement anyway:

```
STABILITY_PAYMENT_STATE_DIVERGENCE  local_expected_usd: 23.8346  signed_expected_usd: 19.9594
STABILITY_PAYMENT_RECORDED          amount_usd: 8.5276  new_backing_sats: 30357  new_native_sats: 14365
```

A 16% expected-USD divergence was only logged as a warning, not rejected. Suggested backstop: make the LSP's divergence check reject beyond a small tolerance (failing the HTLC so sats return to the user), rather than applying the settlement anyway. This would have prevented the loss even with the Android client bug present, and protects against any future client-side computation error more generally — not just this one.

