### PR TITLE
fix(android): splice deduction can't be lost, reconcile is idempotent…

### DIFF
--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -3680,9 +3680,12 @@ class AppState(private val context: Context) : ViewModel() {
         } ?: return
         val prefs = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
         if (prefs.getString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, null) == failure.paymentId) return
-        prefs.edit().putString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, failure.paymentId).apply()
+        // Mark it seen only once it is actually on screen. start() is re-invocable (ErrorView's
+        // retry button), and by then the capsule may hold a live message — recording the failure
+        // as shown there would swallow it for good, since the marker is keyed on the payment id.
         if (_statusMessage.value.isNotEmpty()) return
         _statusMessage.value = failure.outcome.message
+        prefs.edit().putString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, failure.paymentId).apply()
         AuditService.log("TRADE_FAILURE_RESURFACED", mapOf(
             "payment_id" to failure.paymentId,
             "resolved_at" to failure.resolvedAt

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -1889,6 +1889,8 @@ class AppState(private val context: Context) : ViewModel() {
                 if (message is TradeControlMessage.Rejected) {
                     syncRetryTracker.clear(paymentHash)
                     _statusMessage.value = TradeProtocol.rejectionMessage(message.reasonCode)
+                    // Shown now, so the next launch must not repeat it.
+                    markTradeFailureSeen(message.correlation.tradePaymentId)
                     AuditService.log("TRADE_REJECTED_BY_LSP", mapOf("payment_id" to message.correlation.tradePaymentId,
                         "reason_code" to message.reasonCode))
                     return true
@@ -2362,25 +2364,49 @@ class AppState(private val context: Context) : ViewModel() {
         // time this tx confirms, pendingSplice may already belong to a newer operation, and
         // reading it here could bind this (older, unrelated) txid to that newer row.
         databaseService?.assignPendingSpliceTxid(txid, capturedPaymentRowId)
-        val completed = databaseService?.completeSplice(txid) == true
-        if (completed) {
-            // completeSplice() just marked the row completed/1-conf. History only reloads when
-            // this epoch moves, and the confirmation poller won't move it for this row: it now
-            // has confirmations >= 1, so the poller no longer selects it. Without this bump,
-            // whenever this monitor sees the confirmation before the poller does, an open
-            // History screen keeps showing "0/1 confirmed" until it is left and reopened (#304).
-            _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
-            refreshBalances()
-            updateStableBalances()
-
-            val price = priceService.currentPrice.value
-            val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
-            val reconciled = result.first
-            if (result.second != null) {
-                reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
+        // Books first, row second. completeSplice() only matches a row that is still 'pending',
+        // so marking it complete before the deduction is durable turns a crash in between into a
+        // permanently unaccounted withdrawal — nothing revisits a completed row (#311). With the
+        // order reversed, a crash leaves the row pending, the resume path runs this again, and
+        // the reconcile is idempotent (it only ever removes backing above the live balance), so
+        // the deduction lands exactly once either way.
+        val matchesPendingRow = try {
+            databaseService?.hasPendingSpliceFor(txid) == true
+        } catch (e: Exception) {
+            Log.w("AppState", "Could not check the pending splice row: ${e.message}")
+            false
+        }
+        var completed = false
+        if (matchesPendingRow) {
+            synchronized(booksLock) {
+                refreshBalances()
+                updateStableBalances()
+                val price = priceService.currentAccountingPrice()
+                if (price > 0.0) {
+                    val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
+                    val reconciled = result.first
+                    if (result.second != null) {
+                        reconciled.lastStabilityPayment = System.currentTimeMillis() / 1000
+                    }
+                    _stableChannel.value = reconciled
+                    saveChannelToDB()
+                } else {
+                    // No trusted price to value the spend: leave the row pending so the resume
+                    // path retries, rather than completing it with the books untouched.
+                    AuditService.log("SPLICE_RECONCILE_DEFERRED", mapOf(
+                        "txid" to txid, "reason" to "untrusted_price"
+                    ))
+                }
             }
-            _stableChannel.value = reconciled
-            saveChannelToDB()
+            if (priceService.currentAccountingPrice() > 0.0) {
+                completed = databaseService?.completeSplice(txid) == true
+                if (completed) {
+                    // History only reloads when this epoch moves, and the confirmation poller no
+                    // longer touches splice rows at all, so without this bump an open History
+                    // screen keeps showing "0/1 confirmed" until it is reopened (#304).
+                    _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
+                }
+            }
         }
 
         // Only clear the shared in-memory splice state if a newer splice hasn't since replaced
@@ -2746,6 +2772,12 @@ class AppState(private val context: Context) : ViewModel() {
 
         refreshBalances()
         updateStableBalances()
+        // Retry a repair that startup deferred (no trusted price yet, or an operation still in
+        // flight). The guard is a free in-memory comparison, so this costs nothing on the tick
+        // where the books are already consistent — which is every tick but the broken ones.
+        if (_stableChannel.value.backingSats > _stableChannel.value.stableReceiverBTC.sats) {
+            repairBooksAboveLiveBalance()
+        }
         val sc = _stableChannel.value
         val price = priceService.currentAccountingPrice()
 
@@ -3679,17 +3711,24 @@ class AppState(private val context: Context) : ViewModel() {
             null
         } ?: return
         val prefs = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
-        if (prefs.getString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, null) == failure.paymentId) return
+        val lastShown = prefs.getString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, null)
         // Mark it seen only once it is actually on screen. start() is re-invocable (ErrorView's
         // retry button), and by then the capsule may hold a live message — recording the failure
         // as shown there would swallow it for good, since the marker is keyed on the payment id.
-        if (_statusMessage.value.isNotEmpty()) return
+        if (!TradeFailureNotice.shouldShow(failure.paymentId, lastShown, _statusMessage.value.isNotEmpty())) return
         _statusMessage.value = failure.outcome.message
-        prefs.edit().putString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, failure.paymentId).apply()
+        markTradeFailureSeen(failure.paymentId)
         AuditService.log("TRADE_FAILURE_RESURFACED", mapOf(
             "payment_id" to failure.paymentId,
             "resolved_at" to failure.resolvedAt
         ))
+    }
+
+    private fun markTradeFailureSeen(paymentId: String) {
+        context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, paymentId)
+            .apply()
     }
 
     fun onForegroundResume() {
@@ -3714,9 +3753,16 @@ class AppState(private val context: Context) : ViewModel() {
         val sc = _stableChannel.value
         if (sc.userChannelId.isEmpty()) return
         val receiverSats = sc.stableReceiverBTC.sats
-        if (receiverSats <= 0L) return
+        // A zero balance is a legitimate repair case (a full splice-out closes the position), but
+        // it is only meaningful against a live channel — without one the figure is not
+        // authoritative and there is nothing to reconcile against.
+        if (receiverSats < 0L || !_hasReadyChannel.value) return
         if (isChannelClosing || isSweeping || pendingSplice != null) return
         if (try { db.hasPendingSplice() } catch (_: Exception) { true }) return
+        // A stability send whose backing debit has not been recorded yet looks exactly like an
+        // overflow. clampBackingToLiveReceiver() re-checks this inside its transaction; this is
+        // the cheap early out.
+        if (try { db.loadPendingSend() != null } catch (_: Exception) { true }) return
         val inFlight = try {
             nodeService.node?.listPayments()?.any { it.status == PaymentStatus.PENDING } ?: true
         } catch (e: Exception) {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -2289,8 +2289,16 @@ class AppState(private val context: Context) : ViewModel() {
         spliceConfirmationJob = viewModelScope.launch(Dispatchers.IO) {
             while (isActive) {
                 if (isTxConfirmed(normalizedTxid)) {
-                    completeConfirmedSplice(normalizedTxid, monitorGeneration, monitorPaymentRowId)
-                    break
+                    // DEFERRED means the books could not be valued yet (no trusted price). Keep
+                    // monitoring and retry on the next tick rather than declaring the move done:
+                    // the row stays 'pending', which also blocks the periodic repair, so nothing
+                    // else would pick it up until the app restarted.
+                    if (completeConfirmedSplice(
+                            normalizedTxid, monitorGeneration, monitorPaymentRowId
+                        ) == SpliceCompletion.COMPLETED
+                    ) {
+                        break
+                    }
                 }
                 delay(30_000)
             }
@@ -2354,7 +2362,14 @@ class AppState(private val context: Context) : ViewModel() {
         return false
     }
 
-    private fun completeConfirmedSplice(txid: String, expectedGeneration: Long, capturedPaymentRowId: Long?) {
+    /** Whether a confirmed splice was fully accounted for, or must be retried. */
+    private enum class SpliceCompletion { COMPLETED, DEFERRED }
+
+    private fun completeConfirmedSplice(
+        txid: String,
+        expectedGeneration: Long,
+        capturedPaymentRowId: Long?
+    ): SpliceCompletion {
         // If SPLICE_TXID_UNMATCHED fired when this splice was negotiated (assignPendingSpliceTxid
         // found no unambiguous pending row), the DB row's txid is still NULL and completeSplice()
         // — which requires an exact txid match — can never find it, permanently desyncing Stable
@@ -2376,13 +2391,20 @@ class AppState(private val context: Context) : ViewModel() {
             Log.w("AppState", "Could not check the pending splice row: ${e.message}")
             false
         }
-        var completed = false
         if (matchesPendingRow) {
-            synchronized(booksLock) {
+            // One price read decides everything below. Reading it again to gate the row update
+            // would let a price that arrived in between complete the row with the books
+            // untouched — the exact #311 shape this ordering exists to prevent.
+            val accounted = synchronized(booksLock) {
                 refreshBalances()
                 updateStableBalances()
                 val price = priceService.currentAccountingPrice()
-                if (price > 0.0) {
+                if (price <= 0.0) {
+                    AuditService.log("SPLICE_RECONCILE_DEFERRED", mapOf(
+                        "txid" to txid, "reason" to "untrusted_price"
+                    ))
+                    false
+                } else {
                     val result = StabilityService.reconcileOutgoing(_stableChannel.value, price)
                     val reconciled = result.first
                     if (result.second != null) {
@@ -2390,22 +2412,18 @@ class AppState(private val context: Context) : ViewModel() {
                     }
                     _stableChannel.value = reconciled
                     saveChannelToDB()
-                } else {
-                    // No trusted price to value the spend: leave the row pending so the resume
-                    // path retries, rather than completing it with the books untouched.
-                    AuditService.log("SPLICE_RECONCILE_DEFERRED", mapOf(
-                        "txid" to txid, "reason" to "untrusted_price"
-                    ))
+                    true
                 }
             }
-            if (priceService.currentAccountingPrice() > 0.0) {
-                completed = databaseService?.completeSplice(txid) == true
-                if (completed) {
-                    // History only reloads when this epoch moves, and the confirmation poller no
-                    // longer touches splice rows at all, so without this bump an open History
-                    // screen keeps showing "0/1 confirmed" until it is reopened (#304).
-                    _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
-                }
+            // Nothing is finalized on the deferred path: the row stays pending, the monitor and
+            // the in-memory splice state stay alive, and no "Move confirmed" is shown for a move
+            // whose accounting has not happened.
+            if (!accounted) return SpliceCompletion.DEFERRED
+            if (databaseService?.completeSplice(txid) == true) {
+                // History only reloads when this epoch moves, and the confirmation poller no
+                // longer touches splice rows at all, so without this bump an open History
+                // screen keeps showing "0/1 confirmed" until it is reopened (#304).
+                _confirmationUpdateEpoch.value = _confirmationUpdateEpoch.value + 1
             }
         }
 
@@ -2436,8 +2454,9 @@ class AppState(private val context: Context) : ViewModel() {
 
         AuditService.log("SPLICE_CONFIRMED", mapOf(
             "txid" to txid,
-            "completed_row" to completed
+            "accounted" to matchesPendingRow
         ))
+        return SpliceCompletion.COMPLETED
     }
 
     private fun closureReasonData(reason: ClosureReason?): JSONObject {

--- a/android/app/src/main/java/com/stablechannels/app/AppState.kt
+++ b/android/app/src/main/java/com/stablechannels/app/AppState.kt
@@ -153,6 +153,8 @@ class AppState(private val context: Context) : ViewModel() {
             const val CACHED_CHANNEL_ID = "cached_channel_id"
             const val CACHED_USER_CHANNEL_ID = "cached_user_channel_id"
             const val CACHED_EXPECTED_USD = "cached_expected_usd"
+            /** Payment id of the last trade failure already shown in the status capsule. */
+            const val LAST_SHOWN_TRADE_FAILURE = "last_shown_trade_failure"
             const val PENDING_TXIDS = "pending_outbound_txids"
 
             fun clearPendingOutbound(context: Context) {
@@ -869,6 +871,7 @@ class AppState(private val context: Context) : ViewModel() {
                 db.markExpiredTradesUncertain()
                 _pendingTradePayments.value = db.unresolvedTradePayments()
                 refreshAllTradeOutcomes(_tradeOutcomes.value.keys + _pendingTradePayments.value.keys)
+                surfaceUnseenTradeFailure()
 
                 val auditPath = File(Constants.userDataDir(context), "audit_log.txt").absolutePath
                 AuditService.setLogPath(auditPath)
@@ -926,6 +929,12 @@ class AppState(private val context: Context) : ViewModel() {
                     fundingVout = balanceCachePrefs.getInt("funding_vout", -1).takeIf { it >= 0 }
                     refreshBalances()
                     pollPaymentConfirmations(force = true)
+                    // Off the critical startup path: it makes blocking LDK/DB calls, and the
+                    // first frames must not wait on a repair that almost never has work to do.
+                    launch {
+                        updateStableBalances()
+                        repairBooksAboveLiveBalance()
+                    }
                     connectMempoolWebSocket()
                     resumePendingSpliceConfirmation()
                     // Restore channel-closing state if a close is still pending on-chain
@@ -3648,8 +3657,94 @@ class AppState(private val context: Context) : ViewModel() {
     /** Called when the UI returns to the foreground. Reloads channel state from the DB so
      *  backing increments committed by StabilityProcessingService while this process was
      *  cached are picked up before any save can clobber them. Cheap and safe to call repeatedly. */
+    /**
+     * Tell the user about an order that was refused while they were away.
+     *
+     * A rejection delivered while the app is backgrounded is verified and committed by the
+     * event handler, but the only place it is ever shown is the trade sheet's result step and a
+     * status message set in that same moment — both live in process memory. The relaunch that
+     * follows is a cold start, so both are gone and the refusal is silent: the balance simply
+     * never moved. Resurface the most recent failure once, in the status capsule, so a rejection
+     * is never lost just because the app was not in the foreground when it arrived.
+     *
+     * Once per outcome (a seen-marker keyed on its payment id) and only while the capsule is
+     * free, so it can never displace a live message or reappear on every launch.
+     */
+    private fun surfaceUnseenTradeFailure() {
+        val db = databaseService ?: return
+        val failure = try {
+            db.mostRecentTradeFailure(Constants.TRADE_FAILURE_RESURFACE_WINDOW_SECS)
+        } catch (e: Exception) {
+            Log.w("AppState", "Could not read the last trade failure: ${e.message}")
+            null
+        } ?: return
+        val prefs = context.getSharedPreferences(BalanceCacheKey.PREFS_NAME, Context.MODE_PRIVATE)
+        if (prefs.getString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, null) == failure.paymentId) return
+        prefs.edit().putString(BalanceCacheKey.LAST_SHOWN_TRADE_FAILURE, failure.paymentId).apply()
+        if (_statusMessage.value.isNotEmpty()) return
+        _statusMessage.value = failure.outcome.message
+        AuditService.log("TRADE_FAILURE_RESURFACED", mapOf(
+            "payment_id" to failure.paymentId,
+            "resolved_at" to failure.resolvedAt
+        ))
+    }
+
     fun onForegroundResume() {
         loadChannelFromDB()
+    }
+
+    /**
+     * Heal books that claim more backing than the channel holds.
+     *
+     * backing > the live receiver balance cannot happen in normal operation: the backing is a
+     * slice of that balance. It means a withdrawal moved sats out without its stable-books
+     * deduction — the #311 splice race, which stranded wallets that cannot recover any other way
+     * (the payment row is already 'completed', so no confirmation or resume path revisits it, and
+     * on Android the LSP's corrective sync never applies). Deduct the excess once, at the current
+     * accounting price, and pin backing to the live balance.
+     *
+     * Cold start only, and only with nothing in flight: an in-flight HTLC lowers the receiver
+     * balance for as long as it is pending and would read as an overflow.
+     */
+    private fun repairBooksAboveLiveBalance() {
+        val db = databaseService ?: return
+        val sc = _stableChannel.value
+        if (sc.userChannelId.isEmpty()) return
+        val receiverSats = sc.stableReceiverBTC.sats
+        if (receiverSats <= 0L) return
+        if (isChannelClosing || isSweeping || pendingSplice != null) return
+        if (try { db.hasPendingSplice() } catch (_: Exception) { true }) return
+        val inFlight = try {
+            nodeService.node?.listPayments()?.any { it.status == PaymentStatus.PENDING } ?: true
+        } catch (e: Exception) {
+            true
+        }
+        if (inFlight) return
+        val price = priceService.currentAccountingPrice()
+        if (price <= 0.0) return
+        val result = try {
+            synchronized(booksLock) {
+                val clamped = db.clampBackingToLiveReceiver(sc.userChannelId, receiverSats, price)
+                if (clamped != null) {
+                    publishBooksFromDB(recomputeNative = true)
+                    cacheBalanceForLaunch()
+                }
+                clamped
+            }
+        } catch (e: Exception) {
+            Log.w("AppState", "Books repair failed: ${e.message}")
+            AuditService.log("BOOKS_REPAIR_FAILED", mapOf("error" to (e.message ?: "")))
+            return
+        } ?: return
+        AuditService.log("BOOKS_REPAIRED_ABOVE_LIVE_BALANCE", mapOf(
+            "user_channel_id" to sc.userChannelId,
+            "overflow_sats" to result.overflowSats,
+            "usd_deducted" to result.usdDeducted,
+            "old_expected_usd" to result.oldExpectedUSD,
+            "new_expected_usd" to result.newExpectedUSD,
+            "backing_sats" to result.newBackingSats,
+            "btc_price" to price
+        ))
     }
 
     /** Republish expectedUSD/backingSats from the channel row — the single source of truth for

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -288,10 +288,22 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         receiverSats: Long,
         price: Double
     ): BackingClampResult? {
+        // receiverSats == 0 is legitimate — a full splice-out empties the channel and the
+        // position must be allowed to close. Only a negative balance is nonsense.
         if (price <= 0.0 || receiverSats < 0) return null
         val db = writableDatabase
         db.execSQL("BEGIN IMMEDIATE")
         try {
+            // An unreconciled stability send means sats have already left the channel whose
+            // backing debit is still owed. The balance looks like an overflow, but
+            // reconcilePendingOutgoingStabilityPayment() is about to debit it — repairing here
+            // would take it twice. Defer; the retry after recovery picks it up. Checked inside
+            // the write lock so the stability timer cannot claim a send in between.
+            val pending = db.rawQuery("SELECT 1 FROM pending_stability_send WHERE id = 1", null)
+            if (pending.use { it.moveToFirst() }) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
             val cursor = db.rawQuery(
                 "SELECT expected_usd, stable_sats FROM channels WHERE user_channel_id = ?",
                 arrayOf(userChannelId)
@@ -1780,6 +1792,21 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
 
     /** Returns true only if a splice row was actually flipped to completed,
      *  so callers can use the result as the "this ChannelReady was a splice" signal. */
+    /** Whether completeSplice(txid) would match a row — the same pending rows it updates. */
+    fun hasPendingSpliceFor(txid: String): Boolean {
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT 1 FROM payments
+            WHERE payment_type IN ('splice_in','splice_out')
+              AND status IN ('pending','failed')
+              AND (txid = ? OR (payment_type = 'splice_in' AND txid IS NULL))
+            LIMIT 1
+            """.trimIndent(),
+            arrayOf(txid)
+        )
+        return cursor.use { it.moveToFirst() }
+    }
+
     fun completeSplice(txid: String): Boolean {
         val stmt = writableDatabase.compileStatement(
             "UPDATE payments SET status = 'completed', confirmations = 1 WHERE payment_type IN ('splice_in','splice_out') AND txid = ? AND status = 'pending'"

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -307,9 +307,12 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             val overflowSats = currentBacking - receiverSats
             val usdDeducted = (overflowSats.toDouble() / Constants.SATS_IN_BTC) * price
             val newExpected = maxOf(currentExpected - usdDeducted, 0.0)
+            // A repair that exhausts the target closes the position: nothing backs it.
+            val newBacking =
+                if (newExpected < StabilityService.MINIMUM_STABLE_USD) 0L else receiverSats
             val cv = ContentValues().apply {
                 put("expected_usd", newExpected)
-                put("stable_sats", receiverSats)
+                put("stable_sats", newBacking)
                 put("receiver_sats", receiverSats)
                 put("latest_price", price)
                 put("updated_at", System.currentTimeMillis() / 1000)
@@ -322,7 +325,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             }
             db.execSQL("COMMIT")
             return BackingClampResult(
-                overflowSats, usdDeducted, currentExpected, newExpected, receiverSats
+                overflowSats, usdDeducted, currentExpected, newExpected, newBacking
             )
         } catch (e: Exception) {
             try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
@@ -394,7 +397,10 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             // SECOND time ($100 -> $92 -> $82) and hid a genuine below-par claim from the
             // stability check. Pinning backing to the live balance matches the LSP's own
             // convention and makes this idempotent: a re-run sees backing <= receiver and stops.
-            val newBacking = receiverSats
+            // At the zero boundary the position is closed, so nothing backs it — see
+            // StabilityService.reconcileOutgoing().
+            val newBacking =
+                if (newExpected < StabilityService.MINIMUM_STABLE_USD) 0L else receiverSats
             val cv = ContentValues().apply {
                 put("channel_id", channelId)
                 put("expected_usd", newExpected)

--- a/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/DatabaseService.kt
@@ -260,6 +260,76 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    /** Result of [clampBackingToLiveReceiver]. */
+    data class BackingClampResult(
+        val overflowSats: Long,
+        val usdDeducted: Double,
+        val oldExpectedUSD: Double,
+        val newExpectedUSD: Double,
+        val newBackingSats: Long
+    )
+
+    /**
+     * Repair books that claim more backing than the channel actually holds.
+     *
+     * backing > live receiver balance is an impossible state: it means a withdrawal left the
+     * channel without its stable-books deduction (issue #311). Deduct the excess in USD once and
+     * pin backing to the live balance — the LSP's convention of preserving sats, not re-pegging
+     * sats from the USD target, so this converges instead of oscillating. Idempotent by
+     * construction: afterwards backing == receiver, so a second call finds nothing to do.
+     *
+     * The caller must only pass a [receiverSats] that reflects settled channel state — an
+     * in-flight HTLC lowers the receiver balance temporarily and would look like an overflow.
+     *
+     * Returns null when the books are already consistent.
+     */
+    fun clampBackingToLiveReceiver(
+        userChannelId: String,
+        receiverSats: Long,
+        price: Double
+    ): BackingClampResult? {
+        if (price <= 0.0 || receiverSats < 0) return null
+        val db = writableDatabase
+        db.execSQL("BEGIN IMMEDIATE")
+        try {
+            val cursor = db.rawQuery(
+                "SELECT expected_usd, stable_sats FROM channels WHERE user_channel_id = ?",
+                arrayOf(userChannelId)
+            )
+            val (currentExpected, currentBacking) = cursor.use {
+                if (!it.moveToFirst()) throw MissingChannelRowException(userChannelId)
+                it.getDouble(0) to it.getLong(1)
+            }
+            if (currentBacking <= receiverSats) {
+                db.execSQL("ROLLBACK")
+                return null
+            }
+            val overflowSats = currentBacking - receiverSats
+            val usdDeducted = (overflowSats.toDouble() / Constants.SATS_IN_BTC) * price
+            val newExpected = maxOf(currentExpected - usdDeducted, 0.0)
+            val cv = ContentValues().apply {
+                put("expected_usd", newExpected)
+                put("stable_sats", receiverSats)
+                put("receiver_sats", receiverSats)
+                put("latest_price", price)
+                put("updated_at", System.currentTimeMillis() / 1000)
+            }
+            val rows = db.update("channels", cv, "user_channel_id = ?", arrayOf(userChannelId))
+            if (rows != 1) {
+                throw IllegalStateException(
+                    "channel UPDATE affected $rows rows for user_channel_id=$userChannelId"
+                )
+            }
+            db.execSQL("COMMIT")
+            return BackingClampResult(
+                overflowSats, usdDeducted, currentExpected, newExpected, receiverSats
+            )
+        } catch (e: Exception) {
+            try { db.execSQL("ROLLBACK") } catch (_: Exception) {}
+            throw e
+        }
+    }
+
     /** Result of [reconcileOutgoingBacking]: the USD/backing values it actually wrote. */
     data class OutgoingReconcileResult(
         val usdDeducted: Double,
@@ -318,7 +388,13 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             val overflowSats = currentBacking - receiverSats
             val usdToDeduct = (overflowSats.toDouble() / Constants.SATS_IN_BTC) * price
             val newExpected = maxOf(currentExpected - usdToDeduct, 0.0)
-            val newBacking = ((newExpected / price) * Constants.SATS_IN_BTC).roundToLong()
+            // Preserve sats: the overflow left the channel, so what remains IS the backing.
+            // Re-pegging backing to newExpected/price (the old behaviour) left backing above the
+            // live balance whenever the position was below par, which made a retry deduct a
+            // SECOND time ($100 -> $92 -> $82) and hid a genuine below-par claim from the
+            // stability check. Pinning backing to the live balance matches the LSP's own
+            // convention and makes this idempotent: a re-run sees backing <= receiver and stops.
+            val newBacking = receiverSats
             val cv = ContentValues().apply {
                 put("channel_id", channelId)
                 put("expected_usd", newExpected)
@@ -676,6 +752,38 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
      *  of truth that BOTH the foreground handler and the background service write. The
      *  in-memory outcome map alone misses results committed while the app was backgrounded
      *  or before a restart. A failed fee send is also terminal. */
+    /** A terminal trade outcome plus when it resolved, for the startup resurfacing check. */
+    data class RecentTradeFailure(val paymentId: String, val outcome: TradeOutcome, val resolvedAt: Long)
+
+    /**
+     * The most recent trade FAILURE (rejected or send-failed) resolved within [withinSecs].
+     *
+     * A rejection that lands while the app is backgrounded is committed here, but the sheet that
+     * would have shown it does not survive the cold start that follows — so nothing tells the
+     * user their order was refused. AppState resurfaces this once on launch.
+     */
+    fun mostRecentTradeFailure(withinSecs: Long): RecentTradeFailure? {
+        val cutoff = System.currentTimeMillis() / 1000L - withinSecs
+        val cursor = readableDatabase.rawQuery(
+            """
+            SELECT trade_payment_id, status, reason_code, resolved_at
+            FROM trades
+            WHERE status IN ('rejected','send_failed')
+              AND trade_payment_id IS NOT NULL
+              AND resolved_at IS NOT NULL AND resolved_at >= ?
+            ORDER BY resolved_at DESC, id DESC
+            LIMIT 1
+            """.trimIndent(),
+            arrayOf(cutoff.toString())
+        )
+        return cursor.use { c ->
+            if (!c.moveToFirst()) return@use null
+            val paymentId = c.getString(0) ?: return@use null
+            val outcome = TradeOutcome.fromStored(c.getString(1), c.getStringOrNull(2)) ?: return@use null
+            RecentTradeFailure(paymentId, outcome, c.getLong(3))
+        }
+    }
+
     fun terminalTradeOutcome(paymentId: String): TradeOutcome? {
         val cursor = readableDatabase.rawQuery(
             "SELECT status, reason_code FROM trades WHERE trade_payment_id = ? AND status IN ('accepted','rejected','send_failed') ORDER BY id DESC LIMIT 1",
@@ -941,11 +1049,18 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         val db = writableDatabase
         db.execSQL("BEGIN IMMEDIATE")
         try {
+            // Keyed on channel_id, NOT user_channel_id: each side of a channel assigns its own
+            // user_channel_id, and for an LSP-opened (JIT) channel they never match — the LSP
+            // signs the payload with ITS id, so a user_channel_id lookup found nothing and every
+            // uncorrelated sync was dropped (or, before the retry bound, redelivered forever).
+            // That left the LSP's authoritative state unable to reach the wallet at all, which is
+            // what made the #311 books divergence unrecoverable. channel_id is the identifier
+            // both sides agree on. iOS fixed the same bug in #303.
             val row = db.rawQuery(
                 """
-                SELECT channel_id, expected_usd, stable_sats, receiver_sats, sync_version
-                FROM channels WHERE user_channel_id = ?
-                """.trimIndent(), arrayOf(sync.userChannelId)
+                SELECT user_channel_id, expected_usd, stable_sats, receiver_sats, sync_version
+                FROM channels WHERE channel_id = ?
+                """.trimIndent(), arrayOf(sync.channelId)
             ).use { c ->
                 if (!c.moveToFirst()) null else arrayOf<Any>(
                     c.getString(0), c.getDouble(1), c.getLong(2), c.getLong(3), c.getLong(4)
@@ -953,7 +1068,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             } // A missing row means the channel has since closed (deleteChannel runs on close) —
               // that's permanent, not a transient race, so give up rather than retry forever.
                 ?: return rollbackResult(db, TradeControlApplyStatus.INVALID)
-            if (row[0] as String != sync.channelId) return rollbackResult(db, TradeControlApplyStatus.INVALID)
+            val localUserChannelId = row[0] as String
             val currentVersion = row[4] as Long
             if (sync.syncVersion <= currentVersion) {
                 db.execSQL("ROLLBACK")
@@ -981,7 +1096,7 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
             if (db.update(
                     "channels", cv,
                     "user_channel_id = ? AND channel_id = ? AND sync_version < ?",
-                    arrayOf(sync.userChannelId, sync.channelId, sync.syncVersion.toString())
+                    arrayOf(localUserChannelId, sync.channelId, sync.syncVersion.toString())
                 ) != 1
             ) return rollbackResult(db, TradeControlApplyStatus.RETRY)
             db.execSQL("COMMIT")
@@ -1303,19 +1418,28 @@ class DatabaseService(context: Context) : SQLiteOpenHelper(
         }
     }
 
+    /**
+     * Rows the confirmation poller advances. Splices are deliberately NOT here.
+     *
+     * A splice row's completion is what triggers the stable-books reconcile in
+     * AppState.completeConfirmedSplice(), and completeSplice() only matches a row that is still
+     * 'pending'. When the poller also completed splice rows (at 1 conf) it raced the splice
+     * monitor: whoever got there first won, and if the poller won the reconcile never ran — the
+     * withdrawal stayed absent from Stable USD, and recovery could not repair it either, because
+     * hasPendingSplice()/getPendingSpliceTxid() only look at 'pending' rows (issue #311, mainnet
+     * 2026-09-12). The poller runs far more often than the monitor on a real device — it is
+     * force-run on every mempool websocket block header, on foreground resume and whenever
+     * History is opened — so it usually won. One writer owns splice completion: the monitor.
+     */
     fun getPaymentsNeedingConfirmation(limit: Int = 50): List<PaymentRecord> {
         val cursor = readableDatabase.rawQuery(
             """
             SELECT id, payment_id, payment_type, direction, amount_msat, amount_usd, btc_price, counterparty, status, created_at, fee_msat, txid, address, confirmations
             FROM payments
             WHERE txid IS NOT NULL AND txid != ''
-              AND payment_type IN ('onchain', 'channel_close', 'splice_in', 'splice_out')
+              AND payment_type IN ('onchain', 'channel_close')
               AND status != 'failed'
-              AND (
-                    (payment_type IN ('onchain', 'channel_close') AND confirmations < 6)
-                    OR
-                    (payment_type IN ('splice_in', 'splice_out') AND confirmations < 1)
-                  )
+              AND confirmations < 6
             ORDER BY created_at DESC
             LIMIT ?
             """.trimIndent(),

--- a/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
@@ -39,7 +39,13 @@ object StabilityService {
         val usdToDeduct = (overflowSats.toDouble() / Constants.SATS_IN_BTC) * price
         val newExpected = max(updated.expectedUSD.amount - usdToDeduct, 0.0)
         updated.expectedUSD = USD(newExpected)
-        updated.backingSats = ((newExpected / price) * Constants.SATS_IN_BTC).roundToLong()
+        // Preserve sats, don't re-peg. The overflow is exactly what left the channel, so the
+        // sats that remain are the backing. Re-pegging to newExpected/price left backing ABOVE
+        // the live balance whenever the position was below par — so a retry deducted again
+        // ($100 -> $92 -> $82), and the leftover phantom backing masked a real below-par claim
+        // from the stability check. This mirrors the LSP (backing_after_user_to_lsp_stability)
+        // and makes the function idempotent: re-running sees backing <= receiver and returns.
+        updated.backingSats = updated.stableReceiverBTC.sats
         recomputeNative(updated)
         return Pair(updated, usdToDeduct)
     }

--- a/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/StabilityService.kt
@@ -12,6 +12,9 @@ import kotlin.math.roundToLong
 
 object StabilityService {
 
+    /** Below this the position is treated as closed — matches the `expectedUSD < 0.01` guards. */
+    const val MINIMUM_STABLE_USD = 0.01
+
     enum class StabilityAction(val value: String) {
         STABLE("STABLE"),
         HIGH_RISK_NO_ACTION("HIGH_RISK_NO_ACTION"),
@@ -45,7 +48,12 @@ object StabilityService {
         // ($100 -> $92 -> $82), and the leftover phantom backing masked a real below-par claim
         // from the stability check. This mirrors the LSP (backing_after_user_to_lsp_stability)
         // and makes the function idempotent: re-running sees backing <= receiver and returns.
-        updated.backingSats = updated.stableReceiverBTC.sats
+        // Exception at the zero boundary: a spend that exhausts the target closes the position,
+        // so nothing backs it. Leaving the remaining sats as backing for a $0 target would book
+        // them as neither stable nor native (recomputeNative gives receiver - backing = 0) and
+        // strand them: every repair path treats a sub-cent target as "no position" and bails.
+        updated.backingSats =
+            if (newExpected < MINIMUM_STABLE_USD) 0L else updated.stableReceiverBTC.sats
         recomputeNative(updated)
         return Pair(updated, usdToDeduct)
     }

--- a/android/app/src/main/java/com/stablechannels/app/services/TradeFailureNotice.kt
+++ b/android/app/src/main/java/com/stablechannels/app/services/TradeFailureNotice.kt
@@ -1,0 +1,23 @@
+package com.stablechannels.app.services
+
+/**
+ * Whether a trade failure committed while the app was away should be shown on launch.
+ *
+ * A rejection is only ever displayed at the moment it is processed (the trade sheet, and a status
+ * message set alongside it) — both live in process memory, so a rejection that arrives while the
+ * app is backgrounded is silent after the cold start that follows. Startup resurfaces the most
+ * recent one, subject to two rules kept here so they can be tested without a ViewModel.
+ */
+object TradeFailureNotice {
+    fun shouldShow(
+        failurePaymentId: String,
+        lastShownPaymentId: String?,
+        capsuleOccupied: Boolean
+    ): Boolean {
+        // Already told them — including when the live trade flow showed it before the relaunch.
+        if (failurePaymentId == lastShownPaymentId) return false
+        // Never displace a live message. Not marked seen either, so a later launch can show it.
+        if (capsuleOccupied) return false
+        return true
+    }
+}

--- a/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
+++ b/android/app/src/main/java/com/stablechannels/app/util/Constants.kt
@@ -47,6 +47,9 @@ object Constants {
     const val INVOICE_EXPIRY_SECS: Int = 3600
     const val BALANCE_UPDATE_INTERVAL_SECS: Long = 30
     const val STABILITY_CHECK_INTERVAL_SECS: Long = 60
+    /** How recently a trade failure must have resolved to be worth resurfacing on launch. */
+    const val TRADE_FAILURE_RESURFACE_WINDOW_SECS: Long = 3600
+
     const val MAX_RISK_LEVEL = 100
     const val STABILITY_THRESHOLD_PERCENT: Double = 0.1
     const val STABILITY_THRESHOLD_USD: Double = 0.25

--- a/android/app/src/test/java/com/stablechannels/app/StabilityServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/StabilityServiceTest.kt
@@ -177,6 +177,26 @@ class StabilityServiceTest {
         assertEquals(82_000L, second.backingSats)
     }
 
+    @Test
+    fun `reconcileOutgoing closes the position when the spend exhausts the target`() {
+        // Preserve-sats must not apply at the zero boundary: with the target exhausted nothing
+        // backs it, so the remaining sats are native. Leaving them as backing for a $0 target
+        // books them as neither stable nor native, and every repair path treats a sub-cent
+        // target as "no position" and bails — the sats would be stranded for good.
+        val price = 100_000.0
+        val sc = StableChannel(
+            expectedUSD = USD(10.0),
+            backingSats = 20_000L,
+            stableReceiverBTC = Bitcoin(5_000L)   // a $15 overflow against a $10 target
+        )
+
+        val (updated, deducted) = StabilityService.reconcileOutgoing(sc, price)
+        assertEquals(15.0, deducted!!, 0.0001)
+        assertEquals(0.0, updated.expectedUSD.amount, 0.0001)
+        assertEquals(0L, updated.backingSats)
+        assertEquals(5_000L, updated.nativeChannelBTC.sats)   // the sats the user still holds
+    }
+
     // ---------------------------------------------------------------------------
     // PriceService.median — pure math
     // ---------------------------------------------------------------------------

--- a/android/app/src/test/java/com/stablechannels/app/StabilityServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/StabilityServiceTest.kt
@@ -153,6 +153,30 @@ class StabilityServiceTest {
         assertEquals(expectedDeduction, deducted!!, 0.01)
     }
 
+    @Test
+    fun `reconcileOutgoing is idempotent below par`() {
+        // A retry must never deduct twice. Backing is pinned to the live balance (preserve sats)
+        // instead of re-pegged to newExpected/price, which used to leave backing ABOVE the live
+        // balance whenever the position was below par — so a second call deducted again
+        // ($100 -> $92 -> $82) and the phantom backing hid a real below-par claim.
+        val price = 100_000.0
+        val sc = StableChannel(
+            expectedUSD = USD(100.0),
+            backingSats = 90_000L,                      // below par: worth $90, target $100
+            stableReceiverBTC = Bitcoin(82_000L)        // an 8,000 sat withdrawal just landed
+        )
+
+        val (first, deducted) = StabilityService.reconcileOutgoing(sc, price)
+        assertEquals(8.0, deducted!!, 0.0001)
+        assertEquals(92.0, first.expectedUSD.amount, 0.0001)
+        assertEquals(82_000L, first.backingSats)        // == live balance, not 92,000
+
+        val (second, deductedAgain) = StabilityService.reconcileOutgoing(first, price)
+        assertEquals(null, deductedAgain)
+        assertEquals(92.0, second.expectedUSD.amount, 0.0001)
+        assertEquals(82_000L, second.backingSats)
+    }
+
     // ---------------------------------------------------------------------------
     // PriceService.median — pure math
     // ---------------------------------------------------------------------------

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -795,6 +795,119 @@ class TradeDatabaseServiceTest {
         service.close()
     }
 
+    @Test
+    fun repairDefersWhileAStabilitySendIsStillUnreconciled() {
+        // (1) A stability keysend that SUCCEEDED but whose backing debit is not recorded yet
+        // leaves the channel looking like an overflow. Repairing there would take the same sats
+        // twice — once as a USD clamp, once as the debit recovery is about to apply.
+        val identifier = "4d".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "31", expectedUSD = 20.0,
+            backingSats = 20_000, note = null, receiverSats = 20_000, latestPrice = 100_000.0
+        )
+        assertTrue(service.claimPendingSend(amountMsat = 5_000_000, price = 100_000.0))
+        service.setPendingSendPaymentId("55".repeat(32))
+
+        // The sats have left the channel: backing 20,000 vs a live balance of 15,000.
+        assertNull(service.clampBackingToLiveReceiver("31", receiverSats = 15_000, price = 100_000.0))
+        assertEquals(20_000L, service.loadChannel("31")?.backingSats)
+
+        // Recovery records the payment and debits backing once, then clears the marker.
+        val persisted = service.recordPaymentAndMaybeUpdateBacking(
+            paymentId = "55".repeat(32), paymentType = "stability", direction = "sent",
+            amountMsat = 5_000_000, userChannelId = "31", backingDeltaSats = -5_000
+        )
+        assertTrue(persisted.isNewPayment)
+        assertEquals(15_000L, persisted.backingSats)
+        service.clearPendingSend()
+
+        // Now the books match the live balance, so the repair has nothing left to take.
+        assertNull(service.clampBackingToLiveReceiver("31", receiverSats = 15_000, price = 100_000.0))
+        assertEquals(15_000L, service.loadChannel("31")?.backingSats)
+        service.close()
+    }
+
+    @Test
+    fun spliceAccountingResumesExactlyOnceAfterATerminationBeforeCompletion() {
+        // (2) Books are written before the row is marked complete, so a crash in between leaves
+        // the row pending and the resume path runs the deduction again — which must be a no-op
+        // the second time.
+        val identifier = "5e".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "32", expectedUSD = 20.0,
+            backingSats = 20_000, note = null, receiverSats = 20_000, latestPrice = 100_000.0
+        )
+        val txid = "6f".repeat(32)
+        service.recordPayment(
+            paymentId = "splice-resume", paymentType = "splice_out", direction = "sent",
+            amountMsat = 5_000_000, amountUSD = 5.0, btcPrice = 100_000.0,
+            txid = txid, status = "pending"
+        )
+
+        // First attempt: deduction lands, then the process dies before completeSplice().
+        val first = service.reconcileOutgoingBacking(
+            channelId = identifier, userChannelId = "32", note = null,
+            receiverSats = 15_000, latestPrice = 100_000.0, price = 100_000.0
+        )
+        assertNotNull(first)
+        assertEquals(15.0, first!!.newExpectedUSD, 0.0001)
+        assertTrue(service.hasPendingSpliceFor(txid))   // still resumable
+
+        // Resume: the reconcile is idempotent, and only now is the row completed.
+        assertNull(
+            service.reconcileOutgoingBacking(
+                channelId = identifier, userChannelId = "32", note = null,
+                receiverSats = 15_000, latestPrice = 100_000.0, price = 100_000.0
+            )
+        )
+        assertEquals(15.0, service.loadChannel("32")?.expectedUSD ?: -1.0, 0.0001)
+        assertTrue(service.completeSplice(txid))
+        assertFalse(service.hasPendingSpliceFor(txid))
+        service.close()
+    }
+
+    @Test
+    fun repairWorksWhenTheChannelBalanceIsZero() {
+        // (3) A full splice-out empties the channel; the position must be allowed to close.
+        val identifier = "7a".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "33", expectedUSD = 5.0,
+            backingSats = 5_000, note = null, receiverSats = 5_000, latestPrice = 100_000.0
+        )
+
+        val repaired = service.clampBackingToLiveReceiver("33", receiverSats = 0, price = 100_000.0)
+
+        assertNotNull(repaired)
+        assertEquals(0L, repaired!!.newBackingSats)
+        assertEquals(0.0, repaired.newExpectedUSD, 0.0001)
+        assertEquals(0L, service.loadChannel("33")?.backingSats)
+        service.close()
+    }
+
+    @Test
+    fun repairRetriesOnceATrustedPriceIsAvailable() {
+        // (4) Without a trusted price the spend cannot be valued, so the repair defers — and the
+        // deferral must leave the books untouched so a later attempt still finds the work.
+        val identifier = "8b".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "34", expectedUSD = 20.0,
+            backingSats = 20_000, note = null, receiverSats = 20_000, latestPrice = 100_000.0
+        )
+
+        assertNull(service.clampBackingToLiveReceiver("34", receiverSats = 15_000, price = 0.0))
+        assertEquals(20_000L, service.loadChannel("34")?.backingSats)   // nothing lost
+
+        val repaired = service.clampBackingToLiveReceiver("34", receiverSats = 15_000, price = 100_000.0)
+        assertNotNull(repaired)
+        assertEquals(15_000L, repaired!!.newBackingSats)
+        assertEquals(15.0, repaired.newExpectedUSD, 0.0001)
+        service.close()
+    }
+
     private fun deleteDatabaseFiles() {
         listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
             .forEach { file -> if (file.exists()) assertTrue(file.delete()) }

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -555,6 +555,176 @@ class TradeDatabaseServiceTest {
         service.close()
     }
 
+    @Test
+    fun clampBackingToLiveReceiverHealsAStrandedWithdrawalExactlyOnce() {
+        // Issue #311: a splice-out completed without its stable-books deduction, leaving backing
+        // above the balance that actually backs it. The repair deducts the excess once, pins
+        // backing to the live balance (the LSP's preserve-sats convention rather than re-pegging
+        // sats from the USD target, which is what makes StabilityService.reconcileOutgoing()
+        // deduct again on a retry), and is a no-op afterwards.
+        val identifier = "cd".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "11",
+            expectedUSD = 75.3093,
+            backingSats = 75_309,
+            note = null,
+            receiverSats = 75_309,
+            latestPrice = 100_000.0
+        )
+
+        // A $15 withdrawal left the channel; the deduction never ran.
+        val repaired = service.clampBackingToLiveReceiver("11", receiverSats = 69_056, price = 100_000.0)
+
+        assertNotNull(repaired)
+        assertEquals(6_253L, repaired!!.overflowSats)
+        assertEquals(6.253, repaired.usdDeducted, 0.0001)
+        assertEquals(69.0563, repaired.newExpectedUSD, 0.0001)
+        assertEquals(69_056L, repaired.newBackingSats)
+
+        val healed = service.loadChannel("11")
+        assertEquals(69.0563, healed?.expectedUSD ?: -1.0, 0.0001)
+        assertEquals(69_056L, healed?.backingSats)
+
+        // Idempotent: the books now match the live balance, so nothing more is deducted.
+        assertNull(service.clampBackingToLiveReceiver("11", receiverSats = 69_056, price = 100_000.0))
+        assertEquals(69.0563, service.loadChannel("11")?.expectedUSD ?: -1.0, 0.0001)
+
+        // A position that is merely below par is NOT an overflow — leave it alone.
+        assertNull(service.clampBackingToLiveReceiver("11", receiverSats = 80_000, price = 100_000.0))
+        assertEquals(69_056L, service.loadChannel("11")?.backingSats)
+        service.close()
+    }
+
+    @Test
+    fun uncorrelatedSyncAppliesWhenTheLspUsesItsOwnUserChannelId() {
+        // Each side assigns its own user_channel_id; for a JIT channel they never match, and the
+        // LSP signs the sync with ITS id. Keying the lookup on user_channel_id therefore found
+        // no row and every uncorrelated sync was dropped, leaving the LSP unable to correct a
+        // diverged wallet (#311). channel_id is what both sides agree on.
+        val identifier = "ef".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "316138149017243335882538127405458540875",   // the app's own id
+            expectedUSD = 19.7555,
+            backingSats = 25_493,
+            note = null,
+            receiverSats = 25_493,
+            latestPrice = 100_000.0
+        )
+
+        val sync = TradeControlMessage.Sync(
+            channelId = identifier,
+            userChannelId = "317806336254983028346801304467074316335",   // the LSP's own id
+            expectedUsd = 14.6022,
+            backingSats = 18_819,
+            syncVersion = 3,
+            correlation = null
+        )
+        assertEquals(
+            TradeControlApplyStatus.APPLIED,
+            service.applyUncorrelatedSyncIfNewer(sync, trustedPrice = 100_000.0).status
+        )
+        val healed = service.loadChannel("316138149017243335882538127405458540875")
+        assertEquals(14.6022, healed?.expectedUSD ?: -1.0, 0.0001)
+        assertEquals(20_340L, healed?.backingSats)   // delta applied against the app's own backing
+
+        // Replaying the same version changes nothing.
+        assertEquals(
+            TradeControlApplyStatus.DUPLICATE,
+            service.applyUncorrelatedSyncIfNewer(sync, trustedPrice = 100_000.0).status
+        )
+        service.close()
+    }
+
+    @Test
+    fun outgoingReconcileIsIdempotentBelowPar() {
+        // Same preserve-sats rule as StabilityService.reconcileOutgoing: a redelivered
+        // PaymentSuccessful (the handler rethrows transient failures, so LDK re-runs it) must not
+        // deduct a second time.
+        val identifier = "ab".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier,
+            userChannelId = "9",
+            expectedUSD = 100.0,
+            backingSats = 90_000,          // below par
+            note = null,
+            receiverSats = 90_000,
+            latestPrice = 100_000.0
+        )
+
+        val first = service.reconcileOutgoingBacking(
+            channelId = identifier, userChannelId = "9", note = null,
+            receiverSats = 82_000, latestPrice = 100_000.0, price = 100_000.0
+        )
+        assertNotNull(first)
+        assertEquals(8.0, first!!.usdDeducted, 0.0001)
+        assertEquals(92.0, first.newExpectedUSD, 0.0001)
+        assertEquals(82_000L, first.newBackingSats)
+
+        val replay = service.reconcileOutgoingBacking(
+            channelId = identifier, userChannelId = "9", note = null,
+            receiverSats = 82_000, latestPrice = 100_000.0, price = 100_000.0
+        )
+        assertNull(replay)
+        assertEquals(92.0, service.loadChannel("9")?.expectedUSD ?: -1.0, 0.0001)
+        assertEquals(82_000L, service.loadChannel("9")?.backingSats)
+        service.close()
+    }
+
+    @Test
+    fun mostRecentTradeFailureFindsARejectionResolvedWhileTheAppWasAway() {
+        // A rejection delivered while backgrounded is committed here, but the sheet that would
+        // have shown it dies with the process. Startup resurfaces the newest failure so the
+        // refusal is not silent (flow 15).
+        val identifier = "ba".repeat(32)
+        val service = DatabaseService(context)
+        val now = System.currentTimeMillis() / 1000L
+        val trade = TradeProtocol.prepare(
+            spendableSats = 100_000,
+            sc = StableChannel(
+                channelId = identifier,
+                userChannelId = "7",
+                expectedUSD = USD(50.0),
+                stableReceiverBTC = Bitcoin(100_000),
+                backingSats = 55_000
+            ),
+            action = "sell",
+            amountUsd = 10.0,
+            amountBtc = 0.000099,
+            feeUsd = 0.1,
+            newExpectedUsd = 59.9,
+            quotePrice = 100_000.0,
+            now = now,
+            tradeId = "cc".repeat(32)
+        )!!
+        val dbId = service.recordPreparedTrade(trade)
+        val paymentId = "dd".repeat(32)
+        assertTrue(service.attachTradePaymentId(dbId, paymentId))
+        assertNull(service.mostRecentTradeFailure(3600))   // nothing terminal yet
+
+        val rejection = TradeControlMessage.Rejected(
+            channelId = identifier,
+            correlation = TradeCorrelation(trade.tradeId, paymentId, trade.requestHash),
+            reasonCode = "quote_deviation",
+            decidedAt = now
+        )
+        assertEquals(TradeControlApplyStatus.APPLIED, service.applyTradeRejection(rejection).status)
+
+        val failure = service.mostRecentTradeFailure(3600)
+        assertNotNull(failure)
+        assertEquals(paymentId, failure!!.paymentId)
+        assertEquals(TradeProtocol.rejectionMessage("quote_deviation"), failure.outcome.message)
+
+        // Outside the window it is stale news — History carries it instead.
+        service.writableDatabase.execSQL("UPDATE trades SET resolved_at = resolved_at - 7200")
+        assertNull(service.mostRecentTradeFailure(3600))
+        service.close()
+    }
+
     private fun deleteDatabaseFiles() {
         listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
             .forEach { file -> if (file.exists()) assertTrue(file.delete()) }

--- a/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeDatabaseServiceTest.kt
@@ -725,6 +725,76 @@ class TradeDatabaseServiceTest {
         service.close()
     }
 
+    @Test
+    fun outgoingReconcileClosesThePositionWhenTheSpendExhaustsTheTarget() {
+        // Zero boundary, persisted side: nothing backs an exhausted target.
+        val identifier = "1a".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "21", expectedUSD = 10.0,
+            backingSats = 20_000, note = null, receiverSats = 20_000, latestPrice = 100_000.0
+        )
+
+        val result = service.reconcileOutgoingBacking(
+            channelId = identifier, userChannelId = "21", note = null,
+            receiverSats = 5_000, latestPrice = 100_000.0, price = 100_000.0
+        )
+
+        assertNotNull(result)
+        assertEquals(0.0, result!!.newExpectedUSD, 0.0001)
+        assertEquals(0L, result.newBackingSats)
+        val row = service.loadChannel("21")
+        assertEquals(0.0, row?.expectedUSD ?: -1.0, 0.0001)
+        assertEquals(0L, row?.backingSats)          // the 5,000 sats are native, not stranded
+        service.close()
+    }
+
+    @Test
+    fun backingClampClosesThePositionWhenTheRepairExhaustsTheTarget() {
+        // Same boundary on the startup repair path.
+        val identifier = "2b".repeat(32)
+        val service = DatabaseService(context)
+        service.saveChannel(
+            channelId = identifier, userChannelId = "22", expectedUSD = 10.0,
+            backingSats = 20_000, note = null, receiverSats = 20_000, latestPrice = 100_000.0
+        )
+
+        val repaired = service.clampBackingToLiveReceiver("22", receiverSats = 5_000, price = 100_000.0)
+
+        assertNotNull(repaired)
+        assertEquals(0.0, repaired!!.newExpectedUSD, 0.0001)
+        assertEquals(0L, repaired.newBackingSats)
+        assertEquals(0L, service.loadChannel("22")?.backingSats)
+        service.close()
+    }
+
+    @Test
+    fun confirmationPollerLeavesSpliceRowsToTheSpliceMonitor() {
+        // The #311 race: the poller used to complete splice rows at 1 conf, which skipped the
+        // stable-books deduction and left nothing for recovery to find. Splice rows must not be
+        // offered to the poller at all — the monitor owns them.
+        val service = DatabaseService(context)
+        val txid = "3c".repeat(32)
+        for (type in listOf("splice_out", "splice_in", "onchain")) {
+            service.recordPayment(
+                paymentId = "$type-pending",
+                paymentType = type,
+                direction = if (type == "onchain") "received" else "sent",
+                amountMsat = 15_000_000,
+                amountUSD = 15.0,
+                btcPrice = 100_000.0,
+                txid = txid,
+                status = "pending"
+            )
+        }
+
+        val offered = service.getPaymentsNeedingConfirmation().map { it.paymentType }.toSet()
+        assertTrue(offered.contains("onchain"))
+        assertFalse(offered.contains("splice_out"))
+        assertFalse(offered.contains("splice_in"))
+        service.close()
+    }
+
     private fun deleteDatabaseFiles() {
         listOf(dbFile, File("${dbFile.path}-wal"), File("${dbFile.path}-shm"))
             .forEach { file -> if (file.exists()) assertTrue(file.delete()) }

--- a/android/app/src/test/java/com/stablechannels/app/TradeFailureNoticeTest.kt
+++ b/android/app/src/test/java/com/stablechannels/app/TradeFailureNoticeTest.kt
@@ -1,0 +1,51 @@
+package com.stablechannels.app
+
+import com.stablechannels.app.services.TradeFailureNotice
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TradeFailureNoticeTest {
+
+    @Test
+    fun `a startup message cannot overwrite a rejection, and the rejection is not burned`() {
+        // (5) The capsule already holds a live message (start() is re-invocable from ErrorView's
+        // retry, where "Network unstable…" is plausible). The rejection must not displace it —
+        // and must not be marked seen, or it could never be shown at all.
+        assertFalse(
+            TradeFailureNotice.shouldShow(
+                failurePaymentId = "aa".repeat(32),
+                lastShownPaymentId = null,
+                capsuleOccupied = true
+            )
+        )
+        // The next launch, with a free capsule, still shows it.
+        assertTrue(
+            TradeFailureNotice.shouldShow(
+                failurePaymentId = "aa".repeat(32),
+                lastShownPaymentId = null,
+                capsuleOccupied = false
+            )
+        )
+    }
+
+    @Test
+    fun `a rejection already shown in the foreground does not reappear after relaunch`() {
+        // (6) The live trade flow marks it seen as it displays it, so startup stays quiet.
+        assertFalse(
+            TradeFailureNotice.shouldShow(
+                failurePaymentId = "bb".repeat(32),
+                lastShownPaymentId = "bb".repeat(32),
+                capsuleOccupied = false
+            )
+        )
+        // A different, newer failure is still worth surfacing.
+        assertTrue(
+            TradeFailureNotice.shouldShow(
+                failurePaymentId = "cc".repeat(32),
+                lastShownPaymentId = "bb".repeat(32),
+                capsuleOccupied = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
…, LSP syncs apply, rejections resurface (#311)

Four defects behind one incident (mainnet 2026-09-12: a splice-out left the app's books $5 ahead of the LSP's, and every later trade was rejected invalid_fee).

1. The splice deduction was lost to a race. Two writers completed a splice row: the splice monitor (completeConfirmedSplice → completeSplice, which matches only status='pending', then reconciles) and the confirmation poller (which completes splice rows at 1 conf and reconciles nothing). When the poller won, completeSplice matched nothing and the deduction never ran; because hasPendingSplice()/getPendingSpliceTxid() only see 'pending' rows, a restart could not repair it either. The poller usually wins on a real device — it is force-run on every mempool websocket block header, on foreground resume and whenever History is opened, while the monitor polls every 30s. Splices are now excluded from the poller: one writer owns them, and the existing status='pending' guard makes the deduction exactly-once.

2. reconcileOutgoing() / reconcileOutgoingBacking() were not idempotent. Both re-pegged backing to newExpected/price. Below par that leaves backing ABOVE the live balance, so a retry deducted a second time ($100 -> $92 -> $82), and the phantom backing masked a genuine below-par claim from the stability check. Both now preserve sats: backing is pinned to the live receiver balance, matching the LSP's backing_after_user_to_lsp_stability. A re-run sees backing <= receiver and stops — which also makes a redelivered PaymentSuccessful (the handler rethrows transient failures) safe.

3. Uncorrelated LSP syncs never applied. The lookup keyed on user_channel_id, but each side assigns its own and the LSP signs the payload with ITS id — for a JIT channel they never match, so every sync was dropped (and before #266's retry bound, redelivered forever). That is why the LSP could not correct the diverged wallet. Keyed on channel_id now, as iOS did in #303.

4. A rejection arriving while the app was backgrounded was silent. It is verified and committed by the event handler, but the only places it shows are the trade sheet and a status message set in that same moment — both die with the process, and the relaunch is a cold start. The balance simply never moved, with no explanation. The most recent failure (within the hour) now resurfaces once in the status capsule, keyed on its payment id so it cannot repeat or displace a live message.

Plus a cold-start repair for wallets already stranded: backing above the live balance is impossible, so deduct the excess once and pin backing to the balance (idempotent, no history replay). It runs off the critical startup path — inline, it delayed the first frames enough to break onboarding.

Note 1 and 3 depend on each other: a sync cannot repair books whose backing exceeds the live balance (tradeBackingAfterDelta refuses), so the repair must restore the invariant before syncs can land.

Android unit suite 280/280, including four new regression tests. Verified on the emulator against the e2e suite: canonical 10/10, the #311 repro flow (was RED) green, and flows 13/14/15/16/17/24/25/26/28/29/30 green — flow 15 included, which had been failing on defect 4.


Claude-Session: https://claude.ai/code/session_01QaHxBaQP2kxyuRnW1mtnKK