### PR TITLE
feat(cross): unified balance scale launch animation and staged screen flow

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +29,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stablechannels.app.AppState
 import com.stablechannels.app.Phase
+import com.stablechannels.app.ui.components.BalanceScaleKinematics
+import com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage
 import com.stablechannels.app.ui.components.UnifiedBalanceLaunchView
 
 @Composable
@@ -48,11 +51,12 @@ fun ContentView(appState: AppState) {
 fun SyncingView(
     modifier: Modifier = Modifier,
     isSyncComplete: Boolean = false,
-    previewStage: com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage? = null,
+    previewStage: Stage? = null,
     onBalanced: (() -> Unit)? = null,
 ) {
   val elapsedSeconds by
-      produceState(initialValue = 0f) {
+      produceState(initialValue = 0f, key1 = previewStage) {
+        if (previewStage != null) return@produceState
         val startNanos = withFrameNanos { it }
         while (true) {
           withFrameNanos { frameTimeNanos ->
@@ -61,13 +65,14 @@ fun SyncingView(
         }
       }
 
-  val shimmerDuration = 1.15f
+  val kinematics = remember { BalanceScaleKinematics() }
+  val shimmerDuration = kinematics.totalShimmerDuration
   val crossfadeDuration = 0.40f
 
   val effectiveElapsed =
       when (previewStage) {
-        is com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Shimmer -> 0.70f
-        is com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Oscillating -> 1.65f
+        is Stage.Shimmer -> 0.70f
+        is Stage.Oscillating -> 1.65f
         else -> elapsedSeconds
       }
 
@@ -127,7 +132,7 @@ fun SyncingView(
                 },
         ) {
           Text(
-              text = "Wallet Syncing...",
+              text = "Syncing Wallet",
               style = MaterialTheme.typography.titleMedium,
               fontWeight = FontWeight.Bold,
               color = MaterialTheme.colorScheme.onBackground,
@@ -175,9 +180,7 @@ private fun PreviewSyncingFlowDark() {
 private fun PreviewShimmerStageDark() {
   MaterialTheme(colorScheme = darkColorScheme()) {
     Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
-      SyncingView(
-          previewStage = com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Shimmer(0.5f)
-      )
+      SyncingView(previewStage = Stage.Shimmer(0.5f))
     }
   }
 }
@@ -187,9 +190,7 @@ private fun PreviewShimmerStageDark() {
 private fun PreviewOscillatingStageDark() {
   MaterialTheme(colorScheme = darkColorScheme()) {
     Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
-      SyncingView(
-          previewStage = com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Oscillating(4.8f)
-      )
+      SyncingView(previewStage = Stage.Oscillating(4.8f))
     }
   }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/ContentView.kt
@@ -1,115 +1,205 @@
 package com.stablechannels.app.ui
 
-import androidx.compose.animation.core.*
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stablechannels.app.AppState
 import com.stablechannels.app.Phase
-import com.stablechannels.app.R
+import com.stablechannels.app.ui.components.UnifiedBalanceLaunchView
 
 @Composable
 fun ContentView(appState: AppState) {
+  val phase by appState.phase.collectAsState()
+  val errorMessage by appState.errorMessage.collectAsState()
 
-
-    val phase by appState.phase.collectAsState()
-    val errorMessage by appState.errorMessage.collectAsState()
-
-    when (phase) {
-        Phase.LOADING -> LoadingView()
-        Phase.ONBOARDING -> SyncingView() // Auto-create handles this
-        Phase.SYNCING -> SyncingView()
-        Phase.WALLET -> MainTabView(appState)
-        Phase.ERROR -> ErrorView(errorMessage) { appState.start() }
-    }
+  when (phase) {
+    Phase.LOADING,
+    Phase.ONBOARDING,
+    Phase.SYNCING -> SyncingView()
+    Phase.WALLET -> MainTabView(appState)
+    Phase.ERROR -> ErrorView(errorMessage) { appState.start() }
+  }
 }
 
 @Composable
-private fun PulsatingLogo() {
-    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-    val scale by infiniteTransition.animateFloat(
-        initialValue = 0.94f,
-        targetValue = 1.06f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1200, easing = EaseInOut),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "pulse_scale"
-    )
-    Image(
-        painter = painterResource(R.mipmap.ic_launcher),
-        contentDescription = "Stable Channels",
-        modifier = Modifier
-            .size(90.dp)
-            .clip(CircleShape)
-            .scale(scale)
-    )
-}
+fun SyncingView(
+    modifier: Modifier = Modifier,
+    isSyncComplete: Boolean = false,
+    previewStage: com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage? = null,
+    onBalanced: (() -> Unit)? = null,
+) {
+  val elapsedSeconds by
+      produceState(initialValue = 0f) {
+        val startNanos = withFrameNanos { it }
+        while (true) {
+          withFrameNanos { frameTimeNanos ->
+            value = (frameTimeNanos - startNanos) / 1_000_000_000f
+          }
+        }
+      }
 
-@Composable
-private fun LoadingView() {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+  val shimmerDuration = 1.15f
+  val crossfadeDuration = 0.40f
+
+  val effectiveElapsed =
+      when (previewStage) {
+        is com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Shimmer -> 0.70f
+        is com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Oscillating -> 1.65f
+        else -> elapsedSeconds
+      }
+
+  val rawProgress = ((effectiveElapsed - shimmerDuration) / crossfadeDuration).coerceIn(0f, 1f)
+  val smoothProgress = rawProgress * rawProgress * (3f - 2f * rawProgress)
+
+  Box(
+      modifier = modifier.fillMaxSize(),
+      contentAlignment = Alignment.Center,
+  ) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(22.dp),
+    ) {
+      UnifiedBalanceLaunchView(
+          isSyncComplete = isSyncComplete,
+          size = 115.dp,
+          elapsedSeconds = effectiveElapsed,
+          previewStage = previewStage,
+          onBalanced = onBalanced,
+      )
+
+      Box(
+          modifier = Modifier.fillMaxWidth().height(52.dp),
+          contentAlignment = Alignment.Center,
+      ) {
+        // Stage 1: Brand introduction during initial shimmer
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            modifier =
+                Modifier.graphicsLayer {
+                  alpha = 1f - smoothProgress
+                  translationY = -6.dp.toPx() * smoothProgress
+                },
         ) {
-            PulsatingLogo()
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Stable Channels", fontWeight = FontWeight.SemiBold)
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Self-custodial bitcoin trading",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+          Text(
+              text = "Stable Channels",
+              style = MaterialTheme.typography.titleMedium,
+              fontWeight = FontWeight.Bold,
+              color = MaterialTheme.colorScheme.onBackground,
+          )
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+              text = "Self-custodial bitcoin wallet",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
         }
-    }
-}
 
-@Composable
-private fun SyncingView() {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        // Stage 2: Active syncing status during oscillation
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            modifier =
+                Modifier.graphicsLayer {
+                  alpha = smoothProgress
+                  translationY = 6.dp.toPx() * (1f - smoothProgress)
+                },
         ) {
-            PulsatingLogo()
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                CircularProgressIndicator()
-                Spacer(Modifier.height(12.dp))
-                Text("Syncing wallet...")
-                Text(
-                    "This may take a moment",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+          Text(
+              text = "Wallet Syncing...",
+              style = MaterialTheme.typography.titleMedium,
+              fontWeight = FontWeight.Bold,
+              color = MaterialTheme.colorScheme.onBackground,
+          )
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+              text = "This may take a moment",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
         }
+      }
     }
+  }
 }
 
 @Composable
 private fun ErrorView(message: String, onRetry: () -> Unit) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(32.dp)
-        ) {
-            Text("Error", style = MaterialTheme.typography.headlineMedium)
-            Spacer(Modifier.height(8.dp))
-            Text(message, style = MaterialTheme.typography.bodyMedium)
-            Spacer(Modifier.height(16.dp))
-            Button(onClick = onRetry) { Text("Retry") }
-        }
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(32.dp),
+    ) {
+      Text("Error", style = MaterialTheme.typography.headlineMedium)
+      Spacer(Modifier.height(8.dp))
+      Text(message, style = MaterialTheme.typography.bodyMedium)
+      Spacer(Modifier.height(16.dp))
+      Button(onClick = onRetry) { Text("Retry") }
     }
+  }
+}
+
+@Preview(name = "1. App Launch Flow - Dark", showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun PreviewSyncingFlowDark() {
+  MaterialTheme(colorScheme = darkColorScheme()) {
+    Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
+      SyncingView()
+    }
+  }
+}
+
+@Preview(name = "2. Opening Shimmer Beam - Dark", showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun PreviewShimmerStageDark() {
+  MaterialTheme(colorScheme = darkColorScheme()) {
+    Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
+      SyncingView(
+          previewStage = com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Shimmer(0.5f)
+      )
+    }
+  }
+}
+
+@Preview(name = "3. Wallet Syncing Oscillation - Dark", showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun PreviewOscillatingStageDark() {
+  MaterialTheme(colorScheme = darkColorScheme()) {
+    Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
+      SyncingView(
+          previewStage = com.stablechannels.app.ui.components.BalanceScaleKinematics.Stage.Oscillating(4.8f)
+      )
+    }
+  }
+}
+
+@Preview(name = "4. App Launch Flow - Light", showBackground = true, backgroundColor = 0xFFF2F2F7)
+@Composable
+private fun PreviewSyncingFlowLight() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF2F2F7)) {
+      SyncingView()
+    }
+  }
 }

--- a/android/app/src/main/java/com/stablechannels/app/ui/components/BalanceScaleKinematics.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/BalanceScaleKinematics.kt
@@ -1,0 +1,72 @@
+package com.stablechannels.app.ui.components
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.sin
+
+class BalanceScaleKinematics(
+    val shimmerDelay: Float = 0.25f,
+    val shimmerDuration: Float = 0.90f,
+    val oscillationPeriod: Float = 2.0f,
+    val maxAngleDegrees: Float = 4.8f,
+    val settleDuration: Float = 1.2f,
+) {
+  sealed interface Stage {
+    data object Resting : Stage
+
+    data class Shimmer(val progress: Float) : Stage
+
+    data class Oscillating(val angle: Float) : Stage
+
+    data class Settling(val angle: Float) : Stage
+
+    data object Balanced : Stage
+  }
+
+  fun evaluate(
+      elapsedSinceStart: Float,
+      isSyncComplete: Boolean,
+      settleElapsed: Float?,
+  ): Stage {
+    if (isSyncComplete && settleElapsed != null) {
+      if (settleElapsed >= settleDuration) {
+        return Stage.Balanced
+      }
+      val progress = (settleElapsed / settleDuration).coerceIn(0f, 1f)
+      val envelope = exp(-3.2f * progress)
+      val oscillation = cos(3.5f * 2.0f * PI.toFloat() * progress)
+      val linearFade = 1.0f - progress
+      val angle = maxAngleDegrees * envelope * oscillation * linearFade
+      return Stage.Settling(angle)
+    }
+
+    if (elapsedSinceStart < shimmerDelay) {
+      return Stage.Resting
+    }
+
+    val shimmerElapsed = elapsedSinceStart - shimmerDelay
+    if (shimmerElapsed < shimmerDuration) {
+      val progress = shimmerElapsed / shimmerDuration
+      return Stage.Shimmer(progress)
+    }
+
+    val oscillationElapsed = shimmerElapsed - shimmerDuration
+    val cycle =
+        if (oscillationPeriod > 0f) {
+          (oscillationElapsed / oscillationPeriod) % 1.0f
+        } else {
+          0f
+        }
+    val angle = maxAngleDegrees * sin(cycle * 2.0f * PI.toFloat())
+    return Stage.Oscillating(angle)
+  }
+
+  companion object {
+    fun shimmerSweepRange(progress: Float): Pair<Float, Float> {
+      val sweep = progress * 1.8f - 0.4f
+      val bandWidth = 0.28f
+      return Pair(sweep - bandWidth, sweep + bandWidth)
+    }
+  }
+}

