### PR TITLE
fix(android): refresh History when the splice monitor completes a row…

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -2316,6 +2316,12 @@ class AppState(private val context: Context) : ViewModel() {
         databaseService?.assignPendingSpliceTxid(txid, capturedPaymentRowId)
         val completed = databaseService?.completeSplice(txid) == true
         if (completed) {
+            // completeSplice() just marked the row completed/1-conf. History only reloads when
+            // this epoch moves, and the confirmation poller won't move it for this row: it now
+            // has confirmations >= 1, so the poller no longer selects it. Without this bump,
+            // whenever this monitor sees the confirmation before the poller does, an open
+            // History screen keeps showing "0/1 confirmed" until it is left and reopened (#304).
+            _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
             refreshBalances()
             updateStableBalances()
 


### PR DESCRIPTION
… (#304)

Two paths complete a splice payment row: the confirmation poller and the splice monitor's completeConfirmedSplice(). Only the poller bumped _confirmationUpdateEpoch, the sole trigger for History to reload. When the monitor saw the confirmation first, the row was completed silently; the poller then no longer selected it (confirmations >= 1), so nothing bumped and an open History screen kept showing "0/1 confirmed" until reopened.

Bump the epoch as soon as completeSplice() reports a completed row. Covers the splice-in fallback branch too, since it returns through the same flag.

Deterministic under the e2e harness (3 s monitor, no regtest block trigger), which broke flows 25 and 26; on mainnet it needs History left open through confirmation and the block-triggered poll to miss.