--- a/android/app/src/main/java/com/stablechannels/app/ui/components/BalanceScaleKinematics.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/BalanceScaleKinematics.kt
@@ -12,6 +12,9 @@ class BalanceScaleKinematics(
     val maxAngleDegrees: Float = 4.8f,
     val settleDuration: Float = 1.2f,
 ) {
+  val totalShimmerDuration: Float
+    get() = shimmerDelay + shimmerDuration
+
   sealed interface Stage {
     data object Resting : Stage
 

--- a/android/app/src/main/java/com/stablechannels/app/ui/components/UnifiedBalanceLaunchView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/UnifiedBalanceLaunchView.kt
@@ -1,0 +1,420 @@
+package com.stablechannels.app.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+private const val FULCRUM_X = 511.5f
+private const val FULCRUM_Y = 361.0f
+private const val LEFT_PIVOT_X = 273.0f
+private const val LEFT_PIVOT_Y = 361.0f
+
+private const val MARK_WIDTH = 696.4f
+private const val MARK_HEIGHT = 568.0f
+private const val MARK_MIN_X = 171.9f
+private const val MARK_MIN_Y = 210.0f
+
+val DefaultBrandColor = Color(0xFFF7931A)
+
+@Composable
+fun UnifiedBalanceLaunchView(
+    modifier: Modifier = Modifier,
+    isSyncComplete: Boolean = false,
+    size: Dp = 120.dp,
+    baseColor: Color = DefaultBrandColor,
+    elapsedSeconds: Float? = null,
+    previewStage: BalanceScaleKinematics.Stage? = null,
+    kinematics: BalanceScaleKinematics = remember { BalanceScaleKinematics() },
+    onBalanced: (() -> Unit)? = null,
+) {
+  val contentHeight = size * (MARK_HEIGHT / MARK_WIDTH)
+
+  var settleStartTime by remember { mutableStateOf<Float?>(null) }
+  var hasNotifiedBalanced by remember { mutableStateOf(false) }
+
+  val internalElapsed by
+      produceState(initialValue = 0f) {
+        val startNanos = withFrameNanos { it }
+        while (true) {
+          withFrameNanos { frameTimeNanos ->
+            value = (frameTimeNanos - startNanos) / 1_000_000_000f
+          }
+        }
+      }
+
+  val currentElapsed = elapsedSeconds ?: internalElapsed
+
+  LaunchedEffect(isSyncComplete) {
+    if (isSyncComplete && settleStartTime == null) {
+      settleStartTime = currentElapsed
+    }
+  }
+
+  val settleElapsed = settleStartTime?.let { currentElapsed - it }
+  val stage =
+      previewStage
+          ?: kinematics.evaluate(
+              elapsedSinceStart = currentElapsed,
+              isSyncComplete = isSyncComplete,
+              settleElapsed = settleElapsed,
+          )
+
+  LaunchedEffect(stage) {
+    if (stage is BalanceScaleKinematics.Stage.Balanced && !hasNotifiedBalanced) {
+      hasNotifiedBalanced = true
+      onBalanced?.invoke()
+    }
+  }
+
+  val standPath = remember { createStandPath() }
+  val beamPath = remember { createBeamPath() }
+  val panPath = remember { createPanPath() }
+  val coinPath = remember { createCoinPath() }
+  val btcPath = remember { createBtcPath() }
+
+  Box(modifier = modifier.size(size, contentHeight)) {
+    Canvas(modifier = Modifier.matchParentSize()) {
+      val sX = this.size.width / MARK_WIDTH
+      val sY = this.size.height / MARK_HEIGHT
+
+      val angleDegrees =
+          when (stage) {
+            is BalanceScaleKinematics.Stage.Resting,
+            is BalanceScaleKinematics.Stage.Balanced,
+            is BalanceScaleKinematics.Stage.Shimmer -> 0f
+            is BalanceScaleKinematics.Stage.Oscillating -> stage.angle
+            is BalanceScaleKinematics.Stage.Settling -> stage.angle
+          }
+
+      val rad = angleDegrees * (PI.toFloat() / 180f)
+      val leftArmDX = LEFT_PIVOT_X - FULCRUM_X
+      val leftPivotNewX = FULCRUM_X + leftArmDX * cos(rad)
+      val leftPivotNewY = FULCRUM_Y + leftArmDX * sin(rad)
+      val panShiftX = leftPivotNewX - LEFT_PIVOT_X
+      val panShiftY = leftPivotNewY - LEFT_PIVOT_Y
+
+      val shimmerBrush =
+          if (stage is BalanceScaleKinematics.Stage.Shimmer) {
+            val (startNorm, endNorm) = BalanceScaleKinematics.shimmerSweepRange(stage.progress)
+            val startX = MARK_MIN_X + startNorm * MARK_WIDTH
+            val startY = MARK_MIN_Y + startNorm * MARK_HEIGHT
+            val endX = MARK_MIN_X + endNorm * MARK_WIDTH
+            val endY = MARK_MIN_Y + endNorm * MARK_HEIGHT
+
+            Brush.linearGradient(
+                colorStops =
+                    arrayOf(
+                        0.0f to Color.Transparent,
+                        0.32f to Color.White.copy(alpha = 0.20f),
+                        0.50f to Color.White.copy(alpha = 0.90f),
+                        0.68f to Color.White.copy(alpha = 0.20f),
+                        1.0f to Color.Transparent,
+                    ),
+                start = Offset(startX, startY),
+                end = Offset(endX, endY),
+            )
+          } else null
+
+      // 1. Draw Stand
+      withTransform({
+        scale(sX, sY, pivot = Offset.Zero)
+        translate(-MARK_MIN_X, -MARK_MIN_Y)
+      }) {
+        drawPath(path = standPath, color = baseColor)
+        if (shimmerBrush != null) {
+          drawPath(path = standPath, brush = shimmerBrush)
+        }
+      }
+
+      // 2. Draw Beam, Coin, and BTC
+      withTransform({
+        scale(sX, sY, pivot = Offset.Zero)
+        translate(-MARK_MIN_X, -MARK_MIN_Y)
+        rotate(degrees = angleDegrees, pivot = Offset(FULCRUM_X, FULCRUM_Y))
+      }) {
+        drawPath(path = beamPath, color = baseColor)
+        drawPath(path = coinPath, color = baseColor)
+        drawPath(path = btcPath, color = baseColor)
+
+        if (shimmerBrush != null) {
+          drawPath(path = beamPath, brush = shimmerBrush)
+          drawPath(path = coinPath, brush = shimmerBrush)
+          drawPath(path = btcPath, brush = shimmerBrush)
+        }
+      }
+
+      // 3. Draw Hanging Pan
+      withTransform({
+        scale(sX, sY, pivot = Offset.Zero)
+        translate(-MARK_MIN_X, -MARK_MIN_Y)
+        translate(panShiftX, panShiftY)
+      }) {
+        drawPath(path = panPath, color = baseColor)
+        if (shimmerBrush != null) {
+          drawPath(path = panPath, brush = shimmerBrush)
+        }
+      }
+    }
+  }
+}
+
+private fun createStandPath(): Path =
+    Path().apply {
+      fillType = PathFillType.EvenOdd
+      moveTo(519.5f, 352.5f)
+      lineTo(519.2f, 334.2f)
+      cubicTo(519.0f, 318.2f, 519.1f, 316.0f, 520.5f, 316.0f)
+      cubicTo(521.4f, 316.0f, 523.5f, 315.3f, 525.3f, 314.4f)
+      cubicTo(531.8f, 311.1f, 535.8f, 306.9f, 539.2f, 300.3f)
+      cubicTo(542.3f, 294.1f, 542.5f, 293.0f, 542.5f, 283.6f)
+      cubicTo(542.5f, 272.3f, 540.9f, 267.4f, 535.0f, 260.7f)
+      cubicTo(529.3f, 254.2f, 523.9f, 251.7f, 514.5f, 251.2f)
+      cubicTo(500.1f, 250.4f, 490.1f, 255.9f, 484.3f, 267.8f)
+      cubicTo(481.8f, 272.9f, 481.5f, 274.5f, 481.5f, 284.0f)
+      cubicTo(481.5f, 293.1f, 481.8f, 295.2f, 483.9f, 299.5f)
+      cubicTo(487.2f, 306.1f, 493.6f, 312.3f, 499.3f, 314.5f)
+      lineTo(504.0f, 316.3f)
+      lineTo(504.0f, 334.6f)
+      lineTo(504.0f, 353.0f)
+      lineTo(504.0f, 369.0f)
+      lineTo(504.0f, 565.5f)
+      lineTo(504.0f, 762.0f)
+      lineTo(421.6f, 762.0f)
+      cubicTo(348.0f, 762.0f, 339.0f, 762.2f, 337.6f, 763.6f)
+      cubicTo(335.7f, 765.5f, 335.4f, 774.0f, 337.2f, 775.8f)
+      cubicTo(338.1f, 776.7f, 378.2f, 777.0f, 511.6f, 777.0f)
+      cubicTo(706.3f, 777.0f, 688.0f, 777.8f, 688.0f, 769.1f)
+      cubicTo(688.0f, 766.5f, 687.5f, 763.9f, 686.8f, 763.2f)
+      cubicTo(685.9f, 762.3f, 665.8f, 762.0f, 602.3f, 762.0f)
+      lineTo(519.0f, 762.0f)
+      lineTo(519.0f, 565.5f)
+      lineTo(519.0f, 369.0f)
+      lineTo(519.5f, 352.5f)
+      close()
+    }
+
+private fun createBeamPath(): Path =
+    Path().apply {
+      fillType = PathFillType.EvenOdd
+      moveTo(270.0f, 353.0f)
+      lineTo(630.0f, 353.0f)
+      lineTo(630.0f, 369.0f)
+      lineTo(270.0f, 369.0f)
+      close()
+    }
+
+private fun createPanPath(): Path =
+    Path().apply {
+      fillType = PathFillType.EvenOdd
+      moveTo(273.0f, 361.0f)
+      lineTo(265.1f, 353.0f)
+      lineTo(262.6f, 355.2f)
+      cubicTo(261.3f, 356.5f, 244.1f, 387.9f, 224.4f, 425.0f)
+      cubicTo(171.9f, 524.2f, 176.0f, 516.0f, 176.0f, 521.4f)
+      cubicTo(176.0f, 533.2f, 186.3f, 551.5f, 201.0f, 565.9f)
+      cubicTo(207.1f, 571.8f, 223.4f, 582.4f, 230.7f, 585.1f)
+      cubicTo(247.7f, 591.3f, 247.3f, 591.2f, 267.0f, 591.1f)
+      cubicTo(277.2f, 591.1f, 287.8f, 590.6f, 290.5f, 590.1f)
+      cubicTo(299.7f, 588.4f, 313.3f, 582.5f, 323.0f, 576.0f)
+      cubicTo(330.9f, 570.7f, 345.8f, 556.0f, 349.0f, 550.2f)
+      cubicTo(350.3f, 547.9f, 351.7f, 546.0f, 352.1f, 546.0f)
+      cubicTo(352.5f, 546.0f, 353.2f, 545.0f, 353.6f, 543.7f)
+      cubicTo(353.9f, 542.5f, 355.5f, 538.9f, 357.1f, 535.6f)
+      cubicTo(359.6f, 530.7f, 360.0f, 528.6f, 360.0f, 521.8f)
+      cubicTo(360.0f, 514.2f, 358.2f, 508.0f, 356.1f, 508.0f)
+      cubicTo(355.6f, 508.0f, 354.9f, 506.7f, 354.5f, 505.0f)
+      cubicTo(354.1f, 503.4f, 352.8f, 500.5f, 351.5f, 498.6f)
+      cubicTo(350.2f, 496.7f, 348.2f, 493.2f, 347.0f, 490.8f)
+      cubicTo(345.8f, 488.4f, 343.2f, 483.3f, 341.1f, 479.5f)
+      cubicTo(339.0f, 475.6f, 335.9f, 469.8f, 334.1f, 466.5f)
+      cubicTo(332.4f, 463.2f, 329.7f, 458.2f, 328.1f, 455.5f)
+      cubicTo(326.5f, 452.7f, 324.3f, 448.7f, 323.1f, 446.5f)
+      cubicTo(321.9f, 444.3f, 319.5f, 439.8f, 317.6f, 436.5f)
+      cubicTo(315.8f, 433.2f, 313.1f, 428.2f, 311.6f, 425.5f)
+      cubicTo(310.2f, 422.7f, 307.5f, 417.8f, 305.6f, 414.5f)
+      cubicTo(303.8f, 411.2f, 300.8f, 405.8f, 299.1f, 402.5f)
+      cubicTo(297.3f, 399.2f, 294.6f, 394.2f, 293.0f, 391.5f)
+      cubicTo(291.4f, 388.7f, 289.1f, 384.5f, 288.0f, 382.0f)
+      cubicTo(286.8f, 379.5f, 285.3f, 376.8f, 284.6f, 376.0f)
+      cubicTo(283.9f, 375.2f, 282.9f, 373.3f, 282.2f, 371.7f)
+      lineTo(281.0f, 369.0f)
+      lineTo(273.0f, 361.0f)
+      close()
+      moveTo(269.8f, 386.3f)
+      cubicTo(271.1f, 388.6f, 277.8f, 400.8f, 284.7f, 413.5f)
+      cubicTo(291.6f, 426.1f, 301.2f, 443.7f, 306.0f, 452.5f)
+      cubicTo(331.6f, 499.2f, 339.0f, 512.9f, 339.0f, 513.4f)
+      cubicTo(339.0f, 513.7f, 307.0f, 514.0f, 268.0f, 514.0f)
+      lineTo(197.0f, 514.0f)
+      lineTo(198.2f, 511.8f)
+      cubicTo(198.9f, 510.6f, 199.8f, 509.1f, 200.2f, 508.6f)
+      cubicTo(200.6f, 508.0f, 206.8f, 495.8f, 214.0f, 481.5f)
+      cubicTo(221.2f, 467.3f, 227.4f, 455.3f, 227.8f, 455.0f)
+      cubicTo(228.2f, 454.7f, 230.5f, 450.6f, 232.7f, 445.8f)
+      cubicTo(235.0f, 441.0f, 237.4f, 436.5f, 238.0f, 435.8f)
+      cubicTo(238.5f, 435.1f, 242.2f, 428.2f, 246.1f, 420.5f)
+      cubicTo(250.0f, 412.8f, 253.6f, 406.3f, 254.0f, 406.0f)
+      cubicTo(254.4f, 405.7f, 256.6f, 401.5f, 259.0f, 396.6f)
+      cubicTo(261.3f, 391.6f, 263.9f, 387.0f, 264.6f, 386.2f)
+      cubicTo(265.4f, 385.5f, 266.0f, 384.2f, 266.0f, 383.4f)
+      cubicTo(266.0f, 380.9f, 267.5f, 381.9f, 269.8f, 386.3f)
+      moveTo(341.0f, 529.9f)
+      cubicTo(341.0f, 531.9f, 330.3f, 546.8f, 325.1f, 552.1f)
+      cubicTo(318.2f, 559.0f, 306.0f, 567.1f, 298.2f, 570.0f)
+      cubicTo(286.3f, 574.5f, 280.9f, 575.5f, 268.5f, 575.4f)
+      cubicTo(258.3f, 575.3f, 255.2f, 574.9f, 248.0f, 572.5f)
+      cubicTo(237.8f, 569.3f, 228.6f, 564.6f, 220.5f, 558.5f)
+      cubicTo(211.7f, 552.0f, 210.0f, 550.4f, 206.8f, 545.4f)
+      cubicTo(205.1f, 543.0f, 203.4f, 541.0f, 202.9f, 541.0f)
+      cubicTo(202.4f, 541.0f, 202.0f, 540.6f, 202.0f, 540.0f)
+      cubicTo(202.0f, 539.5f, 200.9f, 537.4f, 199.5f, 535.4f)
+      cubicTo(198.1f, 533.4f, 197.0f, 531.1f, 197.0f, 530.4f)
+      cubicTo(197.0f, 529.2f, 208.9f, 529.0f, 269.0f, 529.0f)
+      cubicTo(309.3f, 529.0f, 341.0f, 529.4f, 341.0f, 529.9f)
+    }
+
+private fun createCoinPath(): Path =
+    Path().apply {
+      fillType = PathFillType.EvenOdd
+      moveTo(630.0f, 361.0f)
+      lineTo(630.4f, 377.2f)
+      cubicTo(633.0f, 408.4f, 651.0f, 439.6f, 678.0f, 459.7f)
+      cubicTo(684.7f, 464.7f, 698.9f, 472.2f, 705.0f, 473.9f)
+      cubicTo(707.5f, 474.6f, 710.4f, 475.7f, 711.5f, 476.3f)
+      cubicTo(712.6f, 476.9f, 715.3f, 477.7f, 717.5f, 478.1f)
+      cubicTo(719.7f, 478.5f, 723.5f, 479.4f, 726.0f, 480.0f)
+      cubicTo(731.8f, 481.5f, 758.4f, 481.7f, 767.5f, 480.3f)
+      cubicTo(779.8f, 478.3f, 792.5f, 473.8f, 807.4f, 466.2f)
+      cubicTo(820.7f, 459.3f, 837.4f, 443.5f, 847.2f, 428.5f)
+      cubicTo(850.4f, 423.5f, 853.7f, 418.6f, 854.5f, 417.5f)
+      cubicTo(855.3f, 416.5f, 856.0f, 415.1f, 856.0f, 414.5f)
+      cubicTo(856.0f, 413.9f, 856.9f, 411.8f, 858.0f, 409.7f)
+      cubicTo(859.1f, 407.7f, 860.0f, 405.2f, 860.0f, 404.3f)
+      cubicTo(860.0f, 403.4f, 860.8f, 400.8f, 861.9f, 398.6f)
+      cubicTo(862.9f, 396.3f, 864.2f, 391.6f, 864.9f, 388.0f)
+      cubicTo(865.5f, 384.4f, 866.5f, 379.0f, 867.0f, 376.0f)
+      cubicTo(868.3f, 368.6f, 867.4f, 345.9f, 865.5f, 338.5f)
+      cubicTo(864.6f, 335.2f, 863.5f, 330.7f, 863.0f, 328.5f)
+      cubicTo(861.8f, 323.1f, 855.5f, 308.2f, 853.3f, 305.6f)
+      cubicTo(852.3f, 304.4f, 850.6f, 301.8f, 849.6f, 299.8f)
+      cubicTo(848.6f, 297.8f, 847.0f, 295.3f, 846.1f, 294.3f)
+      cubicTo(845.2f, 293.3f, 843.2f, 290.6f, 841.7f, 288.4f)
+      cubicTo(838.8f, 284.1f, 823.6f, 269.0f, 822.2f, 269.0f)
+      cubicTo(821.7f, 269.0f, 819.9f, 267.7f, 818.0f, 266.0f)
+      cubicTo(814.3f, 262.7f, 800.6f, 255.4f, 792.0f, 252.1f)
+      cubicTo(783.1f, 248.7f, 772.2f, 246.2f, 761.1f, 245.1f)
+      cubicTo(748.4f, 243.8f, 742.1f, 243.8f, 730.5f, 245.5f)
+      cubicTo(713.6f, 247.8f, 700.6f, 252.4f, 686.7f, 260.7f)
+      cubicTo(656.6f, 278.8f, 635.8f, 310.3f, 630.8f, 345.3f)
+      lineTo(629.7f, 353.0f)
+      lineTo(630.0f, 361.0f)
+      close()
+      moveTo(760.0f, 261.9f)
+      cubicTo(774.6f, 264.0f, 777.1f, 264.9f, 792.5f, 272.3f)
+      cubicTo(804.6f, 278.2f, 809.0f, 281.2f, 819.0f, 291.0f)
+      cubicTo(833.7f, 305.3f, 842.6f, 320.5f, 847.7f, 339.9f)
+      cubicTo(850.8f, 351.8f, 851.2f, 370.2f, 848.6f, 381.8f)
+      cubicTo(846.2f, 392.5f, 840.9f, 405.9f, 835.4f, 415.2f)
+      cubicTo(829.6f, 424.8f, 813.6f, 441.6f, 804.5f, 447.5f)
+      cubicTo(772.5f, 468.3f, 736.9f, 470.6f, 703.9f, 454.0f)
+      cubicTo(674.7f, 439.2f, 654.4f, 412.2f, 648.6f, 380.0f)
+      cubicTo(646.3f, 367.4f, 646.6f, 345.2f, 649.1f, 342.5f)
+      cubicTo(649.6f, 342.0f, 650.0f, 340.3f, 650.0f, 338.8f)
+      cubicTo(650.0f, 334.7f, 654.1f, 323.6f, 659.1f, 314.1f)
+      cubicTo(664.2f, 304.6f, 673.7f, 292.6f, 681.8f, 285.6f)
+      cubicTo(688.8f, 279.7f, 700.3f, 272.0f, 702.4f, 272.0f)
+      cubicTo(703.2f, 272.0f, 704.5f, 271.4f, 705.2f, 270.7f)
+      cubicTo(707.5f, 268.4f, 719.2f, 264.7f, 730.0f, 262.9f)
+      cubicTo(734.1f, 262.2f, 738.2f, 261.3f, 739.0f, 260.8f)
+      cubicTo(740.6f, 259.9f, 749.2f, 260.4f, 760.0f, 261.9f)
+    }
+
+private fun createBtcPath(): Path =
+    Path().apply {
+      fillType = PathFillType.EvenOdd
+      moveTo(750.0f, 288.0f)
+      cubicTo(748.3f, 289.7f, 748.0f, 291.3f, 748.0f, 298.5f)
+      lineTo(748.0f, 307.0f)
+      lineTo(745.0f, 307.0f)
+      lineTo(742.0f, 307.0f)
+      lineTo(742.0f, 298.6f)
+      cubicTo(742.0f, 288.1f, 741.2f, 287.0f, 733.0f, 287.0f)
+      cubicTo(724.8f, 287.0f, 724.0f, 288.1f, 724.0f, 298.6f)
+      lineTo(724.0f, 307.0f)
+      lineTo(713.9f, 307.0f)
+      cubicTo(708.4f, 307.0f, 703.0f, 307.4f, 702.0f, 308.0f)
+      cubicTo(698.4f, 310.0f, 696.8f, 318.9f, 699.6f, 322.5f)
+      cubicTo(700.8f, 324.1f, 702.6f, 324.6f, 709.3f, 325.0f)
+      lineTo(717.5f, 325.5f)
+      lineTo(717.8f, 364.2f)
+      lineTo(718.0f, 403.0f)
+      lineTo(710.6f, 403.0f)
+      cubicTo(701.2f, 403.0f, 700.0f, 404.0f, 700.0f, 412.0f)
+      cubicTo(700.0f, 420.4f, 700.8f, 421.0f, 713.6f, 421.0f)
+      lineTo(724.0f, 421.0f)
+      lineTo(724.0f, 429.9f)
+      cubicTo(724.0f, 440.8f, 724.8f, 442.0f, 732.3f, 442.0f)
+      cubicTo(735.2f, 442.0f, 738.0f, 441.6f, 738.6f, 441.2f)
+      cubicTo(741.0f, 439.7f, 742.0f, 435.8f, 742.0f, 428.6f)
+      lineTo(742.0f, 421.0f)
+      lineTo(745.0f, 421.0f)
+      lineTo(748.0f, 421.0f)
+      lineTo(748.0f, 429.4f)
+      cubicTo(748.0f, 437.0f, 748.2f, 438.0f, 750.2f, 439.4f)
+      cubicTo(751.6f, 440.4f, 754.6f, 441.0f, 757.7f, 441.0f)
+      cubicTo(765.6f, 441.0f, 767.0f, 439.1f, 767.0f, 429.1f)
+      lineTo(767.0f, 421.1f)
+      lineTo(772.8f, 420.0f)
+      cubicTo(780.9f, 418.4f, 783.8f, 417.3f, 789.5f, 413.9f)
+      cubicTo(794.6f, 410.8f, 797.7f, 406.1f, 799.5f, 398.7f)
+      cubicTo(799.9f, 397.2f, 800.6f, 395.7f, 801.1f, 395.4f)
+      cubicTo(802.3f, 394.7f, 802.2f, 380.3f, 801.0f, 379.5f)
+      cubicTo(800.5f, 379.2f, 800.0f, 377.8f, 800.0f, 376.4f)
+      cubicTo(800.0f, 372.9f, 797.5f, 368.4f, 792.4f, 363.0f)
+      cubicTo(789.4f, 359.8f, 788.2f, 357.7f, 788.6f, 356.6f)
+      cubicTo(788.9f, 355.7f, 789.6f, 355.0f, 790.1f, 355.0f)
+      cubicTo(793.1f, 355.0f, 794.9f, 331.5f, 792.4f, 325.4f)
+      cubicTo(790.9f, 321.9f, 788.3f, 318.5f, 784.0f, 314.3f)
+      cubicTo(781.4f, 311.8f, 772.3f, 308.0f, 769.0f, 308.0f)
+      cubicTo(767.2f, 308.0f, 767.0f, 307.3f, 767.0f, 299.2f)
+      cubicTo(767.0f, 294.4f, 766.6f, 290.0f, 766.2f, 289.4f)
+      cubicTo(763.7f, 285.6f, 753.3f, 284.7f, 750.0f, 288.0f)
+      moveTo(766.6f, 328.0f)
+      cubicTo(769.5f, 329.4f, 771.4f, 331.4f, 773.0f, 334.4f)
+      cubicTo(775.6f, 339.2f, 775.3f, 342.1f, 771.9f, 346.4f)
+      cubicTo(768.0f, 351.4f, 764.8f, 352.3f, 749.5f, 352.4f)
+      lineTo(735.5f, 352.5f)
+      lineTo(735.2f, 339.2f)
+      lineTo(734.9f, 326.0f)
+      lineTo(748.7f, 326.0f)
+      cubicTo(760.4f, 326.0f, 763.0f, 326.3f, 766.6f, 328.0f)
+      moveTo(776.5f, 376.0f)
+      cubicTo(783.6f, 382.8f, 784.6f, 388.5f, 780.0f, 395.0f)
+      cubicTo(775.6f, 401.2f, 771.4f, 402.3f, 752.3f, 402.8f)
+      lineTo(735.0f, 403.2f)
+      lineTo(735.0f, 387.5f)
+      lineTo(735.0f, 371.8f)
+      lineTo(753.9f, 372.2f)
+      lineTo(772.9f, 372.5f)
+      lineTo(776.5f, 376.0f)
+    }

--- a/android/app/src/main/java/com/stablechannels/app/ui/components/UnifiedBalanceLaunchView.kt
+++ b/android/app/src/main/java/com/stablechannels/app/ui/components/UnifiedBalanceLaunchView.kt
@@ -53,7 +53,8 @@ fun UnifiedBalanceLaunchView(
   var hasNotifiedBalanced by remember { mutableStateOf(false) }
 
   val internalElapsed by
-      produceState(initialValue = 0f) {
+      produceState(initialValue = 0f, key1 = elapsedSeconds) {
+        if (elapsedSeconds != null) return@produceState
         val startNanos = withFrameNanos { it }
         while (true) {
           withFrameNanos { frameTimeNanos ->
@@ -79,8 +80,9 @@ fun UnifiedBalanceLaunchView(
               settleElapsed = settleElapsed,
           )
 
-  LaunchedEffect(stage) {
-    if (stage is BalanceScaleKinematics.Stage.Balanced && !hasNotifiedBalanced) {
+  val isBalanced = stage is BalanceScaleKinematics.Stage.Balanced
+  LaunchedEffect(isBalanced) {
+    if (isBalanced && !hasNotifiedBalanced) {
       hasNotifiedBalanced = true
       onBalanced?.invoke()
     }

--- a/android/app/src/test/java/com/stablechannels/app/ui/components/BalanceScaleKinematicsTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/ui/components/BalanceScaleKinematicsTest.kt
@@ -1,0 +1,64 @@
+package com.stablechannels.app.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class BalanceScaleKinematicsTest {
+    private val kinematics = BalanceScaleKinematics()
+
+    @Test
+    fun testInitialStageIsResting() {
+        val stage = kinematics.evaluate(
+            elapsedSinceStart = 0.10f,
+            isSyncComplete = false,
+            settleElapsed = null
+        )
+        assertEquals(BalanceScaleKinematics.Stage.Resting, stage)
+    }
+
+    @Test
+    fun testShimmerStageProgression() {
+        // Shimmer begins at 0.25s
+        val startStage = kinematics.evaluate(0.25f, false, null)
+        assertTrue(startStage is BalanceScaleKinematics.Stage.Shimmer)
+        assertEquals(0.0f, (startStage as BalanceScaleKinematics.Stage.Shimmer).progress, 0.001f)
+
+        // Mid-shimmer at 0.70s (0.45s elapsed in 0.90s duration)
+        val midStage = kinematics.evaluate(0.70f, false, null)
+        assertTrue(midStage is BalanceScaleKinematics.Stage.Shimmer)
+        assertEquals(0.5f, (midStage as BalanceScaleKinematics.Stage.Shimmer).progress, 0.01f)
+    }
+
+    @Test
+    fun testOscillationStage() {
+        // Oscillation begins at 1.15s (0.25s + 0.90s)
+        val stage = kinematics.evaluate(1.15f, false, null)
+        assertTrue(stage is BalanceScaleKinematics.Stage.Oscillating)
+        assertEquals(0.0f, (stage as BalanceScaleKinematics.Stage.Oscillating).angle, 0.01f)
+
+        // Peak quarter cycle (1.15s + 0.50s = 1.65s)
+        val peakStage = kinematics.evaluate(1.65f, false, null)
+        assertTrue(peakStage is BalanceScaleKinematics.Stage.Oscillating)
+        assertEquals(4.8f, (peakStage as BalanceScaleKinematics.Stage.Oscillating).angle, 0.1f)
+    }
+
+    @Test
+    fun testSettlingStageAndBalanced() {
+        val settlingStage = kinematics.evaluate(2.0f, true, 0.6f)
+        assertTrue(settlingStage is BalanceScaleKinematics.Stage.Settling)
+        val settlingAngle = (settlingStage as BalanceScaleKinematics.Stage.Settling).angle
+        assertTrue(abs(settlingAngle) < 4.8f)
+
+        val balancedStage = kinematics.evaluate(2.0f, true, 1.2f)
+        assertEquals(BalanceScaleKinematics.Stage.Balanced, balancedStage)
+    }
+
+    @Test
+    fun testShimmerSweepRange() {
+        val (start, end) = BalanceScaleKinematics.shimmerSweepRange(0.5f)
+        assertEquals(0.5f * 1.8f - 0.4f - 0.28f, start, 0.001f)
+        assertEquals(0.5f * 1.8f - 0.4f + 0.28f, end, 0.001f)
+    }
+}

--- a/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
+++ b/ios/StableChannels/StableChannels.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		3DBEBB9A611388A35C38F1D2 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623F41D841B312F0C9AE01E6 /* MainTabView.swift */; };
 		3E46529F1181F2F866A0A495 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3940DC5406ABC63AA090441A /* DatabaseService.swift */; };
 		490224CC302F90A500DF84AA /* PriceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490224CB302F90A500DF84AA /* PriceServiceTests.swift */; };
+		4904A0903055544100582069 /* UnifiedBalanceLaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904A08F3055544100582069 /* UnifiedBalanceLaunchView.swift */; };
+		4904A0913055544100582069 /* BalanceScaleKinematics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904A08B3055544100582069 /* BalanceScaleKinematics.swift */; };
 		490A1335304F1467005CDA39 /* SpliceBroadcastChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490A1332304F1467005CDA39 /* SpliceBroadcastChecker.swift */; };
 		490A1339304F147D005CDA39 /* SpliceBroadcastCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490A1336304F147D005CDA39 /* SpliceBroadcastCheckerTests.swift */; };
 		490A133B304F147D005CDA39 /* TradeSyncParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490A1338304F147D005CDA39 /* TradeSyncParityTests.swift */; };
@@ -210,6 +212,8 @@
 		445B52C4DEC5CE8D3B0B3DA9 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		45B3E864653E657FB0FCA3D2 /* Trade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trade.swift; sourceTree = "<group>"; };
 		490224CB302F90A500DF84AA /* PriceServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceServiceTests.swift; sourceTree = "<group>"; };
+		4904A08B3055544100582069 /* BalanceScaleKinematics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceScaleKinematics.swift; sourceTree = "<group>"; };
+		4904A08F3055544100582069 /* UnifiedBalanceLaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedBalanceLaunchView.swift; sourceTree = "<group>"; };
 		490A1332304F1467005CDA39 /* SpliceBroadcastChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpliceBroadcastChecker.swift; sourceTree = "<group>"; };
 		490A1336304F147D005CDA39 /* SpliceBroadcastCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpliceBroadcastCheckerTests.swift; sourceTree = "<group>"; };
 		490A1338304F147D005CDA39 /* TradeSyncParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradeSyncParityTests.swift; sourceTree = "<group>"; };
@@ -582,6 +586,7 @@
 		49FC3EEC2FDC8B200054CD38 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				4904A08B3055544100582069 /* BalanceScaleKinematics.swift */,
 				49BB390B0000000000000001 /* CurveProgressIndicator.swift */,
 				49E4567F2FCC596F00B0CA85 /* FullscreenQRZoomView.swift */,
 				496A44412FCD4F75005AF12F /* QRCodeExtractor.swift */,
@@ -589,6 +594,7 @@
 				496A44422FCD4F75005AF12F /* QRInputToolbar.swift */,
 				4983BC9A2FCCA2B800E3B378 /* ShareableQRGenerator.swift */,
 				4980E2872FCD0EB5009B5A3E /* ShareSheetPresenter.swift */,
+				4904A08F3055544100582069 /* UnifiedBalanceLaunchView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1005,6 +1011,8 @@
 				06C3B1697681F176DD44C146 /* StableChannelsApp.swift in Sources */,
 				49F0B0DE2FC0EF3A003A3B89 /* BackupSettingsView.swift in Sources */,
 				499DBE7B2FD2F06F003E89F9 /* TxidLinkStore.swift in Sources */,
+				4904A0903055544100582069 /* UnifiedBalanceLaunchView.swift in Sources */,
+				4904A0913055544100582069 /* BalanceScaleKinematics.swift in Sources */,
 				499DBE7C2FD2F06F003E89F9 /* DepositRecorder.swift in Sources */,
 				49F0B0DF2FC0EF3A003A3B89 /* ChannelSettingsView.swift in Sources */,
 				49F0B0E02FC0EF3A003A3B89 /* NodeSettingsView.swift in Sources */,

--- a/ios/StableChannels/StableChannels/App/ContentView.swift
+++ b/ios/StableChannels/StableChannels/App/ContentView.swift
@@ -166,7 +166,8 @@ struct SyncingView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var startTime: Double = 0.0
 
-    private let shimmerDuration: Double = 1.15
+    private let kinematics = BalanceScaleKinematics()
+    private var shimmerDuration: Double { kinematics.totalShimmerDuration }
     private let crossfadeDuration: Double = 0.40
 
     var body: some View {
@@ -198,7 +199,7 @@ struct SyncingView: View {
                             .font(.title3.weight(.bold))
                             .foregroundStyle(.primary)
 
-                        Text(String(localized: "custody_subtitle", defaultValue: "Self-custodial bitcoin wallet"))
+                        Text(String(localized: "app_subtitle", defaultValue: "Self-custodial bitcoin wallet"))
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
@@ -208,7 +209,7 @@ struct SyncingView: View {
 
                     // Screen 2: Active syncing status during oscillation
                     VStack(spacing: 6) {
-                        Text(String(localized: "status_syncing_wallet", defaultValue: "Wallet Syncing..."))
+                        Text(String(localized: "status_syncing_wallet", defaultValue: "Syncing Wallet"))
                             .font(.title3.weight(.bold))
                             .foregroundStyle(.primary)
 

--- a/ios/StableChannels/StableChannels/App/ContentView.swift
+++ b/ios/StableChannels/StableChannels/App/ContentView.swift
@@ -25,11 +25,7 @@ struct ContentView: View {
     var body: some View {
         ZStack {
             switch appState.phase {
-            case .loading:
-                LoadingView()
-            case .onboarding:
-                SyncingView()
-            case .syncing:
+            case .loading, .onboarding, .syncing:
                 SyncingView()
             case .wallet:
                 MainTabView()
@@ -163,53 +159,76 @@ struct ContentView: View {
 
 // MARK: - Views
 
-struct LoadingView: View {
-    @State private var pulse = false
-
-    var body: some View {
-        VStack(spacing: 24) {
-            Image("SplashIcon")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 90, height: 90)
-                .clipShape(Circle())
-                .scaleEffect(pulse ? 1.06 : 0.94)
-                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: pulse)
-                .onAppear { pulse = true }
-
-            VStack(spacing: 4) {
-                Text(String(localized: "app_name", defaultValue: "Stable Channels"))
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(.primary)
-                Text(String(localized: "app_subtitle", defaultValue: "Self-custodial bitcoin trading"))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-        }
-    }
-}
-
 struct SyncingView: View {
-    @State private var pulse = false
+    var isSyncComplete: Bool = false
+    var onBalanced: (() -> Void)?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var startTime: Double = 0.0
+
+    private let shimmerDuration: Double = 1.15
+    private let crossfadeDuration: Double = 0.40
 
     var body: some View {
-        VStack(spacing: 24) {
-            Image("SplashIcon")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 90, height: 90)
-                .clipShape(Circle())
-                .scaleEffect(pulse ? 1.06 : 0.94)
-                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: pulse)
-                .onAppear { pulse = true }
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+            let now = timeline.date.timeIntervalSinceReferenceDate
+            let effectiveStart = startTime == 0.0 ? now : startTime
+            let elapsed = max(0.0, now - effectiveStart)
 
-            VStack(spacing: 12) {
-                ProgressView()
-                Text(String(localized: "status_syncing_wallet", defaultValue: "Syncing wallet..."))
-                    .foregroundStyle(.secondary)
-                Text(String(localized: "status_syncing_moment", defaultValue: "This may take a moment"))
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+            let rawProgress = reduceMotion
+                ? (elapsed >= shimmerDuration ? 1.0 : 0.0)
+                : max(0.0, min(1.0, (elapsed - shimmerDuration) / crossfadeDuration))
+
+            // Smoothstep curve for seamless organic crossfade
+            let smoothProgress = rawProgress * rawProgress * (3.0 - 2.0 * rawProgress)
+
+            VStack(spacing: 22) {
+                Spacer()
+
+                UnifiedBalanceLaunchView(
+                    isSyncComplete: isSyncComplete,
+                    size: 115,
+                    onBalanced: onBalanced
+                )
+
+                ZStack {
+                    // Screen 1: Brand title & subtitle during initial shimmer
+                    VStack(spacing: 6) {
+                        Text(String(localized: "app_name", defaultValue: "Stable Channels"))
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(.primary)
+
+                        Text(String(localized: "custody_subtitle", defaultValue: "Self-custodial bitcoin wallet"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .opacity(1.0 - smoothProgress)
+                    .offset(y: reduceMotion ? 0 : -6.0 * smoothProgress)
+                    .allowsHitTesting(smoothProgress < 0.5)
+
+                    // Screen 2: Active syncing status during oscillation
+                    VStack(spacing: 6) {
+                        Text(String(localized: "status_syncing_wallet", defaultValue: "Wallet Syncing..."))
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(.primary)
+
+                        Text(String(localized: "status_syncing_moment", defaultValue: "This may take a moment"))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .opacity(smoothProgress)
+                    .offset(y: reduceMotion ? 0 : 6.0 * (1.0 - smoothProgress))
+                    .allowsHitTesting(smoothProgress >= 0.5)
+                }
+                .frame(minHeight: 52)
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            if startTime == 0.0 {
+                startTime = Date().timeIntervalSinceReferenceDate
             }
         }
     }
@@ -255,5 +274,58 @@ struct PrivacyOverlayModifier: ViewModifier {
                         .zIndex(999)
                 }
             }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("App Launch Flow - Dark") {
+    SyncingFlowPreviewContainer()
+        .preferredColorScheme(.dark)
+}
+
+#Preview("App Launch Flow - Light") {
+    SyncingFlowPreviewContainer()
+        .preferredColorScheme(.light)
+}
+
+private struct SyncingFlowPreviewContainer: View {
+    @State private var replayId = UUID()
+    @State private var isSyncComplete = false
+
+    var body: some View {
+        ZStack {
+            SyncingView(isSyncComplete: isSyncComplete)
+                .id(replayId)
+
+            VStack {
+                Spacer()
+
+                HStack(spacing: 16) {
+                    Button {
+                        isSyncComplete = false
+                        replayId = UUID()
+                    } label: {
+                        Label(
+                            String(localized: "preview_replay", defaultValue: "Replay Flow"),
+                            systemImage: "arrow.counterclockwise"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        isSyncComplete.toggle()
+                    } label: {
+                        Text(
+                            isSyncComplete
+                                ? String(localized: "preview_reset_sync", defaultValue: "Reset Sync")
+                                : String(localized: "preview_complete_sync", defaultValue: "Complete Sync")
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(.bottom, 32)
+            }
+        }
     }
 }

--- a/ios/StableChannels/StableChannels/Components/BalanceScaleKinematics.swift
+++ b/ios/StableChannels/StableChannels/Components/BalanceScaleKinematics.swift
@@ -1,0 +1,81 @@
+//  Pure functional kinematics engine for the unified balance scale launch animation.
+//  Encapsulates time-to-angle mapping, shimmer sweep calculation, and harmonic damping.
+//
+
+import Foundation
+
+public struct BalanceScaleKinematics: Sendable {
+    public enum Stage: Equatable, Sendable {
+        case resting
+        case shimmer(progress: Double)
+        case oscillating(angle: Double)
+        case settling(angle: Double)
+        case balanced
+    }
+
+    public let shimmerDelay: Double
+    public let shimmerDuration: Double
+    public let oscillationPeriod: Double
+    public let maxAngleDegrees: Double
+    public let settleDuration: Double
+
+    public init(
+        shimmerDelay: Double = 0.25,
+        shimmerDuration: Double = 0.90,
+        oscillationPeriod: Double = 2.0,
+        maxAngleDegrees: Double = 4.8,
+        settleDuration: Double = 1.2
+    ) {
+        self.shimmerDelay = shimmerDelay
+        self.shimmerDuration = shimmerDuration
+        self.oscillationPeriod = oscillationPeriod
+        self.maxAngleDegrees = maxAngleDegrees
+        self.settleDuration = settleDuration
+    }
+
+    public func evaluate(
+        elapsedSinceStart: Double,
+        isSyncComplete: Bool,
+        settleElapsed: Double?
+    ) -> Stage {
+        // Stage 4: Settling requested upon sync completion
+        if isSyncComplete, let settleElapsed {
+            if settleElapsed >= settleDuration {
+                return .balanced
+            }
+            let progress = max(0.0, min(1.0, settleElapsed / settleDuration))
+            let envelope = exp(-3.2 * progress)
+            let oscillation = cos(3.5 * 2.0 * .pi * progress)
+            let linearFade = 1.0 - progress
+            let angle = maxAngleDegrees * envelope * oscillation * linearFade
+            return .settling(angle: angle)
+        }
+
+        // Stage 1: Initial resting display
+        if elapsedSinceStart < shimmerDelay {
+            return .resting
+        }
+
+        // Stage 2: Single luminous wake-up shimmer sweep
+        let shimmerElapsed = elapsedSinceStart - shimmerDelay
+        if shimmerElapsed < shimmerDuration {
+            let progress = shimmerElapsed / shimmerDuration
+            return .shimmer(progress: progress)
+        }
+
+        // Stage 3: Continuous harmonic balance oscillation
+        let oscillationElapsed = shimmerElapsed - shimmerDuration
+        let cycle = oscillationPeriod > 0
+            ? (oscillationElapsed / oscillationPeriod).truncatingRemainder(dividingBy: 1.0)
+            : 0.0
+        let angle = maxAngleDegrees * sin(cycle * 2.0 * .pi)
+        return .oscillating(angle: angle)
+    }
+
+    public static func shimmerSweepRange(progress: Double) -> (startNorm: Double, endNorm: Double) {
+        // Normalizes sweep coordinate from top-left (-0.4) to bottom-right (1.4)
+        let sweep = progress * 1.8 - 0.4
+        let bandWidth = 0.28
+        return (sweep - bandWidth, sweep + bandWidth)
+    }
+}

--- a/ios/StableChannels/StableChannels/Components/BalanceScaleKinematics.swift
+++ b/ios/StableChannels/StableChannels/Components/BalanceScaleKinematics.swift
@@ -19,6 +19,10 @@ public struct BalanceScaleKinematics: Sendable {
     public let maxAngleDegrees: Double
     public let settleDuration: Double
 
+    public var totalShimmerDuration: Double {
+        shimmerDelay + shimmerDuration
+    }
+
     public init(
         shimmerDelay: Double = 0.25,
         shimmerDuration: Double = 0.90,

--- a/ios/StableChannels/StableChannels/Components/UnifiedBalanceLaunchView.swift
+++ b/ios/StableChannels/StableChannels/Components/UnifiedBalanceLaunchView.swift
@@ -1,0 +1,1259 @@
+//  Unified cinematic app launch hero component.
+//  Executes a seamless staged choreography:
+//  1. Appearance in balance
+//  2. Single radiant wake-up shimmer sweep
+//  3. Active harmonic balance oscillation while syncing
+//  4. Exponentially damped settling into perfect horizontal equilibrium
+
+import SwiftUI
+
+public struct UnifiedBalanceLaunchView: View {
+    public var isSyncComplete: Bool
+    public var size: CGFloat
+    public var baseColor: Color
+    public var onBalanced: (() -> Void)?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var startTime: Double = 0.0
+    @State private var settleStartTime: Double?
+    @State private var hasNotifiedBalanced = false
+
+    private let kinematics: BalanceScaleKinematics
+
+    private static let fulcrumX: CGFloat = 511.5
+    private static let fulcrumY: CGFloat = 361.0
+    private static let leftPivotX: CGFloat = 273.0
+    private static let leftPivotY: CGFloat = 361.0
+
+    // Bounding box dimensions with safe vertical swing headroom:
+    // Y: 210.0 ... 778.0 (height = 568.0)
+    // X: 171.9 ... 868.3 (width = 696.4)
+    private static let markWidth: CGFloat = 696.4
+    private static let markHeight: CGFloat = 568.0
+    private static let markMinX: CGFloat = 171.9
+    private static let markMinY: CGFloat = 210.0
+
+    public init(
+        isSyncComplete: Bool = false,
+        size: CGFloat = 120,
+        baseColor: Color = Color(red: 0.969, green: 0.576, blue: 0.102),
+        kinematics: BalanceScaleKinematics = BalanceScaleKinematics(),
+        onBalanced: (() -> Void)? = nil
+    ) {
+        self.isSyncComplete = isSyncComplete
+        self.size = size
+        self.baseColor = baseColor
+        self.kinematics = kinematics
+        self.onBalanced = onBalanced
+    }
+
+    private var contentHeight: CGFloat {
+        size * (Self.markHeight / Self.markWidth)
+    }
+
+    public var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+            let now = timeline.date.timeIntervalSinceReferenceDate
+            let effectiveStart = startTime == 0.0 ? now : startTime
+            let elapsed = max(0.0, now - effectiveStart)
+
+            let settleElapsed = settleStartTime.map { max(0.0, now - $0) }
+            let stage = reduceMotion
+                ? .balanced
+                : kinematics.evaluate(
+                    elapsedSinceStart: elapsed,
+                    isSyncComplete: isSyncComplete,
+                    settleElapsed: settleElapsed
+                )
+
+            Canvas { context, canvasSize in
+                drawStage(
+                    stage: stage,
+                    context: context,
+                    canvasSize: canvasSize
+                )
+            }
+            .onChange(of: stage) { _, newStage in
+                if newStage == .balanced && !hasNotifiedBalanced {
+                    hasNotifiedBalanced = true
+                    onBalanced?()
+                }
+            }
+        }
+        .frame(width: size, height: contentHeight)
+        .onAppear {
+            startTime = Date().timeIntervalSinceReferenceDate
+            if isSyncComplete {
+                settleStartTime = startTime
+            }
+        }
+        .onChange(of: isSyncComplete) { _, complete in
+            if complete && settleStartTime == nil {
+                settleStartTime = Date().timeIntervalSinceReferenceDate
+            }
+        }
+    }
+
+    private func drawStage(
+        stage: BalanceScaleKinematics.Stage,
+        context: GraphicsContext,
+        canvasSize: CGSize
+    ) {
+        let sX = canvasSize.width / Self.markWidth
+        let sY = canvasSize.height / Self.markHeight
+        let fitTransform = CGAffineTransform(
+            translationX: -Self.markMinX * sX,
+            y: -Self.markMinY * sY
+        ).scaledBy(x: sX, y: sY)
+
+        let unitRect = CGRect(x: 0, y: 0, width: 1024, height: 1024)
+
+        // Determine current tilt angle
+        let angleDegrees: Double
+        switch stage {
+        case .resting, .balanced:
+            angleDegrees = 0.0
+        case .shimmer:
+            angleDegrees = 0.0
+        case .oscillating(let angle), .settling(let angle):
+            angleDegrees = angle
+        }
+
+        // 1. Draw Grounded Stand
+        let standPath = BalanceScaleStandShape().path(in: unitRect).applying(fitTransform)
+        context.fill(standPath, with: .color(baseColor), style: FillStyle(eoFill: true))
+
+        let rad = CGFloat(angleDegrees * .pi / 180.0)
+
+        // 2. Crossbeam and Right Coin Assembly
+        let armTransform = CGAffineTransform(translationX: Self.fulcrumX, y: Self.fulcrumY)
+            .rotated(by: rad)
+            .translatedBy(x: -Self.fulcrumX, y: -Self.fulcrumY)
+            .concatenating(fitTransform)
+
+        let beamPath = BalanceScaleBeamShape().path(in: unitRect).applying(armTransform)
+        let coinPath = BalanceScaleCoinShape().path(in: unitRect).applying(armTransform)
+        let btcPath = BalanceScaleBtcShape().path(in: unitRect).applying(armTransform)
+
+        context.fill(beamPath, with: .color(baseColor), style: FillStyle(eoFill: true))
+        context.fill(coinPath, with: .color(baseColor), style: FillStyle(eoFill: true))
+        context.fill(btcPath, with: .color(baseColor), style: FillStyle(eoFill: true))
+
+        // 3. Hanging Left Pan
+        let leftArmDX = Self.leftPivotX - Self.fulcrumX
+        let leftPivotNewX = Self.fulcrumX + leftArmDX * cos(rad)
+        let leftPivotNewY = Self.fulcrumY + leftArmDX * sin(rad)
+        let leftPanShiftX = leftPivotNewX - Self.leftPivotX
+        let leftPanShiftY = leftPivotNewY - Self.leftPivotY
+
+        let panTransform = CGAffineTransform(translationX: leftPanShiftX, y: leftPanShiftY)
+            .concatenating(fitTransform)
+
+        let panPath = BalanceScalePanShape().path(in: unitRect).applying(panTransform)
+        context.fill(panPath, with: .color(baseColor), style: FillStyle(eoFill: true))
+
+        // 4. Single Wake-Up Shimmer Wave
+        if case .shimmer(let progress) = stage {
+            let (startNorm, endNorm) = BalanceScaleKinematics.shimmerSweepRange(progress: progress)
+
+            let pStart = CGPoint(
+                x: CGFloat(startNorm) * canvasSize.width,
+                y: CGFloat(startNorm) * canvasSize.height
+            )
+            let pEnd = CGPoint(
+                x: CGFloat(endNorm) * canvasSize.width,
+                y: CGFloat(endNorm) * canvasSize.height
+            )
+
+            let shimmerGradient = Gradient(stops: [
+                .init(color: .clear, location: 0.0),
+                .init(color: Color.white.opacity(0.15), location: 0.32),
+                .init(color: Color.white.opacity(0.85), location: 0.50),
+                .init(color: Color.white.opacity(0.15), location: 0.68),
+                .init(color: .clear, location: 1.0)
+            ])
+
+            // Clip and illuminate each shape individually to prevent even-odd overlap cancellation
+            let paths = [standPath, beamPath, coinPath, btcPath, panPath]
+            for shapePath in paths {
+                var itemContext = context
+                itemContext.clip(to: shapePath, style: FillStyle(eoFill: true))
+                itemContext.fill(
+                    Path(CGRect(origin: .zero, size: canvasSize)),
+                    with: .linearGradient(shimmerGradient, startPoint: pStart, endPoint: pEnd)
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Unified Launch - Interactive") {
+    UnifiedLaunchPreviewContainer()
+}
+
+private struct UnifiedLaunchPreviewContainer: View {
+    @State private var isSyncComplete = false
+    @State private var status = "Syncing..."
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            UnifiedBalanceLaunchView(
+                isSyncComplete: isSyncComplete,
+                size: 130,
+                onBalanced: {
+                    status = "Equilibrium Achieved"
+                }
+            )
+
+            VStack(spacing: 6) {
+                Text(String(localized: "app_name", defaultValue: "Stable Channels"))
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text(status)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(isSyncComplete ? "Restart Flow" : "Complete Sync") {
+                if isSyncComplete {
+                    isSyncComplete = false
+                    status = "Syncing..."
+                } else {
+                    isSyncComplete = true
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.bottom, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Shapes
+
+import SwiftUI
+
+public struct BalanceScaleStandShape: Shape {
+    public func path(in _: CGRect) -> Path {
+        let path = CGMutablePath()
+        let transform = CGAffineTransform.identity
+
+        path.move(to: CGPoint(x: 519.50, y: 352.50))
+        path.addLine(to: CGPoint(x: 519.20, y: 334.20))
+        path.addCurve(
+            to: CGPoint(x: 520.50, y: 316.00),
+            control1: CGPoint(x: 519.00, y: 318.20),
+            control2: CGPoint(x: 519.10, y: 316.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 525.30, y: 314.40),
+            control1: CGPoint(x: 521.40, y: 316.00),
+            control2: CGPoint(x: 523.50, y: 315.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 539.20, y: 300.30),
+            control1: CGPoint(x: 531.80, y: 311.10),
+            control2: CGPoint(x: 535.80, y: 306.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 542.50, y: 283.60),
+            control1: CGPoint(x: 542.30, y: 294.10),
+            control2: CGPoint(x: 542.50, y: 293.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 535.00, y: 260.70),
+            control1: CGPoint(x: 542.50, y: 272.30),
+            control2: CGPoint(x: 540.90, y: 267.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 514.50, y: 251.20),
+            control1: CGPoint(x: 529.30, y: 254.20),
+            control2: CGPoint(x: 523.90, y: 251.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 484.30, y: 267.80),
+            control1: CGPoint(x: 500.10, y: 250.40),
+            control2: CGPoint(x: 490.10, y: 255.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 481.50, y: 284.00),
+            control1: CGPoint(x: 481.80, y: 272.90),
+            control2: CGPoint(x: 481.50, y: 274.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 483.90, y: 299.50),
+            control1: CGPoint(x: 481.50, y: 293.10),
+            control2: CGPoint(x: 481.80, y: 295.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 499.30, y: 314.50),
+            control1: CGPoint(x: 487.20, y: 306.10),
+            control2: CGPoint(x: 493.60, y: 312.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 504.00, y: 316.30))
+        path.addLine(to: CGPoint(x: 504.00, y: 334.60))
+        path.addLine(to: CGPoint(x: 504.00, y: 353.00))
+        path.addLine(to: CGPoint(x: 504.00, y: 369.00))
+        path.addLine(to: CGPoint(x: 504.00, y: 565.50))
+        path.addLine(to: CGPoint(x: 504.00, y: 762.00))
+        path.addLine(to: CGPoint(x: 421.60, y: 762.00))
+        path.addCurve(
+            to: CGPoint(x: 337.60, y: 763.60),
+            control1: CGPoint(x: 348.00, y: 762.00),
+            control2: CGPoint(x: 339.00, y: 762.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 337.20, y: 775.80),
+            control1: CGPoint(x: 335.70, y: 765.50),
+            control2: CGPoint(x: 335.40, y: 774.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 511.60, y: 777.00),
+            control1: CGPoint(x: 338.10, y: 776.70),
+            control2: CGPoint(x: 378.20, y: 777.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 688.00, y: 769.10),
+            control1: CGPoint(x: 706.30, y: 777.00),
+            control2: CGPoint(x: 688.00, y: 777.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 686.80, y: 763.20),
+            control1: CGPoint(x: 688.00, y: 766.50),
+            control2: CGPoint(x: 687.50, y: 763.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 602.30, y: 762.00),
+            control1: CGPoint(x: 685.90, y: 762.30),
+            control2: CGPoint(x: 665.80, y: 762.00),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 519.00, y: 762.00))
+        path.addLine(to: CGPoint(x: 519.00, y: 565.50))
+        path.addLine(to: CGPoint(x: 519.00, y: 369.00))
+        path.addLine(to: CGPoint(x: 519.50, y: 352.50))
+        path.closeSubpath()
+
+        return Path(path)
+    }
+}
+
+public struct BalanceScaleBeamShape: Shape {
+    public func path(in _: CGRect) -> Path {
+        let path = CGMutablePath()
+        let transform = CGAffineTransform.identity
+
+        path.move(to: CGPoint(x: 270.00, y: 353.00))
+        path.addLine(to: CGPoint(x: 630.00, y: 353.00))
+        path.addLine(to: CGPoint(x: 630.00, y: 369.00))
+        path.addLine(to: CGPoint(x: 270.00, y: 369.00))
+        path.closeSubpath()
+
+        return Path(path)
+    }
+}
+
+public struct BalanceScalePanShape: Shape {
+    public func path(in _: CGRect) -> Path {
+        let path = CGMutablePath()
+        let transform = CGAffineTransform.identity
+
+        path.move(to: CGPoint(x: 273.00, y: 361.00))
+        path.addLine(to: CGPoint(x: 265.10, y: 353.00))
+        path.addLine(to: CGPoint(x: 262.60, y: 355.20))
+        path.addCurve(
+            to: CGPoint(x: 224.40, y: 425.00),
+            control1: CGPoint(x: 261.30, y: 356.50),
+            control2: CGPoint(x: 244.10, y: 387.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 176.00, y: 521.40),
+            control1: CGPoint(x: 171.90, y: 524.20),
+            control2: CGPoint(x: 176.00, y: 516.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 201.00, y: 565.90),
+            control1: CGPoint(x: 176.00, y: 533.20),
+            control2: CGPoint(x: 186.30, y: 551.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 230.70, y: 585.10),
+            control1: CGPoint(x: 207.10, y: 571.80),
+            control2: CGPoint(x: 223.40, y: 582.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 267.00, y: 591.10),
+            control1: CGPoint(x: 247.70, y: 591.30),
+            control2: CGPoint(x: 247.30, y: 591.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 290.50, y: 590.10),
+            control1: CGPoint(x: 277.20, y: 591.10),
+            control2: CGPoint(x: 287.80, y: 590.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 323.00, y: 576.00),
+            control1: CGPoint(x: 299.70, y: 588.40),
+            control2: CGPoint(x: 313.30, y: 582.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 349.00, y: 550.20),
+            control1: CGPoint(x: 330.90, y: 570.70),
+            control2: CGPoint(x: 345.80, y: 556.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 352.10, y: 546.00),
+            control1: CGPoint(x: 350.30, y: 547.90),
+            control2: CGPoint(x: 351.70, y: 546.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 353.60, y: 543.70),
+            control1: CGPoint(x: 352.50, y: 546.00),
+            control2: CGPoint(x: 353.20, y: 545.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 357.10, y: 535.60),
+            control1: CGPoint(x: 353.90, y: 542.50),
+            control2: CGPoint(x: 355.50, y: 538.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 360.00, y: 521.80),
+            control1: CGPoint(x: 359.60, y: 530.70),
+            control2: CGPoint(x: 360.00, y: 528.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 356.10, y: 508.00),
+            control1: CGPoint(x: 360.00, y: 514.20),
+            control2: CGPoint(x: 358.20, y: 508.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 354.50, y: 505.00),
+            control1: CGPoint(x: 355.60, y: 508.00),
+            control2: CGPoint(x: 354.90, y: 506.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 351.50, y: 498.60),
+            control1: CGPoint(x: 354.10, y: 503.40),
+            control2: CGPoint(x: 352.80, y: 500.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 347.00, y: 490.80),
+            control1: CGPoint(x: 350.20, y: 496.70),
+            control2: CGPoint(x: 348.20, y: 493.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 341.10, y: 479.50),
+            control1: CGPoint(x: 345.80, y: 488.40),
+            control2: CGPoint(x: 343.20, y: 483.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 334.10, y: 466.50),
+            control1: CGPoint(x: 339.00, y: 475.60),
+            control2: CGPoint(x: 335.90, y: 469.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 328.10, y: 455.50),
+            control1: CGPoint(x: 332.40, y: 463.20),
+            control2: CGPoint(x: 329.70, y: 458.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 323.10, y: 446.50),
+            control1: CGPoint(x: 326.50, y: 452.70),
+            control2: CGPoint(x: 324.30, y: 448.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 317.60, y: 436.50),
+            control1: CGPoint(x: 321.90, y: 444.30),
+            control2: CGPoint(x: 319.50, y: 439.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 311.60, y: 425.50),
+            control1: CGPoint(x: 315.80, y: 433.20),
+            control2: CGPoint(x: 313.10, y: 428.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 305.60, y: 414.50),
+            control1: CGPoint(x: 310.20, y: 422.70),
+            control2: CGPoint(x: 307.50, y: 417.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 299.10, y: 402.50),
+            control1: CGPoint(x: 303.80, y: 411.20),
+            control2: CGPoint(x: 300.80, y: 405.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 293.00, y: 391.50),
+            control1: CGPoint(x: 297.30, y: 399.20),
+            control2: CGPoint(x: 294.60, y: 394.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 288.00, y: 382.00),
+            control1: CGPoint(x: 291.40, y: 388.70),
+            control2: CGPoint(x: 289.10, y: 384.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 284.60, y: 376.00),
+            control1: CGPoint(x: 286.80, y: 379.50),
+            control2: CGPoint(x: 285.30, y: 376.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 282.20, y: 371.70),
+            control1: CGPoint(x: 283.90, y: 375.20),
+            control2: CGPoint(x: 282.90, y: 373.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 281.00, y: 369.00))
+        path.addLine(to: CGPoint(x: 273.00, y: 361.00))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 269.80, y: 386.30))
+        path.addCurve(
+            to: CGPoint(x: 284.70, y: 413.50),
+            control1: CGPoint(x: 271.10, y: 388.60),
+            control2: CGPoint(x: 277.80, y: 400.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 306.00, y: 452.50),
+            control1: CGPoint(x: 291.60, y: 426.10),
+            control2: CGPoint(x: 301.20, y: 443.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 339.00, y: 513.40),
+            control1: CGPoint(x: 331.60, y: 499.20),
+            control2: CGPoint(x: 339.00, y: 512.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 268.00, y: 514.00),
+            control1: CGPoint(x: 339.00, y: 513.70),
+            control2: CGPoint(x: 307.00, y: 514.00),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 197.00, y: 514.00))
+        path.addLine(to: CGPoint(x: 198.20, y: 511.80))
+        path.addCurve(
+            to: CGPoint(x: 200.20, y: 508.60),
+            control1: CGPoint(x: 198.90, y: 510.60),
+            control2: CGPoint(x: 199.80, y: 509.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 214.00, y: 481.50),
+            control1: CGPoint(x: 200.60, y: 508.00),
+            control2: CGPoint(x: 206.80, y: 495.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 227.80, y: 455.00),
+            control1: CGPoint(x: 221.20, y: 467.30),
+            control2: CGPoint(x: 227.40, y: 455.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 232.70, y: 445.80),
+            control1: CGPoint(x: 228.20, y: 454.70),
+            control2: CGPoint(x: 230.50, y: 450.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 238.00, y: 435.80),
+            control1: CGPoint(x: 235.00, y: 441.00),
+            control2: CGPoint(x: 237.40, y: 436.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 246.10, y: 420.50),
+            control1: CGPoint(x: 238.50, y: 435.10),
+            control2: CGPoint(x: 242.20, y: 428.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 254.00, y: 406.00),
+            control1: CGPoint(x: 250.00, y: 412.80),
+            control2: CGPoint(x: 253.60, y: 406.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 259.00, y: 396.60),
+            control1: CGPoint(x: 254.40, y: 405.70),
+            control2: CGPoint(x: 256.60, y: 401.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 264.60, y: 386.20),
+            control1: CGPoint(x: 261.30, y: 391.60),
+            control2: CGPoint(x: 263.90, y: 387.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 266.00, y: 383.40),
+            control1: CGPoint(x: 265.40, y: 385.50),
+            control2: CGPoint(x: 266.00, y: 384.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 269.80, y: 386.30),
+            control1: CGPoint(x: 266.00, y: 380.90),
+            control2: CGPoint(x: 267.50, y: 381.90),
+            transform: transform
+        )
+
+        path.move(to: CGPoint(x: 341.00, y: 529.90))
+        path.addCurve(
+            to: CGPoint(x: 325.10, y: 552.10),
+            control1: CGPoint(x: 341.00, y: 531.90),
+            control2: CGPoint(x: 330.30, y: 546.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 298.20, y: 570.00),
+            control1: CGPoint(x: 318.20, y: 559.00),
+            control2: CGPoint(x: 306.00, y: 567.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 268.50, y: 575.40),
+            control1: CGPoint(x: 286.30, y: 574.50),
+            control2: CGPoint(x: 280.90, y: 575.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 248.00, y: 572.50),
+            control1: CGPoint(x: 258.30, y: 575.30),
+            control2: CGPoint(x: 255.20, y: 574.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 220.50, y: 558.50),
+            control1: CGPoint(x: 237.80, y: 569.30),
+            control2: CGPoint(x: 228.60, y: 564.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 206.80, y: 545.40),
+            control1: CGPoint(x: 211.70, y: 552.00),
+            control2: CGPoint(x: 210.00, y: 550.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 202.90, y: 541.00),
+            control1: CGPoint(x: 205.10, y: 543.00),
+            control2: CGPoint(x: 203.40, y: 541.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 202.00, y: 540.00),
+            control1: CGPoint(x: 202.40, y: 541.00),
+            control2: CGPoint(x: 202.00, y: 540.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 199.50, y: 535.40),
+            control1: CGPoint(x: 202.00, y: 539.50),
+            control2: CGPoint(x: 200.90, y: 537.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 197.00, y: 530.40),
+            control1: CGPoint(x: 198.10, y: 533.40),
+            control2: CGPoint(x: 197.00, y: 531.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 269.00, y: 529.00),
+            control1: CGPoint(x: 197.00, y: 529.20),
+            control2: CGPoint(x: 208.90, y: 529.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 341.00, y: 529.90),
+            control1: CGPoint(x: 309.30, y: 529.00),
+            control2: CGPoint(x: 341.00, y: 529.40),
+            transform: transform
+        )
+
+        return Path(path)
+    }
+}
+
+public struct BalanceScaleCoinShape: Shape {
+    public func path(in _: CGRect) -> Path {
+        let path = CGMutablePath()
+        let transform = CGAffineTransform.identity
+
+        path.move(to: CGPoint(x: 630.00, y: 361.00))
+        path.addLine(to: CGPoint(x: 630.40, y: 377.20))
+        path.addCurve(
+            to: CGPoint(x: 678.00, y: 459.70),
+            control1: CGPoint(x: 633.00, y: 408.40),
+            control2: CGPoint(x: 651.00, y: 439.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 705.00, y: 473.90),
+            control1: CGPoint(x: 684.70, y: 464.70),
+            control2: CGPoint(x: 698.90, y: 472.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 711.50, y: 476.30),
+            control1: CGPoint(x: 707.50, y: 474.60),
+            control2: CGPoint(x: 710.40, y: 475.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 717.50, y: 478.10),
+            control1: CGPoint(x: 712.60, y: 476.90),
+            control2: CGPoint(x: 715.30, y: 477.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 726.00, y: 480.00),
+            control1: CGPoint(x: 719.70, y: 478.50),
+            control2: CGPoint(x: 723.50, y: 479.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 767.50, y: 480.30),
+            control1: CGPoint(x: 731.80, y: 481.50),
+            control2: CGPoint(x: 758.40, y: 481.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 807.40, y: 466.20),
+            control1: CGPoint(x: 779.80, y: 478.30),
+            control2: CGPoint(x: 792.50, y: 473.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 847.20, y: 428.50),
+            control1: CGPoint(x: 820.70, y: 459.30),
+            control2: CGPoint(x: 837.40, y: 443.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 854.50, y: 417.50),
+            control1: CGPoint(x: 850.40, y: 423.50),
+            control2: CGPoint(x: 853.70, y: 418.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 856.00, y: 414.50),
+            control1: CGPoint(x: 855.30, y: 416.50),
+            control2: CGPoint(x: 856.00, y: 415.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 858.00, y: 409.70),
+            control1: CGPoint(x: 856.00, y: 413.90),
+            control2: CGPoint(x: 856.90, y: 411.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 860.00, y: 404.30),
+            control1: CGPoint(x: 859.10, y: 407.70),
+            control2: CGPoint(x: 860.00, y: 405.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 861.90, y: 398.60),
+            control1: CGPoint(x: 860.00, y: 403.40),
+            control2: CGPoint(x: 860.80, y: 400.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 864.90, y: 388.00),
+            control1: CGPoint(x: 862.90, y: 396.30),
+            control2: CGPoint(x: 864.20, y: 391.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 867.00, y: 376.00),
+            control1: CGPoint(x: 865.50, y: 384.40),
+            control2: CGPoint(x: 866.50, y: 379.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 865.50, y: 338.50),
+            control1: CGPoint(x: 868.30, y: 368.60),
+            control2: CGPoint(x: 867.40, y: 345.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 863.00, y: 328.50),
+            control1: CGPoint(x: 864.60, y: 335.20),
+            control2: CGPoint(x: 863.50, y: 330.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 853.30, y: 305.60),
+            control1: CGPoint(x: 861.80, y: 323.10),
+            control2: CGPoint(x: 855.50, y: 308.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 849.60, y: 299.80),
+            control1: CGPoint(x: 852.30, y: 304.40),
+            control2: CGPoint(x: 850.60, y: 301.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 846.10, y: 294.30),
+            control1: CGPoint(x: 848.60, y: 297.80),
+            control2: CGPoint(x: 847.00, y: 295.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 841.70, y: 288.40),
+            control1: CGPoint(x: 845.20, y: 293.30),
+            control2: CGPoint(x: 843.20, y: 290.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 822.20, y: 269.00),
+            control1: CGPoint(x: 838.80, y: 284.10),
+            control2: CGPoint(x: 823.60, y: 269.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 818.00, y: 266.00),
+            control1: CGPoint(x: 821.70, y: 269.00),
+            control2: CGPoint(x: 819.90, y: 267.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 792.00, y: 252.10),
+            control1: CGPoint(x: 814.30, y: 262.70),
+            control2: CGPoint(x: 800.60, y: 255.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 761.10, y: 245.10),
+            control1: CGPoint(x: 783.10, y: 248.70),
+            control2: CGPoint(x: 772.20, y: 246.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 730.50, y: 245.50),
+            control1: CGPoint(x: 748.40, y: 243.80),
+            control2: CGPoint(x: 742.10, y: 243.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 686.70, y: 260.70),
+            control1: CGPoint(x: 713.60, y: 247.80),
+            control2: CGPoint(x: 700.60, y: 252.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 630.80, y: 345.30),
+            control1: CGPoint(x: 656.60, y: 278.80),
+            control2: CGPoint(x: 635.80, y: 310.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 629.70, y: 353.00))
+        path.addLine(to: CGPoint(x: 630.00, y: 361.00))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 760.00, y: 261.90))
+        path.addCurve(
+            to: CGPoint(x: 792.50, y: 272.30),
+            control1: CGPoint(x: 774.60, y: 264.00),
+            control2: CGPoint(x: 777.10, y: 264.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 819.00, y: 291.00),
+            control1: CGPoint(x: 804.60, y: 278.20),
+            control2: CGPoint(x: 809.00, y: 281.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 847.70, y: 339.90),
+            control1: CGPoint(x: 833.70, y: 305.30),
+            control2: CGPoint(x: 842.60, y: 320.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 848.60, y: 381.80),
+            control1: CGPoint(x: 850.80, y: 351.80),
+            control2: CGPoint(x: 851.20, y: 370.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 835.40, y: 415.20),
+            control1: CGPoint(x: 846.20, y: 392.50),
+            control2: CGPoint(x: 840.90, y: 405.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 804.50, y: 447.50),
+            control1: CGPoint(x: 829.60, y: 424.80),
+            control2: CGPoint(x: 813.60, y: 441.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 703.90, y: 454.00),
+            control1: CGPoint(x: 772.50, y: 468.30),
+            control2: CGPoint(x: 736.90, y: 470.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 648.60, y: 380.00),
+            control1: CGPoint(x: 674.70, y: 439.20),
+            control2: CGPoint(x: 654.40, y: 412.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 649.10, y: 342.50),
+            control1: CGPoint(x: 646.30, y: 367.40),
+            control2: CGPoint(x: 646.60, y: 345.20),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 650.00, y: 338.80),
+            control1: CGPoint(x: 649.60, y: 342.00),
+            control2: CGPoint(x: 650.00, y: 340.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 659.10, y: 314.10),
+            control1: CGPoint(x: 650.00, y: 334.70),
+            control2: CGPoint(x: 654.10, y: 323.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 681.80, y: 285.60),
+            control1: CGPoint(x: 664.20, y: 304.60),
+            control2: CGPoint(x: 673.70, y: 292.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 702.40, y: 272.00),
+            control1: CGPoint(x: 688.80, y: 279.70),
+            control2: CGPoint(x: 700.30, y: 272.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 705.20, y: 270.70),
+            control1: CGPoint(x: 703.20, y: 272.00),
+            control2: CGPoint(x: 704.50, y: 271.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 730.00, y: 262.90),
+            control1: CGPoint(x: 707.50, y: 268.40),
+            control2: CGPoint(x: 719.20, y: 264.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 739.00, y: 260.80),
+            control1: CGPoint(x: 734.10, y: 262.20),
+            control2: CGPoint(x: 738.20, y: 261.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 760.00, y: 261.90),
+            control1: CGPoint(x: 740.60, y: 259.90),
+            control2: CGPoint(x: 749.20, y: 260.40),
+            transform: transform
+        )
+
+        return Path(path)
+    }
+}
+
+public struct BalanceScaleBtcShape: Shape {
+    public func path(in _: CGRect) -> Path {
+        let path = CGMutablePath()
+        let transform = CGAffineTransform.identity
+        path.move(to: CGPoint(x: 750.00, y: 288.00))
+        path.addCurve(
+            to: CGPoint(x: 748.00, y: 298.50),
+            control1: CGPoint(x: 748.30, y: 289.70),
+            control2: CGPoint(x: 748.00, y: 291.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 748.00, y: 307.00))
+        path.addLine(to: CGPoint(x: 745.00, y: 307.00))
+        path.addLine(to: CGPoint(x: 742.00, y: 307.00))
+        path.addLine(to: CGPoint(x: 742.00, y: 298.60))
+        path.addCurve(
+            to: CGPoint(x: 733.00, y: 287.00),
+            control1: CGPoint(x: 742.00, y: 288.10),
+            control2: CGPoint(x: 741.20, y: 287.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 724.00, y: 298.60),
+            control1: CGPoint(x: 724.80, y: 287.00),
+            control2: CGPoint(x: 724.00, y: 288.10),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 724.00, y: 307.00))
+        path.addLine(to: CGPoint(x: 713.90, y: 307.00))
+        path.addCurve(
+            to: CGPoint(x: 702.00, y: 308.00),
+            control1: CGPoint(x: 708.40, y: 307.00),
+            control2: CGPoint(x: 703.00, y: 307.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 699.60, y: 322.50),
+            control1: CGPoint(x: 698.40, y: 310.00),
+            control2: CGPoint(x: 696.80, y: 318.90),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 709.30, y: 325.00),
+            control1: CGPoint(x: 700.80, y: 324.10),
+            control2: CGPoint(x: 702.60, y: 324.60),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 717.50, y: 325.50))
+        path.addLine(to: CGPoint(x: 717.80, y: 364.20))
+        path.addLine(to: CGPoint(x: 718.00, y: 403.00))
+        path.addLine(to: CGPoint(x: 710.60, y: 403.00))
+        path.addCurve(
+            to: CGPoint(x: 700.00, y: 412.00),
+            control1: CGPoint(x: 701.20, y: 403.00),
+            control2: CGPoint(x: 700.00, y: 404.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 713.60, y: 421.00),
+            control1: CGPoint(x: 700.00, y: 420.40),
+            control2: CGPoint(x: 700.80, y: 421.00),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 724.00, y: 421.00))
+        path.addLine(to: CGPoint(x: 724.00, y: 429.90))
+        path.addCurve(
+            to: CGPoint(x: 732.30, y: 442.00),
+            control1: CGPoint(x: 724.00, y: 440.80),
+            control2: CGPoint(x: 724.80, y: 442.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 738.60, y: 441.20),
+            control1: CGPoint(x: 735.20, y: 442.00),
+            control2: CGPoint(x: 738.00, y: 441.60),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 742.00, y: 428.60),
+            control1: CGPoint(x: 741.00, y: 439.70),
+            control2: CGPoint(x: 742.00, y: 435.80),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 742.00, y: 421.00))
+        path.addLine(to: CGPoint(x: 745.00, y: 421.00))
+        path.addLine(to: CGPoint(x: 748.00, y: 421.00))
+        path.addLine(to: CGPoint(x: 748.00, y: 429.40))
+        path.addCurve(
+            to: CGPoint(x: 750.20, y: 439.40),
+            control1: CGPoint(x: 748.00, y: 437.00),
+            control2: CGPoint(x: 748.20, y: 438.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 757.70, y: 441.00),
+            control1: CGPoint(x: 751.60, y: 440.40),
+            control2: CGPoint(x: 754.60, y: 441.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 767.00, y: 429.10),
+            control1: CGPoint(x: 765.60, y: 441.00),
+            control2: CGPoint(x: 767.00, y: 439.10),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 767.00, y: 421.10))
+        path.addLine(to: CGPoint(x: 772.80, y: 420.00))
+        path.addCurve(
+            to: CGPoint(x: 789.50, y: 413.90),
+            control1: CGPoint(x: 780.90, y: 418.40),
+            control2: CGPoint(x: 783.80, y: 417.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 799.50, y: 398.70),
+            control1: CGPoint(x: 794.60, y: 410.80),
+            control2: CGPoint(x: 797.70, y: 406.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 801.10, y: 395.40),
+            control1: CGPoint(x: 799.90, y: 397.20),
+            control2: CGPoint(x: 800.60, y: 395.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 801.00, y: 379.50),
+            control1: CGPoint(x: 802.30, y: 394.70),
+            control2: CGPoint(x: 802.20, y: 380.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 800.00, y: 376.40),
+            control1: CGPoint(x: 800.50, y: 379.20),
+            control2: CGPoint(x: 800.00, y: 377.80),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 792.40, y: 363.00),
+            control1: CGPoint(x: 800.00, y: 372.90),
+            control2: CGPoint(x: 797.50, y: 368.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 788.60, y: 356.60),
+            control1: CGPoint(x: 789.40, y: 359.80),
+            control2: CGPoint(x: 788.20, y: 357.70),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 790.10, y: 355.00),
+            control1: CGPoint(x: 788.90, y: 355.70),
+            control2: CGPoint(x: 789.60, y: 355.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 792.40, y: 325.40),
+            control1: CGPoint(x: 793.10, y: 355.00),
+            control2: CGPoint(x: 794.90, y: 331.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 784.00, y: 314.30),
+            control1: CGPoint(x: 790.90, y: 321.90),
+            control2: CGPoint(x: 788.30, y: 318.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 769.00, y: 308.00),
+            control1: CGPoint(x: 781.40, y: 311.80),
+            control2: CGPoint(x: 772.30, y: 308.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 767.00, y: 299.20),
+            control1: CGPoint(x: 767.20, y: 308.00),
+            control2: CGPoint(x: 767.00, y: 307.30),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 766.20, y: 289.40),
+            control1: CGPoint(x: 767.00, y: 294.40),
+            control2: CGPoint(x: 766.60, y: 290.00),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 750.00, y: 288.00),
+            control1: CGPoint(x: 763.70, y: 285.60),
+            control2: CGPoint(x: 753.30, y: 284.70),
+            transform: transform
+        )
+        path.move(to: CGPoint(x: 766.60, y: 328.00))
+        path.addCurve(
+            to: CGPoint(x: 773.00, y: 334.40),
+            control1: CGPoint(x: 769.50, y: 329.40),
+            control2: CGPoint(x: 771.40, y: 331.40),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 771.90, y: 346.40),
+            control1: CGPoint(x: 775.60, y: 339.20),
+            control2: CGPoint(x: 775.30, y: 342.10),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 749.50, y: 352.40),
+            control1: CGPoint(x: 768.00, y: 351.40),
+            control2: CGPoint(x: 764.80, y: 352.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 735.50, y: 352.50))
+        path.addLine(to: CGPoint(x: 735.20, y: 339.20))
+        path.addLine(to: CGPoint(x: 734.90, y: 326.00))
+        path.addLine(to: CGPoint(x: 748.70, y: 326.00))
+        path.addCurve(
+            to: CGPoint(x: 766.60, y: 328.00),
+            control1: CGPoint(x: 760.40, y: 326.00),
+            control2: CGPoint(x: 763.00, y: 326.30),
+            transform: transform
+        )
+        path.move(to: CGPoint(x: 776.50, y: 376.00))
+        path.addCurve(
+            to: CGPoint(x: 780.00, y: 395.00),
+            control1: CGPoint(x: 783.60, y: 382.80),
+            control2: CGPoint(x: 784.60, y: 388.50),
+            transform: transform
+        )
+        path.addCurve(
+            to: CGPoint(x: 752.30, y: 402.80),
+            control1: CGPoint(x: 775.60, y: 401.20),
+            control2: CGPoint(x: 771.40, y: 402.30),
+            transform: transform
+        )
+        path.addLine(to: CGPoint(x: 735.00, y: 403.20))
+        path.addLine(to: CGPoint(x: 735.00, y: 387.50))
+        path.addLine(to: CGPoint(x: 735.00, y: 371.80))
+        path.addLine(to: CGPoint(x: 753.90, y: 372.20))
+        path.addLine(to: CGPoint(x: 772.90, y: 372.50))
+        path.addLine(to: CGPoint(x: 776.50, y: 376.00))
+
+        return Path(path)
+    }
+}


### PR DESCRIPTION
## Summary

Implements a unified balance scale launch hero animation and coordinated two-stage startup flow across iOS (SwiftUI Canvas) and Android (Jetpack Compose Canvas). The implementation extracts motion physics into pure kinematics engines on both platforms, applies shape-aware linear shimmer illumination over vector geometry, and introduces a smooth crossfade from branded hero launch into the main dashboard during node synchronization.

## Problem

1. **Inconsistent Cross-Platform Visuals**: Android used generic spinner loaders during startup, while iOS was experimenting with disparate loader concepts.
2. **Abrupt Startup Transition**: The application launched abruptly into the dashboard before initial node state was settled, causing layout shifts.
3. **Naive Rectangular Shimmering**: Early shimmer prototypes applied bounding-box overlay masks, causing harsh rectangular edges and clipping across curved vector paths (chains, scale pans, and fulcrum).
4. **Coupled Motion Logic**: Physics mathematics and animation phase handling were initially entangled with view hierarchy logic, impeding unit testing and cross-platform parity.

## Changes Made

### 1. Kinematics Engine (Cross-Platform Parity)
- **iOS (`BalanceScaleKinematics.swift`)**:
  - Implemented pure mathematical calculations for beam tilt angle, left/right pan vertical travel, chain angle deflection, and progressive shimmer traversal.
  - Divided motion into distinct, testable phases: initial rest with shimmer sweep, damped harmonic oscillation, and settled equilibrium.
- **Android (`BalanceScaleKinematics.kt`)**:
  - Mirrored the exact mathematical physics formulas in Kotlin as pure functions.
  - Added full unit test coverage in `BalanceScaleKinematicsTest.kt` verifying resting state, shimmer progress, oscillation cycles, and damped decay.

### 2. Unified Hardware-Accelerated Vector Canvas
- **iOS (`UnifiedBalanceLaunchView.swift`)**:
  - Rendered using SwiftUI Canvas backed by Metal.
  - Constructed precise vector paths for base plate, pillar, fulcrum pivot, balance beam, chain links, scale pans, and currency tokens.
  - Applied per-shape shimmer gradient illumination mapped to the kinematics engine's shimmer progress value.
  - Preserved Xcode project references in `project.pbxproj`.
- **Android (`UnifiedBalanceLaunchView.kt`)**:
  - Rendered using Jetpack Compose Canvas with native Android Graphics `Path` operations.
  - Configured custom theme brush definitions for dynamic shimmer highlights across dark and light palettes.
  - Implemented preview annotations for Dark, Light, Shimmering, and Oscillating states.

### 3. Staged Screen Flow and Crossfade
- **iOS (`ContentView.swift`)**:
  - Partitioned the view state into Stage 1 (branded launch with hero balance loader and app identity) and Stage 2 (active synchronization and dashboard).
  - Added a 0.4-second smooth crossfade animation between stages once node initialization commences.
- **Android (`ContentView.kt`)**:
  - Structured Compose state to mirror the two-stage launch flow.
  - Replaced the generic progress indicator with the unified balance scale hero.
  - Coordinated animation timing with `rememberInfiniteTransition` and shared elapsed time clocks.

## Demo Videos

| iOS | Android |
| :---: | :---: |
| https://github.com/user-attachments/assets/4d7991d4-83fc-427f-bdfc-e427e1e41c13 | https://github.com/user-attachments/assets/19727785-74df-4d34-b83c-b4932aee8b46 |

## Related
- Closes #312
